### PR TITLE
yaz180 - handle tail call optimisation for __BREAK

### DIFF
--- a/include/_DEVELOPMENT/clang/arch/yaz180.h
+++ b/include/_DEVELOPMENT/clang/arch/yaz180.h
@@ -9,7 +9,8 @@
 
 // Halt the YAZ180 with single step hardware.
 
-#define __BREAK  __BREAK_HELPER()
+#define __BREAK __BREAK_HELPER()
+
 extern void __BREAK_HELPER(void);
 
 

--- a/include/_DEVELOPMENT/proto/arch/yaz180.h
+++ b/include/_DEVELOPMENT/proto/arch/yaz180.h
@@ -7,7 +7,8 @@ include(__link__.m4)
 
 // Halt the YAZ180 with single step hardware.
 
-#define __BREAK  __BREAK_HELPER()
+#define __BREAK __BREAK_HELPER()
+
 __OPROTO(`a,d,e,h,l,iy,iyh',`a,d,e,h,l,iyl,iyh',void,,__BREAK_HELPER,void)
 
 #endif

--- a/include/_DEVELOPMENT/sccz80/arch/yaz180.h
+++ b/include/_DEVELOPMENT/sccz80/arch/yaz180.h
@@ -9,7 +9,8 @@
 
 // Halt the YAZ180 with single step hardware.
 
-#define __BREAK  __BREAK_HELPER()
+#define __BREAK __BREAK_HELPER()
+
 extern void __LIB__ __BREAK_HELPER(void) __smallc;
 
 

--- a/include/_DEVELOPMENT/sdcc/arch/yaz180.h
+++ b/include/_DEVELOPMENT/sdcc/arch/yaz180.h
@@ -9,7 +9,8 @@
 
 // Halt the YAZ180 with single step hardware.
 
-#define __BREAK  __BREAK_HELPER()
+#define __BREAK __BREAK_HELPER()
+
 extern void __BREAK_HELPER(void) __preserves_regs(a,d,e,h,l,iyl,iyh);
 
 

--- a/lib/yaz180_rules.1
+++ b/lib/yaz180_rules.1
@@ -13,3 +13,21 @@
 	ENDIF
 	ld	bc,__IO_BREAK
 	out	(c),c
+
+	jp  ___BREAK_HELPER
+=
+	IFNDEF __IO_BREAK
+	EXTERN	__IO_BREAK
+	ENDIF
+	ld	bc,__IO_BREAK
+	out	(c),c
+	ret
+
+	jp  __BREAK_HELPER
+=
+	IFNDEF __IO_BREAK
+	EXTERN	__IO_BREAK
+	ENDIF
+	ld	bc,__IO_BREAK
+	out	(c),c
+	ret


### PR DESCRIPTION
A simple fix for #374 and #373 for tail call optimisation.

I spent a while looking at pragmas to disable optimisation,
but sdcc doesn't allow `#pragma` within a function.

I think this achieves the desired outcome, without much further thought investment.

Just to note that this solution is whitespace sensitive.
`call  __BREAK_HELPER` contains a tab character
`jp  __BREAK_HELPER` contains two spaces
If the peep-hole optimisation whitespace usage changes, this solution may break.