### PR TITLE
snprintf not defined in Visual Studio 2013

### DIFF
--- a/src/lstmanip/lstmanip.c
+++ b/src/lstmanip/lstmanip.c
@@ -15,7 +15,9 @@
 
 #if defined(_WIN32) || defined(WIN32)
 #define strcasecmp(a,b) stricmp(a,b)
+#define snprintf _snprintf
 #endif
+
 
 static void read_list_file(char *filename);
 static void usage(void);

--- a/src/portability.h
+++ b/src/portability.h
@@ -4,6 +4,7 @@
 // strcasecmp()
 #if defined(_WIN32) || defined(WIN32)
 #define strcasecmp(a,b) stricmp(a,b)
+#define snprintf _snprintf
 #endif
 
 // glob()

--- a/src/sccz80/ccdefs.h
+++ b/src/sccz80/ccdefs.h
@@ -29,6 +29,9 @@
 #define FILENAME_LEN FILENAME_MAX
 #endif
 
+#if defined(_WIN32) || defined(WIN32)
+#define snprintf _snprintf
+#endif
 
 /*
  *      Now some system files for good luck

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <ctype.h>
 
+#if defined(_WIN32) || defined(WIN32)
+#define snprintf _snprintf
+#endif
+
 #include "utlist.h"
 
 #include "ticks.h"

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -2,6 +2,9 @@
 #include <stdio.h>
 #include "ticks.h"
 
+#if defined(_WIN32) || defined(WIN32)
+#define snprintf _snprintf
+#endif
 
 
 

--- a/src/ticks/linenoise.c
+++ b/src/ticks/linenoise.c
@@ -132,6 +132,10 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#if defined(_WIN32) || defined(WIN32)
+#define snprintf _snprintf
+#endif
+
 #include "linenoise.h"
 #include "utf8.h"
 

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -4,6 +4,10 @@
 #include <ctype.h>
 #include "ticks.h"
 
+#if defined(_WIN32) || defined(WIN32)
+#define snprintf _snprintf
+#endif
+
 static symbol  *symbols[65536] = {0};
 static symbol  *symbols_byname = NULL;
 

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -6,6 +6,7 @@
 
 #if defined(_WIN32) || defined(WIN32)
 #define strcasecmp(a,b) stricmp(a,b)
+#define snprintf _snprintf
 #endif
 
 

--- a/src/z88dk-lib/z88dk-lib.c
+++ b/src/z88dk-lib/z88dk-lib.c
@@ -19,6 +19,10 @@
 #include <dirent.h>
 #endif
 
+#if defined(_WIN32) || defined(WIN32)
+#define snprintf _snprintf
+#endif
+
 #define PATHSIZE 1024
 
 // Version Information


### PR DESCRIPTION
Need to define snprintf as _snprintf to compile with Visual Studio 2013