### PR TITLE
sccz80: Cleanup fp const handling

### DIFF
--- a/src/sccz80/ccdefs.h
+++ b/src/sccz80/ccdefs.h
@@ -69,6 +69,7 @@ extern void       write_double_queue(void);
 extern void       decrement_double_ref(LVALUE *lval);
 extern void       increment_double_ref(LVALUE *lval);
 extern void       decrement_double_ref_direct(double value);
+extern void       indicate_double_written(int litlab);
 
 extern void       dofloat(double raw, unsigned char fa[]);
 #include "data.h"

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -604,11 +604,9 @@ void immed2(void)
 }
 
 /* Partial instruction to access literal */
-void immedlit(int lab)
+void immedlit(int lab, int offs)
 {
-    immed();
-    queuelabel(lab);
-    outbyte('+');
+    outfmt("\tld\thl,i_%d+%d",lab,offs);
 }
 
 /* Push long onto stack */

--- a/src/sccz80/codegen.h
+++ b/src/sccz80/codegen.h
@@ -16,7 +16,7 @@ extern void indirect(LVALUE *lval);
 extern void swap(void);
 extern void immed(void);
 extern void immed2(void);
-extern void immedlit(int lab);
+extern void immedlit(int lab,int offs);
 extern void lpush(void);
 extern void zpushde(void);
 extern void zpush(void);

--- a/src/sccz80/declinit.c
+++ b/src/sccz80/declinit.c
@@ -341,7 +341,7 @@ static void output_double_string_load(double value)
     output_section(c_init_section);
     lval.const_val = value;
     load_double_into_fa(&lval);
-    immedlit(dumplocation); outdec(0); nl();
+    immedlit(dumplocation,0); nl();
     callrts("dstore");
     output_section(c_data_section);
 }

--- a/src/sccz80/define.h
+++ b/src/sccz80/define.h
@@ -75,6 +75,7 @@ typedef enum {
     KIND_CARRY
 } Kind;
 
+#define kind_is_integer(k) ( k == KIND_CHAR || k == KIND_INT || k == KIND_SHORT || k == KIND_LONG )
 
 typedef struct {
     size_t    size;

--- a/src/sccz80/io.c
+++ b/src/sccz80/io.c
@@ -150,6 +150,7 @@ void discardbuffer(t_buffer* buf)
         return;
     if (currentbuffer == buf)
         currentbuffer = (t_buffer*)currentbuffer->before;
+    *buf->next = '\0';
     FREENULL(buf->start);
     buf->start = buf->next = 0;
     FREENULL(buf);
@@ -183,10 +184,10 @@ void setstage(char** before, char** start)
 
 void clearstage_info(const char *file, int line, char* before, char* start)
 {
-   // printf("%s:%d Clearing stage %s\n",file, line,before);
     *stagenext = 0;
-    if ((stagenext = before))
+    if ((stagenext = before)) {
         return;
+    }
     if (start) {
         if (output != NULL) {
 #ifdef INBUILT_OPTIMIZER
@@ -259,6 +260,16 @@ int outstage(char c)
 
 void outstr(const char *ptr)
 {
+    const char *loc;
+    if ( stagenext == NULL && currentbuffer == NULL) {
+        loc = ptr;
+        while (   (loc = strstr(loc,"ld\thl,i_")) != NULL ) {
+            int lab;
+            loc += strlen("ld\thl,i_");
+            lab = atoi(loc);
+            indicate_double_written(lab);     
+        }
+    }
     while (outbyte(*ptr++))
         ;
 }

--- a/src/sccz80/primary.c
+++ b/src/sccz80/primary.c
@@ -48,8 +48,7 @@ int primary(LVALUE* lval)
             lval->ptr_type = KIND_CHAR; /* djm 9/3/99 */
             lval->val_type = KIND_INT;
             lval->flags = FLAGS_NONE;
-            immedlit(litlab);
-            outdec(lval->const_val);
+            immedlit(litlab,lval->const_val);
             nl();
             return 0;
         } else if ((ptr = findloc(sname))) {

--- a/testsuite/results/Issue_1007_Fix_FP_Constant_Multiplication.opt
+++ b/testsuite/results/Issue_1007_Fix_FP_Constant_Multiplication.opt
@@ -14,13 +14,9 @@
 
 
 ._main
-	ld	hl,i_3+0
-	call	dload
-	call	ifix
+	ld	hl,9	;const
 	push	hl
-	ld	hl,i_5+0
-	call	dload
-	call	ifix
+	ld	hl,20	;const
 	push	hl
 	call	_do_something
 	pop	bc
@@ -28,19 +24,6 @@
 	ret
 
 
-	SECTION	rodata_compiler
-.i_2
-	;0.450000
-	defb	102,102,102,102,102,127
-.i_3
-	;9.000000
-	defb	0,0,0,0,16,132
-.i_4
-	;0.500000
-	defb	0,0,0,0,0,128
-.i_5
-	;20.000000
-	defb	0,0,0,0,32,133
 
 
 	SECTION	bss_compiler


### PR DESCRIPTION
Only output those constants that are actually referenced.

Don't load a double and downcast an integer const. just load an integer const. 