### PR TITLE
Changed character input/output to handle DELete

### DIFF
--- a/lib/target/mz/classic/mz_crt0.asm
+++ b/lib/target/mz/classic/mz_crt0.asm
@@ -1,7 +1,9 @@
-;       Stub for the SHARP MZ family
+-;       Stub for the SHARP MZ family
 ;
 ;       Stefano Bodrato - 5/5/2000
 ;
+; 	UncleBod	-  2018-09-25
+;	Changed default org to 1200
 ;       $Id: mz_crt0.asm,v 1.24 2016-07-15 21:03:25 dom Exp $
 ;
 
@@ -28,7 +30,7 @@
 ; Now, getting to the real stuff now!
 
         IF      !DEFINED_CRT_ORG_CODE
-                defc    CRT_ORG_CODE  = $1300
+                defc    CRT_ORG_CODE  = $1200
         ENDIF
 
         defc    CONSOLE_COLUMNS = 40

--- a/lib/target/mz/classic/mz_crt0.asm
+++ b/lib/target/mz/classic/mz_crt0.asm
@@ -1,4 +1,4 @@
--;       Stub for the SHARP MZ family
+;       Stub for the SHARP MZ family
 ;
 ;       Stefano Bodrato - 5/5/2000
 ;

--- a/libsrc/stdio/mz/fgetc_cons.asm
+++ b/libsrc/stdio/mz/fgetc_cons.asm
@@ -8,6 +8,11 @@
 ;	No auto-repeat for now.
 ;	Maybe someone wants to improve this ?
 ;
+;	UncleBod - 2018-09-25
+;	Added handling of DEL key
+;
+;	TODO
+;	Conversion of mzASCII to real ASCII, especially codes 0-127
 ;
 ;	$Id: fgetc_cons.asm,v 1.5 2016-06-12 17:32:01 dom Exp $
 ;
@@ -38,6 +43,12 @@ ELSE
 		ld	a,13
 ENDIF
 .noenter
+; Handling of DEL key
+		cp	$60	;DEL
+		jr	nz,nodelkey
+		ld	a,8	;DEL_KEY
+.nodelkey		
+
 		ld	l,a
 		ld	h,0
 		ret

--- a/libsrc/stdio/mz/fputc_cons.asm
+++ b/libsrc/stdio/mz/fputc_cons.asm
@@ -10,6 +10,11 @@
 ;
 ;       Stefano Bodrato - 5/5/2000
 ;
+;	UncleBod - 2018-09-25
+;	Added handling of DEL key
+;
+;	TODO
+;	Conversion of mzASCII to real ASCII, especially codes 0-127
 ;
 ;	$Id: fputc_cons.asm,v 1.4 2016-05-15 20:15:45 dom Exp $
 ;
@@ -45,6 +50,11 @@ IF STANDARDESCAPECHARS
 .notCR
 ENDIF
 
+; Handling of DEL-key
+	cp	8
+	jr	nz,notback
+	ld	a,$14 ; move left on MZ700
+.notback
 
 	; Some undercase text?  Transform in UPPER !
 	cp	97

--- a/libsrc/stdio/mz/getk.asm
+++ b/libsrc/stdio/mz/getk.asm
@@ -5,6 +5,11 @@
 ;
 ;	Stefano Bodrato - 5/5/2000
 ;
+;	UncleBod - 2018-09-25
+;
+;	TODO
+;	Conversion of mzASCII to real ASCII, especially codes 0-127
+
 ;
 ;	$Id: getk.asm,v 1.4 2016-06-12 17:32:01 dom Exp $
 ;


### PR DESCRIPTION
Changed standard origin to 1200H
Changed so DElete key on MZ-700 is handled correctly.

Tested with https://sourceforge.net/projects/mz800emu/ and works there.
(I don't have any physical MZ-700 any more.)
