### PR TITLE
Feature/issue 571 harmonise pragmas

### DIFF
--- a/lib/abc80_crt0.asm
+++ b/lib/abc80_crt0.asm
@@ -32,8 +32,8 @@ IF      !DEFINED_CRT_ORG_CODE
         defc    CRT_ORG_CODE  = 50000
 ENDIF
 
-	defc	DEF__clib_exit_stack_size = 32
-	defc	DEF__register_sp = -1
+	defc	TAR__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/abc80_crt0.asm
+++ b/lib/abc80_crt0.asm
@@ -5,20 +5,20 @@
 ;       $Id: abc80_crt0.asm,v 1.20 2016-07-15 21:03:25 dom Exp $
 ;
 
-                MODULE  abc80_crt0
+        MODULE  abc80_crt0
 
 ;
 ; Initially include the zcc_opt.def file to find out lots of lovely
 ; information about what we should do..
 ;
 
-       		defc    crt0 = 1
-                INCLUDE "zcc_opt.def"
+        defc    crt0 = 1
+        INCLUDE "zcc_opt.def"
 
 ; No matter what set up we have, main is always, always external to
 ; this file
 
-                EXTERN    _main
+	EXTERN    _main
 
 ;
 ; Some variables which are needed for both app and basic startup
@@ -31,26 +31,25 @@
 IF      !DEFINED_CRT_ORG_CODE
         defc    CRT_ORG_CODE  = 50000
 ENDIF
+
+	defc	DEF__clib_exit_stack_size = 32
+	defc	DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
+
         org     CRT_ORG_CODE
 
 
 start:
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        ld      (start1+1),sp
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
         call    _main
         

--- a/lib/ace_crt0.asm
+++ b/lib/ace_crt0.asm
@@ -42,8 +42,8 @@
             ENDIF
         ENDIF
 
-	defc	DEF__clib_exit_stack_size = 32
-	defc	DEF__register_sp = -1
+	defc	TAR__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/ace_crt0.asm
+++ b/lib/ace_crt0.asm
@@ -42,6 +42,9 @@
             ENDIF
         ENDIF
 
+	defc	DEF__clib_exit_stack_size = 32
+	defc	DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
@@ -64,9 +67,8 @@ ELSE
         ld      hl,0
         add     hl,sp
         ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 ENDIF
 	call	crt0_init_bss
         ld      (exitsp),sp

--- a/lib/aquarius_crt0.asm
+++ b/lib/aquarius_crt0.asm
@@ -32,8 +32,8 @@
         ENDIF
 
 
-	defc	DEF__clib_exit_stack_size = 32
-	defc	DEF__register_sp = -1
+	defc	TAR__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 
 	org	CRT_ORG_CODE

--- a/lib/aquarius_crt0.asm
+++ b/lib/aquarius_crt0.asm
@@ -31,13 +31,17 @@
                 defc    CRT_ORG_CODE  = 14712
         ENDIF
 
+
+	defc	DEF__clib_exit_stack_size = 32
+	defc	DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
+
 	org	CRT_ORG_CODE
 
 start:
         ld      (start1+1),sp	;Save entry stack
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/bee_crt0.asm
+++ b/lib/bee_crt0.asm
@@ -36,8 +36,8 @@
 
 
 
-	defc	DEF__clib_exit_stack_size = 32
-	defc	DEF__register_sp = -1
+	defc	TAR__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE
@@ -46,6 +46,7 @@
 
 
 start:
+	ld	(start1+1),sp
         INCLUDE "crt/crt_init_sp.asm"
         INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss

--- a/lib/bee_crt0.asm
+++ b/lib/bee_crt0.asm
@@ -35,19 +35,19 @@
         ENDIF
 
 
-; Now, getting to the real stuff now!
 
+	defc	DEF__clib_exit_stack_size = 32
+	defc	DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
 
-		org     CRT_ORG_CODE
+	org     CRT_ORG_CODE
 
 
 
 
 start:
-
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp
-	ld	sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld	(exitsp),sp
 

--- a/lib/c128_crt0.asm
+++ b/lib/c128_crt0.asm
@@ -33,8 +33,8 @@
                 defc    CRT_ORG_CODE  = $3000	; no, use a fixed entry location at $3000, 'appmake' is not ready for different values!
         ENDIF
 
-	defc	DEF__clib_exit_stack_size = 32
-	defc	DEF__register_sp = -1
+	defc	TAR__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
         org     CRT_ORG_CODE
 

--- a/lib/c128_crt0.asm
+++ b/lib/c128_crt0.asm
@@ -33,6 +33,9 @@
                 defc    CRT_ORG_CODE  = $3000	; no, use a fixed entry location at $3000, 'appmake' is not ready for different values!
         ENDIF
 
+	defc	DEF__clib_exit_stack_size = 32
+	defc	DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
         org     CRT_ORG_CODE
 
 
@@ -100,9 +103,8 @@ z80start:
 ;        ld      hl,0
 ;        add     hl,sp
         ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/c7420_crt0.asm
+++ b/lib/c7420_crt0.asm
@@ -32,7 +32,7 @@
         ENDIF   
 
 
-	defc	DEF__clib_exit_stack_size = 32
+	defc	TAR__clib_exit_stack_size = 32
 	defc	TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 

--- a/lib/c7420_crt0.asm
+++ b/lib/c7420_crt0.asm
@@ -27,58 +27,55 @@
         PUBLIC    l_dcal          ;jp(hl)
 
 
-; Now, getting to the real stuff now!
-
         IF      !DEFINED_CRT_ORG_CODE
                 defc    CRT_ORG_CODE  = 35055
         ENDIF   
+
+
+	defc	DEF__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
 
 start:
         ld      (start1+1),sp	;Save entry stack
-        IF !STACKPTR
-        ;ld      hl,-64
-        ;add     hl,sp
-        ;ld      sp,hl
-		ELSE
-        ld      sp,STACKPTR-64
-		ENDIF
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 
-		call    crt0_init_bss
+	call    crt0_init_bss
         ld      (exitsp),sp
 		
 ; Optional definition for auto MALLOC init
 ; it assumes we have free space between the end of 
 ; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
-		call    _main
+	call    _main
 cleanup:
-		push	hl
+	push	hl
 ;
 ;       Deallocate memory which has been allocated here!
 ;
 
 IF !DEFINED_nostreams
-		EXTERN	closeall
-		call	closeall
+	EXTERN	closeall
+	call	closeall
 ENDIF
-
-		pop	hl
+	pop	hl
 start1:
-		ld  sp,0
-		ld	a,l
-		jp	$19f9	; $1994 for french version ??
-				; perhaps we should first spot the right location,
-				; looking around for the 47h, AFh sequence
+	ld 	sp,0
+	ld	a,l
+	jp	$19f9	; $1994 for french version ??
+			; perhaps we should first spot the right location,
+			; looking around for the 47h, AFh sequence
 
 
 l_dcal:
-		jp	(hl)	; Used for function pointer calls
+	jp	(hl)	; Used for function pointer calls
 
 
 

--- a/lib/cpc_crt0.asm
+++ b/lib/cpc_crt0.asm
@@ -28,14 +28,18 @@
 		
 	GLOBAL    __interposer_isr__
 
+	defc	  TAR__register_sp = -0xae60
+        defc	DEF__clib_exit_stack_size = 32
+	INCLUDE	"crt/crt_rules.inc"
+
 ;--------
 ; Set an origin for the application (-zorg=) default to $1200
 ;--------
 
 IF      !DEFINED_CRT_ORG_CODE
-		defc    CRT_ORG_CODE  = $1200
+	defc    CRT_ORG_CODE  = $1200
 ENDIF   
-                org     CRT_ORG_CODE
+	org     CRT_ORG_CODE
 
 
 ;--------
@@ -46,18 +50,8 @@ start:
 
         di
         ld      (start1+1),sp
-IFNDEF STACKPTR
-	ld sp,(0xae60)               ; set stack location to last byte of udg area
-ELSE
-    IF STACKPTR > -1
-	ld sp,STACKPTR          ; user supplied stack location
-    ENDIF
-ENDIF
-		
-	; make room for exit stack
-	ld      hl,-64                  ; reserve space for 32 entries on the exit stack
-	add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/cpc_crt0.asm
+++ b/lib/cpc_crt0.asm
@@ -28,8 +28,8 @@
 		
 	GLOBAL    __interposer_isr__
 
-	defc	  TAR__register_sp = -0xae60
-        defc	DEF__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -0xae60
+        defc	TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
 ;--------

--- a/lib/cpm_crt0.asm
+++ b/lib/cpm_crt0.asm
@@ -40,8 +40,8 @@
 	PUBLIC    cleanup		;jp'd to by exit()
 	PUBLIC    l_dcal		;jp(hl)
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 IF (startup=2)
@@ -87,7 +87,6 @@ ENDIF
 	nop	 ;   Those extra bytes fix the Amstrad NC's ZCN support !!?!
 	nop
 
-        call    crt0_init_bss   ;Initialise any data setup by sdcc
 	ld      (start1+1),sp	;Save entry stack
 IF (startup=3)
 	; Increase to cover +3 MEM banking
@@ -97,6 +96,7 @@ IF (startup=3)
 ENDIF
         INCLUDE "crt/crt_init_sp.asm"
         INCLUDE "crt/crt_init_atexit.asm"
+        call    crt0_init_bss   ;Initialise any data setup by sdcc
 	ld      (exitsp),sp
 
 ; Memory banking for Spectrum +3

--- a/lib/cpm_crt0.asm
+++ b/lib/cpm_crt0.asm
@@ -40,6 +40,9 @@
 	PUBLIC    cleanup		;jp'd to by exit()
 	PUBLIC    l_dcal		;jp(hl)
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
 IF (startup=2)
         org     32768
@@ -87,12 +90,13 @@ ENDIF
         call    crt0_init_bss   ;Initialise any data setup by sdcc
 	ld      (start1+1),sp	;Save entry stack
 IF (startup=3)
-	ld      hl,-64-18-18	;Add on space for atexit() stack and +3 MEM banking
-ELSE
-	ld      hl,-64		;Add on space for atexit() stack
+	; Increase to cover +3 MEM banking
+	defc	__clib_exit_stack_size_t  = __clib_exit_stack_size + 18
+	UNDEFINE __clib_exit_stack_size
+	defc	__clib_exit_stack_size = __clib_exit_stack_size_t
 ENDIF
-	add     hl,sp
-	ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	ld      (exitsp),sp
 
 ; Memory banking for Spectrum +3

--- a/lib/crt/crt_init_atexit.asm
+++ b/lib/crt/crt_init_atexit.asm
@@ -1,0 +1,9 @@
+
+	PUBLIC	__clib_exit_stack_size
+
+IF __clib_exit_stack_size > 0
+	ld	hl, __clib_exit_stack_size * 2
+	add	hl,sp
+	ld	sp,hl
+ENDIF
+

--- a/lib/crt/crt_init_sp.asm
+++ b/lib/crt/crt_init_sp.asm
@@ -1,0 +1,14 @@
+IF __register_sp < -1
+
+   ld sp,(-__register_sp)      ; stack location is stored at memory address
+
+ELSE
+
+   IF __register_sp != -1
+
+      ld sp,__register_sp      ; stack is at fixed address
+
+   ENDIF
+
+ENDIF
+

--- a/lib/crt/crt_rules.inc
+++ b/lib/crt/crt_rules.inc
@@ -1,0 +1,24 @@
+
+   IFDEF REGISTER_SP
+      defc __register_sp = REGISTER_SP
+   ELSE
+      IFDEF STACKPTR
+         defc __register_sp = STACKPTR
+      ELSE
+         IFDEF TAR__register_sp
+            defc __register_sp = TAR__register_sp
+         ELSE
+            defc __register_sp = DEF__register_sp
+         ENDIF
+      ENDIF
+   ENDIF
+
+   IFDEF CLIB_EXIT_STACK_SIZE
+      defc __clib_exit_stack_size = CLIB_EXIT_STACK_SIZE
+   ELSE
+      IFDEF TAR__clib_exit_stack_size
+         defc __clib_exit_stack_size = TAR__clib_exit_stack_size
+      ELSE
+         defc __clib_exit_stack_size = DEF__clib_exit_stack_size
+      ENDIF
+   ENDIF

--- a/lib/crt0_section.asm
+++ b/lib/crt0_section.asm
@@ -12,12 +12,14 @@
 crt0_init_bss:
         EXTERN  __BSS_head
         EXTERN  __BSS_END_tail
+IF CRT_INITIALIZE_BSS	
         ld      hl,__BSS_head
         ld      de,__BSS_head + 1
         ld      bc,__BSS_END_tail - __BSS_head - 1
         xor     a 
 	ld	(hl),a
         ldir
+ENDIF
 
 	; a = 0 - reset exitcount
         ld      (exitcount),a

--- a/lib/embedded_crt0.asm
+++ b/lib/embedded_crt0.asm
@@ -38,8 +38,8 @@ IF      !CRT_ORG_CODE
 	defc	CRT_ORG_CODE = ROM_Start
 ENDIF
 	
-	defc	DEF__register_sp = Stack_Top
-        defc    DEF__clib_exit_stack_size = 32
+	defc	TAR__register_sp = Stack_Top
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
 	org    	CRT_ORG_CODE

--- a/lib/enterprise_crt0.asm
+++ b/lib/enterprise_crt0.asm
@@ -87,6 +87,9 @@
 		PUBLIC    _esccmd_cr
 		PUBLIC    _esccmd_pd
 
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 0x7f00
+        INCLUDE "crt/crt_rules.inc"
 
 IF      !DEFINED_CRT_ORG_CODE
 		defc    CRT_ORG_CODE  = 100h
@@ -120,9 +123,10 @@ ENDIF
 
 ; Inspired by the DizzyLord loader by ORKSOFT
         ;di
+        ld      (start1+1),sp
         ld    a, 004h
         out   (0bfh), a
-        ld    sp, 07F00h
+	INCLUDE "crt/crt_init_sp.asm"
         ld    a, 0ffh
         out   (0b2h), a
 
@@ -157,14 +161,9 @@ ENDIF
         rst   30h
         defb  11						; set 40x25 characters window
 
-	call	crt0_init_bss
 
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),sp
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_atexit.asm"
+	call	crt0_init_bss
         ld      (exitsp),sp
 
 ; Optional definition for auto MALLOC init

--- a/lib/g800_crt0.asm
+++ b/lib/g800_crt0.asm
@@ -30,31 +30,26 @@
 ;--------
 
 IF      !DEFINED_CRT_ORG_CODE
-                defc    CRT_ORG_CODE  = $100
+	defc    CRT_ORG_CODE  = $100
 ENDIF
+
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE
 
 start:
 
         ld      (start1+1),sp   ;Save entry stack
-IF      STACKPTR
-        ld      sp,STACKPTR
-ELSE
-;		ld sp, $77df-64
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
-ENDIF
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
         call    _main           ;Call user program
 

--- a/lib/g800_crt0.asm
+++ b/lib/g800_crt0.asm
@@ -33,8 +33,8 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $100
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE

--- a/lib/gal_crt0.asm
+++ b/lib/gal_crt0.asm
@@ -7,7 +7,7 @@
 
 
 
-                MODULE  gal_crt0
+	MODULE  gal_crt0
 ;--------
 ; Include zcc_opt.def to find out some info
 ;--------
@@ -24,29 +24,26 @@
         PUBLIC    cleanup         ;jp'd to by exit()
         PUBLIC    l_dcal          ;jp(hl)
 
+IF      !DEFINED_CRT_ORG_CODE
+	defc	CRT_ORG_CODE = 0x2c3a
+ENDIF
 
-;--------
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
 
-        org     $2c3a
+        org     CRT_ORG_CODE
 
 start:
         ld      (start1+1),sp   ;Save entry stack
-IF      STACKPTR
-        ld      sp,STACKPTR
-ENDIF
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
-
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
         call    _main           ;Call user program
 
@@ -64,8 +61,6 @@ start1: ld      sp,0            ;Restore stack to entry value
         ret
 
 l_dcal: jp      (hl)            ;Used for function pointer calls
-
-
 
 
 

--- a/lib/gal_crt0.asm
+++ b/lib/gal_crt0.asm
@@ -28,8 +28,8 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc	CRT_ORG_CODE = 0x2c3a
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/kc_crt0.asm
+++ b/lib/kc_crt0.asm
@@ -38,7 +38,7 @@ IF      !DEFINED_CRT_ORG_CODE
 ENDIF
 
 	defc	TAR__register_sp = CRT_ORG_CODE-2
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE

--- a/lib/kc_crt0.asm
+++ b/lib/kc_crt0.asm
@@ -33,9 +33,13 @@
 	PUBLIC    l_dcal          ;jp(hl)
 
 
-	IF      !DEFINED_CRT_ORG_CODE
-			defc    CRT_ORG_CODE  = $1000
-	ENDIF
+IF      !DEFINED_CRT_ORG_CODE
+	defc    CRT_ORG_CODE  = $1000
+ENDIF
+
+	defc	TAR__register_sp = CRT_ORG_CODE-2
+        defc    DEF__clib_exit_stack_size = 32
+	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE
 
@@ -72,18 +76,8 @@ IF !DEFINED_nosound
 ENDIF
 	
 	ld	(start1+1),sp	;Save entry stack
-	
-IF      STACKPTR
-	ld  sp,STACKPTR
-ELSE
-	ld	sp,CRT_ORG_CODE-2
-ENDIF
-	
-;	ld      hl,-64
-;	add     hl,sp
-;	ld      sp,hl
-;	ld		sp,CRT_ORG_CODE
-	
+	INCLUDE	"crt/crt_init_sp.asm"	
+	INCLUDE	"crt/crt_init_atexit.asm"	
 	call	crt0_init_bss
 	ld      (exitsp),sp
 

--- a/lib/lynx_crt0.asm
+++ b/lib/lynx_crt0.asm
@@ -39,8 +39,8 @@
                 defc    CRT_ORG_CODE  = $7000
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
         org     CRT_ORG_CODE
 

--- a/lib/lynx_crt0.asm
+++ b/lib/lynx_crt0.asm
@@ -39,7 +39,9 @@
                 defc    CRT_ORG_CODE  = $7000
         ENDIF
 
-
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
         org     CRT_ORG_CODE
 
 start:
@@ -47,10 +49,8 @@ start:
         ld      hl,0
         add     hl,sp
         ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
-
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/m5_crt0.asm
+++ b/lib/m5_crt0.asm
@@ -45,8 +45,8 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $7300
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc
         org     CRT_ORG_CODE
 

--- a/lib/m5_crt0.asm
+++ b/lib/m5_crt0.asm
@@ -45,15 +45,15 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $7300
 ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc
         org     CRT_ORG_CODE
 
 start:
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        ld      (start1+1),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/mc1000_crt0.asm
+++ b/lib/mc1000_crt0.asm
@@ -50,17 +50,19 @@
 
 
         IF      !DEFINED_CRT_ORG_CODE
-			IF (startup=2)
-				defc    CRT_ORG_CODE  = $100  ; Direct M/C mode, including system variables on top 100h bytes
-			ELSE
-				defc    CRT_ORG_CODE  = 981	; BASIC startup mode (correct location TBD)
-			ENDIF
+	   IF (startup=2)
+		defc    CRT_ORG_CODE  = $100  ; Direct M/C mode, including system variables on top 100h bytes
+ 	   ELSE
+		defc    CRT_ORG_CODE  = 981	; BASIC startup mode (correct location TBD)
+	   ENDIF
         ENDIF
 
 
-; Now, getting to the real stuff now!
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = 0	; 0 = autodetect
+        INCLUDE "crt/crt_rules.inc"
 
-		org     CRT_ORG_CODE
+	org     CRT_ORG_CODE
 
 
 IF (startup=2)
@@ -270,9 +272,8 @@ start:
 	;LD ($106),a
 		;ld		hl,$106
 		;ld		(hl),255	; disable gaming mode (shouldn't this work by putting 255??)
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),hl
+        ld      (start1+1),sp
+IF __register_sp == 0
         ld      hl,$bfff	; 48K ?
         ld      (hl),$55
         ld      a,$AA
@@ -282,21 +283,23 @@ start:
         ld      hl,$3fff	; 48K.
 has48k:
         ld      sp,hl
+	UNDEFINE  __register_sp
+	defc	__register_sp = -1
+ENDIF
         
         ;ei
         ;xor     a
         ;out     ($80),a
         ;call    $c021      ; setup text page (ptr in HL)
-        
+       
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm" 
 	call	crt0_init_bss
-	ld		(exitsp),sp
+	ld	(exitsp),sp
 		
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 		
 
         call    _main

--- a/lib/mc1000_crt0.asm
+++ b/lib/mc1000_crt0.asm
@@ -58,8 +58,8 @@
         ENDIF
 
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = 0	; 0 = autodetect
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 0	; 0 = autodetect
         INCLUDE "crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE

--- a/lib/msx_crt0.asm
+++ b/lib/msx_crt0.asm
@@ -59,8 +59,8 @@ ELSE
         ENDIF
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 	org CRT_ORG_CODE
@@ -182,8 +182,8 @@ ELSE
 	PUBLIC	l_dcal	; jp(hl) instruction
 	PUBLIC cleanup
 
-        defc    DEF__clib_exit_stack_size = 0
-        defc    DEF__register_sp = -0xfc4a
+        defc    TAR__clib_exit_stack_size = 0
+        defc    TAR__register_sp = -0xfc4a
         INCLUDE "crt/crt_rules.inc"
 
 ;

--- a/lib/msx_crt0.asm
+++ b/lib/msx_crt0.asm
@@ -59,7 +59,11 @@ ELSE
         ENDIF
 ENDIF
 
-org CRT_ORG_CODE
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
+	org CRT_ORG_CODE
 
 ;----------------------
 ; Execution starts here
@@ -86,12 +90,9 @@ begin:
 ENDIF
 ENDIF
 
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        ld      (start1+1),sp
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
@@ -181,6 +182,10 @@ ELSE
 	PUBLIC	l_dcal	; jp(hl) instruction
 	PUBLIC cleanup
 
+        defc    DEF__clib_exit_stack_size = 0
+        defc    DEF__register_sp = -0xfc4a
+        INCLUDE "crt/crt_rules.inc"
+
 ;
 ;  Main Code Entrance Point
 ;
@@ -198,7 +203,7 @@ ENDIF
 
 start:
 	di
-	ld sp, ($FC4A)
+	INCLUDE	"crt/crt_init_sp.asm"
 	ei
 
 ; port fixing; required for ROMs
@@ -214,6 +219,7 @@ start:
 	or d
 	out ($A8),a
 
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         
 IF (HEAPSIZE > 4)

--- a/lib/mtx_crt0.asm
+++ b/lib/mtx_crt0.asm
@@ -40,8 +40,8 @@
             ENDIF
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/mtx_crt0.asm
+++ b/lib/mtx_crt0.asm
@@ -40,6 +40,9 @@
             ENDIF
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
@@ -48,9 +51,8 @@ start:
 
         ld      (start1+1),sp   ; Save entry stack
 
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 
 	call	crt0_init_bss
         ld      (exitsp),sp

--- a/lib/mz_crt0.asm
+++ b/lib/mz_crt0.asm
@@ -31,22 +31,21 @@
                 defc    CRT_ORG_CODE  = $1300
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
 start:
         ld      (start1+1),sp	;Save entry stack
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
         call    _main

--- a/lib/mz_crt0.asm
+++ b/lib/mz_crt0.asm
@@ -31,8 +31,8 @@
                 defc    CRT_ORG_CODE  = $1300
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/nascom_crt0.asm
+++ b/lib/nascom_crt0.asm
@@ -32,9 +32,12 @@
 	PUBLIC    montest         ;NASCOM: check the monitor type
 
 	IF      !DEFINED_CRT_ORG_CODE
-			defc    CRT_ORG_CODE  = 1000h
+		defc    CRT_ORG_CODE  = 1000h
 	ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = 0xe000
+        INCLUDE "crt/crt_rules.inc"
 	org     CRT_ORG_CODE
 
 ; NASSYS1..NASSYS3
@@ -46,9 +49,8 @@
 start:
 
 	ld	(start1+1),sp	;Save entry stack
-
-	ld	hl,0xe000
-	ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld      (exitsp),sp
 

--- a/lib/nascom_crt0.asm
+++ b/lib/nascom_crt0.asm
@@ -35,8 +35,8 @@
 		defc    CRT_ORG_CODE  = 1000h
 	ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = 0xe000
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 0xe000
         INCLUDE "crt/crt_rules.inc"
 	org     CRT_ORG_CODE
 

--- a/lib/nc100_crt0.asm
+++ b/lib/nc100_crt0.asm
@@ -32,31 +32,33 @@
 		PUBLIC    cleanup		;jp'd to by exit()
 		PUBLIC    l_dcal		;jp(hl)
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
 
 IF (startup=2)
-
-		defc    CRT_ORG_CODE  = $8C00
-		org     CRT_ORG_CODE
-		jp	start
+	defc    CRT_ORG_CODE  = $8C00
+	org     CRT_ORG_CODE
+	jp	start
 
 ELSE
 
-		defc    CRT_ORG_CODE  = $C000
-		org     CRT_ORG_CODE
-		jp	start
+	defc    CRT_ORG_CODE  = $C000
+	org     CRT_ORG_CODE
+	jp	start
 
 IF DEFINED_USING_amalloc
 ;EXTERN ASMTAIL
 PUBLIC _heap
 ; We have 509 bytes we can use here..
 _heap:
-		defw 0
-		defw 0
+	defw 0
+	defw 0
 _mblock:
-		defs	505		; Few bytes for malloc() stuff
+	defs	505		; Few bytes for malloc() stuff
 ELSE
-		defs	509		; Waste 509 bytes of space
+	defs	509		; Waste 509 bytes of space
 ENDIF
 
 ;--------
@@ -74,9 +76,8 @@ ENDIF
 start:
 		;Entry point at $c2220
         ld      (start1+1),sp   ;Save entry stack
-        ld      hl,-64		;Create the atexit stack
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/nc100_crt0.asm
+++ b/lib/nc100_crt0.asm
@@ -32,8 +32,8 @@
 		PUBLIC    cleanup		;jp'd to by exit()
 		PUBLIC    l_dcal		;jp(hl)
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 

--- a/lib/newbrain_crt0.asm
+++ b/lib/newbrain_crt0.asm
@@ -5,7 +5,7 @@
 ;       $Id: newbrain_crt0.asm,v 1.20 2016-07-15 21:03:25 dom Exp $
 ;
 
-                MODULE  newbrain_crt0
+	MODULE  newbrain_crt0
 ;--------
 ; Include zcc_opt.def to find out some info
 ;--------
@@ -30,27 +30,28 @@ IF (startup=2)
 ENDIF
 
 
-        IF      !DEFINED_CRT_ORG_CODE
-                defc    CRT_ORG_CODE  = 10000
-        ENDIF
-                org     CRT_ORG_CODE
+IF      !DEFINED_CRT_ORG_CODE
+	defc    CRT_ORG_CODE  = 10000
+ENDIF
+
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
+        org     CRT_ORG_CODE
 
 
 start:
         ld      (start1+1),sp   ;Save entry stack
-        ld      hl,-64		;Create the atexit stack
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
         
 IF (startup=2)
 	ld	hl,(57)
@@ -58,8 +59,6 @@ IF (startup=2)
 	ld	hl,nbckcount
 	ld	(57),hl
 ENDIF
-
-
 
         call    _main		;Call user program
 

--- a/lib/newbrain_crt0.asm
+++ b/lib/newbrain_crt0.asm
@@ -34,8 +34,8 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = 10000
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/osca_crt0.asm
+++ b/lib/osca_crt0.asm
@@ -7,7 +7,7 @@
 ;
 ;		At C source level:
 ;       #pragma output osca_bank=(0..14) set the memory bank for locations > 32768 before loading program
-;		#pragma output osca_stack=<value> put the stack in a differen place, i.e. 32767
+;		#pragma output REGISTER_SP=<value> put the stack in a differen place, i.e. 32767
 ;		#pragma output nostreams       - No stdio disc files
 ;		#pragma output noredir         - do not insert the file redirection option while parsing the
 ;		                                 command line arguments (useless if "nostreams" is set)
@@ -94,6 +94,10 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $5000
 ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = 65536 - 6
+        INCLUDE "crt/crt_rules.inc"
+
 
 IF ((CRT_ORG_CODE = $5000) | (!DEFINED_osca_bank))
        org	CRT_ORG_CODE
@@ -119,15 +123,9 @@ start:
 	ld	b,h
 	ld	c,l
 
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),hl
-IF (!DEFINED_osca_stack)
-        ld      sp,-64
-ELSE
-        ld      sp,osca_stack
-ENDIF
-        ;ld      sp,$7FFF
+        ld      (start1+1),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	push	bc		
 	call	crt0_init_bss
 	pop	bc

--- a/lib/osca_crt0.asm
+++ b/lib/osca_crt0.asm
@@ -94,8 +94,8 @@ IF      !DEFINED_CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $5000
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = 65536 - 6
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 65536 - 6
         INCLUDE "crt/crt_rules.inc"
 
 

--- a/lib/oz_crt0.asm
+++ b/lib/oz_crt0.asm
@@ -29,6 +29,11 @@
 		defc	NEED_ansiterminal = 1
 		INCLUDE "zcc_opt.def"
 
+
+	        defc    TAR__clib_exit_stack_size = 32
+        	defc    TAR__register_sp = -1
+        	INCLUDE "crt/crt_rules.inc"
+
 ;-------
 ; Some general scope declarations
 ;-------
@@ -197,9 +202,8 @@ ENDIF
 
 ;------- Z88DK specific code (begin) -------
 		ld      (start1+1),sp	;Save entry stack
-		ld      hl,-64
-		add     hl,sp
-		ld      sp,hl
+		INCLUDE	"crt/crt_init_sp.asm"
+		INCLUDE	"crt/crt_init_atexit.asm"
 		call	crt0_init_bss
 		ld      (exitsp),sp
 

--- a/lib/p2000_crt0.asm
+++ b/lib/p2000_crt0.asm
@@ -29,6 +29,9 @@
                 defc    CRT_ORG_CODE  = $6547
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
@@ -62,18 +65,14 @@ basic_end:
 
 start:
         ld      (start1+1),sp	;Save entry stack
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
         call    _main

--- a/lib/p2000_crt0.asm
+++ b/lib/p2000_crt0.asm
@@ -29,8 +29,8 @@
                 defc    CRT_ORG_CODE  = $6547
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/pc6001_crt0.asm
+++ b/lib/pc6001_crt0.asm
@@ -58,7 +58,7 @@ IF      !CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $c437  ; PC6001 - 16K
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
 	defc	DEF__register_sp = -1
 	INCLUDE	"crt/crt_rules.inc"
 

--- a/lib/pc6001_crt0.asm
+++ b/lib/pc6001_crt0.asm
@@ -39,13 +39,13 @@ ENDIF
 
 IF (startup=4)
 	defc    CRT_ORG_CODE  = $4000	 ; ROM
-IF !DEFINED_CRT_ORG_BSS
+  IF !DEFINED_CRT_ORG_BSS
 	defc CRT_ORG_BSS =  $c500   ; Static variables are kept in RAM
 	defc DEFINED_CRT_ORG_BSS = 1
-ENDIF
+    ENDIF
 	defc	__crt_org_bss = CRT_ORG_BSS
 	; In ROM mode we MUST setup the stack
-	defc	STACKPTR = $ffff
+	defc	TAR__register_sp = 0xffff
 	; If we were given a model then use it
 	IF DEFINED_CRT_MODEL
 		defc __crt_model = CRT_MODEL
@@ -58,11 +58,12 @@ IF      !CRT_ORG_CODE
 	defc    CRT_ORG_CODE  = $c437  ; PC6001 - 16K
 ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+	defc	DEF__register_sp = -1
+	INCLUDE	"crt/crt_rules.inc"
 
-; Now, getting to the real stuff now!
 
-
-		org     CRT_ORG_CODE
+	org     CRT_ORG_CODE
 
 IF (startup=4)
 	defb $41
@@ -93,31 +94,17 @@ start:
 
 		
         ld      (start1+1),sp   ;Save entry stack
-
-IF      STACKPTR
-        ld      sp,STACKPTR
-ENDIF
-;ELSE
-;        ld      sp,$FFFF
-;ENDIF
-        ;ld      hl,-64
-        ;add     hl,sp
-        ;ld		sp,hl
-        ;ld      sp,$F000
-	
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 
 ; Optional definition for auto MALLOC init
 ; it assumes we have free space between the end of 
 ; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
-
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 		
         call    _main
 cleanup:

--- a/lib/pps_crt0.asm
+++ b/lib/pps_crt0.asm
@@ -25,7 +25,9 @@
         PUBLIC    cleanup         ;jp'd to by exit()
         PUBLIC    l_dcal          ;jp(hl)
 
-
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
         org     $8100 - 512
 
@@ -44,9 +46,8 @@
 
 start:
         ld      (start1+1),sp	;Save entry stack
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/pps_crt0.asm
+++ b/lib/pps_crt0.asm
@@ -25,8 +25,8 @@
         PUBLIC    cleanup         ;jp'd to by exit()
         PUBLIC    l_dcal          ;jp(hl)
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     $8100 - 512

--- a/lib/rex_crt0.asm
+++ b/lib/rex_crt0.asm
@@ -35,6 +35,10 @@ ENDIF
 ; Main code starts here
 ;--------
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 65535
+        INCLUDE "crt/crt_rules.inc"
+
         org    $8000
 
 		
@@ -51,14 +55,8 @@ lib:
 	push	hl
 	jp	_LibMain
 start:
-; Make room for the atexit() stack
-	ld	hl,65535-64	;Initialise sp
-	ld	sp,hl
-	ld	hl,$f033	;Clear static memory
-	ld	de,$f034
-	ld	bc,$ffff-$f033
-	ld	(hl),0
-	ldir
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp	;Store atexit() stack
 ; Entry to the user code
@@ -78,16 +76,10 @@ farret:				;Used for farcall logic
 ELSE
 
 start:
-; Make room for the atexit() stack
-	ld	hl,65535-64	;Initialise sp
-	ld	sp,hl
-	ld	hl,$f033	;Clear static memory
-	ld	de,$f034
-	ld	bc,$ffff-$f033
-	ld	(hl),0
-	ldir
-        ld      (exitsp),sp	;Store atexit() stack
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
+        ld      (exitsp),sp	;Store atexit() stack
 ; Entry to the user code
         call    _main		;Call the users code
 cleanup:

--- a/lib/rex_crt0.asm
+++ b/lib/rex_crt0.asm
@@ -35,7 +35,7 @@ ENDIF
 ; Main code starts here
 ;--------
 
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
         defc    TAR__register_sp = 65535
         INCLUDE "crt/crt_rules.inc"
 

--- a/lib/sam_crt0.asm
+++ b/lib/sam_crt0.asm
@@ -30,15 +30,17 @@
         PUBLIC    cleanup
         PUBLIC    l_dcal
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
         org     32768
 
 
 start:
         ld      (start1+1),sp   ;Save entry stack
-        ld      hl,-64		;Create the atexit stack
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/sam_crt0.asm
+++ b/lib/sam_crt0.asm
@@ -30,8 +30,8 @@
         PUBLIC    cleanup
         PUBLIC    l_dcal
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     32768

--- a/lib/sc3000_crt0.asm
+++ b/lib/sc3000_crt0.asm
@@ -66,11 +66,16 @@
 
 IF (startup=2)
 	defc    CRT_ORG_CODE  = ROM_Start
+        defc    TAR__register_sp = Stack_Top
 ELSE
 	IF      !CRT_ORG_CODE
 		defc    CRT_ORG_CODE  = $9817
 	ENDIF
+        defc    TAR__register_sp = -1
 ENDIF
+
+        defc    TAR__clib_exit_stack_size = 32
+	INCLUDE	"crt/crt_rules.inc"
         org     CRT_ORG_CODE
 
 IF (startup=2)
@@ -161,8 +166,8 @@ filler3:
 
 start:
 ; Make room for the atexit() stack
-	ld	hl,Stack_Top-64
-	ld	sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 ; Clear static memory
 	ld	hl,RAM_Start
 	ld	de,RAM_Start+1
@@ -177,10 +182,9 @@ ELSE
 start:
         ld      hl,0
         add     hl,sp
-        ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        ld      (start1+1),sp
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 ENDIF
 
 ;  ******************** ********************

--- a/lib/sms_crt0.asm
+++ b/lib/sms_crt0.asm
@@ -54,6 +54,10 @@
 	PUBLIC	RG6SAV
 	PUBLIC	RG7SAV
 
+
+        defc    TAR__register_sp = Stack_Top
+        defc    TAR__clib_exit_stack_size = 32
+        INCLUDE "crt/crt_rules.inc"
 	org    ROM_Start
 
 	jp	start
@@ -146,8 +150,8 @@ filler3:
 
 start:
 ; Make room for the atexit() stack
-	ld	hl,Stack_Top-64
-	ld	sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 ; Clear static memory
 	ld	hl,RAM_Start
 	ld	de,RAM_Start+1

--- a/lib/sorcerer_crt0.asm
+++ b/lib/sorcerer_crt0.asm
@@ -38,6 +38,10 @@
                 defc    CRT_ORG_CODE  = 100h
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
         org     CRT_ORG_CODE
 
 ;----------------------
@@ -45,18 +49,14 @@
 ;----------------------
 start:
 	ld      (start1+1),sp	;Save entry stack
-	ld      hl,-64
-	add     hl,sp
-	ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld      (exitsp),sp
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
 

--- a/lib/sorcerer_crt0.asm
+++ b/lib/sorcerer_crt0.asm
@@ -38,8 +38,8 @@
                 defc    CRT_ORG_CODE  = 100h
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/sos_crt0.asm
+++ b/lib/sos_crt0.asm
@@ -37,6 +37,9 @@
                 defc    CRT_ORG_CODE  = $3000
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -0x1f6a	;;Upper limit of the user area
+        INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
@@ -51,12 +54,9 @@
 ;----------------------
 start:
 	ld      (start1+1),sp	;Save entry stack
-
-        ld      sp,($1f6a)	;Upper limit of the user area
-
-        ld      hl,-65
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
+	dec	sp	
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/sos_crt0.asm
+++ b/lib/sos_crt0.asm
@@ -37,8 +37,8 @@
                 defc    CRT_ORG_CODE  = $3000
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -0x1f6a	;;Upper limit of the user area
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -0x1f6a	;;Upper limit of the user area
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/spec_crt0.asm
+++ b/lib/spec_crt0.asm
@@ -58,7 +58,7 @@
 
 
 	defc	DEF__register_sp = -1
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/svi_crt0.asm
+++ b/lib/svi_crt0.asm
@@ -36,15 +36,15 @@ IFNDEF CRT_ORG_CODE
 		defc CRT_ORG_CODE  = 34816
 ENDIF
 
-org CRT_ORG_CODE
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+	org CRT_ORG_CODE
 
 start:
-        ld      hl,0
-        add     hl,sp
-        ld      (start1+1),hl
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+        ld      (start1+1),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/svi_crt0.asm
+++ b/lib/svi_crt0.asm
@@ -36,8 +36,8 @@ IFNDEF CRT_ORG_CODE
 		defc CRT_ORG_CODE  = 34816
 ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 	org CRT_ORG_CODE
 

--- a/lib/test_crt0.asm
+++ b/lib/test_crt0.asm
@@ -26,6 +26,10 @@
         PUBLIC    l_dcal          ;jp(hl)
 
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = 65280
+        INCLUDE "crt/crt_rules.inc"
+
 
 if (ASMPC<>$0000)
         defs    CODE_ALIGNMENT_ERROR
@@ -92,10 +96,8 @@ restart30:
 	ret
 
 program:
-	ld	sp,65280
-	ld	hl,-64
-	add	hl,sp
-	ld	sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call    crt0_init_bss
 	ld	(exitsp),sp
 IF !__CPU_R2K__

--- a/lib/test_crt0.asm
+++ b/lib/test_crt0.asm
@@ -26,8 +26,8 @@
         PUBLIC    l_dcal          ;jp(hl)
 
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = 65280
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 65280
         INCLUDE "crt/crt_rules.inc"
 
 

--- a/lib/ti82_crt0.asm
+++ b/lib/ti82_crt0.asm
@@ -29,8 +29,8 @@
 	INCLUDE "Ti82.def"	; ROM / RAM adresses on Ti82
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 
-        defc    DEF__clib_exit_stack_size = 3
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 3
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 	
 ;OS82Head:

--- a/lib/ti82_crt0.asm
+++ b/lib/ti82_crt0.asm
@@ -28,6 +28,10 @@
         defc    crt0 = 1
 	INCLUDE "Ti82.def"	; ROM / RAM adresses on Ti82
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
+
+        defc    DEF__clib_exit_stack_size = 3
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 	
 ;OS82Head:
 ;    defb     $FE,$82,$0F
@@ -57,29 +61,15 @@ ENDIF
 ; End of header, begin of startup part
 ;-------------------------------------
 start:
-	ld	hl,0
-	add	hl,sp
-	ld	(start1+1),hl
-IF !DEFINED_atexit		; Less stack use
-	ld	hl,-6		; 3 pointers (more likely value)
-	add	hl,sp
-	ld	sp,hl
+	ld	(start1+1),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
         call    crt0_init_bss
 	ld	(exitsp),sp
-ELSE
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp
-	ld	sp,hl
-        call    crt0_init_bss
-	ld	(exitsp),sp
-ENDIF
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
 	EXTERN	fputc_cons

--- a/lib/ti83_crt0.asm
+++ b/lib/ti83_crt0.asm
@@ -46,6 +46,10 @@
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 	LSTON			; List again
 
+        defc    DEF__clib_exit_stack_size = 3
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
 ;----------------------------------
 ; 2-Venus and 8-Venus Explorer (VE)
 ;----------------------------------
@@ -262,29 +266,15 @@ start:
 IF ZASMLOAD
 	call	_runindicoff	; stop anoing run-indicator
 ENDIF
-	ld	hl,0		; Store current StackPointer
-	add	hl,sp
-	ld	(start1+1),hl
-IF !DEFINED_atexit		; Less stack use
-	ld	hl,-6		; 3 pointers (more likely value)
-	add	hl,sp
-	ld	sp,hl
+	ld	(start1+1),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld	(exitsp),sp
-ELSE
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp
-	ld	sp,hl
-	call	crt0_init_bss
-	ld	(exitsp),sp
-ENDIF
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
 	EXTERN	fputc_cons

--- a/lib/ti83_crt0.asm
+++ b/lib/ti83_crt0.asm
@@ -46,8 +46,8 @@
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 	LSTON			; List again
 
-        defc    DEF__clib_exit_stack_size = 3
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 3
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 ;----------------------------------

--- a/lib/ti83p_crt0.asm
+++ b/lib/ti83p_crt0.asm
@@ -40,6 +40,10 @@
 	INCLUDE "Ti83p.def"	; ROM / RAM adresses on Ti83+[SE]
         defc    crt0 = 1
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
+
+        defc    DEF__clib_exit_stack_size = 3
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 	
 ;-----------------------------
 ;2 - MirageOS without quit key
@@ -152,29 +156,15 @@ IF DEFINED_GimmeSpeed
 	rst	28		; bcall(SetExSpeed)
 	defw	SetExSpeed	;
 ENDIF				;
-	ld	hl,0		;
-	add	hl,sp		;
-	ld	(start1+1),hl	;
-IF !DEFINED_atexit		; Less stack use
-	ld	hl,-6		; 3 pointers (more likely value)
-	add	hl,sp		;
-	ld	sp,hl		;
-	call	crt0_init_bss
-	ld	(exitsp),sp	;
-ELSE				;
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp		;
-	ld	sp,hl		;
-	call	crt0_init_bss
-	ld	(exitsp),sp	;
-ENDIF
+	ld	(start1+1),sp	;
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
+        call    crt0_init_bss
+        ld      (exitsp),sp
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
 	EXTERN	fputc_cons

--- a/lib/ti83p_crt0.asm
+++ b/lib/ti83p_crt0.asm
@@ -41,8 +41,8 @@
         defc    crt0 = 1
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 
-        defc    DEF__clib_exit_stack_size = 3
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 3
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 	
 ;-----------------------------

--- a/lib/ti85_crt0.asm
+++ b/lib/ti85_crt0.asm
@@ -31,8 +31,8 @@
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 	LSTON
 
-        defc    DEF__clib_exit_stack_size = 3
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 3
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 ;

--- a/lib/ti85_crt0.asm
+++ b/lib/ti85_crt0.asm
@@ -31,6 +31,10 @@
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 	LSTON
 
+        defc    DEF__clib_exit_stack_size = 3
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
 ;
 ;PROGRAMS:
 ;~~~~~~~~~
@@ -163,26 +167,13 @@ ENDIF
 ;-------------------------------------
 start:
 	ld	(start1+1),sp
-IF !DEFINED_atexit		; Less stack use
-	ld	hl,-6		; 3 pointers (more likely value)
-	add	hl,sp
-	ld	sp,hl
-	call	crt0_init_bss
-	ld	(exitsp),sp
-ELSE
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp
-	ld	sp,hl
-	call	crt0_init_bss
-	ld	(exitsp),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
+        call    crt0_init_bss
+        ld      (exitsp),sp
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
 ENDIF
-
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
 
 
 	EXTERN	fputc_cons

--- a/lib/ti86_crt0.asm
+++ b/lib/ti86_crt0.asm
@@ -40,6 +40,10 @@
         defc    crt0 = 1
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 
+        defc    DEF__clib_exit_stack_size = 3
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
 ;-----------------------------
 ;2 - ASE, Rascal, emanon, etc.
 ;-----------------------------
@@ -203,19 +207,10 @@ ENDIF
 	ld	hl,0
 	add	hl,sp
 	ld	(start1+1),hl
-IF !DEFINED_atexit		; Less stack use
-	ld	hl,-6		; 3 pointers (more likely value)
-	add	hl,sp
-	ld	sp,hl
-	call	crt0_init_bss
-	ld	(exitsp),sp
-ELSE
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp
-	ld	sp,hl
-	call	crt0_init_bss
-	ld	(exitsp),sp
-ENDIF
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
+        call    crt0_init_bss
+        ld      (exitsp),sp
 
 ; Optional definition for auto MALLOC init
 ; it assumes we have free space between the end of 

--- a/lib/ti86_crt0.asm
+++ b/lib/ti86_crt0.asm
@@ -40,8 +40,8 @@
         defc    crt0 = 1
 	INCLUDE	"zcc_opt.def"	; Receive all compiler-defines
 
-        defc    DEF__clib_exit_stack_size = 3
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 3
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 ;-----------------------------

--- a/lib/trs80_crt0.asm
+++ b/lib/trs80_crt0.asm
@@ -37,16 +37,16 @@ IF      !DEFINED_CRT_ORG_CODE
 	ENDIF
 ENDIF
 
+	defc	DEF__register_sp = -1
+        defc    DEF__clib_exit_stack_size = 32
+	INCLUDE	"crt/crt_rules.inc"
+
 	org     CRT_ORG_CODE
 
 start:
         ld      (start1+1),sp   ;Save entry stack
-IF      STACKPTR
-        ld      sp,STACKPTR
-ENDIF
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/trs80_crt0.asm
+++ b/lib/trs80_crt0.asm
@@ -37,8 +37,8 @@ IF      !DEFINED_CRT_ORG_CODE
 	ENDIF
 ENDIF
 
-	defc	DEF__register_sp = -1
-        defc    DEF__clib_exit_stack_size = 32
+	defc	TAR__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE

--- a/lib/ts2068_crt0.asm
+++ b/lib/ts2068_crt0.asm
@@ -52,7 +52,7 @@
         ENDIF
 
 	defc	DEF__register_sp = CRT_ORG_CODE - 1
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE "crt/crt_rules.inc"
         org     CRT_ORG_CODE
 

--- a/lib/vg5k_crt0.asm
+++ b/lib/vg5k_crt0.asm
@@ -32,6 +32,10 @@
                 defc    CRT_ORG_CODE  = 20480
         ENDIF   
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
         org     CRT_ORG_CODE
 
 
@@ -41,10 +45,9 @@ start:
 
 	ex		de,hl ; preserve HL
         ld      (start1+1),sp	;Save entry stack
-        ld      hl,-64
-        add     hl,sp
-        ld      sp,hl
-	call	crt0_init_bss
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
+        call    crt0_init_bss
         ld      (exitsp),sp
 		
 	push    de ; save HL

--- a/lib/vg5k_crt0.asm
+++ b/lib/vg5k_crt0.asm
@@ -32,8 +32,8 @@
                 defc    CRT_ORG_CODE  = 20480
         ENDIF   
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/vz_crt0.asm
+++ b/lib/vz_crt0.asm
@@ -43,8 +43,12 @@
 
 ; Now, getting to the real stuff now!
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
-		org     CRT_ORG_CODE-24
+
+	org     CRT_ORG_CODE-24
 
 IF (startup=3)
 ;  STARTUP=3 -> plain binary block
@@ -91,10 +95,9 @@ ENDIF
 ENDIF
 
 start:
-
-	ld	hl,-64		; 32 pointers (ANSI standard)
-	add	hl,sp
-	ld	sp,hl
+	ld	(start1+1),sp
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld	(exitsp),sp
 

--- a/lib/vz_crt0.asm
+++ b/lib/vz_crt0.asm
@@ -43,8 +43,8 @@
 
 ; Now, getting to the real stuff now!
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 

--- a/lib/x07_crt0.asm
+++ b/lib/x07_crt0.asm
@@ -32,6 +32,10 @@
                 defc    CRT_ORG_CODE  = $800
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
         org     CRT_ORG_CODE
 
 ;----------------------
@@ -41,19 +45,15 @@ start:
 	;di
 
 	ld      (start1+1),sp	;Save entry stack
-	ld      hl,-64
-	add     hl,sp
-	ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld      (exitsp),sp
 
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 	;ld a,65	; (Debugging:  print 'A' char)
 	;call $009F

--- a/lib/x07_crt0.asm
+++ b/lib/x07_crt0.asm
@@ -32,8 +32,8 @@
                 defc    CRT_ORG_CODE  = $800
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/x1_crt0.asm
+++ b/lib/x1_crt0.asm
@@ -34,13 +34,14 @@
         IF      !DEFINED_CRT_ORG_CODE
  	    IF (startup=2)
                 defc    CRT_ORG_CODE  = 32768
+        	defc    TAR__register_sp = 0xFDFF
             ELSE
                 defc    CRT_ORG_CODE  = 0
+        	defc    TAR__register_sp = 65535
             ENDIF
         ENDIF
 
         defc    TAR__clib_exit_stack_size = 32
-        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
@@ -57,8 +58,7 @@ IF (!DEFINED_startup | (startup=1))
 if (CRT_ORG_CODE > 0)
         defs    ZORG_NOT_ZERO
 endif
-
-        ld      sp,$FFFF
+	INCLUDE	"crt/crt_init_sp.asm"
 	im 1
 	ei
 ENDIF
@@ -70,7 +70,7 @@ if (CRT_ORG_CODE < 32768)
         defs    ZORG_TOO_LOW
 endif
 
-	ld      sp,$FDFF
+	INCLUDE	"crt/crt_init_sp.asm"
 
 	; re-activate IPL
 	ld bc,$1D00
@@ -112,7 +112,7 @@ ENDIF
 ;	EXTERN _x1_cls
 ;	call _x1_cls
 ;ENDIF
-
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 
 ; INIT math identify platform

--- a/lib/x1_crt0.asm
+++ b/lib/x1_crt0.asm
@@ -39,6 +39,9 @@
             ENDIF
         ENDIF
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 

--- a/lib/x1_crt0.asm
+++ b/lib/x1_crt0.asm
@@ -39,8 +39,8 @@
             ENDIF
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/z1013_crt0.asm
+++ b/lib/z1013_crt0.asm
@@ -34,7 +34,7 @@ IF      !DEFINED_CRT_ORG_CODE
 ENDIF
 
 	defc	TAR__register_sp = 0xdfff
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE

--- a/lib/z1013_crt0.asm
+++ b/lib/z1013_crt0.asm
@@ -29,35 +29,28 @@
 	PUBLIC    l_dcal          ;jp(hl)
 
 
-	IF      !DEFINED_CRT_ORG_CODE
-			defc    CRT_ORG_CODE  = 100h
-	ENDIF
+IF      !DEFINED_CRT_ORG_CODE
+	defc    CRT_ORG_CODE  = 100h
+ENDIF
+
+	defc	TAR__register_sp = 0xdfff
+        defc    DEF__clib_exit_stack_size = 32
+	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE
 
 start:
 	ld	(start1+1),sp	;Save entry stack
 
-IF      STACKPTR
-	ld  sp,STACKPTR
-ELSE
-	ld      sp,$dfff
-ENDIF
-
-;	ld      hl,-64
-;	add     hl,sp
-;	ld      sp,hl
-	
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld      (exitsp),sp
 
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 
 	call    _main	;Call user program
@@ -74,7 +67,7 @@ ENDIF
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value
-	jp $F000
+	jp	$F000
 
 l_dcal:	jp	(hl)		;Used for function pointer calls
 

--- a/lib/z88a_crt0.asm
+++ b/lib/z88a_crt0.asm
@@ -47,6 +47,11 @@
         IF      !DEFINED_CRT_ORG_CODE
                 defc    CRT_ORG_CODE  = 49152
         ENDIF
+
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
         org     CRT_ORG_CODE
 
 ;--------
@@ -130,9 +135,8 @@ init_continue:			;We had enough memory
         ld      hl,clrscr2
         call_oz(gn_sop)
 	
-        ld      hl,-64		;Setup atexit() stack
-        add     hl,sp
-        ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/z88a_crt0.asm
+++ b/lib/z88a_crt0.asm
@@ -48,8 +48,8 @@
                 defc    CRT_ORG_CODE  = 49152
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/z88b_crt0.asm
+++ b/lib/z88b_crt0.asm
@@ -22,8 +22,8 @@
         defc    z88_map_segment = 192
 
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -0x1ffe	; oz safe place
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -0x1ffe	; oz safe place
         INCLUDE "crt/crt_rules.inc"
 
 

--- a/lib/z88b_crt0.asm
+++ b/lib/z88b_crt0.asm
@@ -21,6 +21,12 @@
         defc    z88_map_bank = $4D3
         defc    z88_map_segment = 192
 
+
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -0x1ffe	; oz safe place
+        INCLUDE "crt/crt_rules.inc"
+
+
         org $2300
 
 ;-----------
@@ -42,11 +48,9 @@ bas_last:
 ;-----------
 start:
 	ld	(start1+1),sp	;Save starting stack
-        ld      sp,($1ffe)	;Pick up stack from OZ safe place
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
         call    crt0_init_bss
-        ld      hl,-64		;Make room for the atexit() table
-        add     hl,sp
-        ld      sp,hl
         ld      (exitsp),sp
 
 ; Optional definition for auto MALLOC init

--- a/lib/z88s_crt0.asm
+++ b/lib/z88s_crt0.asm
@@ -12,8 +12,8 @@
 
 	INCLUDE	"shellapi.def"
 
-        defc    DEF__clib_exit_stack_size = 32
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
 
 	org	shell_loadaddr-shell_headerlen

--- a/lib/z88s_crt0.asm
+++ b/lib/z88s_crt0.asm
@@ -12,6 +12,10 @@
 
 	INCLUDE	"shellapi.def"
 
+        defc    DEF__clib_exit_stack_size = 32
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
+
 	org	shell_loadaddr-shell_headerlen
 
 header_start:
@@ -38,9 +42,9 @@ start:
 	ld	de,(shell_cmdaddr)
 	add	hl,de
 	ld	(hl),0		; terminate command line
-	ld	hl,-100		; atexit stack (64) + argv space
-	add	hl,sp
-	ld      sp,hl
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
+	call	crt0_init_bss
 	ld      (exitsp),sp	
 
 ; Optional definition for auto MALLOC init

--- a/lib/z9001_crt0.asm
+++ b/lib/z9001_crt0.asm
@@ -34,7 +34,7 @@ IF      !DEFINED_CRT_ORG_CODE
 ENDIF
 
 	defc	TAR__register_sp = CRT_ORG_CODE - 2
-        defc    DEF__clib_exit_stack_size = 32
+        defc    TAR__clib_exit_stack_size = 32
 	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE

--- a/lib/z9001_crt0.asm
+++ b/lib/z9001_crt0.asm
@@ -29,35 +29,28 @@
 	PUBLIC    l_dcal          ;jp(hl)
 
 
-	IF      !DEFINED_CRT_ORG_CODE
-			defc    CRT_ORG_CODE  = 1000h
-	ENDIF
+IF      !DEFINED_CRT_ORG_CODE
+	defc    CRT_ORG_CODE  = 1000h
+ENDIF
+
+	defc	TAR__register_sp = CRT_ORG_CODE - 2
+        defc    DEF__clib_exit_stack_size = 32
+	INCLUDE	"crt/crt_rules.inc"
 
 	org     CRT_ORG_CODE
 
 start:
 	ld	(start1+1),sp	;Save entry stack
-	
-;	ld      hl,-64
-;	add     hl,sp
-;	ld      sp,hl
-IF      STACKPTR
-	ld  sp,STACKPTR
-ELSE
-	ld	sp,CRT_ORG_CODE-2
-ENDIF
-	
+
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
 	ld      (exitsp),sp
 
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "amalloc.def"
-	ENDIF
-
+IF DEFINED_USING_amalloc
+	INCLUDE "amalloc.def"
+ENDIF
 
 	call    _main	;Call user program
 

--- a/lib/zx80_crt0.asm
+++ b/lib/zx80_crt0.asm
@@ -49,7 +49,9 @@
                 defc    CRT_ORG_CODE  = 16525
         ENDIF
 
-
+        defc    DEF__clib_exit_stack_size = 0
+        defc    DEF__register_sp = -1
+        INCLUDE "crt/crt_rules.inc"
         org     CRT_ORG_CODE
 
 start:
@@ -70,10 +72,8 @@ start:
 	; for high-resolution graphics.
 	
         ld      (start1+1),sp   ;Save entry stack
-        ;ld      hl,-64          ;Create an atexit() stack
-        ld      hl,0            ;Create an atexit() stack
-        add     hl,sp
-        ld      sp,hl
+        INCLUDE "crt/crt_init_sp.asm"
+        INCLUDE "crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/lib/zx80_crt0.asm
+++ b/lib/zx80_crt0.asm
@@ -49,8 +49,8 @@
                 defc    CRT_ORG_CODE  = 16525
         ENDIF
 
-        defc    DEF__clib_exit_stack_size = 0
-        defc    DEF__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 0
+        defc    TAR__register_sp = -1
         INCLUDE "crt/crt_rules.inc"
         org     CRT_ORG_CODE
 

--- a/lib/zx81_crt0.asm
+++ b/lib/zx81_crt0.asm
@@ -78,8 +78,8 @@ ENDIF
 	    ENDIF
         ENDIF
 
-	defc	DEF__register_sp = -1
-        defc    DEF__clib_exit_stack_size = 4
+	defc	TAR__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 4
 	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE

--- a/lib/zx81_crt0.asm
+++ b/lib/zx81_crt0.asm
@@ -78,6 +78,9 @@ ENDIF
 	    ENDIF
         ENDIF
 
+	defc	DEF__register_sp = -1
+        defc    DEF__clib_exit_stack_size = 4
+	INCLUDE	"crt/crt_rules.inc"
 
         org     CRT_ORG_CODE
 
@@ -184,12 +187,9 @@ ENDIF
 	; for high-resolution graphics.
 	
         ld      (start1+1),sp   ;Save entry stack
-IF      STACKPTR
-        ld      sp,STACKPTR
-ENDIF
-	ld      hl,-8        ;Create an atexit() stack
-        add     hl,sp
-        ld      sp,hl
+
+	INCLUDE	"crt/crt_init_sp.asm"
+	INCLUDE	"crt/crt_init_atexit.asm"
 	call	crt0_init_bss
         ld      (exitsp),sp
 

--- a/libsrc/stdlib/atexit.asm
+++ b/libsrc/stdlib/atexit.asm
@@ -14,6 +14,7 @@
 SECTION code_clib
 PUBLIC atexit
 PUBLIC _atexit
+EXTERN __clib_exit_stack_size
 EXTERN exitsp, exitcount
 
 ; enter : hl = atexit function
@@ -27,7 +28,7 @@ EXTERN exitsp, exitcount
 
    ld hl,exitcount
    ld a,(hl)
-   cp 32                     ; can only hold 32 levels..
+   cp __clib_exit_stack_size  ; can only hold 32 levels..
    ret nc                    ; if full returns with hl!=0
    inc (hl)                  ; increment number of levels
 

--- a/src/zpragma/zpragma.c
+++ b/src/zpragma/zpragma.c
@@ -347,6 +347,10 @@ int main(int argc, char **argv)
                     *offs = 0;
                 }
                 write_defined(ptr,value,exp);
+
+                if ( strcmp(ptr, "STACKPTR")) {
+                    write_defined(ptr,"REGISTER_SP",exp);                    
+                }
             } else if ( strncmp(ptr, "redirect",8) == 0 ) {
                 char *offs;
                 char *value = "0";


### PR DESCRIPTION
Harmonises some of the common pragmas from newlib and adds them to classic.

Most ports can now have their initial sp and atexit stack size changed.