### PR TITLE
Callee function leave cleanup

### DIFF
--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -2215,3 +2215,7 @@
 	ex	de,hl
 	ex	de,hl
 =
+
+	exx
+	exx
+=

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -996,9 +996,12 @@ void point(void)
         ol("defw\tASMPC+2");
 }
 
-/* Modify the stack pointer to the new value indicated */
+/* Modify the stack pointer to the new value indicated 
+ * \param newsp - Where we need to be 
+ * \param save - NO or the variable type that we need to preserve
+ * \param saveaf - Whether we should save af
+ */
 int modstk(int newsp, int save, int saveaf)
-/*  newsp - if true save hl;  save - preserve contents of af */
 {
     int k, flag = NO;
 
@@ -1074,13 +1077,17 @@ modstkcht:
             doexx();
     }
 #else
-    if (save)
-        doexx();
+    if (save) {
+        if (c_notaltreg) savehl();
+        else doexx();
+    }
     vconst(k);
     ol("add\thl,sp");
     ol("ld\tsp,hl");
-    if (save)
-        doexx();
+    if (save) {
+        if (c_notaltreg) restorehl();
+        else doexx();
+    }
 #endif
     if (saveaf) {
         if (c_notaltreg) {

--- a/src/sccz80/primary.c
+++ b/src/sccz80/primary.c
@@ -700,11 +700,13 @@ int constexpr(int32_t* val, int flag)
 {
     char *before, *start;
     int con, valtemp;
+    int savesp = Zsp;
 
     setstage(&before, &start);
     expression(&con, &valtemp);
     *val = (long)valtemp;
     clearstage(before, 0); /* scratch generated code */
+    Zsp = savesp;
     if (flag && con == 0)
         error(E_CONSTANT);
     return con;


### PR DESCRIPTION
Issue 109: Callee cleanup

C functions that are callee should now cleanup properly and not corrupt the return value.

-noaltreg compiles no longer use the exx set for modstk()

If a double is returned, then we don't touch the exx set (needed for math48)