### PR TITLE
Issue #352: Sort some problems with int32 division.

### DIFF
--- a/lib/crt0_section.asm
+++ b/lib/crt0_section.asm
@@ -62,6 +62,7 @@ ENDIF
 		SECTION code_clib
 		SECTION code_crt0_sccz80
 		SECTION code_l_sdcc
+		SECTION code_l_sccz80
 		SECTION code_l
 		SECTION code_compress_zx7
 		SECTION code_fp

--- a/libsrc/z80_crt0s/crt0_long/l_long_div.asm
+++ b/libsrc/z80_crt0s/crt0_long/l_long_div.asm
@@ -10,121 +10,25 @@
 ;
 ;       Replaced use of ix with bcbc'
 
-                SECTION   code_crt0_sccz80
-PUBLIC    l_long_div
+SECTION code_clib
+SECTION code_l_sccz80
 
-EXTERN     l_long_div_u, l_long_neg
-EXTERN    L_LONG_DIVIDE0, L_LONG_DIVENTRY
+PUBLIC l_long_div
 
-; 32 bit division
-; enter:
-;    dehl = arg2
-;   stack = arg1, ret
-; exit:
-;    dehl = arg1/arg2
-;   de'hl'= arg1%arg2
+EXTERN l_divs_32_32x32
 
-.l_long_div
+l_long_div:
 
-   ld a,d
-   or e
-   or h
-   or l
-   jp z, l_long_div_u + L_LONG_DIVIDE0
-
-   pop af
-   push hl
+   ; dehl  = divisor
+   ; stack = dividend, ret
+   
    exx
+   pop bc
+
+   pop hl
    pop de
-   pop bc
-   ld hl,0
+
+   push bc
    exx
-   pop bc
-   ld hl,0
-   push af
-
-   ; bcbc' = arg1
-   ; hlhl' = res
-   ; dede' = arg2
-
-   ; some nastiness to deal with signs
-
-   ld a,c
-   ld c,d
-   push bc                     ; b = sgn(arg1), c = sgn(arg2)
-   ld c,a
-
-   bit 7,b
-   jr z, skipnegbcbc
-
-.negbcbc
-
-   exx
-   ld a,c
-   cpl
-   ld c,a
-   ld a,b
-   cpl
-   ld b,a
-   ld a,b
-   or c
-   inc bc
-   exx
-   ld a,c
-   cpl
-   ld c,a
-   ld a,b
-   cpl
-   ld b,a
-   jr nz, skipnegbcbc
-   inc bc
-
-.skipnegbcbc
-
-   bit 7,d
-   jr z, skipnegdede
-
-.negdede
-
-   exx
-   ld a,e
-   cpl
-   ld e,a
-   ld a,d
-   cpl
-   ld d,a
-   ld a,d
-   or e
-   inc de
-   exx
-   ld a,e
-   cpl
-   ld e,a
-   ld a,d
-   cpl
-   ld d,a
-   jr nz, skipnegdede
-   inc de
-
-.skipnegdede
-
-   call l_long_div_u + L_LONG_DIVENTRY
-
-   ; dehl   = quotient
-   ; de'hl' = remainder
-
-   ; deal with the signs
    
-   pop bc                      ; b = sgn(arg1), c = sgn(arg2)
-
-   ld a,b
-   xor c
-   call m, l_long_neg
-   
-   ld a,b
-   and $80
-   ret p
-   exx
-   call l_long_neg
-   exx
-   ret
+   jp l_divs_32_32x32

--- a/libsrc/z80_crt0s/crt0_long/l_long_div_u.asm
+++ b/libsrc/z80_crt0s/crt0_long/l_long_div_u.asm
@@ -12,107 +12,23 @@
 ;
 ;       Replaced use of ix with bcbc'
 
-                SECTION   code_crt0_sccz80
-PUBLIC    l_long_div_u
-PUBLIC    L_LONG_DIVIDE0, L_LONG_DIVENTRY
+SECTION code_clib
+SECTION code_crt0_sccz80
 
-; 32 bit division
-; enter:
-;    dehl = arg2
-;   stack = arg1, ret
-; exit:
-;    dehl = arg1/arg2
-;   de'hl'= arg1%arg2
+PUBLIC l_long_div_u
 
-.l_long_div_u
+EXTERN l_divu_32_32x32
 
-   ld a,d
-   or e
-   or h
-   or l
-   jr z, divide0
+l_long_div_u:
+
+   ; dehl  = divisor
+   ; stack = dividend, ret
    
-   pop af
-   push hl
-   exx
-   pop de
-   pop bc
-   ld hl,0
    exx
    pop bc
-   ld hl,0
-   push af
-
-.entry
-
-   ld a,32
-   or a
-
-   ; bcbc' = arg1
-   ; hlhl' = res
-   ; dede' = arg2
-
-.l_long_div1
-
-   exx                         ; arg1 <<= 1
-   rl c
-   rl b
-   exx
-   rl c
-   rl b
    
-   exx                         ; res <<= 1
-   adc hl,hl
-   exx
-   adc hl,hl
-   
-   exx                         ; res -= arg2
-   sbc hl,de
-   exx
-   sbc hl,de
-   jr nc, l_long_div2
-
-   exx                         ; res += arg2
-   add hl,de
-   exx
-   adc hl,de
-
-.l_long_div2
-
-   ccf
-   dec a
-   jp nz, l_long_div1
-
-   exx                         ; arg1 <<= 1
-   rl c
-   rl b
-   exx
-   rl c
-   rl b
-
-   ; looking to return:
-   ;  dehl  = quotient = arg1
-   ; de'hl' = remainder = res
-   
-   push hl
-   exx
-   pop de
-   push bc
-   exx
-   pop hl
-   ld e,c
-   ld d,b
-   ret
-
-.divide0
-
-   exx
-   pop bc
    pop hl
    pop de
+   
    push bc
-   exx
-   ret
-
-DEFC L_LONG_DIVIDE0 = # divide0 - l_long_div_u
-DEFC L_LONG_DIVENTRY = # entry - l_long_div_u
+   jp l_divu_32_32x32 - 1

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -2596,6 +2596,16 @@ void vlongconst(uint32_t val)
     const2(val / 65536);
 }
 
+
+void vlongconst_tostack(uint32_t val)
+{
+    constbc(val / 65536);
+    ol("push\tbc");
+    constbc(val % 65536);
+    ol("push\tbc");
+    Zsp -= 4;
+}
+
 void vlongconst_noalt(uint32_t val)
 {
     constbc(val / 65536);

--- a/src/sccz80/codegen.h
+++ b/src/sccz80/codegen.h
@@ -93,6 +93,7 @@ extern void convUlong2doub(void);
 extern void convdoub2int(void);
 extern void DoubSwap(void);
 extern void vlongconst(uint32_t val);
+extern void vlongconst_tostack(uint32_t val);
 extern void vlongconst_noalt(uint32_t val);
 extern void vconst(int32_t val);
 extern void const2(int32_t val);

--- a/src/sccz80/const.c
+++ b/src/sccz80/const.c
@@ -192,8 +192,10 @@ typecheck:
     while (checkws() == 0 && (rcmatch('L') || rcmatch('U') || rcmatch('S') || rcmatch('f'))) {
         if (cmatch('L'))
             lval->val_type = LONG;
-        if (cmatch('U'))
+        if (cmatch('U')) {
             lval->flags |= UNSIGNED;
+            lval->const_val = (uint32_t)k;
+        }
         if (cmatch('S'))
             lval->flags &= ~UNSIGNED;
         if (cmatch('f'))

--- a/src/sccz80/plunge.c
+++ b/src/sccz80/plunge.c
@@ -158,8 +158,12 @@ void plnge2a(int (*heir)(LVALUE* lval), LVALUE* lval, LVALUE* lval2, void (*oper
         } else if (lval->val_type == LONG) {
             widenlong(lval, lval2);
             lval2->val_type = LONG; /* Kludge */
-            lpush();
-            vlongconst(lval->const_val);
+            if ( oper == zdiv || oper == zmod ) {
+                vlongconst_tostack(lval->const_val);
+            } else {
+                lpush();
+                vlongconst(lval->const_val);
+            }
         } else {
             if ( lval2->val_type == LONG ) {
                 vlongconst_noalt(lval->const_val); 

--- a/src/sccz80/primary.c
+++ b/src/sccz80/primary.c
@@ -166,9 +166,9 @@ double calcun(
     void (*oper)(LVALUE *),
     double right)
 {
-    if (oper == zdiv)
+    if (oper == zdiv)   {
         return (left / right);
-    else if (oper == zmod)
+    } else if (oper == zmod)
         return ((unsigned int)left % (unsigned int)right);
     else if (oper == zle)
         return (left <= right);
@@ -339,6 +339,10 @@ void widenlong(LVALUE* lval, LVALUE* lval2)
                 convSint2long();
             lval->val_type = LONG;
         }
+    }
+    if ((lval->flags & UNSIGNED) || (lval2->flags & UNSIGNED)) {
+         lval->flags |= UNSIGNED;
+         lval2->flags |= UNSIGNED;
     }
 }
 

--- a/test/suites/sccz80/Makefile
+++ b/test/suites/sccz80/Makefile
@@ -5,7 +5,7 @@ include ../make.config
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test_mult.bin test_callee.bin test_lshift.bin test_autoinit.bin test_sizeof.bin
+all:	test_mult.bin test_callee.bin test_lshift.bin test_autoinit.bin test_sizeof.bin test_division.bin
 
 
 

--- a/test/suites/sccz80/division.c
+++ b/test/suites/sccz80/division.c
@@ -1,0 +1,39 @@
+#include "test.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+
+void test_ulong_division()
+{
+     uint32_t val = 0x80000000;
+     uint32_t res;
+     Assert( val / 512         == 0x400000, "val / 512");
+     Assert( 0x80000000UL/ 512 == 0x400000, "0x80000000/ 512");
+}
+
+void test_long_division()
+{
+     int32_t val = -1;
+     Assert( val / 512         == 0, "val / 512");
+     Assert( 0x80000000/ 512 == 0xffc00000, "0x80000000/ 512");
+}
+
+int suite_mult()
+{
+    suite_setup("Division Tests");
+
+    suite_add_test(test_ulong_division);
+    suite_add_test(test_long_division);
+
+    return suite_run();
+}
+
+
+int main(int argc, char *argv[])
+{
+    int  res = 0;
+
+    res += suite_mult();
+
+    exit(res);
+}


### PR DESCRIPTION
If a constant was on the right then the division was incorrect (quotient/dividend).

The classic library signed division was incorrect if dividend was -1. Use newlib
versions of division to cut down code duplication.