### PR TITLE
 Create a Dockerfile for z88dk

### DIFF
--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:latest
+# To create the image:
+#  macOS / GNU/Linux:
+#   $ docker build --squash -t z88dk - < z88dk.Dockerfile
+#  Windows 10 PowerShell:
+#   PS> cmd /c 'docker build --squash -t z88dk - < z88dk.Dockerfile'
+# To run the container (works for macOS, GNU/Linux & Windows PowerShell):
+#  docker run -v ${PWD}:/src/ -it z88dk <command>
 
-LABEL Maintainer="Garrafon Software (@garrafonsoft)"
-LABEL Version="0.4"
-LABEL Date="2018-Apr-03"
-LABEL Description="A basic Docker container to compile and use z88dk from GIT"
-LABEL Creation_Command="docker build -t z88dk - < z88dk.Dockerfile"
-LABEL Execution_Command="docker run -v ${PWD}:/src/ -it z88dk <command>"
+FROM alpine:latest
 
-RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex libboost-dev texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
+LABEL Version="0.5" Date="2018-Apr-05" Maintainer="Garrafon Software (@garrafonsoft)" Description="A basic Docker container to compile and use z88dk from GIT"
 
-RUN cd /opt && git clone --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
+RUN apk add --no-cache build-base m4 bison flex libxml2 boost && apk add --no-cache -t .build_deps libxml2-dev git subversion boost-dev texinfo && mkdir /opt
 
-RUN cd /opt && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port --disable-ucsim --disable-device-lib --disable-packihx && make && cd bin && mv sdcc /opt/z88dk/bin/zsdcc && cp sdcpp /opt/z88dk/bin/zsdcpp
+RUN cd /opt && git clone --depth 1 --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
 
-# Uncomment the following line to have an unpatched SDCC r9958 installed:
-# RUN cd /opt/sdcc && patch -Rp0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch && make && make install
+RUN cd /opt && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port --disable-ucsim --disable-device-lib --disable-packihx && make && cd bin && mv sdcc /opt/z88dk/bin/zsdcc && mv sdcpp /opt/z88dk/bin/zsdcpp && cd / && rm -fR /opt/sdcc && apk del .build_deps
 
 ENV PATH="/opt/z88dk/bin:${PATH}"
 ENV ZCCCFG="/opt/z88dk/lib/config/"

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:latest
+
+LABEL Maintainer="Garrafon Software (@garrafonsoft)"
+LABEL Version="0.1"
+LABEL Date="2018-Apr-01"
+LABEL Description="A basic Docker container to compile and use z88dk from GIT"
+LABEL Creation_Command="docker build -t z88dk - < z88dk.Dockerfile"
+LABEL Execution_Command="docker run -v '$PWD:/src/' -it z88dk <command>"
+
+RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex python libboost-dev gputils texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN cd / && git clone --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
+
+RUN cd / && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-ds390-port --disable-ds400-port && make && cd bin && mv sdcc /z88dk/bin/zsdcc && cp sdcpp /z88dk/bin/zsdcpp
+
+ENV PATH="/z88dk/bin:${PATH}"
+ENV ZCCCFG="/z88dk/lib/config/"
+
+WORKDIR /src/

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -1,17 +1,17 @@
 FROM ubuntu:latest
 
 LABEL Maintainer="Garrafon Software (@garrafonsoft)"
-LABEL Version="0.1"
-LABEL Date="2018-Apr-01"
+LABEL Version="0.2"
+LABEL Date="2018-Apr-02"
 LABEL Description="A basic Docker container to compile and use z88dk from GIT"
 LABEL Creation_Command="docker build -t z88dk - < z88dk.Dockerfile"
 LABEL Execution_Command="docker run -v $PWD:/src/ -it z88dk <command>"
 
-RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex python libboost-dev gputils texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex libboost-dev texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN cd / && git clone --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
 
-RUN cd / && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-ds390-port --disable-ds400-port && make && cd bin && mv sdcc /z88dk/bin/zsdcc && cp sdcpp /z88dk/bin/zsdcpp
+RUN cd / && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port --disable-ucsim --disable-device-lib --disable-packihx && make && cd bin && mv sdcc /z88dk/bin/zsdcc && cp sdcpp /z88dk/bin/zsdcpp
 
 ENV PATH="/z88dk/bin:${PATH}"
 ENV ZCCCFG="/z88dk/lib/config/"

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:latest
 
 LABEL Maintainer="Garrafon Software (@garrafonsoft)"
-LABEL Version="0.3"
-LABEL Date="2018-Apr-02"
+LABEL Version="0.4"
+LABEL Date="2018-Apr-03"
 LABEL Description="A basic Docker container to compile and use z88dk from GIT"
 LABEL Creation_Command="docker build -t z88dk - < z88dk.Dockerfile"
-LABEL Execution_Command="docker run -v $PWD:/src/ -it z88dk <command>"
+LABEL Execution_Command="docker run -v ${PWD}:/src/ -it z88dk <command>"
 
 RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex libboost-dev texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
 LABEL Maintainer="Garrafon Software (@garrafonsoft)"
-LABEL Version="0.2"
+LABEL Version="0.3"
 LABEL Date="2018-Apr-02"
 LABEL Description="A basic Docker container to compile and use z88dk from GIT"
 LABEL Creation_Command="docker build -t z88dk - < z88dk.Dockerfile"
@@ -9,11 +9,14 @@ LABEL Execution_Command="docker run -v $PWD:/src/ -it z88dk <command>"
 
 RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex libboost-dev texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN cd / && git clone --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
+RUN cd /opt && git clone --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
 
-RUN cd / && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port --disable-ucsim --disable-device-lib --disable-packihx && make && cd bin && mv sdcc /z88dk/bin/zsdcc && cp sdcpp /z88dk/bin/zsdcpp
+RUN cd /opt && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port --disable-ucsim --disable-device-lib --disable-packihx && make && cd bin && mv sdcc /opt/z88dk/bin/zsdcc && cp sdcpp /opt/z88dk/bin/zsdcpp
 
-ENV PATH="/z88dk/bin:${PATH}"
-ENV ZCCCFG="/z88dk/lib/config/"
+# Uncomment the following line to have an unpatched SDCC r9958 installed:
+# RUN cd /opt/sdcc && patch -Rp0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch && make && make install
+
+ENV PATH="/opt/z88dk/bin:${PATH}"
+ENV ZCCCFG="/opt/z88dk/lib/config/"
 
 WORKDIR /src/

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -8,15 +8,36 @@
 
 FROM alpine:latest
 
-LABEL Version="0.5" Date="2018-Apr-05" Maintainer="Garrafon Software (@garrafonsoft)" Description="A basic Docker container to compile and use z88dk from GIT"
+LABEL Version="0.6" \
+      Date="2018-Apr-05" \
+      Maintainer="Garrafon Software (@garrafonsoft)" \
+      Description="A basic Docker container to compile and use z88dk from GIT"
 
-RUN apk add --no-cache build-base m4 bison flex libxml2 boost && apk add --no-cache -t .build_deps libxml2-dev git subversion boost-dev texinfo && mkdir /opt
+RUN apk add --no-cache build-base m4 bison flex libxml2 boost \ 
+    && apk add --no-cache -t .build_deps libxml2-dev git subversion boost-dev texinfo \
+    && mkdir /opt \
+    && cd /opt \
+    && git clone --depth 1 --recursive https://github.com/z88dk/z88dk.git \
+    && cd z88dk \
+    && chmod 777 build.sh \
+    && ./build.sh \
+    && cd /opt \
+    && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc \
+    && cd sdcc \
+    && patch -p0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch \
+    && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port \
+                   --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port \
+                   --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port \
+                   --disable-ucsim --disable-device-lib --disable-packihx \
+    && make \
+    && cd bin \
+    && mv sdcc /opt/z88dk/bin/zsdcc \
+    && mv sdcpp /opt/z88dk/bin/zsdcpp \
+    && cd / \
+    && rm -fR /opt/sdcc \
+    && apk del .build_deps
 
-RUN cd /opt && git clone --depth 1 --recursive https://github.com/z88dk/z88dk.git && cd z88dk && chmod 777 build.sh && ./build.sh
-
-RUN cd /opt && svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc && cd sdcc && patch -p0 < /opt/z88dk/src/zsdcc/sdcc-z88dk.patch && ./configure --disable-mcs51-port --disable-gbz80-port --disable-avr-port --disable-ds390-port --disable-ds400-port --disable-hc08-port --disable-pic-port --disable-pic14-port --disable-pic16-port --disable-stm8-port --disable-tlcs90-port --disable-s08-port --disable-ucsim --disable-device-lib --disable-packihx && make && cd bin && mv sdcc /opt/z88dk/bin/zsdcc && mv sdcpp /opt/z88dk/bin/zsdcpp && cd / && rm -fR /opt/sdcc && apk del .build_deps
-
-ENV PATH="/opt/z88dk/bin:${PATH}"
-ENV ZCCCFG="/opt/z88dk/lib/config/"
+ENV PATH="/opt/z88dk/bin:${PATH}" \
+    ZCCCFG="/opt/z88dk/lib/config/"
 
 WORKDIR /src/

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -5,7 +5,7 @@ LABEL Version="0.1"
 LABEL Date="2018-Apr-01"
 LABEL Description="A basic Docker container to compile and use z88dk from GIT"
 LABEL Creation_Command="docker build -t z88dk - < z88dk.Dockerfile"
-LABEL Execution_Command="docker run -v '$PWD:/src/' -it z88dk <command>"
+LABEL Execution_Command="docker run -v $PWD:/src/ -it z88dk <command>"
 
 RUN apt-get update && apt-get install -y build-essential git m4 libxml2-dev subversion bison flex python libboost-dev gputils texinfo && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -1,20 +1,21 @@
 # To create the image:
 #  macOS / GNU/Linux:
-#   $ docker build --squash -t z88dk - < z88dk.Dockerfile
+#   $ docker build -t z88dk - < z88dk.Dockerfile
 #  Windows 10 PowerShell:
-#   PS> cmd /c 'docker build --squash -t z88dk - < z88dk.Dockerfile'
+#   PS> cmd /c 'docker build -t z88dk - < z88dk.Dockerfile'
 # To run the container (works for macOS, GNU/Linux & Windows PowerShell):
 #  docker run -v ${PWD}:/src/ -it z88dk <command>
 
 FROM alpine:latest
 
-LABEL Version="0.6" \
+LABEL Version="0.7" \
       Date="2018-Apr-05" \
+      Docker_Version="18.03.0-ce-mac60 (23751)" \
       Maintainer="Garrafon Software (@garrafonsoft)" \
       Description="A basic Docker container to compile and use z88dk from GIT"
 
-RUN apk add --no-cache build-base m4 bison flex libxml2 boost \ 
-    && apk add --no-cache -t .build_deps libxml2-dev git subversion boost-dev texinfo \
+RUN apk add --no-cache build-base libxml2 \ 
+    && apk add --no-cache -t .build_deps m4 bison flex libxml2-dev git subversion boost-dev texinfo \
     && mkdir /opt \
     && cd /opt \
     && git clone --depth 1 --recursive https://github.com/z88dk/z88dk.git \


### PR DESCRIPTION
This file creates a container that includes a compiled z88dk git snapshot including a patched SDCC version to be used with Docker.
Note: in SDCC compilation the ds390 and ds400 ports had to be disabled to avoid compile errors. On the other hand I am not sure which other ports can be disabled to have a minimal SDCC compilation to be used in z88dk.