### PR TITLE
yaz180 - stack canary and reduce CA1 baggage

### DIFF
--- a/include/_DEVELOPMENT/clang/arch/yaz180.h
+++ b/include/_DEVELOPMENT/clang/arch/yaz180.h
@@ -19,12 +19,6 @@ extern uint16_t *bank_sp;       // bank SP storage, in Page0 TCB 0x003B
 
 extern uint8_t bios_ioByte;     // intel I/O byte
 
-// provide the location for important Page 0 bank addresses
-
-extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
-extern uint8_t bank_cmp_default_drive;  // CP/M default drive
-extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
-
 // provide the simple mutex locks for hardware resources
 
 extern uint8_t shadowLock;      //  mutex for alternate registers
@@ -44,6 +38,18 @@ extern uint8_t APULock;         //  mutex for APU
 // provide the simple mutex locks for the BANK (for system usage)
 
 extern uint8_t bankLockBase[];  // base address for 16 BANK locks
+
+// provide the location of the bios stack canary
+// this location holds 0xAA55 and if it does not
+// it means that the bios stack has collided with code
+
+extern uint16_t bios_stack_canary;      // two bytes of stack canary
+
+// provide the location for important CP/M Page 0 bank addresses
+
+extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
+extern uint8_t bank_cmp_default_drive;  // CP/M default drive
+extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
 
 // IO MAPPED REGISTERS
 
@@ -108,12 +114,9 @@ extern uint8_t bank_get_abs(int8_t bankRel);
 
 
 
-// provide memcpy_far and memset_far functions
+// provide memcpy_far function
 
 extern void *memcpy_far(void *str1,int8_t bank1,const void *str2,const int8_t bank2,size_t n);
-
-
-extern void *memset_far(void *str,int8_t bank,const int16_t c,size_t n);
 
 
 

--- a/include/_DEVELOPMENT/proto/arch/yaz180.h
+++ b/include/_DEVELOPMENT/proto/arch/yaz180.h
@@ -17,12 +17,6 @@ extern uint16_t *bank_sp;       // bank SP storage, in Page0 TCB 0x003B
 
 extern uint8_t bios_ioByte;     // intel I/O byte
 
-// provide the location for important Page 0 bank addresses
-
-extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
-extern uint8_t bank_cmp_default_drive;  // CP/M default drive
-extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
-
 // provide the simple mutex locks for hardware resources
 
 extern uint8_t shadowLock;      //  mutex for alternate registers
@@ -42,6 +36,18 @@ extern uint8_t APULock;         //  mutex for APU
 // provide the simple mutex locks for the BANK (for system usage)
 
 extern uint8_t bankLockBase[];  // base address for 16 BANK locks
+
+// provide the location of the bios stack canary
+// this location holds 0xAA55 and if it does not
+// it means that the bios stack has collided with code
+
+extern uint16_t bios_stack_canary;      // two bytes of stack canary
+
+// provide the location for important CP/M Page 0 bank addresses
+
+extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
+extern uint8_t bank_cmp_default_drive;  // CP/M default drive
+extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
 
 // IO MAPPED REGISTERS
 
@@ -96,10 +102,9 @@ __DPROTO(`b,c,d,e,iyh,iyl',`b,c,d,e,iyh,iyl',void,,lock_give,uint8_t * mutex)
 __DPROTO(`b,c,d,e,h,iyh,iyl',`b,c,d,e,h,iyh,iyl',int8_t,,bank_get_rel,uint8_t bankAbs)
 __DPROTO(`b,c,d,e,h,iyh,iyl',`b,c,d,e,h,iyh,iyl',uint8_t,,bank_get_abs,int8_t bankRel)
 
-// provide memcpy_far and memset_far functions
+// provide memcpy_far function
 
 __OPROTO(`iyh,iyl',`iyh,iyl',void,*,memcpy_far,void *str1, int8_t bank1, const void *str2, const int8_t bank2, size_t n)
-__OPROTO(`b,c,iyh,iyl',`b,c,iyh,iyl',void,*,memset_far,void *str, int8_t bank, const int16_t c, size_t n)
 
 // provide load_hex function
 

--- a/include/_DEVELOPMENT/sccz80/arch/yaz180.h
+++ b/include/_DEVELOPMENT/sccz80/arch/yaz180.h
@@ -19,12 +19,6 @@ extern uint16_t *bank_sp;       // bank SP storage, in Page0 TCB 0x003B
 
 extern uint8_t bios_ioByte;     // intel I/O byte
 
-// provide the location for important Page 0 bank addresses
-
-extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
-extern uint8_t bank_cmp_default_drive;  // CP/M default drive
-extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
-
 // provide the simple mutex locks for hardware resources
 
 extern uint8_t shadowLock;      //  mutex for alternate registers
@@ -44,6 +38,18 @@ extern uint8_t APULock;         //  mutex for APU
 // provide the simple mutex locks for the BANK (for system usage)
 
 extern uint8_t bankLockBase[];  // base address for 16 BANK locks
+
+// provide the location of the bios stack canary
+// this location holds 0xAA55 and if it does not
+// it means that the bios stack has collided with code
+
+extern uint16_t bios_stack_canary;      // two bytes of stack canary
+
+// provide the location for important CP/M Page 0 bank addresses
+
+extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
+extern uint8_t bank_cmp_default_drive;  // CP/M default drive
+extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
 
 // IO MAPPED REGISTERS
 
@@ -108,12 +114,9 @@ extern uint8_t __LIB__ bank_get_abs(int8_t bankRel) __smallc __z88dk_fastcall;
 
 
 
-// provide memcpy_far and memset_far functions
+// provide memcpy_far function
 
 extern void __LIB__ *memcpy_far(void *str1,int8_t bank1,const void *str2,const int8_t bank2,size_t n) __smallc;
-
-
-extern void __LIB__ *memset_far(void *str,int8_t bank,const int16_t c,size_t n) __smallc;
 
 
 

--- a/include/_DEVELOPMENT/sdcc/arch/yaz180.h
+++ b/include/_DEVELOPMENT/sdcc/arch/yaz180.h
@@ -19,12 +19,6 @@ extern uint16_t *bank_sp;       // bank SP storage, in Page0 TCB 0x003B
 
 extern uint8_t bios_ioByte;     // intel I/O byte
 
-// provide the location for important Page 0 bank addresses
-
-extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
-extern uint8_t bank_cmp_default_drive;  // CP/M default drive
-extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
-
 // provide the simple mutex locks for hardware resources
 
 extern uint8_t shadowLock;      //  mutex for alternate registers
@@ -44,6 +38,18 @@ extern uint8_t APULock;         //  mutex for APU
 // provide the simple mutex locks for the BANK (for system usage)
 
 extern uint8_t bankLockBase[];  // base address for 16 BANK locks
+
+// provide the location of the bios stack canary
+// this location holds 0xAA55 and if it does not
+// it means that the bios stack has collided with code
+
+extern uint16_t bios_stack_canary;      // two bytes of stack canary
+
+// provide the location for important CP/M Page 0 bank addresses
+
+extern uint8_t bank_cpm_iobyte;         // CP/M IOBYTE
+extern uint8_t bank_cmp_default_drive;  // CP/M default drive
+extern uint16_t *bank_cpm_bdos_addr;    // CPM/ BDOS entry address
 
 // IO MAPPED REGISTERS
 
@@ -118,11 +124,9 @@ extern uint8_t bank_get_abs_fastcall(int8_t bankRel) __preserves_regs(b,c,d,e,h,
 
 
 
-// provide memcpy_far and memset_far functions
+// provide memcpy_far function
 
 extern void *memcpy_far(void *str1,int8_t bank1,const void *str2,const int8_t bank2,size_t n) __preserves_regs(iyh,iyl);
-
-extern void *memset_far(void *str,int8_t bank,const int16_t c,size_t n) __preserves_regs(b,c,iyh,iyl);
 
 
 // provide load_hex function

--- a/libsrc/_DEVELOPMENT/target/yaz180/crt_yabios_def.inc
+++ b/libsrc/_DEVELOPMENT/target/yaz180/crt_yabios_def.inc
@@ -63,132 +63,126 @@ DEFC _exit_far                       = $F74B
 PUBLIC _memcpy_far
 DEFC _memcpy_far                     = $F78D
 
-PUBLIC _memset_far
-DEFC _memset_far                     = $F825
-
 PUBLIC _load_hex_fastcall
-DEFC _load_hex_fastcall              = $F874
+DEFC _load_hex_fastcall              = $F829
 
 PUBLIC _bank_get_rel
-DEFC _bank_get_rel                   = $F925
+DEFC _bank_get_rel                   = $F8DA
 
 PUBLIC _bank_get_rel_fastcall
-DEFC _bank_get_rel_fastcall          = $F929
+DEFC _bank_get_rel_fastcall          = $F8DE
 
 PUBLIC _bank_get_abs
-DEFC _bank_get_abs                   = $F937
+DEFC _bank_get_abs                   = $F8EC
 
 PUBLIC _bank_get_abs_fastcall
-DEFC _bank_get_abs_fastcall          = $F93B
+DEFC _bank_get_abs_fastcall          = $F8F0
 
 PUBLIC _lock_get
-DEFC _lock_get                       = $F949
+DEFC _lock_get                       = $F8FE
 
 PUBLIC _lock_get_fastcall
-DEFC _lock_get_fastcall              = $F94D
+DEFC _lock_get_fastcall              = $F902
 
 PUBLIC _lock_try
-DEFC _lock_try                       = $F952
+DEFC _lock_try                       = $F907
 
 PUBLIC _lock_try_fastcall
-DEFC _lock_try_fastcall              = $F956
+DEFC _lock_try_fastcall              = $F90B
 
 PUBLIC _lock_give
-DEFC _lock_give                      = $F95E
+DEFC _lock_give                      = $F913
 
 PUBLIC _lock_give_fastcall
-DEFC _lock_give_fastcall             = $F962
+DEFC _lock_give_fastcall             = $F917
+
+PUBLIC _bios_stack_canary
+DEFC _bios_stack_canary              = $FEDC
 
 PUBLIC _apu_init
-DEFC _apu_init                       = $F989
+DEFC _apu_init                       = $F949
 
 PUBLIC _apu_reset
-DEFC _apu_reset                      = $FA31
+DEFC _apu_reset                      = $F9F1
 
 PUBLIC _apu_chk_idle_fastcall
-DEFC _apu_chk_idle_fastcall          = $FA97
+DEFC _apu_chk_idle_fastcall          = $FA57
 
 PUBLIC _apu_cmd_ld_callee
-DEFC _apu_cmd_ld_callee              = $FAAE
+DEFC _apu_cmd_ld_callee              = $FA6E
 
 PUBLIC _apu_op_rem_callee
-DEFC _apu_op_rem_callee              = $FAF1
+DEFC _apu_op_rem_callee              = $FAB1
 
 PUBLIC _asci0_init
-DEFC _asci0_init                     = $FB7B
+DEFC _asci0_init                     = $FB3B
 
 PUBLIC _asci0_flush_Rx_di
-DEFC _asci0_flush_Rx_di              = $FB94
+DEFC _asci0_flush_Rx_di              = $FB54
 
 PUBLIC _asci0_flush_Tx_di
-DEFC _asci0_flush_Tx_di              = $FBAC
+DEFC _asci0_flush_Tx_di              = $FB6C
 
 PUBLIC _asci0_reset
-DEFC _asci0_reset                    = $FBC4
+DEFC _asci0_reset                    = $FB84
 
 PUBLIC _asci0_getc
-DEFC _asci0_getc                     = $FBCE
+DEFC _asci0_getc                     = $FB8E
 
 PUBLIC _asci0_peekc
-DEFC _asci0_peekc                    = $FBE4
+DEFC _asci0_peekc                    = $FBA4
 
 PUBLIC _asci0_pollc
-DEFC _asci0_pollc                    = $FBF2
+DEFC _asci0_pollc                    = $FBB2
 
 PUBLIC _asci0_putc
-DEFC _asci0_putc                     = $FBFA
+DEFC _asci0_putc                     = $FBBA
 
 PUBLIC _asci1_init
-DEFC _asci1_init                     = $FC96
+DEFC _asci1_init                     = $FC56
 
 PUBLIC _asci1_flush_Rx_di
-DEFC _asci1_flush_Rx_di              = $FCAF
+DEFC _asci1_flush_Rx_di              = $FC6F
 
 PUBLIC _asci1_flush_Tx_di
-DEFC _asci1_flush_Tx_di              = $FCC7
+DEFC _asci1_flush_Tx_di              = $FC87
 
 PUBLIC _asci1_reset
-DEFC _asci1_reset                    = $FCDF
+DEFC _asci1_reset                    = $FC9F
 
 PUBLIC _asci1_getc
-DEFC _asci1_getc                     = $FCE9
+DEFC _asci1_getc                     = $FCA9
 
 PUBLIC _asci1_peekc
-DEFC _asci1_peekc                    = $FCFF
+DEFC _asci1_peekc                    = $FCBF
 
 PUBLIC _asci1_pollc
-DEFC _asci1_pollc                    = $FD0D
+DEFC _asci1_pollc                    = $FCCD
 
 PUBLIC _asci1_putc
-DEFC _asci1_putc                     = $FD15
+DEFC _asci1_putc                     = $FCD5
 
 PUBLIC ide_read_sector
-DEFC ide_read_sector                 = $FE61
+DEFC ide_read_sector                 = $FE21
 
 PUBLIC ide_write_sector
-DEFC ide_write_sector                = $FE91
-
-PUBLIC rhexwd
-DEFC rhexwd                          = $FEBE
+DEFC ide_write_sector                = $FE51
 
 PUBLIC rhex
-DEFC rhex                            = $FECD
+DEFC rhex                            = $FEB8
 
 PUBLIC phexwd
-DEFC phexwd                          = $FF05
+DEFC phexwd                          = $FE91
 
 PUBLIC phex
-DEFC phex                            = $FF19
-
-PUBLIC phexwdreg
-DEFC phexwdreg                       = $FF0F
+DEFC phex                            = $FE9B
 
 PUBLIC pstring
-DEFC pstring                         = $FEF1
+DEFC pstring                         = $FE7E
 
 PUBLIC pnewline
-DEFC pnewline                        = $FEFB
+DEFC pnewline                        = $FE88
 
 PUBLIC _common1_phase_end
-DEFC _common1_phase_end              = $FF36
+DEFC _common1_phase_end              = $FEDE
 

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/yabios/asm_common1_data.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/yabios/asm_common1_data.asm
@@ -139,9 +139,9 @@ _ideLock:       defb    $FE             ; mutex for IDE drive
 
 PUBLIC initString, invalidTypeStr, badCheckSumStr, LoadOKStr
 
-initString:     defm    CHAR_CR,CHAR_LF,"LoadHex::",0
-invalidTypeStr: defm    CHAR_CR,CHAR_LF,"Invalid Type",CHAR_CR,CHAR_LF,0
-badCheckSumStr: defm    CHAR_CR,CHAR_LF,"Checksum Error",CHAR_CR,CHAR_LF,0
-LoadOKStr:      defm    CHAR_CR,CHAR_LF,"Done",CHAR_CR,CHAR_LF,0
+initString:     defm    CHAR_CR,CHAR_LF,"::",0
+invalidTypeStr: defm    CHAR_CR,CHAR_LF,"Type!",CHAR_CR,CHAR_LF,0
+badCheckSumStr: defm    CHAR_CR,CHAR_LF,"Checksum!",CHAR_CR,CHAR_LF,0
+LoadOKStr:      defm    CHAR_CR,CHAR_LF,"Done!",CHAR_CR,CHAR_LF,0
 
 DEPHASE


### PR DESCRIPTION
Implemented a simple bios_stack canary, only to find it died continually.

Therefore, removed baggage the `memset_far` function from CA1.
We can do without it.
And further slimmed debugging functions to minimum.

That creates 256 bytes of bios_stack, which keeps the canary alive.