### PR TITLE
remove unnecessary signature

### DIFF
--- a/lib/target/vz/classic/vz_crt0.asm
+++ b/lib/target/vz/classic/vz_crt0.asm
@@ -132,10 +132,6 @@ l_dcal:
         jp      (hl)
 
 
-
-	defm  "Small C+ VZ"
-	defb   0
-
         INCLUDE "crt/classic/crt_runtime_selection.asm"
 
 	INCLUDE "crt/classic/crt_section.asm"


### PR DESCRIPTION
As for `+laser500`, this removes the "Small C+ VZ" signature string for `+vz` targets