### PR TITLE
Fix #312 z80asm: implement zx next opcodes

### DIFF
--- a/src/z80asm/dev/cpu/cpu.pl
+++ b/src/z80asm/dev/cpu/cpu.pl
@@ -574,9 +574,9 @@ for my $cpu (@CPUS) {
 		add_opc($cpu, "sub dehl, a", 	0xED, 0x3C);
 		add_opc($cpu, "sub dehl, bc", 	0xED, 0x3D);
 		
-		add_opc($cpu, "mmu %c, %n",		0xED, '0x80+%c(0..7)', '%n');
+		add_opc($cpu, "mmu %c, %n",		0xED, 0x91, '0x50+%c(0..7)', '%n');
 		for my $page (0..7) {
-			add_opc($cpu, "mmu$page %n",0xED, 0x80+$page, '%n');
+			add_opc($cpu, "mmu$page %n",0xED, 0x91, 0x50+$page, '%n');
 		}
 
 		add_opc($cpu, "push %m",	 	0xED, 0x8A, '%m', '%m');
@@ -895,7 +895,7 @@ sub parse_code {
 			"DO_STMT_LABEL();",
 			"if (expr_error) return FALSE;",
 			"if (expr_value < 0 || expr_value > 7) error_int_range(expr_value);",
-			"DO_stmt_n(0xED80 + expr_value);";
+			"DO_stmt_n(0xED9150 + expr_value);";
 		my $code = join("\n", @code);
 		return $code;
 	}

--- a/src/z80asm/dev/cpu/cpu_rules.h
+++ b/src/z80asm/dev/cpu/cpu_rules.h
@@ -26289,7 +26289,7 @@ if (expr_in_parens) warn_expr_in_parens();
 DO_STMT_LABEL();
 if (expr_error) return FALSE;
 if (expr_value < 0 || expr_value > 7) error_int_range(expr_value);
-DO_stmt_n(0xED80 + expr_value);
+DO_stmt_n(0xED9150 + expr_value);
 break;
 default: error_illegal_ident(); }
 }
@@ -26298,7 +26298,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED80);
+DO_stmt_n(0xED9150);
 break;
 default: error_illegal_ident(); }
 }
@@ -26307,7 +26307,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED81);
+DO_stmt_n(0xED9151);
 break;
 default: error_illegal_ident(); }
 }
@@ -26316,7 +26316,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED82);
+DO_stmt_n(0xED9152);
 break;
 default: error_illegal_ident(); }
 }
@@ -26325,7 +26325,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED83);
+DO_stmt_n(0xED9153);
 break;
 default: error_illegal_ident(); }
 }
@@ -26334,7 +26334,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED84);
+DO_stmt_n(0xED9154);
 break;
 default: error_illegal_ident(); }
 }
@@ -26343,7 +26343,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED85);
+DO_stmt_n(0xED9155);
 break;
 default: error_illegal_ident(); }
 }
@@ -26352,7 +26352,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED86);
+DO_stmt_n(0xED9156);
 break;
 default: error_illegal_ident(); }
 }
@@ -26361,7 +26361,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN: 
 if (expr_in_parens) warn_expr_in_parens();
-DO_stmt_n(0xED87);
+DO_stmt_n(0xED9157);
 break;
 default: error_illegal_ident(); }
 }

--- a/src/z80asm/dev/cpu/cpu_test_z80_zxn_ixiy_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_z80_zxn_ixiy_ok.asm
@@ -845,54 +845,54 @@
  ldpirx                         ; ED B7
  mirror a                       ; ED 24
  mirror de                      ; ED 26
- mmu 0, -128                    ; ED 80 80
- mmu 0, 127                     ; ED 80 7F
- mmu 0, 255                     ; ED 80 FF
- mmu 1, -128                    ; ED 81 80
- mmu 1, 127                     ; ED 81 7F
- mmu 1, 255                     ; ED 81 FF
- mmu 2, -128                    ; ED 82 80
- mmu 2, 127                     ; ED 82 7F
- mmu 2, 255                     ; ED 82 FF
- mmu 3, -128                    ; ED 83 80
- mmu 3, 127                     ; ED 83 7F
- mmu 3, 255                     ; ED 83 FF
- mmu 4, -128                    ; ED 84 80
- mmu 4, 127                     ; ED 84 7F
- mmu 4, 255                     ; ED 84 FF
- mmu 5, -128                    ; ED 85 80
- mmu 5, 127                     ; ED 85 7F
- mmu 5, 255                     ; ED 85 FF
- mmu 6, -128                    ; ED 86 80
- mmu 6, 127                     ; ED 86 7F
- mmu 6, 255                     ; ED 86 FF
- mmu 7, -128                    ; ED 87 80
- mmu 7, 127                     ; ED 87 7F
- mmu 7, 255                     ; ED 87 FF
- mmu0 -128                      ; ED 80 80
- mmu0 127                       ; ED 80 7F
- mmu0 255                       ; ED 80 FF
- mmu1 -128                      ; ED 81 80
- mmu1 127                       ; ED 81 7F
- mmu1 255                       ; ED 81 FF
- mmu2 -128                      ; ED 82 80
- mmu2 127                       ; ED 82 7F
- mmu2 255                       ; ED 82 FF
- mmu3 -128                      ; ED 83 80
- mmu3 127                       ; ED 83 7F
- mmu3 255                       ; ED 83 FF
- mmu4 -128                      ; ED 84 80
- mmu4 127                       ; ED 84 7F
- mmu4 255                       ; ED 84 FF
- mmu5 -128                      ; ED 85 80
- mmu5 127                       ; ED 85 7F
- mmu5 255                       ; ED 85 FF
- mmu6 -128                      ; ED 86 80
- mmu6 127                       ; ED 86 7F
- mmu6 255                       ; ED 86 FF
- mmu7 -128                      ; ED 87 80
- mmu7 127                       ; ED 87 7F
- mmu7 255                       ; ED 87 FF
+ mmu 0, -128                    ; ED 91 50 80
+ mmu 0, 127                     ; ED 91 50 7F
+ mmu 0, 255                     ; ED 91 50 FF
+ mmu 1, -128                    ; ED 91 51 80
+ mmu 1, 127                     ; ED 91 51 7F
+ mmu 1, 255                     ; ED 91 51 FF
+ mmu 2, -128                    ; ED 91 52 80
+ mmu 2, 127                     ; ED 91 52 7F
+ mmu 2, 255                     ; ED 91 52 FF
+ mmu 3, -128                    ; ED 91 53 80
+ mmu 3, 127                     ; ED 91 53 7F
+ mmu 3, 255                     ; ED 91 53 FF
+ mmu 4, -128                    ; ED 91 54 80
+ mmu 4, 127                     ; ED 91 54 7F
+ mmu 4, 255                     ; ED 91 54 FF
+ mmu 5, -128                    ; ED 91 55 80
+ mmu 5, 127                     ; ED 91 55 7F
+ mmu 5, 255                     ; ED 91 55 FF
+ mmu 6, -128                    ; ED 91 56 80
+ mmu 6, 127                     ; ED 91 56 7F
+ mmu 6, 255                     ; ED 91 56 FF
+ mmu 7, -128                    ; ED 91 57 80
+ mmu 7, 127                     ; ED 91 57 7F
+ mmu 7, 255                     ; ED 91 57 FF
+ mmu0 -128                      ; ED 91 50 80
+ mmu0 127                       ; ED 91 50 7F
+ mmu0 255                       ; ED 91 50 FF
+ mmu1 -128                      ; ED 91 51 80
+ mmu1 127                       ; ED 91 51 7F
+ mmu1 255                       ; ED 91 51 FF
+ mmu2 -128                      ; ED 91 52 80
+ mmu2 127                       ; ED 91 52 7F
+ mmu2 255                       ; ED 91 52 FF
+ mmu3 -128                      ; ED 91 53 80
+ mmu3 127                       ; ED 91 53 7F
+ mmu3 255                       ; ED 91 53 FF
+ mmu4 -128                      ; ED 91 54 80
+ mmu4 127                       ; ED 91 54 7F
+ mmu4 255                       ; ED 91 54 FF
+ mmu5 -128                      ; ED 91 55 80
+ mmu5 127                       ; ED 91 55 7F
+ mmu5 255                       ; ED 91 55 FF
+ mmu6 -128                      ; ED 91 56 80
+ mmu6 127                       ; ED 91 56 7F
+ mmu6 255                       ; ED 91 56 FF
+ mmu7 -128                      ; ED 91 57 80
+ mmu7 127                       ; ED 91 57 7F
+ mmu7 255                       ; ED 91 57 FF
  mul                            ; ED 30
  neg                            ; ED 44
  neg a                          ; ED 44

--- a/src/z80asm/dev/cpu/cpu_test_z80_zxn_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_z80_zxn_ok.asm
@@ -845,54 +845,54 @@
  ldpirx                         ; ED B7
  mirror a                       ; ED 24
  mirror de                      ; ED 26
- mmu 0, -128                    ; ED 80 80
- mmu 0, 127                     ; ED 80 7F
- mmu 0, 255                     ; ED 80 FF
- mmu 1, -128                    ; ED 81 80
- mmu 1, 127                     ; ED 81 7F
- mmu 1, 255                     ; ED 81 FF
- mmu 2, -128                    ; ED 82 80
- mmu 2, 127                     ; ED 82 7F
- mmu 2, 255                     ; ED 82 FF
- mmu 3, -128                    ; ED 83 80
- mmu 3, 127                     ; ED 83 7F
- mmu 3, 255                     ; ED 83 FF
- mmu 4, -128                    ; ED 84 80
- mmu 4, 127                     ; ED 84 7F
- mmu 4, 255                     ; ED 84 FF
- mmu 5, -128                    ; ED 85 80
- mmu 5, 127                     ; ED 85 7F
- mmu 5, 255                     ; ED 85 FF
- mmu 6, -128                    ; ED 86 80
- mmu 6, 127                     ; ED 86 7F
- mmu 6, 255                     ; ED 86 FF
- mmu 7, -128                    ; ED 87 80
- mmu 7, 127                     ; ED 87 7F
- mmu 7, 255                     ; ED 87 FF
- mmu0 -128                      ; ED 80 80
- mmu0 127                       ; ED 80 7F
- mmu0 255                       ; ED 80 FF
- mmu1 -128                      ; ED 81 80
- mmu1 127                       ; ED 81 7F
- mmu1 255                       ; ED 81 FF
- mmu2 -128                      ; ED 82 80
- mmu2 127                       ; ED 82 7F
- mmu2 255                       ; ED 82 FF
- mmu3 -128                      ; ED 83 80
- mmu3 127                       ; ED 83 7F
- mmu3 255                       ; ED 83 FF
- mmu4 -128                      ; ED 84 80
- mmu4 127                       ; ED 84 7F
- mmu4 255                       ; ED 84 FF
- mmu5 -128                      ; ED 85 80
- mmu5 127                       ; ED 85 7F
- mmu5 255                       ; ED 85 FF
- mmu6 -128                      ; ED 86 80
- mmu6 127                       ; ED 86 7F
- mmu6 255                       ; ED 86 FF
- mmu7 -128                      ; ED 87 80
- mmu7 127                       ; ED 87 7F
- mmu7 255                       ; ED 87 FF
+ mmu 0, -128                    ; ED 91 50 80
+ mmu 0, 127                     ; ED 91 50 7F
+ mmu 0, 255                     ; ED 91 50 FF
+ mmu 1, -128                    ; ED 91 51 80
+ mmu 1, 127                     ; ED 91 51 7F
+ mmu 1, 255                     ; ED 91 51 FF
+ mmu 2, -128                    ; ED 91 52 80
+ mmu 2, 127                     ; ED 91 52 7F
+ mmu 2, 255                     ; ED 91 52 FF
+ mmu 3, -128                    ; ED 91 53 80
+ mmu 3, 127                     ; ED 91 53 7F
+ mmu 3, 255                     ; ED 91 53 FF
+ mmu 4, -128                    ; ED 91 54 80
+ mmu 4, 127                     ; ED 91 54 7F
+ mmu 4, 255                     ; ED 91 54 FF
+ mmu 5, -128                    ; ED 91 55 80
+ mmu 5, 127                     ; ED 91 55 7F
+ mmu 5, 255                     ; ED 91 55 FF
+ mmu 6, -128                    ; ED 91 56 80
+ mmu 6, 127                     ; ED 91 56 7F
+ mmu 6, 255                     ; ED 91 56 FF
+ mmu 7, -128                    ; ED 91 57 80
+ mmu 7, 127                     ; ED 91 57 7F
+ mmu 7, 255                     ; ED 91 57 FF
+ mmu0 -128                      ; ED 91 50 80
+ mmu0 127                       ; ED 91 50 7F
+ mmu0 255                       ; ED 91 50 FF
+ mmu1 -128                      ; ED 91 51 80
+ mmu1 127                       ; ED 91 51 7F
+ mmu1 255                       ; ED 91 51 FF
+ mmu2 -128                      ; ED 91 52 80
+ mmu2 127                       ; ED 91 52 7F
+ mmu2 255                       ; ED 91 52 FF
+ mmu3 -128                      ; ED 91 53 80
+ mmu3 127                       ; ED 91 53 7F
+ mmu3 255                       ; ED 91 53 FF
+ mmu4 -128                      ; ED 91 54 80
+ mmu4 127                       ; ED 91 54 7F
+ mmu4 255                       ; ED 91 54 FF
+ mmu5 -128                      ; ED 91 55 80
+ mmu5 127                       ; ED 91 55 7F
+ mmu5 255                       ; ED 91 55 FF
+ mmu6 -128                      ; ED 91 56 80
+ mmu6 127                       ; ED 91 56 7F
+ mmu6 255                       ; ED 91 56 FF
+ mmu7 -128                      ; ED 91 57 80
+ mmu7 127                       ; ED 91 57 7F
+ mmu7 255                       ; ED 91 57 FF
  mul                            ; ED 30
  neg                            ; ED 44
  neg a                          ; ED 44

--- a/src/z80asm/parse_rules.h
+++ b/src/z80asm/parse_rules.h
@@ -68035,7 +68035,7 @@ if (expr_in_parens) warn_expr_in_parens();
 asm_cond_LABEL(stmt_label);
 if (expr_error) return FALSE;
 if (expr_value < 0 || expr_value > 7) error_int_range(expr_value);
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED80 + expr_value), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9150 + expr_value), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68045,7 +68045,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED80), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9150), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68055,7 +68055,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED81), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9151), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68065,7 +68065,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED82), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9152), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68075,7 +68075,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED83), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9153), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68085,7 +68085,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED84), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9154), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68095,7 +68095,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED85), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9155), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68105,7 +68105,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED86), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9156), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }
@@ -68115,7 +68115,7 @@ default: error_illegal_ident(); }
 switch (opts.cpu) {
 case CPU_Z80_ZXN:
 if (expr_in_parens) warn_expr_in_parens();
-do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED87), expr); } while(0);
+do { Expr *expr = pop_expr(ctx); asm_cond_LABEL(stmt_label); add_opcode_n((0xED9157), expr); } while(0);
 break;
 default: error_illegal_ident(); }
 }

--- a/src/z80asm/t/option_cpu_z80-zxn.t
+++ b/src/z80asm/t/option_cpu_z80-zxn.t
@@ -144,17 +144,17 @@ add("test a,31",		0xED, 0x27, 0x1F);
 # Memory mapping - specify which 8k ram page is placed into
 # the corresponding 8k slot of the z80's 64k memory space.
 # 
-# 8T*  mmu0 NN           ED 80 NN      Ram page in 0-8k (not complete yet)
-# 8T*  mmu1 NN           ED 81 NN      Ram page in 8k-16k (not complete yet)
-# 8T*  mmu2 NN           ED 82 NN      Ram page in 16k-24k
-# 8T*  mmu3 NN           ED 83 NN      Ram page in 24k-32k
-# 8T*  mmu4 NN           ED 84 NN      Ram page in 32k-40k
-# 8T*  mmu5 NN           ED 85 NN      Ram page in 40k-48k
-# 8T*  mmu6 NN           ED 86 NN      Ram page in 48k-56k
-# 8T*  mmu7 NN           ED 87 NN      Ram page in 56k-64k
+# 12T*  mmu0 NN           ED 91 50 NN      macro: Ram page in slot 0-8k
+# 12T*  mmu1 NN           ED 91 51 NN      macro: Ram page in slot 8k-16k
+# 12T*  mmu2 NN           ED 91 52 NN      macro: Ram page in slot 16k-24k
+# 12T*  mmu3 NN           ED 91 53 NN      macro: Ram page in slot 24k-32k
+# 12T*  mmu4 NN           ED 91 54 NN      macro: Ram page in slot 32k-40k
+# 12T*  mmu5 NN           ED 91 55 NN      macro: Ram page in slot 40k-48k
+# 12T*  mmu6 NN           ED 91 56 NN      macro: Ram page in slot 48k-56k
+# 12T*  mmu7 NN           ED 91 57 NN      macro: Ram page in slot 56k-64k
 for my $page (0..7) {
-	add("mmu$page 31",	0xED, 0x80 + $page, 0x1F);
-	add("mmu $page,31",	0xED, 0x80 + $page, 0x1F);
+	add("mmu$page 31",	0xED, 0x91, 0x50 + $page, 0x1F);
+	add("mmu $page,31",	0xED, 0x91, 0x50 + $page, 0x1F);
 }
 
 # 


### PR DESCRIPTION
Changed Memory Mapping opcodes

12T*  mmu0 NN           ED 91 50 NN      macro: Ram page in slot 0-8k
12T*  mmu1 NN           ED 91 51 NN      macro: Ram page in slot 8k-16k
12T*  mmu2 NN           ED 91 52 NN      macro: Ram page in slot 16k-24k
12T*  mmu3 NN           ED 91 53 NN      macro: Ram page in slot 24k-32k
12T*  mmu4 NN           ED 91 54 NN      macro: Ram page in slot 32k-40k
12T*  mmu5 NN           ED 91 55 NN      macro: Ram page in slot 40k-48k
12T*  mmu6 NN           ED 91 56 NN      macro: Ram page in slot 48k-56k
12T*  mmu7 NN           ED 91 57 NN      macro: Ram page in slot 56k-64k