### PR TITLE
Bugfix/issue 653 division opts

### DIFF
--- a/lib/z80_crt0.hdr
+++ b/lib/z80_crt0.hdr
@@ -73,7 +73,9 @@
 	EXTERN    l_cmp		;Int signed compare
 	EXTERN    l_ucmp		;Int unsigned compare
 	EXTERN    l_asr		;Int signed >>
+	EXTERN    l_asr_hl_by_e		;Int signed >>
 	EXTERN    l_asr_u		;Int unsigned >>
+	EXTERN    l_asr_u_hl_by_e		;Int unsigned >>
 	EXTERN    l_asl		;Int <<
 	EXTERN    l_sub		;Int subtract
 	EXTERN    l_neg		;Int negate

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -2915,12 +2915,3 @@
 	pop	hl
 	push	hl
 	ld	h,0
-
-	ld	de,0	;const
-	call	l_eq
-=
-	ld	a,h
-	or	l
-	ld	hl,0
-	jr	nz,ASMPC+3
-	inc	hl

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -2915,3 +2915,12 @@
 	pop	hl
 	push	hl
 	ld	h,0
+
+	ld	de,0	;const
+	call	l_eq
+=
+	ld	a,h
+	or	l
+	ld	hl,0
+	jr	nz,ASMPC+3
+	inc	hl

--- a/libsrc/_DEVELOPMENT/l/sccz80/crt0/l_asr.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/crt0/l_asr.asm
@@ -10,12 +10,14 @@ SECTION code_clib
 SECTION code_l_sccz80
 
 PUBLIC l_asr
+PUBLIC l_asr_hl_by_e
 
 EXTERN l_asr_hl
 
 l_asr:
 
-   ld a,l
    ex de,hl
+l_asr_hl_by_e:
+   ld a,e
    
    jp l_asr_hl

--- a/libsrc/_DEVELOPMENT/l/sccz80/crt0/l_asr_u.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/crt0/l_asr_u.asm
@@ -10,12 +10,14 @@ SECTION code_clib
 SECTION code_l_sccz80
 
 PUBLIC l_asr_u
+PUBLIC l_asr_u_hl_by_e
 
 EXTERN l_lsr_hl
 
 l_asr_u:
 
-   ld a,l
    ex de,hl
+l_asr_u_hl_by_e:
+   ld a,e
    
    jp l_lsr_hl

--- a/libsrc/z80_crt0s/crt0/l_asr.asm
+++ b/libsrc/z80_crt0s/crt0/l_asr.asm
@@ -9,9 +9,11 @@
 
                 SECTION   code_crt0_sccz80
                 PUBLIC    l_asr
+		PUBLIC	  l_asr_hl_by_e
 
 .l_asr
         ex      de,hl
+.l_asr_hl_by_e
 .l_asr1
         dec     e
         ret     m

--- a/libsrc/z80_crt0s/crt0/l_asr_u.asm
+++ b/libsrc/z80_crt0s/crt0/l_asr_u.asm
@@ -8,9 +8,11 @@
 
                 SECTION   code_crt0_sccz80
                 PUBLIC    l_asr_u
+		PUBLIC    l_asr_u_hl_by_e
 
 .l_asr_u
         ex      de,hl
+.l_asr_u_hl_by_e
 .l_asr_u_1
         dec     e
         ret     m

--- a/test/suites/sccz80/division.c
+++ b/test/suites/sccz80/division.c
@@ -7,16 +7,68 @@ void test_ulong_division()
 {
      uint32_t val = 0x80000000;
      uint32_t res;
-     Assert( val / 512         == 0x400000, "val / 512");
+     Assert( val / 2           == 0x40000000, "val / 2");
+     Assert( val / 4           == 0x20000000, "val / 4");
+     Assert( val / 8           == 0x10000000, "val / 8");
+     Assert( val / 16          == 0x08000000, "val / 16");
+     Assert( val / 32          == 0x04000000, "val / 32");
+     Assert( val / 64          == 0x02000000, "val / 64");
+     Assert( val / 128         == 0x01000000, "val / 128");
+     Assert( val / 256         == 0x00800000, "val / 256");
+     Assert( val / 512         == 0x00400000, "val / 512");
      Assert( 0x80000000UL/ 512 == 0x400000, "0x80000000/ 512");
 }
 
 void test_long_division()
 {
      int32_t val = -1;
+     Assert( val / 2           == 0, "val / 2");
+     Assert( val / 4           == 0, "val / 4");
+     Assert( val / 8           == 0, "val / 8");
+     Assert( val / 16          == 0, "val / 16");
+     Assert( val / 32          == 0, "val / 32");
+     Assert( val / 64          == 0, "val / 64");
+     Assert( val / 128         == 0, "val / 128");
+     Assert( val / 256         == 0, "val / 256");
      Assert( val / 512         == 0, "val / 512");
      Assert( 0x80000000/ 512 == 0xffc00000, "0x80000000/ 512");
 }
+
+void test_long_mod()
+{
+     int32_t val = -1;
+     Assert( val % 2           == 1, "val % 2");
+     Assert( val % 4           == 1, "val % 4");
+}
+
+void test_signed_division()
+{
+    int16_t val = -1;
+
+    Assert( val / 2  == 0, "-1 / 2");
+    Assert( val / 4  == 0, "-1 / 4");
+    Assert( val / 8  == 0, "-1 / 8");
+    Assert( val / 16  == 0, "-1 / 16");
+    Assert( val / 32  == 0, "-1 / 32");
+    Assert( val / 64  == 0, "-1 / 64");
+    Assert( val / 128  == 0, "-1 / 128");
+    Assert( val / 256  == 0, "-1 / 256");
+}
+
+void test_signed_mod()
+{
+    int16_t val = -1;
+
+    Assert( val % 2  == 1, "-1 % 2");
+    Assert( val % 4  == 1, "-1 % 4");
+    Assert( val % 8  == 1, "-1 % 8");
+    Assert( val % 16  == 1, "-1 % 16");
+    Assert( val % 32  == 1, "-1 % 32");
+    Assert( val % 64  == 1, "-1 % 64");
+    Assert( val % 128  == 1, "-1 % 128");
+    Assert( val % 256  == 1, "-1 % 256");
+}
+
 
 int suite_mult()
 {
@@ -24,6 +76,9 @@ int suite_mult()
 
     suite_add_test(test_ulong_division);
     suite_add_test(test_long_division);
+    suite_add_test(test_long_mod);
+    suite_add_test(test_signed_division);
+    suite_add_test(test_signed_mod);
 
     return suite_run();
 }

--- a/testsuite/results/Issue_452_pointers.opt
+++ b/testsuite/results/Issue_452_pointers.opt
@@ -80,9 +80,10 @@
 	ex	de,hl
 	and	a
 	sbc	hl,de
-	ld	de,2
-	ex	de,hl
-	call	l_asr_u
+	srl	h
+	rr	l
+	srl	h
+	rr	l
 	pop	bc
 	pop	bc
 	ret

--- a/testsuite/results/Issue_490_ptr_arithmetic.opt
+++ b/testsuite/results/Issue_490_ptr_arithmetic.opt
@@ -72,9 +72,10 @@
 	ex	de,hl
 	and	a
 	sbc	hl,de
-	ld	de,2
-	ex	de,hl
-	call	l_asr_u
+	srl	h
+	rr	l
+	srl	h
+	rr	l
 	exx
 	ld	hl,22	;const
 	add	hl,sp

--- a/testsuite/results/Issue_98_check_int.opt
+++ b/testsuite/results/Issue_98_check_int.opt
@@ -67,6 +67,10 @@
 	pop	hl
 	push	hl
 	push	bc
+	bit	7,h
+	jr	z,i_2
+	inc	hl
+.i_2
 	sra	h
 	rr	l
 	ret

--- a/testsuite/results/Issue_98_underlying.opt
+++ b/testsuite/results/Issue_98_underlying.opt
@@ -86,6 +86,10 @@
 	ld	hl,2	;const
 	add	hl,sp
 	call	l_glong
+	bit	7,d
+	jr	z,i_2
+	call	l_inclong
+.i_2
 	sra	d
 	rr	e
 	rr	h


### PR DESCRIPTION
Signed division optimisations for negative numbers ended up with the wrong result.

Likewise modulus.