### PR TITLE
Issue #564: Casts and structs

### DIFF
--- a/src/sccz80/expr.c
+++ b/src/sccz80/expr.c
@@ -720,12 +720,20 @@ int heirb(LVALUE* lval)
             /* Handle structures... come in here with lval holding tehe previous
              * pointer to the struct thing..*/
             else if ((direct = cmatch('.')) || match("->")) {
-                Type *str = lval->ltype->tag;
+                Type *str = lval->ltype;
                 Type *member_type;
 
-                if ( lval->ltype->kind == KIND_PTR || lval->ltype->kind == KIND_CPTR) {
-                    str = lval->ltype->ptr->tag;
+                // If there's a cast active, then use the cast type
+                if ( lval->cast_type ) {
+                    str = lval->cast_type;
                 }
+
+                if ( str->kind == KIND_PTR || str->kind == KIND_CPTR) {
+                    str = str->ptr->tag;
+                } else {
+                    str = str->tag;
+                }
+            
 
                 if (str == NULL ) {
                     errorfmt("Can't take member", 1);
@@ -733,7 +741,7 @@ int heirb(LVALUE* lval)
                     return 0;
                 }
                 if (symname(sname) == 0 || (member_type = find_tag_field(str, sname)) == NULL) {
-                    errorfmt("Unknown member: %s", 1, sname);
+                    errorfmt("Unknown member: '%s' of struct '%s'", 1, sname, str->name);
                     junk();
                     return 0;
                 }

--- a/testsuite/Issue_564_casting.c
+++ b/testsuite/Issue_564_casting.c
@@ -1,0 +1,27 @@
+
+typedef struct {
+        int _x;
+        int     _y;
+        int _status;
+} Character;
+
+typedef struct {
+   Character  _character;
+} Item;
+
+void value(int v);
+
+void func3(Item *item)
+{
+   return (long)item->_character->_x;
+
+}
+void func2(int val)
+{
+	value( (((Character *) val))->_y);
+}
+
+void func(Item *itemptr)
+{
+	value( ( (Character *) itemptr )->_y);
+}

--- a/testsuite/Issue_564_casting.c
+++ b/testsuite/Issue_564_casting.c
@@ -11,7 +11,8 @@ typedef struct {
 
 void value(int v);
 
-void func3(Item *item)
+
+long func3(Item *item)
 {
    return (long)item->_character->_x;
 
@@ -24,4 +25,17 @@ void func2(int val)
 void func(Item *itemptr)
 {
 	value( ( (Character *) itemptr )->_y);
+}
+
+
+Item item;
+
+void func4()
+{
+    value( (((Character *) &item))->_y);
+}
+
+long func5()
+{
+   return (long)item._character->_x;
 }

--- a/testsuite/results/Issue_564_casting.opt
+++ b/testsuite/results/Issue_564_casting.opt
@@ -50,8 +50,25 @@
 
 
 
+._func4
+	ld	hl,(_item+1+1)
+	push	hl
+	call	_value
+	pop	bc
+	ret
+
+
+
+._func5
+	ld	hl,(_item)
+	call	l_int2long_s
+	ret
+
+
+
 
 	SECTION	bss_compiler
+._item	defs	6
 	SECTION	code_compiler
 
 
@@ -60,6 +77,9 @@
 	GLOBAL	_func3
 	GLOBAL	_func2
 	GLOBAL	_func
+	GLOBAL	_item
+	GLOBAL	_func4
+	GLOBAL	_func5
 
 
 

--- a/testsuite/results/Issue_564_casting.opt
+++ b/testsuite/results/Issue_564_casting.opt
@@ -1,0 +1,66 @@
+
+
+
+	MODULE	Issue_564_casting
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._func3
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	call	l_gint	;
+	call	l_int2long_s
+	ret
+
+
+
+._func2
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	inc	hl
+	inc	hl
+	call	l_gint	;
+	push	hl
+	call	_value
+	pop	bc
+	ret
+
+
+
+._func
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	inc	hl
+	inc	hl
+	call	l_gint	;
+	push	hl
+	call	_value
+	pop	bc
+	ret
+
+
+
+
+	SECTION	bss_compiler
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_value
+	GLOBAL	_func3
+	GLOBAL	_func2
+	GLOBAL	_func
+
+
+
+


### PR DESCRIPTION
Fix an issue around casts and structs - the cast wasn't being applied
before doing the lookup.

However, doing the cast early breaks the lookup, so use the cast
type when doing the member lookup.