### PR TITLE
Filled in missing definitions in stdbool.h

### DIFF
--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -9,7 +9,15 @@
 
 #include <sys/compiler.h>
 
+// bool should really be an unsigned char, but because it was originally 
+// typedef'ed to an unsigned int in z88dk, leaving it as such as to maintain 
+// backwards compatibility.
 typedef unsigned int bool;
+
+#define true 1
+#define false 0
+
+#define __bool_true_false_are_defined 1
 
 #endif
 


### PR DESCRIPTION
`stdbool.h` was missing definitions for `true` and `false`. This change brings `stdbool.h` inline with the C99 standard that `true` and `false` be defined. However, since z88dk doesn't have a `_Bool` type, I left the bool typedef pointing at an `unsigned int`. `bool` probably should be typedef'ed to an `unsigned char` for compactness, but changing that now might break existing code written to expect that a `bool` is two bytes rather than one.