### PR TITLE
Feature/force main to stdc

### DIFF
--- a/lib/cpm_crt0.asm
+++ b/lib/cpm_crt0.asm
@@ -131,13 +131,8 @@ ENDIF
 
 
 	INCLUDE	"crt0_command_line.asm"
-IF DEFINED_Z88DK_USES_SDCC
 	push	hl	;argv
 	push	bc	;argc
-ELSE
-	push	bc	;argc
-	push	hl	;argv
-ENDIF
         call    _main		;Call user code
 	pop	bc	;kill argv
 	pop	bc	;kill argc

--- a/lib/msx_crt0.asm
+++ b/lib/msx_crt0.asm
@@ -118,13 +118,8 @@ IF (startup=2)
         add     hl,bc   ;now points to the end of the command line
 	INCLUDE	"crt0_command_line.asm"
 
-IF DEFINED_Z88DK_USES_SDCC
         push    hl      ;argv
         push    bc      ;argc
-ELSE
-        push    bc      ;argc
-        push    hl      ;argv
-ENDIF
         call    _main		;Call user code
 	pop	bc	;kill argv
 	pop	bc	;kill argc

--- a/lib/osca_crt0.asm
+++ b/lib/osca_crt0.asm
@@ -186,13 +186,8 @@ find_end:
 
 	INCLUDE "crt0_command_line.asm"
 
-IF DEFINED_Z88DK_USES_SDCC
         push    hl      ;argv
         push    bc      ;argc
-ELSE
-        push    bc      ;argc
-        push    hl      ;argv
-ENDIF
 
 	call    _main		;Call user code
 

--- a/lib/pps_crt0.asm
+++ b/lib/pps_crt0.asm
@@ -78,13 +78,8 @@ ENDIF
 
 	INCLUDE	"crt0_command_line.asm"
 
-IF DEFINED_Z88DK_USES_SDCC
         push    hl      ;argv
         push    bc      ;argc
-ELSE
-        push    bc      ;argc
-        push    hl      ;argv
-ENDIF
         call    _main           ;Call user code
         pop     bc      ;kill argv
         pop     bc      ;kill argc

--- a/lib/sos_crt0.asm
+++ b/lib/sos_crt0.asm
@@ -102,13 +102,8 @@ find_end:
 	ld	b,0
 	INCLUDE	"crt0_command_line.asm"
 
-IF DEFINED_Z88DK_USES_SDCC
         push    hl      ;argv
         push    bc      ;argc
-ELSE
-        push    bc      ;argc
-        push    hl      ;argv
-ENDIF	
         call    _main		;Call user code
 	pop	bc	;kill argv
 	pop	bc	;kill argc

--- a/lib/test_cmds.def
+++ b/lib/test_cmds.def
@@ -1,10 +1,28 @@
 lstoff
+; See also src/ticks/cmds.h
 
+	defc    argv_length = 65280
+        defc    argv_start = 65281
 
 	defc	CMD_EXIT = 0
 	defc	CMD_PRINTCHAR = 1
 	defc	CMD_READKEY = 2
 
+        defc    CMD_OPENF = 3
+        defc    CMD_CLOSEF = 4
+        defc    CMD_WRITEBYTE = 5
+        defc    CMD_READBYTE = 6
+        defc    CMD_WRITEBLOCK = 7
+        defc    CMD_READBLOCK = 8
+        defc    CMD_SEEK = 0
+        defc    CMD_STAT = 10
+
+
+        defc    CMD_REMOVE = 20
+        defc    CMD_RENAME = 21
+
         defc    CMD_GETTIME = 30
 
+        defc    CMD_MKDIR = 40
+        defc    CMD_RMDIR = 41
 lston

--- a/lib/test_crt0.asm
+++ b/lib/test_crt0.asm
@@ -90,14 +90,27 @@ restart30:
 	ret
 
 program:
-	ld	sp,65535
+	ld	sp,65280
 	ld	hl,-64
 	add	hl,sp
 	ld	sp,hl
 	call    crt0_init_bss
 	ld	(exitsp),sp
     	ei
+	ld	a,(argv_length)
+	and	a
+	jr	z,argv_done
+	ld	c,a
+	ld	b,0
+	ld	hl,argv_start
+	add	hl,bc	; now points to end of the command line
+	defc DEFINED_noredir = 1
+	INCLUDE "crt0_command_line.asm"
+	push	hl	;argv
+	push	bc	;argc
 	call	_main
+	pop	bc
+	pop	bc
 cleanup:
 	ld	a,CMD_EXIT	;exit
 	rst	8
@@ -105,7 +118,11 @@ cleanup:
 
 l_dcal: jp      (hl)            ;Used for function pointer calls
 
+
+
 	INCLUDE "crt0_runtime_selection.asm" 
 	
 	INCLUDE	"crt0_section.asm"
 
+	SECTION rodata_clib
+end:            defb    0               ; null file name

--- a/lib/z88s_crt0.asm
+++ b/lib/z88s_crt0.asm
@@ -101,13 +101,8 @@ argv_none:
 	ld	hl,0
 	add	hl,sp		; address of argv
 	ld	b,0
-IF DEFINED_Z88DK_USES_SDCC
         push    hl      ;argv
         push    bc      ;argc
-ELSE
-        push    bc      ;argc
-        push    hl      ;argv
-ENDIF
 	ld	hl,(shell_cmdlen)
 	ld	(shell_cmdptr),hl
 	call_oz(gn_nln)		; Start a new line...

--- a/src/sccz80/declfunc.c
+++ b/src/sccz80/declfunc.c
@@ -232,6 +232,7 @@ SYMBOL *AddFuncCode(char* n, char type, enum ident_type ident, char sign, char z
     locptr = STARTLOC; /* "clear" local symbol table */
     undeclared = 0; /* init arg count */
 
+
     /* Check to see if we are doing ANSI fn defs - must be a better way of
      * doing this! (Have an array and check by that?)           
      */
@@ -431,6 +432,12 @@ void setlocvar(SYMBOL* prevarg, SYMBOL* currfn)
     if (c_useframepointer || (currfn->flags & SAVEFRAME))
         where += 2;
 
+    /* main is always __stdc */
+    if ( strcmp(currfn->name,"main") == 0 ) {
+        currfn->flags &= ~SMALLC;
+    }
+
+
     /* For SMALLC we need to start counting from the last argument */
     if ( (currfn->flags & SMALLC) == SMALLC ) {
         while (prevarg) {
@@ -586,6 +593,10 @@ SYMBOL *dofnansi(SYMBOL* currfn, int32_t* addr)
 
     blanks();
     check_trailing_modifiers(currfn);
+    /* main is always __stdc */
+    if ( strcmp(currfn->name,"main") == 0 ) {
+        currfn->flags &= ~SMALLC;
+    }
 
     if (cmatch(';'))
         return (prevarg);

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -446,6 +446,9 @@ unsigned char
 
 unsigned char * mem;
 
+char   cmd_arguments[255];
+int    cmd_arguments_len = 0;
+
 long tapcycles(void){
   mues= 1;
   wavpos!=0x20000 && (ear^= 64);
@@ -565,6 +568,16 @@ int main (int argc, char **argv){
             printf("\nInvalid header size\n"),
             exit(-1);
           wavpos= 44;
+          break;
+        case '-':
+          while ( argc > 1 ) {
+            // I think windows is now comformant with snprintf? Either way, we can't grow the arugment buffer...
+            cmd_arguments_len += snprintf(cmd_arguments + cmd_arguments_len, sizeof(cmd_arguments) - cmd_arguments_len, "%s%s",cmd_arguments_len > 0 ? " " : "", argv[1]);
+            argc--;
+            argv++;
+          }
+          mem[65280] = cmd_arguments_len % 256;
+          memcpy(&mem[65281], cmd_arguments, cmd_arguments_len % 256);
           break;
         default:
           printf("\nWrong Argument: %s\n", argv[0]);
@@ -686,6 +699,8 @@ int main (int argc, char **argv){
   if( !size )
     printf("File not specified or zero length\n");
   stint= intr;
+
+
   do{
     if( pc==start )
       st= 0,


### PR DESCRIPTION
Make main __stdc always.

Remove swapping around of argc,argv in the affected crt files.

Pass through arguments to the ticks target.

