### PR TITLE
__z88dk_sdccdecl + definition in for loop initial clause

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -57,10 +57,15 @@ z88dk vX.XX  - XX.XX.XXXX
 - [sccz80] #220: sccz80 now supports __critical blocks and functions
 - [sccz80] #275: don't swallow white space before constant L,U,S modify 
 - [sccz80] ZX Next specific code can now be generated
+- [sccz80] #419: Extern function declarations are now accepted with blocks
 - [sccz80] #452: Declaration parser rewritten
 - [sccz80] #452: Multi dimensional arrays are now supported
 - [sccz80] #452: Function pointers can now be defined with parameters
 - [sccz80] #481: z180 mlt instruction is now used
+- [sccz80] #485: Functions marked __z88dk_sdccdecl use sdcc calling spec for
+  chars (and become r->l)
+- [sccz80] #489: Loop variables can now be defined in the initialisation clause
+  of a for statement
 - [ticks] [classiclib] #101,#106: Now supports the +test target
 - [ticks] [classiclib] File IO is now available
 - [ticks] A debugger is now available

--- a/include/sys/compiler.h
+++ b/include/sys/compiler.h
@@ -13,6 +13,7 @@
 #define __Z88DK_R2L_CALLING_CONVENTION 1
 #define __stdc
 #define __z88dk_deprecated
+#define __z88dk_sdccdecl
 #else
 #define __vasmallc __smallc
 #define __z88dk_deprecated

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -1537,11 +1537,11 @@
 	jp	%1
 
 	push	hl
-	ld	hl,#%1
+	ld	hl,%1
 	pop	de
 =
 	ex	de,hl
-	ld	hl,#%1
+	ld	hl,%1
 
 	push	bc
 	ld	hl,%1	;const
@@ -2409,7 +2409,7 @@
 	ld	a,l
 	call	l_sxt
 =
-	ld	hl,%1
+	ld	hl,%1	;const
 
 	push	hl
 	ld	hl,%1

--- a/src/sccz80/ccdefs.h
+++ b/src/sccz80/ccdefs.h
@@ -46,6 +46,7 @@ extern void     callfunction(SYMBOL *ptr, Type *func_ptr_call_type);
 
 #include "codegen.h"
 extern void copy_to_stack(char *label, int stack_offset,  int size);
+extern void push_char_sdcc_style(void);
 #include "const.h"
 extern void dofloat(double raw, unsigned char fa[]);
 #include "data.h"

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -3293,6 +3293,14 @@ int zcriticaloffset(void)
     return 2;
 }
 
+void push_char_sdcc_style(void)
+{
+    ol("ld\tb,l");
+    ol("push\tbc");
+    ol("inc\tsp");
+    Zsp++;
+}
+
 
 /*
  * Local Variables:

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -3298,7 +3298,7 @@ void push_char_sdcc_style(void)
     ol("ld\tb,l");
     ol("push\tbc");
     ol("inc\tsp");
-    Zsp++;
+    Zsp--;
 }
 
 

--- a/src/sccz80/declinit.c
+++ b/src/sccz80/declinit.c
@@ -220,6 +220,7 @@ static int init(Type *type, int dump)
         /* djm, catch label names in structures (for (*name)() initialisation */
         char sname[NAMESIZE];
         SYMBOL *ptr;
+        cmatch('&');
         if (symname(sname) && strcmp(sname, "sizeof")) { /* We have got something.. */
             if ((ptr = findglb(sname))) {
                 /* Actually found sommat..very good! */

--- a/src/sccz80/declparse.c
+++ b/src/sccz80/declparse.c
@@ -482,6 +482,9 @@ static void parse_trailing_modifiers(Type *type)
         }
     }
 
+    if ( type->flags & SDCCDECL ) {
+        type->flags &= ~SMALLC;
+    }
 
 
     if ( (type->flags & (NAKED|CRITICAL) ) == (NAKED|CRITICAL) ) {
@@ -1108,6 +1111,9 @@ void flags_describe(int32_t flags, UT_string *output)
     if ( flags & SAVEFRAME ) {
         utstring_printf(output,"__z88dk_saveframe ");
     }  
+    if ( flags & SDCCDECL ) {
+        utstring_printf(output,"__z88dk_sdccdecl ");
+    }
     if ( flags & NAKED ) {
         utstring_printf(output,"__naked ");
     }  

--- a/src/sccz80/declparse.c
+++ b/src/sccz80/declparse.c
@@ -461,6 +461,9 @@ static void parse_trailing_modifiers(Type *type)
         } else if ( amatch("__critical")) {
             type->flags |= CRITICAL;
             continue;
+        } else if ( amatch("__z88dk_sdccdecl")) {
+            type->flags |= SDCCDECL;
+            continue;
         } else if (amatch("__preserves_regs")) {
             int c;
             needchar('(');
@@ -1249,11 +1252,11 @@ int type_matches(Type *t1, Type *t2)
 }
 
 
-static int get_parameter_size(Type *type)
+static int get_parameter_size(Type *functype, Type *type)
 {
     switch ( type->kind ) {
         case KIND_CHAR:
-            return 2;
+            return functype->flags & SDCCDECL ? 1 : 2;
         case KIND_CPTR:
             return 4;
         default:
@@ -1363,7 +1366,7 @@ static void declfunc(Type *type, enum storage_type storage)
             outfmt("; parameter '%s' at %d size(%d)\n",utstring_body(str),where, ptype->size);
             utstring_free(str);
             ptr->isassigned = 1;
-            where += get_parameter_size(ptype);
+            where += get_parameter_size(type,ptype);
         }
     } else {
         int i;
@@ -1387,7 +1390,7 @@ static void declfunc(Type *type, enum storage_type storage)
             outfmt("; parameter '%s' at %d size(%d)\n", utstring_body(str),where, ptype->size);  
             utstring_free(str);            
             ptr->isassigned = 1;            
-            where += get_parameter_size(ptype);
+            where += get_parameter_size(type, ptype);
         }
     }
 

--- a/src/sccz80/expr.c
+++ b/src/sccz80/expr.c
@@ -598,7 +598,7 @@ int heirb(LVALUE* lval)
                     Zsp += 2; /* undo push */
                     if (lval->ltype->kind == KIND_CPTR)
                         Zsp += 2;
-                    if ( val > lval->ltype->len && lval->ltype->kind == KIND_ARRAY) {
+                    if ( val > lval->ltype->len && lval->ltype->len != -1 && lval->ltype->kind == KIND_ARRAY) {
                         warningfmt("Access of array at index %d is greater than size %d", val, lval->ltype->len);
                     }
                     cscale(lval->ltype, &val);

--- a/src/sccz80/primary.c
+++ b/src/sccz80/primary.c
@@ -229,7 +229,7 @@ int intcheck(LVALUE* lval, LVALUE* lval2)
 
 /* Forces result, having type t2, to have type t1 */
 /* Must take account of sign in here somewhere, also there is a problem    possibly with longs.. */
-void force(Kind t1, Kind t2, char sign1, char sign2, int lconst)
+void force(Kind t1, Kind t2, char sign1, char sign2, int isconst)
 {
     if (t2 == KIND_CARRY) {
         zcarryconv();
@@ -249,7 +249,7 @@ void force(Kind t1, Kind t2, char sign1, char sign2, int lconst)
     /* int to long, if signed, do sign, if not ld de,0 */
     /* Check to see if constant or not... */
     if (t1 == KIND_LONG) {
-        if (t2 != KIND_LONG && (!lconst)) {
+        if (t2 != KIND_LONG && (!isconst)) {
             if (sign2 == NO && sign1 == NO && t2 != KIND_CARRY) {
                 convSint2long();
             } else
@@ -265,12 +265,12 @@ void force(Kind t1, Kind t2, char sign1, char sign2, int lconst)
         warning(W_FARNR);
 
     /* Char conversion */
-    if (t1 == KIND_CHAR && sign2 == NO && !lconst) {
+    if (t1 == KIND_CHAR && sign2 == NO && !isconst) {
         if (sign1 == NO)
             convSint2char();
         else
             convUint2char();
-    } else if (t1 == KIND_CHAR && sign2 == YES && !lconst) {
+    } else if (t1 == KIND_CHAR && sign2 == YES && !isconst) {
         if (sign1 == NO)
             convSint2char();
         else

--- a/src/sccz80/stmt.c
+++ b/src/sccz80/stmt.c
@@ -344,15 +344,21 @@ void dofor()
 {
     WHILE_TAB wq;
     int l_condition;
+    int savedsp;
+    SYMBOL *savedloc;
     t_buffer *buf2, *buf3;
 
     addwhile(&wq);
     l_condition = getlabel();
+    savedsp = Zsp;
+    savedloc = locptr;
 
     needchar('(');
     if (cmatch(';') == 0) {
-        doexpr(); /*         initialization             */
-        ns();
+        if ( declare_local(0) == 0 ) {
+            doexpr(); /*         initialization             */
+            ns();
+        }
     }
 
     buf2 = startbuffer(1); /* save condition to buf2 */
@@ -377,7 +383,9 @@ void dofor()
     statement(); /*         statement                  */
     jump(wq.loop); /*         goto loop                  */
     postlabel(wq.exit); /* .exit                              */
-
+    modstk(savedsp, NO, NO);
+    Zsp = savedsp;
+    locptr = savedloc;
     delwhile();
 }
 

--- a/src/sccz80/stmt.h
+++ b/src/sccz80/stmt.h
@@ -4,7 +4,7 @@ extern void ns(void);
 extern void compound(void);
 extern void doiferror(void);
 extern void doif(void);
-extern int doexpr(void);
+extern Type *doexpr(void);
 extern void dowhile(void);
 extern void dodo(void);
 extern void dofor(void);

--- a/testsuite/Issue_452_far_pointers.c
+++ b/testsuite/Issue_452_far_pointers.c
@@ -38,7 +38,7 @@ int func5(far char *ptr, char val)
 int func6()
 {
 	char   *ptr;
-	func5(ptr);
+	func5(ptr,1);
 }
 
 struct x {

--- a/testsuite/Issue_485_sdccdecl.c
+++ b/testsuite/Issue_485_sdccdecl.c
@@ -1,0 +1,12 @@
+
+
+int func(char v,char x) __z88dk_sdccdecl
+{
+	return v + x;
+}
+
+
+int main()
+{
+	func(1,2);
+}

--- a/testsuite/Issue_489_variable_defn_in_forloop.c
+++ b/testsuite/Issue_489_variable_defn_in_forloop.c
@@ -1,0 +1,19 @@
+void func2(int i);
+
+void func()
+{
+	int	k;
+	for ( int i = 0; i < 10; i++ ) {
+		func2(i);
+	}
+	func2(100);
+}
+
+void func3()
+{
+	int	k;
+	for ( long i = 0; i < 10; i++ ) {
+		func2(i);
+	}
+	func2(100);
+}

--- a/testsuite/results/Issue_452_far_pointers.opt
+++ b/testsuite/results/Issue_452_far_pointers.opt
@@ -98,7 +98,7 @@
 	call	l_getptr
 	push	de
 	push	hl
-	ld	hl,1
+	ld	hl,1	;const
 	push	hl
 	call	_func5
 	pop	bc
@@ -115,7 +115,10 @@
 	ld	de,0
 	push	de
 	push	hl
+	ld	hl,1	;const
+	push	hl
 	call	_func5
+	pop	bc
 	pop	bc
 	pop	bc
 	pop	bc

--- a/testsuite/results/Issue_485_sdccdecl.opt
+++ b/testsuite/results/Issue_485_sdccdecl.opt
@@ -1,0 +1,50 @@
+
+
+
+	MODULE	Issue_485_sdccdecl
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._func
+	ld	hl,3	;const
+	call	l_gcharspsp	;
+	ld	hl,4	;const
+	add	hl,sp
+	call	l_gchar
+	pop	de
+	add	hl,de
+	ret
+
+
+
+._main
+	ld	hl,1	;const
+	ld	b,l
+	push	bc
+	inc	sp
+	ld	hl,2	;const
+	ld	b,l
+	push	bc
+	inc	sp
+	call	_func
+	pop	bc
+	ret
+
+
+
+
+	SECTION	bss_compiler
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_func
+	GLOBAL	_main
+
+
+
+

--- a/testsuite/results/Issue_485_sdccdecl.opt
+++ b/testsuite/results/Issue_485_sdccdecl.opt
@@ -10,9 +10,9 @@
 	SECTION	code_compiler
 
 ._func
-	ld	hl,3	;const
+	ld	hl,2	;const
 	call	l_gcharspsp	;
-	ld	hl,4	;const
+	ld	hl,5	;const
 	add	hl,sp
 	call	l_gchar
 	pop	de
@@ -22,11 +22,11 @@
 
 
 ._main
-	ld	hl,1	;const
+	ld	hl,2	;const
 	ld	b,l
 	push	bc
 	inc	sp
-	ld	hl,2	;const
+	ld	hl,1	;const
 	ld	b,l
 	push	bc
 	inc	sp

--- a/testsuite/results/Issue_489_variable_defn_in_forloop.opt
+++ b/testsuite/results/Issue_489_variable_defn_in_forloop.opt
@@ -1,0 +1,101 @@
+
+
+
+	MODULE	Issue_489_variable_defn_in_forloop
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._func
+	push	bc
+	ld	hl,0	;const
+	push	hl
+	jp	i_4
+.i_2
+	pop	hl
+	inc	hl
+	push	hl
+	dec	hl
+.i_4
+	pop	de
+	push	de
+	ld	hl,10	;const
+	call	l_lt
+	jp	nc,i_3
+	pop	hl
+	push	hl
+	push	hl
+	call	_func2
+	pop	bc
+	jp	i_2
+.i_3
+	pop	bc
+	ld	hl,100	;const
+	push	hl
+	call	_func2
+	pop	bc
+	pop	bc
+	ret
+
+
+
+._func3
+	push	bc
+	ld	hl,0	;const
+	ld	d,h
+	ld	e,l
+	push	de
+	push	hl
+	jp	i_7
+.i_5
+	ld	hl,0	;const
+	add	hl,sp
+	push	hl
+	call	l_glong
+	call	l_inclong
+	pop	bc
+	call	l_plong
+	call	l_declong
+.i_7
+	ld	hl,0	;const
+	add	hl,sp
+	call	l_glong2sp
+	ld	hl,10	;const
+	ld	de,0
+	call	l_long_lt
+	jp	nc,i_6
+	ld	hl,0	;const
+	add	hl,sp
+	call	l_glong
+	push	hl
+	call	_func2
+	pop	bc
+	jp	i_5
+.i_6
+	pop	bc
+	pop	bc
+	ld	hl,100	;const
+	push	hl
+	call	_func2
+	pop	bc
+	pop	bc
+	ret
+
+
+
+
+	SECTION	bss_compiler
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_func2
+	GLOBAL	_func
+	GLOBAL	_func3
+
+
+
+


### PR DESCRIPTION
Add support for __z88dk_sdccdecl for sccz80. Issue #485 

This passes chars as a single byte on the stack. Both calling functions and compiling functions with this flag are supported.

Support defining the loop variable inside the for: Issue #489 