### PR TITLE
Issue #791: Build a conio (i.e. generic console) equivalent

### DIFF
--- a/examples/console/Makefile
+++ b/examples/console/Makefile
@@ -3,7 +3,9 @@ TARGETS = abc80 abc800 ace aquarius bee c128 c7420 cpc cpm enterprise g800 gal k
 
 TARGETANSI = abc80 ace aquarius bee cpc gal mc1000 msx mtx mz nascom osca p2000 pc6001 pps sam sc3000 svi ti82 ti83 ti85 ti86 ti8x ts2068 vz x1 z1013 z88 zx 
 
-EXES = $(addprefix bin/,$(addsuffix /world, $(TARGETS))) $(addprefix bin/,$(addsuffix /ansitest, $(TARGETANSI)))
+TARGETGENERIC = abc80 ace aquarius cpc mc1000 nascom pv1000 srr pps trs80 vg5k vz z1013 zx80 zx81 msx pv2000 sc3000 svi m5 mtx
+
+EXES = $(addprefix bin/,$(addsuffix /world, $(TARGETS))) $(addprefix bin/,$(addsuffix /ansitest, $(TARGETANSI))) $(addprefix bin/,$(addsuffix /world_conio, $(TARGETGENERIC)))
 
 all: $(EXES)
 
@@ -22,6 +24,9 @@ targets := $(foreach target, $(TARGETS), \
 	) 
 targets += $(foreach target, $(TARGETANSI), \
 		$(eval $(call build_for,$(target),ansitest.c,-clib=ansi)) \
+	)
+targets += $(foreach target, $(TARGETGENERIC), \
+		$(eval $(call build_for,$(target),world_conio.c,-pragma-redirect:fputc_cons=fputc_cons_generic -clib=default)) \
 	)
 
 clean:

--- a/examples/console/world_conio.c
+++ b/examples/console/world_conio.c
@@ -1,0 +1,15 @@
+/*
+ *	Hello World
+ */
+
+
+#include <conio.h>
+
+
+main()
+{
+	cprintf("Hello world! %d\n",12);
+        while(!kbhit()){
+        };
+        getch();
+}

--- a/lib/config/srr.cfg
+++ b/lib/config/srr.cfg
@@ -7,4 +7,7 @@ CRT0		 DESTDIR/lib/target/srr/classic/sorcerer_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -iquote. -lsorcerer_clib -DZ80 -DSORCERER -D__SORCERER__ -M -Cc-standard-escape-chars -Cz+srr -Cz--audio
+OPTIONS		 -O2 -iquote. -lsorcerer_clib -DZ80 -DSORCERER -D__SORCERER__ -M -Cc-standard-escape-chars -Cz+srr -Cz--audio -clib=default
+
+
+CLIB	default 

--- a/libsrc/pv1000.lst
+++ b/libsrc/pv1000.lst
@@ -1,5 +1,6 @@
 stdio/pv1000/generic_console
 stdio/pv1000/fgetc_cons
+stdio/pv1000/getk
 @stdio/stdio.lst
 games/pv1000/joystick
 @gfxbase.lst

--- a/libsrc/stdio/pv1000/getk.asm
+++ b/libsrc/stdio/pv1000/getk.asm
@@ -1,0 +1,15 @@
+;
+;	Placeholder for reading a key from the keyboard
+;
+;	Yet the PV-1000 doesnt have a keybaord...
+;
+
+        SECTION code_clib
+	PUBLIC	getk
+	PUBLIC	_getk
+
+getk:
+_getk:
+
+	ld hl,0
+	ret


### PR DESCRIPTION
 Build a conio (i.e. generic console) equivalent of world.c on each build

This just calls cprintf() and kbhit() / getch() as a fairly
primitive test.

Add a couple more dummy funcs for pv1000