### PR TITLE
Slightly faster, smaller zx_py2saddr

### DIFF
--- a/libsrc/spectrum/display/zx_py2saddr.asm
+++ b/libsrc/spectrum/display/zx_py2saddr.asm
@@ -10,13 +10,13 @@ PUBLIC _zx_py2saddr
 
    ld a,l
    and $07
-   or $40
    ld h,a
    ld a,l
+   and $c0
    rra
-   rra
-   rra
-   and $18
+   inc a
+   rrca
+   rrca
    or h
    ld h,a
    


### PR DESCRIPTION
Instead of setting the upper address bit using "or $40" I do that with a carefully placed "inc a" while shifting other address bits into place.

This saves 1 byte and 3 T-States.