### PR TITLE
Issue #159. Allow environment variable substitution in list files

### DIFF
--- a/src/z80asm/CHANGES.md
+++ b/src/z80asm/CHANGES.md
@@ -9,6 +9,7 @@ Z88DK Z80 Module Assembler Change Log
 - 2017-02-08 Fix #53 public constants not being listed in global .def file
 - 2017-02-09 Fix #54 overflow errors in calculated constants at linking stage
 - 2017-02-12 Fix #65 separate BSS section not generated from object file if BSS org was -1 at assembly time
+- 2017-04-12 Fix #159 allow environment variables ${VAR} in the command line options and arguments and list files (contribution from dom@suborbital.org.uk)
 
 2016
 ----

--- a/src/z80asm/options.c
+++ b/src/z80asm/options.c
@@ -184,16 +184,20 @@ static void process_opt( int *parg, int argc, char *argv[] )
                 break;
 
             case OptCallArg:
-                if ( *opt_arg_ptr )
-                    ( ( void ( * )( char * ) )( opts_lu[j].arg ) )( opt_arg_ptr );
+				if (*opt_arg_ptr) {
+					opt_arg_ptr = expand_environment_variables(opt_arg_ptr);
+					((void(*)(char *))(opts_lu[j].arg))(opt_arg_ptr);
+				}
                 else
                     error_illegal_option( argv[II] );
 
                 break;
 
             case OptString:
-                if ( *opt_arg_ptr )
+				if (*opt_arg_ptr) {
+					opt_arg_ptr = expand_environment_variables(opt_arg_ptr);
                     *( ( char ** )( opts_lu[j].arg ) ) = opt_arg_ptr;
+				}
                 else
                     error_illegal_option( argv[II] );
 
@@ -203,6 +207,7 @@ static void process_opt( int *parg, int argc, char *argv[] )
 				if (*opt_arg_ptr)
 				{
 					UT_array **p_path = (UT_array **)opts_lu[j].arg;
+					opt_arg_ptr = expand_environment_variables(opt_arg_ptr);
 					utarray_push_back(*p_path, &opt_arg_ptr);
 				}
                 else
@@ -286,6 +291,7 @@ static char *expand_environment_variables(char *arg)
 	char  *rep, *start;
 	char  *value = strdup(arg);
 	char   varname[300];
+	char  *ret;
 
 	start = value;
 	while ((ptr = strchr(start, '$')) != NULL) 
@@ -315,8 +321,9 @@ static char *expand_environment_variables(char *arg)
 		}
 	}
 
+	ret = strpool_add(value);		// free memory, return pooled string
 	free(value);
-	return nval ? nval : arg;
+	return ret;
 }
 
 /* From: http://creativeandcritical.net/str-replace-c/ */

--- a/src/z80asm/t/directives.t
+++ b/src/z80asm/t/directives.t
@@ -91,6 +91,34 @@ z80asm(
 ASM
 );
 
+# test -I using environment variables
+unlink "test.inc";
+make_path("test_dir");
+	write_file("test_dir/test.inc", 'ld a,10');
+	
+	z80asm(
+		asm		=> 'include "test.inc"	;; error: cannot read file \'test.inc\'',
+	);
+	
+	z80asm(
+		asm		=> 'include "test.inc"		;; 3E 0A',
+		options	=> "-b -Itest_dir",
+	);
+
+	$ENV{TEST_ENV} = 'test';
+	z80asm(
+		asm		=> 'include "test.inc"		;; 3E 0A',
+		options	=> '-b -I${TEST_ENV}_dir',
+	);
+
+	delete $ENV{TEST_ENV};
+	z80asm(
+		asm		=> 'include "test.inc"		;; 3E 0A',
+		options	=> '-b -Itest${TEST_ENV}_dir',
+	);
+
+remove_tree("test_dir");
+
 #------------------------------------------------------------------------------
 # DEFGROUP - simple use tested in opcodes.t
 # test error messages here

--- a/src/z80asm/t/test_utils.pl
+++ b/src/z80asm/t/test_utils.pl
@@ -25,7 +25,7 @@ my $test	 = "test";
 sub z80asm	 { $ENV{Z80ASM} || "./z80asm" }
 
 my @TEST_EXT = (qw( asm lis inc bin map o lib sym def err 
-					exe c asmlst prj i reloc ));
+					exe c lst prj i reloc ));
 my @MAIN_TEST_FILES;
 my @TEST_FILES;
 my @IDS = ("", 0 .. 20);


### PR DESCRIPTION
I've taken some code from zcc to do this.

I think there's possibly a leak every time a filename has a substitution in it.

