### PR TITLE
(classic) Mitsubishi Multi 8 platform (WiP)

### DIFF
--- a/lib/config/multi8.cfg
+++ b/lib/config/multi8.cfg
@@ -1,0 +1,16 @@
+#
+# Target configuration file for z88dk
+#
+
+# Asm file which contains the startup code (without suffix)
+CRT0		 DESTDIR/lib/target/multi8/classic/multi8_crt0
+
+# Any default options you want - these are options to zcc which are fed
+# through to compiler, assembler etc as necessary
+OPTIONS		 -O2 -SO2 -iquote. -DZ80 -D__MULTI8__ -M -subtype=default -clib=default
+
+CLIB		default -lmulti8_clib -lndos -Cc-standard-escape-chars
+
+SUBTYPE     none 
+SUBTYPE		default -Cz+multi8
+

--- a/lib/config/multi8.cfg
+++ b/lib/config/multi8.cfg
@@ -9,8 +9,9 @@ CRT0		 DESTDIR/lib/target/multi8/classic/multi8_crt0
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote. -DZ80 -D__MULTI8__ -M -subtype=default -clib=default
 
-CLIB		default -lmulti8_clib -lndos -Cc-standard-escape-chars
+CLIB		default -lmulti8_clib -lndos -Cc-standard-escape-chars 
 
 SUBTYPE     none 
-SUBTYPE		default -Cz+multi8
+SUBTYPE		default -Cz+multi8 -startup=1
+SUBTYPE		64k -Cz+multi8 -startup=2
 

--- a/lib/target/multi8/classic/16k.asm
+++ b/lib/target/multi8/classic/16k.asm
@@ -1,0 +1,48 @@
+;       CRT0 for the Multi8 (16k mode)
+;
+
+	IF      !DEFINED_CRT_ORG_CODE
+		defc    CRT_ORG_CODE  = 0xC000
+	ENDIF
+
+
+	defc	VRAM_IN = 0x17
+	defc	VRAM_OUT = 0x0f
+
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
+        INCLUDE "crt/classic/crt_rules.inc"
+	org     CRT_ORG_CODE
+
+start:
+
+	ld	(start1+1),sp	;Save entry stack
+        INCLUDE "crt/classic/crt_init_sp.asm"
+        INCLUDE "crt/classic/crt_init_atexit.asm"
+	call	crt0_init_bss
+	ld      (exitsp),sp
+
+
+; Optional definition for auto MALLOC init
+; it assumes we have free space between the end of 
+; the compiled program and the stack pointer
+	IF DEFINED_USING_amalloc
+		INCLUDE "crt/classic/crt_init_amalloc.asm"
+	ENDIF
+
+
+	call    _main	;Call user program
+
+cleanup:
+;
+;       Deallocate memory which has been allocated here!
+;
+	push	hl
+IF CRT_ENABLE_STDIO = 1
+	EXTERN	closeall
+	call	closeall
+ENDIF
+
+	pop	bc
+start1:	ld	sp,0		;Restore stack to entry value
+	ret

--- a/lib/target/multi8/classic/64k.asm
+++ b/lib/target/multi8/classic/64k.asm
@@ -1,0 +1,113 @@
+;	CRT0 stub for 64k Mode Multi8
+;
+;
+
+
+	defc    CRT_ORG_CODE  = 0x0000
+        defc    TAR__register_sp = 0xffff
+        defc    TAR__clib_exit_stack_size = 0
+	defc	VRAM_IN = 0x37;
+	defc	VRAM_OUT = 0x2f
+	INCLUDE	"crt/classic/crt_rules.inc"
+
+        org     CRT_ORG_CODE
+
+if (ASMPC<>$0000)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+	di
+        jp      program
+
+        defs    $0008-ASMPC
+if (ASMPC<>$0008)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart08
+
+        defs    $0010-ASMPC
+if (ASMPC<>$0010)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart10
+
+        defs    $0018-ASMPC
+if (ASMPC<>$0018)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart18
+
+        defs    $0020-ASMPC
+if (ASMPC<>$0020)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart20
+
+    defs        $0028-ASMPC
+if (ASMPC<>$0028)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart28
+        defs    $0030-ASMPC
+if (ASMPC<>$0030)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart30
+
+        defs    $0038-ASMPC
+if (ASMPC<>$0038)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+	; TODO: Some interrupt routine
+	ei	
+	reti
+
+        defs    $0066 - ASMPC
+if (ASMPC<>$0066)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+nmi:
+	retn
+
+restart10:
+restart08:
+restart18:
+restart20:
+restart28:
+restart30:
+        ret
+
+program:
+; Make room for the atexit() stack
+	INCLUDE	"crt/classic/crt_init_sp.asm"
+	INCLUDE	"crt/classic/crt_init_atexit.asm"
+
+	call	crt0_init_bss
+	ld      (exitsp),sp
+
+; Optional definition for auto MALLOC init
+; it assumes we have free space between the end of 
+; the compiled program and the stack pointer
+	IF DEFINED_USING_amalloc
+		INCLUDE "crt/classic/crt_init_amalloc.asm"
+	ENDIF
+
+
+	im	1
+	ei
+
+; Entry to the user code
+	call    _main
+
+cleanup:
+;
+;       Deallocate memory which has been allocated here!
+;
+	push	hl
+IF CRT_ENABLE_STDIO = 1
+	EXTERN 	closeall
+	call	closeall
+ENDIF
+
+endloop:
+	jr	endloop
+

--- a/lib/target/multi8/classic/multi8_crt0.asm
+++ b/lib/target/multi8/classic/multi8_crt0.asm
@@ -22,8 +22,9 @@
 
 
 
-        defc    CONSOLE_ROWS = 24
-        defc    CONSOLE_COLUMNS = 32
+        defc    CONSOLE_ROWS = 20
+        defc    CONSOLE_COLUMNS = 40
+	defc	CRT_KEY_DEL = 8
 
 	IF      !DEFINED_CRT_ORG_CODE
 		defc    CRT_ORG_CODE  = 0xC000

--- a/lib/target/multi8/classic/multi8_crt0.asm
+++ b/lib/target/multi8/classic/multi8_crt0.asm
@@ -1,0 +1,79 @@
+;       CRT0 for the Multi8
+;
+
+
+	MODULE multi8_crt0 
+
+;-------
+; Include zcc_opt.def to find out information about us
+;-------
+
+        defc    crt0 = 1
+	INCLUDE "zcc_opt.def"
+
+;-------
+; Some general scope declarations
+;-------
+
+	EXTERN    _main           ;main() is always external to crt0 code
+
+	PUBLIC    cleanup         ;jp'd to by exit()
+	PUBLIC    l_dcal          ;jp(hl)
+
+
+
+        defc    CONSOLE_ROWS = 24
+        defc    CONSOLE_COLUMNS = 32
+
+	IF      !DEFINED_CRT_ORG_CODE
+		defc    CRT_ORG_CODE  = 0xC000
+	ENDIF
+
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = -1
+	defc	__CPU_CLOCK = 4000000
+        INCLUDE "crt/classic/crt_rules.inc"
+	org     CRT_ORG_CODE
+
+start:
+
+	ld	(start1+1),sp	;Save entry stack
+        INCLUDE "crt/classic/crt_init_sp.asm"
+        INCLUDE "crt/classic/crt_init_atexit.asm"
+	call	crt0_init_bss
+	ld      (exitsp),sp
+
+
+; Optional definition for auto MALLOC init
+; it assumes we have free space between the end of 
+; the compiled program and the stack pointer
+	IF DEFINED_USING_amalloc
+		INCLUDE "crt/classic/crt_init_amalloc.asm"
+	ENDIF
+
+
+	call    _main	;Call user program
+
+cleanup:
+;
+;       Deallocate memory which has been allocated here!
+;
+	push	hl
+IF CRT_ENABLE_STDIO = 1
+	EXTERN	closeall
+	call	closeall
+ENDIF
+
+	pop	bc
+start1:	ld	sp,0		;Restore stack to entry value
+	ret
+
+l_dcal:	jp	(hl)		;Used for function pointer calls
+
+
+         defm  "Small C+ Multi8"	;Unnecessary file signature
+         defb	0
+
+        INCLUDE "crt/classic/crt_runtime_selection.asm"
+	INCLUDE "crt/classic/crt_section.asm"
+

--- a/lib/target/multi8/classic/multi8_crt0.asm
+++ b/lib/target/multi8/classic/multi8_crt0.asm
@@ -22,53 +22,19 @@
 
 
 
+        defc    TAR__fputc_cons_generic = 1
         defc    CONSOLE_ROWS = 20
         defc    CONSOLE_COLUMNS = 40
 	defc	CRT_KEY_DEL = 8
 
-	IF      !DEFINED_CRT_ORG_CODE
-		defc    CRT_ORG_CODE  = 0xC000
-	ENDIF
-
-        defc    TAR__clib_exit_stack_size = 32
-        defc    TAR__register_sp = -1
 	defc	__CPU_CLOCK = 4000000
-        INCLUDE "crt/classic/crt_rules.inc"
-	org     CRT_ORG_CODE
-
-start:
-
-	ld	(start1+1),sp	;Save entry stack
-        INCLUDE "crt/classic/crt_init_sp.asm"
-        INCLUDE "crt/classic/crt_init_atexit.asm"
-	call	crt0_init_bss
-	ld      (exitsp),sp
 
 
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of 
-; the compiled program and the stack pointer
-	IF DEFINED_USING_amalloc
-		INCLUDE "crt/classic/crt_init_amalloc.asm"
-	ENDIF
-
-
-	call    _main	;Call user program
-
-cleanup:
-;
-;       Deallocate memory which has been allocated here!
-;
-	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
+IF startup = 2
+        INCLUDE "target/multi8/classic/64k.asm"
+ELSE
+        INCLUDE "target/multi8/classic/16k.asm"
 ENDIF
-
-	pop	bc
-start1:	ld	sp,0		;Restore stack to entry value
-	ret
-
 l_dcal:	jp	(hl)		;Used for function pointer calls
 
 
@@ -77,4 +43,10 @@ l_dcal:	jp	(hl)		;Used for function pointer calls
 
         INCLUDE "crt/classic/crt_runtime_selection.asm"
 	INCLUDE "crt/classic/crt_section.asm"
+
+	SECTION data_crt
+	PUBLIC	__vram_in
+	PUBLIC	__vram_out
+__vram_in:	defb	VRAM_IN
+__vram_out:	defb	VRAM_OUT
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -26,7 +26,7 @@ all: genlibs rs232libs z88libs tilibs zxlibs eplibs c128libs nclibs cpclibs \
 	svi_clib.lib sam_clib.lib  sorcerer_clib.lib  sos_clib.lib tiki100.lib \
 	trs80_clib.lib vg5k_clib.lib vz_clib.lib  x07_clib.lib \
 	embedded_clib.lib test_clib.lib testrcm_clib.lib z1013_clib.lib z9001_clib.lib kc_clib.lib \
-	pv1000_clib.lib pv2000_clib.lib coleco_clib.lib \
+	pv1000_clib.lib pv2000_clib.lib coleco_clib.lib multi8_clib.lib \
 	preempt.lib x1ansi_clib.lib zx80_clib.lib zx81libs sp1-all rcmx000_clib.lib
 
 genlibs: z80_crt0.lib math48.lib gen_math.lib gendos.lib ndos.lib  \
@@ -860,6 +860,14 @@ kc_clib.lib:
 	$(MAKE) gfxdeps
 	$(call buildgeneric,kc)
 	TARGET=kc TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORkc -x$(OUTPUT_DIRECTORY)/kc_clib @$(LISTFILE_DIRECTORY)/kc.lst
+
+# Mitsubishi Multi8 - dom
+multi8_clib.lib:
+	@echo ''
+	@echo '--- Building Mitsubishi Multi8 Library ---'
+	@echo ''
+	$(call buildgeneric,multi8)
+	TARGET=multi8 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORmulti8 -x$(OUTPUT_DIRECTORY)/multi8_clib @$(LISTFILE_DIRECTORY)/multi8.lst
 
 # Casio PV1000 - dom
 pv1000_clib.lib:

--- a/libsrc/multi8.lst
+++ b/libsrc/multi8.lst
@@ -2,5 +2,7 @@ stdio/multi8/fputc_cons_native
 stdio/multi8/fgetc_cons
 stdio/multi8/getk
 stdio/multi8/generic_console
+multi8/tape_load
+multi8/asm_tape_load
 @stdio/stdio.lst
 @z80.lst

--- a/libsrc/multi8.lst
+++ b/libsrc/multi8.lst
@@ -1,5 +1,6 @@
 stdio/multi8/fputc_cons_native
 stdio/multi8/fgetc_cons
 stdio/multi8/getk
+stdio/multi8/generic_console
 @stdio/stdio.lst
 @z80.lst

--- a/libsrc/multi8.lst
+++ b/libsrc/multi8.lst
@@ -1,0 +1,5 @@
+stdio/multi8/fputc_cons_native
+stdio/multi8/fgetc_cons
+stdio/multi8/getk
+@stdio/stdio.lst
+@z80.lst

--- a/libsrc/multi8/asm_tape_load.asm
+++ b/libsrc/multi8/asm_tape_load.asm
@@ -1,0 +1,99 @@
+
+
+	MODULE	asm_tape_load
+
+	SECTION	code_clib
+	PUBLIC	asm_tape_load
+;
+; Load a block to the address specified in the file header
+;
+; Exit: nc = success
+;        c = failure
+;
+asm_tape_load:
+	call	initialise_hw
+	ld	a,$4e
+	out	($21),a
+	ld	a,$14
+	out	($21),a
+	in	a,($20)
+wait_for_ready:
+	in	a,($21)
+	bit	1,a
+	jr	z,wait_for_ready
+	in	a,($21)
+	and	$30
+	jr	nz,asm_tape_load
+	in	a,($20)			;ac4
+	cp	$3a
+	jr	nz,asm_tape_load
+	call	read_byte
+	ld	c,a
+	ld	h,a
+	call	read_byte
+	ld	l,a
+	add	c
+	ld	c,a
+	call	read_byte
+	add	c
+	jr	nz,failure		;@0b07
+next_block:
+	call	read_byte
+	cp	$3a
+	jr	nz,failure
+	call	read_byte
+	ld	c,a
+	ld	b,a
+	or	a
+	ret	z			;end of file
+read_block_loop:
+	call	read_byte
+IF VERIFY
+	push	af
+	ld	a,(some_var)		;some_var = f97b
+	or	a
+	jr	z,skip_verify
+	pop	af
+	cp	(hl)
+	jr	nz,failure
+	jr	rejoin
+skip_verify:
+	pop	af
+ENDIF
+	ld	(hl),a
+rejoin:
+	add	c
+	ld	c,a
+	inc	hl
+	dec	b
+	jr	nz,read_block_loop
+	call	read_byte
+	add	c
+	jr	z,next_block
+failure:
+	scf
+	ret
+failure_pop:
+	pop	af	;return address from read_byte
+	jr	failure
+
+read_byte:
+	in	a,($21)
+	bit	1,a
+	jr	z,read_byte
+	in	a,($21)
+	and	$30
+	jr	nz,failure_pop
+	in	a,($20)
+	ret
+
+
+initialise_hw:
+	ld	a,$ce
+	out	($21),a
+	ld	a,$27
+	out	($21),a
+	ld	a,$77
+	out	($21),a
+	ret
+

--- a/libsrc/multi8/tape_load.asm
+++ b/libsrc/multi8/tape_load.asm
@@ -1,0 +1,18 @@
+
+		MODULE	tape_load
+		SECTION	code_clib
+
+		PUBLIC	tape_load
+		PUBLIC	_tape_load
+
+
+		EXTERN	asm_tape_load
+
+tape_load:
+_tape_load:
+	call	asm_tape_load
+	ld	hl,0
+	ret	nc		;Success
+	dec	hl
+	ret
+

--- a/libsrc/stdio/multi8/fgetc_cons.asm
+++ b/libsrc/stdio/multi8/fgetc_cons.asm
@@ -7,8 +7,17 @@
 	PUBLIC	fgetc_cons
 	PUBLIC	_fgetc_cons
 
+	EXTERN	getk
+	EXTERN	msleep
+	EXTERN	__CLIB_FGETC_CONS_DELAY
+
 fgetc_cons:
 _fgetc_cons:
-
-	ld hl,0
+        ld      hl,__CLIB_FGETC_CONS_DELAY
+        call    msleep
+loop:
+	call	getk
+	ld	a,h
+	or	l
+	jr	z,loop
 	ret

--- a/libsrc/stdio/multi8/fgetc_cons.asm
+++ b/libsrc/stdio/multi8/fgetc_cons.asm
@@ -1,0 +1,14 @@
+;
+;
+;	getkey() Wait for keypress
+;
+
+        SECTION code_clib
+	PUBLIC	fgetc_cons
+	PUBLIC	_fgetc_cons
+
+fgetc_cons:
+_fgetc_cons:
+
+	ld hl,0
+	ret

--- a/libsrc/stdio/multi8/fputc_cons_native.asm
+++ b/libsrc/stdio/multi8/fputc_cons_native.asm
@@ -1,0 +1,16 @@
+
+		SECTION	code_clib
+		PUBLIC	fputc_cons_native
+
+
+; (char to print)
+fputc_cons_native:
+        ld      hl,2
+        add     hl,sp
+	ld	a,(hl)
+	cp	10
+	jr	nz,not_lf
+	ld	a,13
+not_lf:
+	rst	$18
+	ret

--- a/libsrc/stdio/multi8/generic_console.asm
+++ b/libsrc/stdio/multi8/generic_console.asm
@@ -8,7 +8,9 @@
 ; Text mode = two bytes get written 2k apart
 ;
 
-		SECTION		code_clib
+		; In code_driver so we are low down in memory and hopefully
+		; never paged out
+		SECTION		code_driver
 
 		PUBLIC		generic_console_cls
 		PUBLIC		generic_console_vpeek
@@ -24,6 +26,8 @@
 
 		EXTERN		CONSOLE_COLUMNS
 		EXTERN		CONSOLE_ROWS
+		EXTERN		__vram_in
+		EXTERN		__vram_out
 
 		defc		DISPLAY = 0x8000
 
@@ -53,7 +57,7 @@ store:
 
 generic_console_cls:
 	call	l_push_di
-	ld	a,0x17		
+	ld	a,(__vram_in)
 	out	($2a),a
 	ld	hl, DISPLAY
 	ld	de, DISPLAY +1
@@ -66,7 +70,7 @@ generic_console_cls:
 	ld	a,(__multi8_attr)
 	ld	(hl),a
 	ldir
-	ld	a,0xf
+	ld	a,(__vram_out)
 	out	($2a),a
 	call	l_pop_ei
 	ret
@@ -80,14 +84,14 @@ generic_console_printc:
 	call	xypos
 	ld	e,a
         call    l_push_di
-        ld      a,0x17       
+	ld	a,(__vram_in)
         out     ($2a),a
 	ld	(hl),e
 	ld	bc,0x800
 	add	hl,bc
 	ld	a,(__multi8_attr)
 	ld	(hl),a
-	ld	a,0xf
+	ld	a,(__vram_out)
 	out	($2a),a
 	call	l_pop_ei
 	ret
@@ -101,10 +105,10 @@ generic_console_vpeek:
 	sla	c		;40 column to 80 columns translation
 	call	xypos
 	call	l_push_di
-	ld	a,0x17
+	ld	a,(__vram_in)
 	out	($2a),a
 	ld	b,(hl)
-	ld	a,0xf
+	ld	a,(__vram_out)
 	out	($2a),a
 	call	l_pop_ei
 	ld	a,b
@@ -125,7 +129,7 @@ generic_console_scrollup:
 	push	de
 	push	bc
 	call	l_push_di
-	ld	a,0x17
+	ld	a,(__vram_in)
 	out	($2a),a
 	ld	hl, DISPLAY + 80
 	ld	de, DISPLAY
@@ -149,7 +153,7 @@ generic_console_scrollup_4:
 	ld	(hl),a
 	inc	hl
 	djnz	generic_console_scrollup_4
-	ld	a,0xf
+	ld	a,(__vram_out)
 	out	($2a),a
 	call	l_pop_ei
 	pop	bc

--- a/libsrc/stdio/multi8/generic_console.asm
+++ b/libsrc/stdio/multi8/generic_console.asm
@@ -1,0 +1,128 @@
+;
+; The Multi8 can operate in multiple modes
+;
+; - Text/character based - 40x25, 80x25 there's attributes there as well
+; - Full RGB - they actually end up being superimposed on each other (when in text mode)
+;
+;
+; Text mode = two bytes get written 2k apart
+;
+
+		SECTION		code_clib
+
+		PUBLIC		generic_console_cls
+		PUBLIC		generic_console_vpeek
+		PUBLIC		generic_console_printc
+		PUBLIC		generic_console_scrollup
+		PUBLIC		generic_console_ioctl
+                PUBLIC          generic_console_set_ink
+                PUBLIC          generic_console_set_paper
+                PUBLIC          generic_console_set_inverse
+
+		EXTERN		l_push_di
+		EXTERN		l_pop_ei
+
+		EXTERN		CONSOLE_COLUMNS
+		EXTERN		CONSOLE_ROWS
+
+		defc		DISPLAY = 0x8000
+
+generic_console_ioctl:
+	scf
+generic_console_set_ink:
+generic_console_set_paper:
+generic_console_set_inverse:
+	ret
+
+generic_console_cls:
+	call	l_push_di
+	ld	a,0x17		
+	out	($2a),a
+	ld	hl, DISPLAY
+	ld	de, DISPLAY +1
+	ld	bc, 80 * 25 - 1
+	ld	(hl),32
+	ldir
+	ld	a,0xf
+	out	($2a),a
+	call	l_pop_ei
+	ret
+
+; c = x
+; b = y
+; a = d character to print
+; e = raw
+generic_console_printc:
+	sla	c		;40 column to 80 columns translation
+	call	xypos
+	ld	e,a
+        call    l_push_di
+        ld      a,0x17       
+        out     ($2a),a
+	ld	(hl),e
+	ld	bc,0x800
+	add	hl,bc
+	ld	a,(__multi8_attr)
+	ld	(hl),a
+	ld	a,0xf
+	out	($2a),a
+	call	l_pop_ei
+	ret
+
+;Entry: c = x,
+;	b = y
+;Exit:	nc = success
+;	 a = character,
+;	 c = failure
+generic_console_vpeek:
+	sla	c		;40 column to 80 columns translation
+	call	xypos
+	call	l_push_di
+	ld	a,0x17
+	out	($2a),a
+	ld	b,(hl)
+	ld	a,0xf
+	out	($2a),a
+	call	l_pop_ei
+	ld	a,b
+	and	a
+	ret
+
+xypos:
+	ld	hl, DISPLAY - 80
+	ld	de,80
+generic_console_printc_1:
+	add	hl,de
+	djnz	generic_console_printc_1
+generic_console_printc_3:
+	add	hl,bc			;hl now points to address in display
+	ret
+
+generic_console_scrollup:
+	push	de
+	push	bc
+	call	l_push_di
+	ld	a,0x17
+	out	($2a),a
+	ld	hl, DISPLAY + 80
+	ld	de, DISPLAY
+	ld	bc, 80 * 25
+	ldir
+	; And blank out row 15
+	ex	de,hl
+	ld	b,80
+generic_console_scrollup_3:
+	ld	(hl),32
+	inc	hl
+	djnz	generic_console_scrollup_3
+	ld	a,0xf
+	out	($2a),a
+	call	l_pop_ei
+	pop	bc
+	pop	de
+	ret
+
+
+	SECTION		bss_clib
+
+__multi8_attr:	defb	0

--- a/libsrc/stdio/multi8/getk.asm
+++ b/libsrc/stdio/multi8/getk.asm
@@ -1,0 +1,13 @@
+;
+;	Placeholder for reading a key from the keyboard
+;
+
+        SECTION code_clib
+	PUBLIC	getk
+	PUBLIC	_getk
+
+getk:
+_getk:
+
+	ld hl,0
+	ret

--- a/libsrc/stdio/multi8/getk.asm
+++ b/libsrc/stdio/multi8/getk.asm
@@ -8,6 +8,18 @@
 
 getk:
 _getk:
+	in	a,($00)		;Key code
+	ld	l,a
+	in	a,($01)		;Flags
+				;bit 7 = shift
+				;bit 6 = function key
+				;bit 3 = not pressed/pressed
+	bit	3,a
+	jr	z,key_pressed
+	ld	hl,0
+	ret
 
-	ld hl,0
+key_pressed:
+	; TODO: Take account of shift/function key etc
+	ld	h,0
 	ret

--- a/src/appmake/Makefile
+++ b/src/appmake/Makefile
@@ -5,7 +5,7 @@ INCLUDES += -I..
 OBJS = appmake.o z88.o zxvgs.o zx.o z88shell.o abc80.o zx81.o msx.o mtx.o mz.o nec.o p2000.o px.o \
 	aquarius.o c7420.o rom.o sorcerer.o sos.o svi.o sc3000.o ace-tap.o hex.o lynx.o rex6000.o tixx.o nascom.o \
 	cpc.o cpm.o m5.o mc.o newbrain.o newext.o sms.o trs80.o c128.o galaksija.o vz.o enterprise.o x07.o residos.o \
-	inject.o vg5k.o z1013.o extract.o z9001.o kc.o glue.o zxn.o zx-util.o x1.o
+	inject.o vg5k.o z1013.o extract.o z9001.o kc.o glue.o zxn.o zx-util.o x1.o multi8.o
 
 
 all: appmake$(EXESUFFIX)

--- a/src/appmake/appmake.h
+++ b/src/appmake/appmake.h
@@ -99,6 +99,9 @@ extern option_t  msx_options;
 extern int       mtx_exec(char *target);
 extern option_t  mtx_options;
 
+extern int       multi8_exec(char *target);
+extern option_t  multi8_options;
+
 extern int       mz_exec(char *target);
 extern option_t  mz_options;
 
@@ -275,6 +278,10 @@ struct {
       "Memotech MTX file format packaging, optional WAV format",
       NULL,
       mtx_exec,     &mtx_options },
+    { "bin2m8",   "multi8",   "(C) 2018 Dominic Morris",
+      "Generates a tape file for the Mitsubishi Multi8 computers",
+      NULL,
+      multi8_exec,      &multi8_options },
     { "bin2m12",  "mz",       "(C) 2000,2003 S. Bodrato, J.F.J. Laros, M. Nemecek",
       "Generates a tape file for the Sharp MZ computers",
       NULL,

--- a/src/appmake/multi8.c
+++ b/src/appmake/multi8.c
@@ -1,0 +1,113 @@
+/*
+ *        Multi8 cas generator
+ *
+ *        $Id: multi8.c,v 1.6 2016-06-26 00:46:55 aralbrec Exp $
+ */
+
+#include "appmake.h"
+
+
+static char             *binname      = NULL;
+static char             *crtfile      = NULL;
+static char             *outfile      = NULL;
+static int               origin       = -1;
+static char              help         = 0;
+
+
+/* Options that are available for this module */
+option_t multi8_options[] = {
+    { 'h', "help",     "Display this help",          OPT_BOOL,  &help},
+    { 'b', "binfile",  "Linked binary file",         OPT_STR,   &binname },
+    { 'c', "crt0file", "crt0 file used in linking",  OPT_STR,   &crtfile },
+    { 'o', "output",   "Name of output file",        OPT_STR,   &outfile },
+    {  0 , "org",      "Origin of the binary",       OPT_INT,   &origin },
+    {  0 ,  NULL,       NULL,                        OPT_NONE,  NULL }
+};
+
+
+int multi8_exec(char *target)
+{
+    char    filename[FILENAME_MAX+1];
+    char    name[11];
+    FILE    *fpin, *fpout;
+    long    pos;
+    int     c;
+    int     i;
+    int     len, blocklen;
+
+    if ( help )
+        return -1;
+
+    if ( binname == NULL || ( crtfile == NULL && origin == -1 ) ) {
+        return -1;
+    }
+
+    if ( outfile == NULL ) {
+        strcpy(filename,binname);
+        suffix_change(filename,".cas");
+    } else {
+        strcpy(filename,outfile);
+    }
+
+    if ( origin != -1 ) {
+        pos = origin;
+    } else {
+        if ( (pos = get_org_addr(crtfile)) == -1 ) {
+            myexit("Could not find parameter ZORG (not z88dk compiled?)\n",1);
+        }
+    }
+
+
+   if ( (fpin=fopen_bin(binname, crtfile) ) == NULL ) {
+        fprintf(stderr,"Can't open input file %s\n",binname);
+        myexit(NULL,1);
+    }
+
+    /* Determine size of input file */
+    if ( fseek(fpin,0,SEEK_END) ) {
+        fprintf(stderr,"Couldn't determine size of file\n");
+        fclose(fpin);
+        myexit(NULL,1);
+    }
+
+    len=ftell(fpin);
+
+    fseek(fpin,0L,SEEK_SET);
+
+    if ( (fpout=fopen(filename,"wb") ) == NULL ) {
+        fclose(fpin);
+        myexit("Can't open output file\n",1);
+    }
+
+    writebyte(0x3a, fpout);
+    writebyte(pos / 256, fpout);
+    writebyte(pos % 256, fpout);
+    writebyte((-((pos / 256) + (pos % 256))) & 0xff, fpout);
+
+    for (i=0; i<(len / 255) * 255;i++) {
+      if (((i%255)==0)&&(i!=len)) {
+         writebyte(0x3a,fpout);
+         writebyte(0xff,fpout);
+      }
+      c=getc(fpin);
+      writebyte(c,fpout);
+    }
+
+    if ( len != i ) {
+        writebyte(0x3a,fpout);
+        writebyte(len - i,fpout);
+        for ( ; i < len ; i++ ) {
+            c=getc(fpin);
+            writebyte(c,fpout);
+        }
+    }
+    writebyte(0x3a,fpout);
+    writebyte(0x00,fpout);
+    writebyte(0x00,fpout);
+
+    fclose(fpin);
+    fclose(fpout);
+
+    return 0;
+}
+

--- a/src/appmake/multi8.c
+++ b/src/appmake/multi8.c
@@ -34,6 +34,7 @@ int multi8_exec(char *target)
     int     c;
     int     i;
     int     len, blocklen;
+    int     cksum;
 
     if ( help )
         return -1;
@@ -86,20 +87,32 @@ int multi8_exec(char *target)
 
     for (i=0; i<(len / 255) * 255;i++) {
       if (((i%255)==0)&&(i!=len)) {
+         if ( i != 0 ) {
+             writebyte(-cksum,fpout);
+         }
          writebyte(0x3a,fpout);
          writebyte(0xff,fpout);
+	 cksum = 255;
       }
       c=getc(fpin);
+      cksum += c;
       writebyte(c,fpout);
+    }
+
+    if ( i ) {
+        writebyte(-cksum,fpout);
     }
 
     if ( len != i ) {
         writebyte(0x3a,fpout);
         writebyte(len - i,fpout);
+        cksum = len - i;
         for ( ; i < len ; i++ ) {
             c=getc(fpin);
             writebyte(c,fpout);
+            cksum += c;
         }
+        writebyte(-cksum,fpout);
     }
     writebyte(0x3a,fpout);
     writebyte(0x00,fpout);

--- a/support/multi8/bootstrap.c
+++ b/support/multi8/bootstrap.c
@@ -1,0 +1,59 @@
+/*
+ * Bootstrap program for loading larger programs in 64k mode
+ * on the Mitsubishi Multi8
+ *
+ * zcc +multi8 bootstrap.c -create-app
+ */
+
+#include <stdio.h>
+#include <arch/multi8.h>
+
+
+extern void start() @ 0x0000;
+
+#pragma define CRT_ENABLE_STDIO=0
+#pragma redirect fputc_cons=fputc_cons_native
+
+static void setup_memory_map() __naked
+{
+#asm
+	; Here we need to switch to 64k RAM mode
+	; We have no access to the display (unless we page it in)
+	di
+	ld	a,@00100000	;bit 5 set = RAM
+				;bit 4 reset = RAM
+	out	($2a),a
+	ret
+#endasm
+}
+
+static void reset_memory_map() __naked
+{
+#asm
+	; Here we need to switch to 64k RAM mode
+	; We have no access to the display (unless we page it in)
+	ld	a,@00010000	;bit 5 set = RAM
+				;bit 4 reset = RAM
+	out	($2a),a
+	ei
+	ret
+#endasm
+}
+
+static void write_string(unsigned char *str) __z88dk_fastcall 
+{
+    while (*str)
+       fputc_cons(*str++);
+}
+
+int main() 
+{
+    write_string("z88dk Multi8 bootstrap starting\n");
+    setup_memory_map();
+    if ( tape_load() == 0 ) {
+        start();
+    } else {
+        reset_memory_map();
+        write_string("Loading failed\n");
+    }
+}


### PR DESCRIPTION
Start of a port for the Multi8.

* Z80 @ 3.993600 MHz
* 64k RAM, 32k ROM + chargen
* VRAM: 48k, paged in at 0x8000
* Program: At 0xc000 (or 0x0000 for all RAM configuration)
* Audio: AY-3-8912 on ports 0x18, 0x19

Using Takeda emulator

- [x] Appmake creating appropriate .cas files
- [x] Native console output using firmware
- [x] Generic console (with colour)
- [x] Keyboard input
- [ ] Graphics (possible 640x400)
- [ ] Add AY support
- [x] Paging support for programs > 16k

Won't be doing:

- Disk IO (can't find disk rom to download)

There's not much in the way of docs for this one, working from the notes linked from here: http://takeda-toshiya.my.coocan.jp/multi8/index.html, the source code of the emulator and disassembling the ROM