### PR TITLE
Fix #442: support globbing in file names and in list files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "UNIXem"]
+	path = UNIXem
+	url = https://github.com/synesissoftware/UNIXem.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "UNIXem"]
+	path = UNIXem
+	url = https://github.com/z88dk/UNIXem.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "UNIXem"]
-	path = UNIXem
-	url = https://github.com/synesissoftware/UNIXem.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "UNIXem"]
-	path = UNIXem
+	path = ext/UNIXem
 	url = https://github.com/z88dk/UNIXem.git

--- a/src/portability.h
+++ b/src/portability.h
@@ -11,3 +11,8 @@
 #include <unixem/glob.h>
 #endif
 #include <glob.h>
+
+// OSX does not have GLOB_ONLYDIR
+#ifndef GLOB_ONLYDIR
+#define GLOB_ONLYDIR 0
+#endif

--- a/src/portability.h
+++ b/src/portability.h
@@ -1,0 +1,13 @@
+// Portability defines for building z88dk
+#pragma once
+
+// strcasecmp()
+#if defined(_WIN32) || defined(WIN32)
+#define strcasecmp(a,b) stricmp(a,b)
+#endif
+
+// glob()
+#if defined(_WIN32) || defined(WIN32)
+#include <unixem/glob.h>
+#endif
+#include <glob.h>

--- a/src/z80asm/Makefile
+++ b/src/z80asm/Makefile
@@ -39,8 +39,8 @@ LOCAL_LIB :=	lib
 LOCAL_CFLAGS +=	-MMD -I. -I$(LOCAL_LIB) -It -g -Wall -ftabstop=4 $(STD) $(OPT)
 
 ifeq ($(OS),Windows_NT)
-LOCAL_CFLAGS +=	-I../../UNIXem/include
-OBJS		+= ../../UNIXem/src/glob.o
+LOCAL_CFLAGS	+= -I../../ext/UNIXem/include
+OBJS			+= ../../ext/UNIXem/src/glob.o
 endif
 
 #------------------------------------------------------------------------------

--- a/src/z80asm/Makefile
+++ b/src/z80asm/Makefile
@@ -38,6 +38,11 @@ STD = -std=gnu11
 LOCAL_LIB :=	lib
 LOCAL_CFLAGS +=	-MMD -I. -I$(LOCAL_LIB) -It -g -Wall -ftabstop=4 $(STD) $(OPT)
 
+ifeq ($(OS),Windows_NT)
+LOCAL_CFLAGS +=	-I../../UNIXem/include
+OBJS		+= ../../UNIXem/src/glob.o
+endif
+
 #------------------------------------------------------------------------------
 # main
 #------------------------------------------------------------------------------

--- a/src/z80asm/Makefile
+++ b/src/z80asm/Makefile
@@ -38,7 +38,9 @@ STD = -std=gnu11
 LOCAL_LIB :=	lib
 LOCAL_CFLAGS +=	-MMD -I. -I$(LOCAL_LIB) -It -g -Wall -ftabstop=4 $(STD) $(OPT)
 
-ifeq ($(OS),Windows_NT)
+# Use these flags both in Windows_NT and in a MinGW build in Unix
+#ifeq ($(OS),Windows_NT)
+ifeq ($(EXE),.exe)
 LOCAL_CFLAGS	+= -I../../ext/UNIXem/include
 OBJS			+= ../../ext/UNIXem/src/glob.o
 endif

--- a/src/z80asm/error_func.c
+++ b/src/z80asm/error_func.c
@@ -69,6 +69,24 @@ void error_illegal_src_filename(char *filename)
 	
 	STR_DELETE(msg);
 }
+void error_glob(char *filename, char *error)
+{
+	STR_DEFINE(msg, STR_SIZE);
+
+	str_append_sprintf( msg, "problem with '%s': %s", filename, error );
+	do_error( ErrError, str_data(msg) );
+	
+	STR_DELETE(msg);
+}
+void error_glob_no_files(char *filename)
+{
+	STR_DEFINE(msg, STR_SIZE);
+
+	str_append_sprintf( msg, "pattern '%s' returned no files", filename );
+	do_error( ErrError, str_data(msg) );
+	
+	STR_DELETE(msg);
+}
 void warn_symbol_different(char *name, char *used)
 {
 	STR_DEFINE(msg, STR_SIZE);

--- a/src/z80asm/error_func.c
+++ b/src/z80asm/error_func.c
@@ -87,6 +87,15 @@ void error_glob_no_files(char *filename)
 	
 	STR_DELETE(msg);
 }
+void error_not_regular_file(char *filename)
+{
+	STR_DEFINE(msg, STR_SIZE);
+
+	str_append_sprintf( msg, "file '%s' is not a regular file", filename );
+	do_error( ErrError, str_data(msg) );
+	
+	STR_DELETE(msg);
+}
 void warn_symbol_different(char *name, char *used)
 {
 	STR_DEFINE(msg, STR_SIZE);

--- a/src/z80asm/error_func.h
+++ b/src/z80asm/error_func.h
@@ -9,6 +9,8 @@ extern void error_include_recursion(char *filename);
 extern void error_no_src_file(void);
 extern void error_illegal_option(char *option);
 extern void error_illegal_src_filename(char *filename);
+extern void error_glob(char *filename, char *error);
+extern void error_glob_no_files(char *filename);
 extern void warn_symbol_different(char *name, char *used);
 extern void warn_expr_in_parens(void);
 extern void error_syntax(void);

--- a/src/z80asm/error_func.h
+++ b/src/z80asm/error_func.h
@@ -11,6 +11,7 @@ extern void error_illegal_option(char *option);
 extern void error_illegal_src_filename(char *filename);
 extern void error_glob(char *filename, char *error);
 extern void error_glob_no_files(char *filename);
+extern void error_not_regular_file(char *filename);
 extern void warn_symbol_different(char *name, char *used);
 extern void warn_expr_in_parens(void);
 extern void error_syntax(void);

--- a/src/z80asm/errors.c
+++ b/src/z80asm/errors.c
@@ -19,7 +19,6 @@ Error handling.
 #include "types.h"
 #include "init.h"
 #include <stdio.h>
-#include <sys/stat.h>
 
 static void file_error( char *filename, Bool writing );
 
@@ -147,9 +146,6 @@ void open_error_file( char *src_filename )
 
 void close_error_file( void )
 {
-	struct stat st;
-	int stat_res;
-
     init_module();
 
     /* close current file if any */
@@ -158,12 +154,8 @@ void close_error_file( void )
 		myfclose(error_file.file);
 
 		/* delete file if no errors found */
-		if (error_file.filename != NULL)
-		{
-			stat_res = stat(error_file.filename, &st);
-			if (stat_res == 0 && st.st_size == 0)
-				remove(error_file.filename);
-		}
+		if (error_file.filename != NULL && file_size(error_file.filename) == 0)
+			remove(error_file.filename);
 	}
 
     /* reset */

--- a/src/z80asm/lib/fileutil.c
+++ b/src/z80asm/lib/fileutil.c
@@ -723,8 +723,27 @@ char *search_file( char *filename, UT_array *dir_list )
 Bool file_exists(char *filename)
 {
 	struct stat  sb;
-	if ((stat(filename, &sb) == 0)  && !(sb.st_mode & S_IFDIR))
+	if ((stat(filename, &sb) == 0)  && (sb.st_mode & S_IFREG))
 		return TRUE;
 	else
 		return FALSE;
 }
+
+Bool dir_exists(char *dirname)
+{
+	struct stat  sb;
+	if ((stat(dirname, &sb) == 0) && (sb.st_mode & S_IFDIR))
+		return TRUE;
+	else
+		return FALSE;
+}
+
+int file_size(char *filename)	// file size, -1 if not regular file
+{
+	struct stat  sb;
+	if ((stat(filename, &sb) == 0) && (sb.st_mode & S_IFREG))
+		return sb.st_size;
+	else
+		return -1;
+}
+

--- a/src/z80asm/lib/fileutil.h
+++ b/src/z80asm/lib/fileutil.h
@@ -96,5 +96,7 @@ extern char *search_file(char *filename, UT_array *dir_list);	/* returned string
    all files with these names are deleted on exit */
 extern char *temp_filename( char *filename );
 
-/* check if file exists */
+/* check if file/directory exists */
 extern Bool file_exists(char *filename);
+extern Bool dir_exists(char *dirname);
+extern int file_size(char *filename);	// file size, -1 if not regular file

--- a/src/z80asm/options.h
+++ b/src/z80asm/options.h
@@ -1,7 +1,6 @@
 /*
-Z88DK Z80 Macro Assembler
+Z88DK Z80 Module Assembler
 
-Copyright (C) Gunther Strube, InterLogic 1993-99
 Copyright (C) Paulo Custodio, 2011-2017
 License: The Artistic License 2.0, http://www.perlfoundation.org/artistic_license_2_0
 Repository: https://github.com/pauloscustodio/z88dk-z80asm

--- a/src/z80asm/t/errors.t
+++ b/src/z80asm/t/errors.t
@@ -482,7 +482,7 @@ t_binary(read_binfile("test.bin"), "\xFE\x10");
 #------------------------------------------------------------------------------
 unlink_testfiles();
 
-my $objs = "errors.o error_func.o scan.o lib/array.o lib/class.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o options.o model.o module.o sym.o symtab.o codearea.o expr.o listfile.o lib/srcfile.o hist.o lib/dbg.o";
+my $objs = "errors.o error_func.o scan.o lib/array.o lib/class.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o options.o model.o module.o sym.o symtab.o codearea.o expr.o listfile.o lib/srcfile.o hist.o lib/dbg.o ../../UNIXem/src/glob.o";
 
 # get init code except init() and main()
 my $init = <<'END';

--- a/src/z80asm/t/errors.t
+++ b/src/z80asm/t/errors.t
@@ -482,7 +482,7 @@ t_binary(read_binfile("test.bin"), "\xFE\x10");
 #------------------------------------------------------------------------------
 unlink_testfiles();
 
-my $objs = "errors.o error_func.o scan.o lib/array.o lib/class.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o options.o model.o module.o sym.o symtab.o codearea.o expr.o listfile.o lib/srcfile.o hist.o lib/dbg.o ../../UNIXem/src/glob.o";
+my $objs = "errors.o error_func.o scan.o lib/array.o lib/class.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o options.o model.o module.o sym.o symtab.o codearea.o expr.o listfile.o lib/srcfile.o hist.o lib/dbg.o ../../ext/UNIXem/src/glob.o";
 
 # get init code except init() and main()
 my $init = <<'END';

--- a/src/z80asm/t/objfile.t
+++ b/src/z80asm/t/objfile.t
@@ -4455,7 +4455,7 @@ t_binary(read_binfile(bin_file()), "\xC3\x00\x00");
 #------------------------------------------------------------------------------
 unlink_testfiles();
 
-my $objs = "objfile.o lib/class.o lib/array.o errors.o error_func.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o scan.o options.o model.o module.o sym.o symtab.o lib/srcfile.o hist.o expr.o listfile.o codearea.o lib/dbg.o ../../UNIXem/src/glob.o";
+my $objs = "objfile.o lib/class.o lib/array.o errors.o error_func.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o scan.o options.o model.o module.o sym.o symtab.o lib/srcfile.o hist.o expr.o listfile.o codearea.o lib/dbg.o ../../ext/UNIXem/src/glob.o";
 
 # get init code except init() and main()
 my $init = <<'END';

--- a/src/z80asm/t/objfile.t
+++ b/src/z80asm/t/objfile.t
@@ -4455,7 +4455,7 @@ t_binary(read_binfile(bin_file()), "\xC3\x00\x00");
 #------------------------------------------------------------------------------
 unlink_testfiles();
 
-my $objs = "objfile.o lib/class.o lib/array.o errors.o error_func.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o scan.o options.o model.o module.o sym.o symtab.o lib/srcfile.o hist.o expr.o listfile.o codearea.o lib/dbg.o";
+my $objs = "objfile.o lib/class.o lib/array.o errors.o error_func.o lib/str.o lib/strhash.o lib/list.o lib/fileutil.o scan.o options.o model.o module.o sym.o symtab.o lib/srcfile.o hist.o expr.o listfile.o codearea.o lib/dbg.o ../../UNIXem/src/glob.o";
 
 # get init code except init() and main()
 my $init = <<'END';

--- a/src/z80asm/t/scan.t
+++ b/src/z80asm/t/scan.t
@@ -19,7 +19,7 @@ my $objs = "scan.o errors.o error_func.o model.o module.o codearea.o listfile.o 
 		   "options.o hist.o sym.o symtab.o expr.o ".
 		   "lib/str.o lib/strhash.o lib/fileutil.o ".
 		   "lib/srcfile.o lib/class.o ".
-		   "lib/list.o lib/array.o lib/dbg.o ../../UNIXem/src/glob.o";
+		   "lib/list.o lib/array.o lib/dbg.o ../../ext/UNIXem/src/glob.o";
 		   
 my $init = <<'END';
 #include "scan.h"

--- a/src/z80asm/t/scan.t
+++ b/src/z80asm/t/scan.t
@@ -19,7 +19,7 @@ my $objs = "scan.o errors.o error_func.o model.o module.o codearea.o listfile.o 
 		   "options.o hist.o sym.o symtab.o expr.o ".
 		   "lib/str.o lib/strhash.o lib/fileutil.o ".
 		   "lib/srcfile.o lib/class.o ".
-		   "lib/list.o lib/array.o lib/dbg.o";
+		   "lib/list.o lib/array.o lib/dbg.o ../../UNIXem/src/glob.o";
 		   
 my $init = <<'END';
 #include "scan.h"

--- a/src/z80asm/t/source_lists.t
+++ b/src/z80asm/t/source_lists.t
@@ -12,19 +12,15 @@ use strict;
 use warnings;
 use v5.10;
 use Test::More;
+use File::Path 'make_path';
 require './t/testlib.pl';
 
-unlink_testfiles();
-spew("test1.asm", "defb 1");
-spew("test2.asm", "defb 2");
-spew("test3.asm", "defb 3");
-spew("test4.asm", "defb 4");
-
+make_test_files();
 run('z80asm -b test1.asm test2.asm test3.asm test4.asm');
 check_bin_file("test1.bin", pack("C*", 1..4));
-ok unlink "test1.bin";
 
 # list file with blank lines and comments
+make_test_files();
 spew("test1.lst", <<'END');
 ; comment followed by blank line
 
@@ -43,9 +39,9 @@ spew("test2.lst",
 
 run('z80asm -b test1.asm @test1.lst');
 check_bin_file("test1.bin", pack("C*", 1..4));
-ok unlink "test1.bin";
 
 # recursive includes
+make_test_files();
 spew("test1.lst", 
 	"\r\r\n\n  ".
 	"test2.asm".
@@ -63,12 +59,13 @@ Error at file 'test2.lst' line 7: cannot include file 'test1.lst' recursively
 ERR
 
 # expand environment variables in source and list files
+make_test_files();
 $ENV{TEST_ENV} = 'test';
 
 run('z80asm -b ${TEST_ENV}1.asm ${TEST_ENV}2.asm ${TEST_ENV}3.asm ${TEST_ENV}4.asm');
 check_bin_file("test1.bin", pack("C*", 1..4));
-ok unlink "test1.bin";
 
+make_test_files();
 spew("test1.lst", <<'END');
   ${TEST_ENV}1.asm
   ${TEST_ENV}2.asm
@@ -84,15 +81,15 @@ END
 
 run('z80asm -b @test1.lst');
 check_bin_file("test1.bin", pack("C*", 1..4));
-ok unlink "test1.bin";
 
 # non-existent environment variable is empty
 delete $ENV{TEST_ENV};
 
+make_test_files();
 run('z80asm -b te${TEST_ENV}st1.asm te${TEST_ENV}st2.asm te${TEST_ENV}st3.asm te${TEST_ENV}st4.asm');
 check_bin_file("test1.bin", pack("C*", 1..4));
-ok unlink "test1.bin";
 
+make_test_files();
 spew("test1.lst", <<'END');
   te${TEST_ENV}st1.asm
   te${TEST_ENV}st2.asm
@@ -108,7 +105,74 @@ END
 
 run('z80asm -b @test1.lst');
 check_bin_file("test1.bin", pack("C*", 1..4));
-ok unlink "test1.bin";
+
+# use globs in command line
+# Note: only relevant for Windows as Unix expands the command line 
+# before calling the command
+make_test_files("test_dir");
+run('z80asm -b test_dir/*.asm');
+check_bin_file("test_dir/test1.bin", pack("C*", 1..4));
+
+# use globs in list file
+make_test_files("test_dir");
+spew("test1.lst", <<'END');
+	test_dir/*.asm
+END
+run('z80asm -b @test1.lst');
+check_bin_file("test_dir/test1.bin", pack("C*", 1..4));
+
+# error if no files are returned
+unlink_testfiles();
+mkdir("test_dir");
+spew("test1.lst", <<'END');
+	test_dir/*.asm
+END
+run('z80asm -b @test1.lst', 1, "", <<'ERR');
+Error at file 'test1.lst' line 1: pattern 'test_dir/*.asm' returned no files
+1 errors occurred during assembly
+ERR
+
+# use globs in recursive list file name
+make_test_files("test_dir");
+spew("test1.lst", <<'END');
+	@ test_dir/*.lst
+END
+for (1..4) {
+	spew("test_dir/test$_.lst", "test_dir/test$_.asm");
+}
+run('z80asm -b @test1.lst');
+check_bin_file("test_dir/test1.bin", pack("C*", 1..4));
+
+# use ** glob for any number of directories
+unlink_testfiles(); 
+mkdir("test_dir");
+for (1..4) {
+	my $dir = "test_dir/$_/a/b";
+	make_path($dir);
+	spew("$dir/test$_.asm", "defb $_");
+	ok -f "$dir/test$_.asm", "create $dir/test$_.asm"
+}
+spew("test1.lst", <<'END');
+	test_dir/**/*.asm
+END
+run('z80asm -b @test1.lst');
+check_bin_file("test_dir/1/a/b/test1.bin", pack("C*", 1..4));
+
+# run again, .o files are not read as asm
+run('z80asm -b @test1.lst');
+check_bin_file("test_dir/1/a/b/test1.bin", pack("C*", 1..4));
 
 unlink_testfiles();
 done_testing();
+
+sub make_test_files {
+	my($dir) = @_;
+	$dir ||= ".";
+	
+	unlink_testfiles(); 
+	mkdir($dir);
+	for (1..4) {
+		spew("$dir/test$_.asm", "defb $_");
+		ok -f "$dir/test$_.asm", "create $dir/test$_.asm"
+	}
+}

--- a/src/z80asm/t/testlib.pl
+++ b/src/z80asm/t/testlib.pl
@@ -18,6 +18,8 @@ use File::Path 'remove_tree';
 my $IS_WIN32 = $^O eq 'MSWin32';
 my @TEST_EXT = qw( asm bin c d dat def err inc lis lst map o P out sym tap );
 
+# run z80asm from .
+$ENV{PATH} = ".".($IS_WIN32 ? ";" : ":").$ENV{PATH};
 
 # add path to z80asm top directory
 _prepend_path(_root());

--- a/src/z80asm/tt/error_func.yaml
+++ b/src/z80asm/tt/error_func.yaml
@@ -47,6 +47,16 @@ errors:
     args	: char *filename
     message	: "\"illegal source filename '%s'\", filename"
 	
+  - type	: ErrError
+    func	: error_glob
+    args	: char *filename, char *error
+    message	: "\"problem with '%s': %s\", filename, error"
+	
+  - type	: ErrError
+    func	: error_glob_no_files
+    args	: char *filename
+    message	: "\"pattern '%s' returned no files\", filename"
+	
   # Warnings
   - type	: ErrWarn
     func	: warn_symbol_different

--- a/src/z80asm/tt/error_func.yaml
+++ b/src/z80asm/tt/error_func.yaml
@@ -57,6 +57,11 @@ errors:
     args	: char *filename
     message	: "\"pattern '%s' returned no files\", filename"
 	
+  - type	: ErrError
+    func	: error_not_regular_file
+    args	: char *filename
+    message	: "\"file '%s' is not a regular file\", filename"
+	
   # Warnings
   - type	: ErrWarn
     func	: warn_symbol_different

--- a/src/z80asm/z80asm.c
+++ b/src/z80asm/z80asm.c
@@ -139,11 +139,11 @@ static void query_assemble( char *src_filename )
 	char *obj_filename = get_obj_filename( src_filename );
 
     /* get time stamp of files, error if source not found */
-    src_stat_result = stat( src_filename, &src_stat );	/* BUG_0033 */
+    src_stat_result = stat( src_filename, &src_stat );		/* BUG_0033 */
     obj_stat_result = stat( obj_filename, &obj_stat );
 
-    if ( opts.date_stamp &&								/* -d option */
-            obj_stat_result >= 0 &&					/* object file exists */
+    if ( opts.date_stamp &&									/* -d option */
+            obj_stat_result >= 0 &&							/* object file exists */
             ( src_stat_result >= 0 ?						/* if source file exists, ... */
               src_stat.st_mtime <= obj_stat.st_mtime		/* ... source older than object */
               : TRUE										/* ... else source does not exist, but object exists

--- a/win32/UNIXem/UNIXem.vcxproj
+++ b/win32/UNIXem/UNIXem.vcxproj
@@ -19,15 +19,50 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\getopt\getopt.h" />
+    <ClCompile Include="..\..\UNIXem\src\atomic.c" />
+    <ClCompile Include="..\..\UNIXem\src\dirent.c" />
+    <ClCompile Include="..\..\UNIXem\src\dlfcn.c" />
+    <ClCompile Include="..\..\UNIXem\src\glob.c" />
+    <ClCompile Include="..\..\UNIXem\src\hostname.c" />
+    <ClCompile Include="..\..\UNIXem\src\internal\util.c" />
+    <ClCompile Include="..\..\UNIXem\src\mmap.c" />
+    <ClCompile Include="..\..\UNIXem\src\resource.c" />
+    <ClCompile Include="..\..\UNIXem\src\setenv.c" />
+    <ClCompile Include="..\..\UNIXem\src\time.c" />
+    <ClCompile Include="..\..\UNIXem\src\uio.c" />
+    <ClCompile Include="..\..\UNIXem\src\unistd.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\getopt\getopt.c" />
+    <ClInclude Include="..\..\UNIXem\include\arpa\inet.h" />
+    <ClInclude Include="..\..\UNIXem\include\asm\atomic.h" />
+    <ClInclude Include="..\..\UNIXem\include\dirent.h" />
+    <ClInclude Include="..\..\UNIXem\include\dlfcn.h" />
+    <ClInclude Include="..\..\UNIXem\include\glob.h" />
+    <ClInclude Include="..\..\UNIXem\include\netinet\in.h" />
+    <ClInclude Include="..\..\UNIXem\include\unistd.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\arpa\inet.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\asm\atomic.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\dirent.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\dlfcn.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\glob.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\implicit_link.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\internal\safestr.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\internal\util.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\internal\winsock.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\netinet\in.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\setenv.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\mman.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\resource.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\socket.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\time.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\uio.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\unistd.h" />
+    <ClInclude Include="..\..\UNIXem\include\unixem\unixem.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{0E6DEEBD-2979-4AB0-AB8A-5A51F6579AAF}</ProjectGuid>
+    <ProjectGuid>{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>getopt</RootNamespace>
+    <RootNamespace>UNIXem</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -82,7 +117,8 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -108,7 +144,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/win32/UNIXem/UNIXem.vcxproj
+++ b/win32/UNIXem/UNIXem.vcxproj
@@ -19,45 +19,51 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\UNIXem\src\atomic.c" />
-    <ClCompile Include="..\..\UNIXem\src\dirent.c" />
-    <ClCompile Include="..\..\UNIXem\src\dlfcn.c" />
-    <ClCompile Include="..\..\UNIXem\src\glob.c" />
-    <ClCompile Include="..\..\UNIXem\src\hostname.c" />
-    <ClCompile Include="..\..\UNIXem\src\internal\util.c" />
-    <ClCompile Include="..\..\UNIXem\src\mmap.c" />
-    <ClCompile Include="..\..\UNIXem\src\resource.c" />
-    <ClCompile Include="..\..\UNIXem\src\setenv.c" />
-    <ClCompile Include="..\..\UNIXem\src\time.c" />
-    <ClCompile Include="..\..\UNIXem\src\uio.c" />
-    <ClCompile Include="..\..\UNIXem\src\unistd.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\atomic.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\dirent.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\dlfcn.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\glob.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\hostname.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\internal\util.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\mmap.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\resource.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\setenv.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\time.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\uio.c" />
+    <ClCompile Include="..\..\ext\UNIXem\src\unistd.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\UNIXem\include\arpa\inet.h" />
-    <ClInclude Include="..\..\UNIXem\include\asm\atomic.h" />
-    <ClInclude Include="..\..\UNIXem\include\dirent.h" />
-    <ClInclude Include="..\..\UNIXem\include\dlfcn.h" />
-    <ClInclude Include="..\..\UNIXem\include\glob.h" />
-    <ClInclude Include="..\..\UNIXem\include\netinet\in.h" />
-    <ClInclude Include="..\..\UNIXem\include\unistd.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\arpa\inet.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\asm\atomic.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\dirent.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\dlfcn.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\glob.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\implicit_link.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\internal\safestr.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\internal\util.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\internal\winsock.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\netinet\in.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\setenv.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\mman.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\resource.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\socket.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\time.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\uio.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\unistd.h" />
-    <ClInclude Include="..\..\UNIXem\include\unixem\unixem.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\arpa\inet.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\asm\atomic.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\dirent.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\dlfcn.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\glob.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\netinet\in.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\mman.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\resource.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\select.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\socket.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\time.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\uio.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unistd.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\arpa\inet.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\asm\atomic.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\dirent.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\dlfcn.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\glob.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\implicit_link.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\internal\safestr.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\internal\util.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\internal\winsock.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\netinet\in.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\setenv.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\mman.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\resource.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\socket.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\time.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\uio.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\unistd.h" />
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\unixem.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}</ProjectGuid>
@@ -118,7 +124,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\ext\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,7 +151,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\ext\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/win32/UNIXem/UNIXem.vcxproj.filters
+++ b/win32/UNIXem/UNIXem.vcxproj.filters
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\internal">
+      <UniqueIdentifier>{19977e65-71d7-4e75-9809-948ce90af49f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\arpa">
+      <UniqueIdentifier>{e7866fa6-2a89-4867-ac1c-81db36c85ed8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\asm">
+      <UniqueIdentifier>{bc02c3af-06cf-4195-8396-9363fae7f05d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\netinet">
+      <UniqueIdentifier>{db90a902-def9-4733-90a9-5005ed46d0f6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\sys">
+      <UniqueIdentifier>{4866958b-e8a0-4e27-9482-975d4619cae2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\unixem">
+      <UniqueIdentifier>{8cce4f92-12b7-4c55-a0d6-e369ad223821}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\unixem\arpa">
+      <UniqueIdentifier>{ad8610d4-fa41-4019-bc65-ee1244b12ccf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\unixem\asm">
+      <UniqueIdentifier>{d73f13b9-0a04-4ea3-9217-4deb4cef61f4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\unixem\netinet">
+      <UniqueIdentifier>{ffb3a8bc-0d55-44e2-b00c-e3ff383a5137}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\unixem\sys">
+      <UniqueIdentifier>{f4999614-adc1-4f2f-a2bf-23f8721889b8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\unixem\internal">
+      <UniqueIdentifier>{1a029fe3-4d5a-4f87-9613-0d491e51a6aa}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\UNIXem\src\atomic.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\dirent.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\dlfcn.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\glob.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\hostname.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\mmap.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\resource.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\setenv.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\time.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\uio.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\unistd.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UNIXem\src\internal\util.c">
+      <Filter>Source Files\internal</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\UNIXem\include\dirent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\dlfcn.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\glob.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unistd.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\arpa\inet.h">
+      <Filter>Header Files\arpa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\asm\atomic.h">
+      <Filter>Header Files\asm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\netinet\in.h">
+      <Filter>Header Files\netinet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\dirent.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\dlfcn.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\glob.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\implicit_link.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\setenv.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\unistd.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\unixem.h">
+      <Filter>Header Files\unixem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\arpa\inet.h">
+      <Filter>Header Files\unixem\arpa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\asm\atomic.h">
+      <Filter>Header Files\unixem\asm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\netinet\in.h">
+      <Filter>Header Files\unixem\netinet</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\internal\safestr.h">
+      <Filter>Header Files\unixem\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\internal\util.h">
+      <Filter>Header Files\unixem\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\internal\winsock.h">
+      <Filter>Header Files\unixem\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\mman.h">
+      <Filter>Header Files\unixem\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\resource.h">
+      <Filter>Header Files\unixem\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\socket.h">
+      <Filter>Header Files\unixem\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\time.h">
+      <Filter>Header Files\unixem\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UNIXem\include\unixem\sys\uio.h">
+      <Filter>Header Files\unixem\sys</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/win32/UNIXem/UNIXem.vcxproj.filters
+++ b/win32/UNIXem/UNIXem.vcxproj.filters
@@ -48,117 +48,135 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\UNIXem\src\atomic.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\atomic.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\dirent.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\dirent.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\dlfcn.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\dlfcn.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\glob.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\glob.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\hostname.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\hostname.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\mmap.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\mmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\resource.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\resource.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\setenv.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\setenv.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\time.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\time.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\uio.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\uio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\unistd.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\unistd.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\UNIXem\src\internal\util.c">
+    <ClCompile Include="..\..\ext\UNIXem\src\internal\util.c">
       <Filter>Source Files\internal</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\UNIXem\include\dirent.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\dirent.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\dlfcn.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\dlfcn.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\glob.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\glob.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unistd.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unistd.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\arpa\inet.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\arpa\inet.h">
       <Filter>Header Files\arpa</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\asm\atomic.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\asm\atomic.h">
       <Filter>Header Files\asm</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\netinet\in.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\netinet\in.h">
       <Filter>Header Files\netinet</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\dirent.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\mman.h">
+      <Filter>Header Files\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\resource.h">
+      <Filter>Header Files\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\select.h">
+      <Filter>Header Files\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\socket.h">
+      <Filter>Header Files\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\time.h">
+      <Filter>Header Files\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\sys\uio.h">
+      <Filter>Header Files\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\dirent.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\dlfcn.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\dlfcn.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\glob.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\glob.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\implicit_link.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\implicit_link.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\setenv.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\setenv.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\unistd.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\unistd.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\unixem.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\unixem.h">
       <Filter>Header Files\unixem</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\arpa\inet.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\arpa\inet.h">
       <Filter>Header Files\unixem\arpa</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\asm\atomic.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\asm\atomic.h">
       <Filter>Header Files\unixem\asm</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\netinet\in.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\internal\safestr.h">
+      <Filter>Header Files\unixem\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\internal\util.h">
+      <Filter>Header Files\unixem\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\internal\winsock.h">
+      <Filter>Header Files\unixem\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\netinet\in.h">
       <Filter>Header Files\unixem\netinet</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\internal\safestr.h">
-      <Filter>Header Files\unixem\internal</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\internal\util.h">
-      <Filter>Header Files\unixem\internal</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\internal\winsock.h">
-      <Filter>Header Files\unixem\internal</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\mman.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\mman.h">
       <Filter>Header Files\unixem\sys</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\resource.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\resource.h">
       <Filter>Header Files\unixem\sys</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\socket.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\socket.h">
       <Filter>Header Files\unixem\sys</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\time.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\time.h">
       <Filter>Header Files\unixem\sys</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UNIXem\include\unixem\sys\uio.h">
+    <ClInclude Include="..\..\ext\UNIXem\include\unixem\sys\uio.h">
       <Filter>Header Files\unixem\sys</Filter>
     </ClInclude>
   </ItemGroup>

--- a/win32/z80asm/z80asm.vcxproj
+++ b/win32/z80asm/z80asm.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\z80asm\lib;$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\z80asm\lib;$(ProjectDir)\..\..\ext\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -129,7 +129,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\z80asm\lib;$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\z80asm\lib;$(ProjectDir)\..\..\ext\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/win32/z80asm/z80asm.vcxproj
+++ b/win32/z80asm/z80asm.vcxproj
@@ -29,14 +29,14 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>NotSet</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\z80asm\lib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\z80asm\lib;$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -129,7 +129,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\z80asm\lib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\z80asm\lib;$(ProjectDir)\..\..\UNIXem\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -216,6 +216,8 @@
     <ClCompile Include="..\..\src\z80asm\z80pass.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\config.h" />
+    <ClInclude Include="..\..\src\portability.h" />
     <ClInclude Include="..\..\src\z80asm\codearea.h" />
     <ClInclude Include="..\..\src\z80asm\directives.h" />
     <ClInclude Include="..\..\src\z80asm\errors.h" />
@@ -270,6 +272,11 @@
     <None Include="..\..\src\z80asm\tt\error_func.yaml" />
     <None Include="..\..\src\z80asm\tt\tokens.h.tt" />
     <None Include="..\..\src\z80asm\tt\tokens.yaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UNIXem\UNIXem.vcxproj">
+      <Project>{7d0213a3-87fa-4f56-a5d6-cc23682acad8}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win32/z80asm/z80asm.vcxproj.filters
+++ b/win32/z80asm/z80asm.vcxproj.filters
@@ -245,6 +245,12 @@
     <ClInclude Include="..\..\src\z80asm\z80asm.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\portability.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\z80asm\parse_rules.rl">

--- a/win32/z80nm/z80nm.vcxproj
+++ b/win32/z80nm/z80nm.vcxproj
@@ -29,14 +29,14 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>NotSet</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/win32/z88dk.sln
+++ b/win32/z88dk.sln
@@ -79,6 +79,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "z88dk-map", "z88dk-map\z88d
 		{E82ADEEF-219A-44C3-A670-AACFD2D419EA} = {E82ADEEF-219A-44C3-A670-AACFD2D419EA}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UNIXem", "UNIXem\UNIXem.vcxproj", "{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -223,6 +225,14 @@ Global
 		{EECB51F1-0E9B-4C9D-95D8-20E477CA3DEC}.Release|Win32.Build.0 = Release|Win32
 		{EECB51F1-0E9B-4C9D-95D8-20E477CA3DEC}.Release|x64.ActiveCfg = Release|x64
 		{EECB51F1-0E9B-4C9D-95D8-20E477CA3DEC}.Release|x64.Build.0 = Release|x64
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Debug|Win32.Build.0 = Debug|Win32
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Debug|x64.ActiveCfg = Debug|x64
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Debug|x64.Build.0 = Debug|x64
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Release|Win32.ActiveCfg = Release|Win32
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Release|Win32.Build.0 = Release|Win32
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Release|x64.ActiveCfg = Release|x64
+		{7D0213A3-87FA-4F56-A5D6-CC23682ACAD8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add globbing support to z80asm in the command line args (for the Windows users) and
in list files. The standard '*' and '?' of glob.h are supported.

Added also the extended pattern '**' that expands to all subdirectories from the given point,
i.e. lib/**/*.asm will expand to all asm files in any subdirectory of lib.