### PR TITLE
Gimme some (build) speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 cache:
   directories:
-  - perl_modules
+  - ~/perl5/lib/perl5/
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 #        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.4
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
 
 before_install:
   - eval "${MATRIX_EVAL}"
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cpanm dos2unix  ; fi
   - cpanm --local-lib=~/perl5 local::lib App::Prove Modern::Perl Capture::Tiny Capture::Tiny::Extended Path::Tiny File::Path Template Template::Plugin::YAML Test::Differences CPU::Z80::Assembler Test::HexDifferences Data::HexDump Object::Tiny::RW Regexp::Common List::Uniq
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
 
 before_install:
   - eval "${MATRIX_EVAL}"
-#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cpanm dos2unix  ; fi
   - cpanm --local-lib=~/perl5 local::lib App::Prove Modern::Perl Capture::Tiny Capture::Tiny::Extended Path::Tiny File::Path Template Template::Plugin::YAML Test::Differences CPU::Z80::Assembler Test::HexDifferences Data::HexDump Object::Tiny::RW Regexp::Common List::Uniq
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 
 cache:
-  ccache
   directories:
   - ~/perl5/
+  - ~/.ccache
  
 
 language: c
@@ -57,7 +57,7 @@ before_install:
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 
 before_script:
-  - export PATH=`pwd`/bin:/usr/local/opt/ccache/libexec:$PATH
+  - export PATH=`pwd`/bin:$PATH
   - export ZCCCFG=`pwd`/lib/config
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 
+cache:
+  directories:
+  - perl_modules
+
 language: c
 
 # https://docs.travis-ci.com/user/languages/cpp/ - support C11

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
             - texinfo
             - texi2html
       env:
-         - MATRIX_EVAL="CC=\"ccache gcc-4.9\" && CXX=\"ccache g++-4.9\""
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
 #    - os: linux
 #      addons:
@@ -48,7 +48,7 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       env:
-        - MATRIX_EVAL="CC=\"ccache clang\" && CXX=\"ccache clang++\""
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 cache:
   directories:
   - ~/perl5/
+ 
+cache:
+  ccache 
 
 language: c
 
@@ -24,7 +27,7 @@ matrix:
             - texinfo
             - texi2html
       env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+         - MATRIX_EVAL="CC=\"ccache gcc-4.9\" && CXX=\"ccache g++-4.9\""
 
 #    - os: linux
 #      addons:
@@ -45,12 +48,13 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
+        - MATRIX_EVAL="CC=\"ccache clang\" && CXX=\"ccache clang++\""
 
 before_install:
   - eval "${MATRIX_EVAL}"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cpanm dos2unix  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cpanm dos2unix ccache  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; export PATH="/usr/local/opt/ccache/libexec:$PATH" ; fi
   - cpanm --local-lib=~/perl5 local::lib App::Prove Modern::Perl Capture::Tiny Capture::Tiny::Extended Path::Tiny File::Path Template Template::Plugin::YAML Test::Differences CPU::Z80::Assembler Test::HexDifferences Data::HexDump Object::Tiny::RW Regexp::Common List::Uniq
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,11 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cpanm dos2unix ccache  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; export PATH="/usr/local/opt/ccache/libexec:$PATH" ; fi
   - cpanm --local-lib=~/perl5 local::lib App::Prove Modern::Perl Capture::Tiny Capture::Tiny::Extended Path::Tiny File::Path Template Template::Plugin::YAML Test::Differences CPU::Z80::Assembler Test::HexDifferences Data::HexDump Object::Tiny::RW Regexp::Common List::Uniq
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 
 before_script:
-  - export PATH=`pwd`/bin:$PATH
+  - export PATH=`pwd`/bin:/usr/local/opt/ccache/libexec:$PATH
   - export ZCCCFG=`pwd`/lib/config
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 cache:
   directories:
-  - ~/perl5/lib/perl5/
+  - ~/perl5/
 
 language: c
 
@@ -43,7 +43,7 @@ matrix:
 #        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode7.3
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: false
 
 cache:
+  ccache
   directories:
   - ~/perl5/
  
-cache:
-  ccache 
 
 language: c
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ CC ?= gcc
 EXEC_PREFIX ?=
 CROSS ?= 0
 
+ifneq (, $(shell which ccache))
+   OCC := $(CC)
+   CC := ccache $(CC)
+endif
+
 SDCC_PATH	= /tmp/sdcc
 Z88DK_PATH	= $(shell pwd)
 
@@ -55,7 +60,7 @@ zsdcc: bin/zsdcc$(EXESUFFIX)
 bin/zsdcc$(EXESUFFIX):
 	svn checkout -r 9958 svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc -q $(SDCC_PATH)
 	cd $(SDCC_PATH) && patch -p0 < $(Z88DK_PATH)/src/zsdcc/sdcc-z88dk.patch
-	cd $(SDCC_PATH) && ./configure --disable-mcs51-port --disable-gbz80-port \
+	cd $(SDCC_PATH) && CC=$(OCC) ./configure --disable-mcs51-port --disable-gbz80-port \
 				       --disable-avr-port --disable-ds390-port \
 				       --disable-ds400-port --disable-hc08-port \
 				       --disable-pic-port --disable-pic14-port \


### PR DESCRIPTION
Squash this on merge (not sure there's much reason to preserve random travis experiments)

Tweaks to speed up the build:

- Cache the perl modules so we don't rebuild them al time (5-10 mins+)
- Use ccache for compilation (5 mins)

Brings linux build back down to 15 minutes and osx down to about 20. Better than nothing.

Will need to:

- Figure out how to remove the brew update (would save about 3 minutes)
- Upgrade to a new distro when/if travis supports it
- Upgrade Xcode to a newer version at some point (but there's a broken perl command about the place if so)

