### PR TITLE
YAZ180 - I/O wait states for APU

### DIFF
--- a/libsrc/_DEVELOPMENT/target/yaz180/crt_preamble.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/crt_preamble.asm
@@ -26,8 +26,8 @@ SECTION code_crt_init
     out0    (CCR),a         ; CPU Control Reg (CCR)
 
                             ; DMA/Wait Control Reg Set I/O Wait States
-    ld      a,DCNTL_MWI0|DCNTL_IWI0
-    out0    (DCNTL),a       ; 1 Memory Wait & 2 I/O Wait
+    ld      a,DCNTL_MWI0|DCNTL_IWI1
+    out0    (DCNTL),a       ; 1 Memory Wait & 3 I/O Wait
 
                             ; Set Logical RAM Addresses
                             ; $F000-$FFFF RAM   CA1  -> $F.


### PR DESCRIPTION
On testing the Am9511A APU with PHI/16 hardware modification,
3 wait states are required to reliably read when PHI = 36.864MHz.
Write is unchanged, requiring PHI = 9.216MHz.

This timing slows down the 82c55 based IDE interface slightly,
but it returns it to operate within timing specification.