### PR TITLE
(classic) Keyboard joystick support

### DIFF
--- a/include/games.h
+++ b/include/games.h
@@ -199,6 +199,13 @@ extern unsigned char *joystick_type[];
 	#define GAME_DEVICES 4
 #endif
 
+#ifdef __ALPHATRO__
+#ifdef DEFINE_JOYSTICK_TYPE
+	unsigned char *joystick_type[] = {"QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
+#endif
+	#define GAME_DEVICES 4
+#endif
+
 #ifdef __TRS80__
 #ifdef DEFINE_JOYSTICK_TYPE
 	unsigned char *joystick_type[] = {"QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};

--- a/include/games.h
+++ b/include/games.h
@@ -166,9 +166,9 @@ extern unsigned char *joystick_type[];
 
 #ifdef __SVI__
 #ifdef DEFINE_JOYSTICK_TYPE
-	unsigned char *joystick_type[] = { "Cursor", "Joystick 1", "Joystick 2"};
+	unsigned char *joystick_type[] = { "Joystick 1", "Joystick 2", "QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
 #endif
-	#define GAME_DEVICES 3
+	#define GAME_DEVICES 6
 #endif
 
 #ifdef __SC3000__

--- a/include/games.h
+++ b/include/games.h
@@ -173,9 +173,9 @@ extern unsigned char *joystick_type[];
 
 #ifdef __SC3000__
 #ifdef DEFINE_JOYSTICK_TYPE
-	unsigned char *joystick_type[] = { "Joystick 1", "Joystick 2"};
+	unsigned char *joystick_type[] = { "Joystick 1", "Joystick 2", "QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
 #endif
-	#define GAME_DEVICES 2
+	#define GAME_DEVICES 6
 #endif
 
 #ifdef __SPECTRUM__

--- a/include/games.h
+++ b/include/games.h
@@ -199,6 +199,13 @@ extern unsigned char *joystick_type[];
 	#define GAME_DEVICES 4
 #endif
 
+#ifdef __TRS80__
+#ifdef DEFINE_JOYSTICK_TYPE
+	unsigned char *joystick_type[] = {"QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
+#endif
+	#define GAME_DEVICES 4
+#endif
+
 
 #ifdef __ACE__
 #ifdef DEFINE_JOYSTICK_TYPE

--- a/include/games.h
+++ b/include/games.h
@@ -157,6 +157,13 @@ extern unsigned char *joystick_type[];
 	#define GAME_DEVICES 2
 #endif
 
+#ifdef __LYNX__
+#ifdef DEFINE_JOYSTICK_TYPE
+	unsigned char *joystick_type[] = { "QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
+#endif
+	#define GAME_DEVICES 4
+#endif
+
 #ifdef __RX78__
 #ifdef DEFINE_JOYSTICK_TYPE
 	unsigned char *joystick_type[] = {"Joystick 1", "Joystick 2", "QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};

--- a/include/games.h
+++ b/include/games.h
@@ -96,9 +96,9 @@ extern unsigned char *joystick_type[];
 
 #ifdef __M5__
 #ifdef DEFINE_JOYSTICK_TYPE
-	unsigned char *joystick_type[] = { "Cursor keys + Space"};
+	unsigned char *joystick_type[] = { "Joystick 1 + Space", "QAOP-MN", "8246-05", "hjkl-sd"};
 #endif
-	#define GAME_DEVICES 1
+	#define GAME_DEVICES 4
 #endif
 
 #ifdef __MSX__

--- a/include/games.h
+++ b/include/games.h
@@ -2,6 +2,7 @@
 #define __GAMES_H__
 
 #include <sys/compiler.h>
+#include <stdint.h>
 
 #ifdef __TIKI100__
 #include <tiki100.h>
@@ -40,6 +41,10 @@ extern void __LIB__ putsprite(int ortype, int x, int y, void *sprite) __smallc;
 
 /* Joystick (or whatever game device) control function */
 extern unsigned int __LIB__  joystick(int game_device) __z88dk_fastcall;
+
+/* Internal keyboard joysticks that use inkey driver */
+extern uint8_t __LIB__ joystick_sc(int *scan_codes) __z88dk_fastcall;
+extern uint8_t __LIB__ kjoystick(uint8_t keycodes) __z88dk_fastcall;
 
 #define MOVE_RIGHT 1
 #define MOVE_LEFT  2
@@ -154,9 +159,9 @@ extern unsigned char *joystick_type[];
 
 #ifdef __RX78__
 #ifdef DEFINE_JOYSTICK_TYPE
-	unsigned char *joystick_type[] = {"Joystick 1", "Joystick 2"};
+	unsigned char *joystick_type[] = {"Joystick 1", "Joystick 2", "QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
 #endif
-	#define GAME_DEVICES 2
+	#define GAME_DEVICES 6
 #endif
 
 #ifdef __SVI__
@@ -179,6 +184,21 @@ extern unsigned char *joystick_type[];
 #endif
 	#define GAME_DEVICES 5
 #endif
+
+#ifdef __SUPER80__
+#ifdef DEFINE_JOYSTICK_TYPE
+	unsigned char *joystick_type[] = {"QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
+#endif
+	#define GAME_DEVICES 4
+#endif
+
+#ifdef __AQUARIUS__
+#ifdef DEFINE_JOYSTICK_TYPE
+	unsigned char *joystick_type[] = {"QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};
+#endif
+	#define GAME_DEVICES 4
+#endif
+
 
 #ifdef __ACE__
 #ifdef DEFINE_JOYSTICK_TYPE

--- a/include/games.h
+++ b/include/games.h
@@ -131,9 +131,9 @@ extern unsigned char *joystick_type[];
 
 #ifdef __LASER500__
 #ifdef DEFINE_JOYSTICK_TYPE
-	unsigned char *joystick_type[] = {"Joystick 1"};
+	unsigned char *joystick_type[] = {"Joystick 1", "QAOP-MN", "8246-05", "hjkl-sd"};
 #endif
-	#define GAME_DEVICES 1
+	#define GAME_DEVICES 4
 #endif
 
 #ifdef __MC1000__

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -986,6 +986,7 @@ alphatro_clib.lib:
 	@$(RM) -f video/mc6845/*.o
 	$(MAKE) gfxdeps
 	$(call buildgeneric,alphatro)
+	$(MAKE) -C games TARGET=alphatro
 	TARGET=alphatro TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORalphatro -x$(OUTPUT_DIRECTORY)/alphatro_clib @$(LISTFILE_DIRECTORY)/alphatro.lst
 
 # SPC-1000 - dom

--- a/libsrc/alphatro.lst
+++ b/libsrc/alphatro.lst
@@ -18,4 +18,6 @@ graphics/__gfx_coords
 graphics/alphatro/textpixl6
 graphics/alphatro/cleargraphics
 @video/mc6845/mc6845.lst
+games/alphatro/keys_joystick
+@games/games.lst
 @z80.lst

--- a/libsrc/aquarius.lst
+++ b/libsrc/aquarius.lst
@@ -19,6 +19,7 @@ games/aquarius/bit_open
 games/aquarius/bit_open_di
 games/aquarius/bit_close
 games/aquarius/bit_close_ei
+games/aquarius/keys_joystick
 @games/games.lst
 psg/aquarius/set_psg
 psg/aquarius/set_psg_callee

--- a/libsrc/games/alphatro/keys_joystick.asm
+++ b/libsrc/games/alphatro/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$0202, $0402, $0102, $0802, $0403, $0000
+
+keys_qaop:
+	defw	$0107, $8008, $0209, $0207, $2008, $4008, $0000
+
+keys_vi:
+	defw	$1008, $0108, $0408, $0808, $0807, $1009, $0000
+
+keys_8246:
+	defw	$4005, $1005, $0405, $0104, $0105, $2005, $0000

--- a/libsrc/games/aquarius/keys_joystick.asm
+++ b/libsrc/games/aquarius/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$0243, $1043, $2042, $0442, $1006, $0000
+
+keys_qaop:
+	defw	$0801, $0202, $2006, $0807, $0802, $1002, $0000
+
+keys_vi:
+	defw	$1001, $1003, $2002, $0402, $0406, $1005, $0000
+
+keys_8246:
+	defw	$0104, $0405, $0107, $0103, $0401, $0105, $0000

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -118,6 +118,7 @@ IF FORtrs80
         defc sndbit_port   = 255
         defc sndbit_bit    = 1
         defc sndbit_mask   = 3
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 IF FORvg5k

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -64,6 +64,13 @@ IF FORaquarius
 	defc JOYSTICK_inkey = 1
 ENDIF
 
+IF FORalphatro
+        defc sndbit_port   = 0
+        defc sndbit_bit    = 0
+        defc sndbit_mask   = 0
+	defc JOYSTICK_inkey = 1
+ENDIF
+
 IF FORenterprise
         defc sndbit_port   = $A8
         defc sndbit_bit    = 5

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -226,6 +226,7 @@ IF FORlynx
         defc sndbit_port   = 0
         defc sndbit_bit    = 0
         defc sndbit_mask   = 0
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 IF FORosca

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -36,6 +36,7 @@ IF FORsvi
         defc sndbit_port   = 150
         defc sndbit_bit    = 7
         defc sndbit_mask   = 158        ; bit 7 (key click) and 5 (tape)
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 IF FORsam
@@ -60,6 +61,7 @@ IF FORaquarius
         defc sndbit_port   = 252
         defc sndbit_bit    = 0
         defc sndbit_mask   = 1
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 IF FORenterprise
@@ -183,6 +185,7 @@ IF FORsuper80
 	defc	sndbit_port = $F0
 	defc	sndbit_bit = 3
 	defc	sndbit_mask = 8
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 
@@ -264,6 +267,13 @@ IF FORpv2000
 ENDIF
 
 
+IF FORrx78
+	defc sndbit_port	= $FF
+	defc sndbit_bit    = 3
+	defc sndbit_mask   = $0F			; $0F for full volume output
+	defc JOYSTICK_inkey = 1
+ENDIF
+
 ; ********************************************************
 ;   This last part refers to NOT YET supported hardware
 ; ********************************************************
@@ -280,11 +290,6 @@ IF FORpasopia
     defc sndbit_mask   = $0F			; $0F for full volume output
 ENDIF
 
-IF FORrx78
-	defc sndbit_port	= $FF
-    defc sndbit_bit    = 3
-    defc sndbit_mask   = $0F			; $0F for full volume output
-ENDIF
 
 IF FORsmc777
 	defc sndbit_port	= $53		; possibly valid also for Sony SMC 70
@@ -293,3 +298,6 @@ IF FORsmc777
 ENDIF
 
 
+IF !JOYSTICK_inkey
+	defc	JOYSTICK_inkey = 0
+ENDIF

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -246,14 +246,16 @@ ENDIF
 
 IF FORsc3000
 	defc sndbit_port	= $7F		; also valid for SG-1000
-    defc sndbit_bit    = 3
-    defc sndbit_mask   = $0F			; $0F for full volume output
+        defc sndbit_bit    = 3
+        defc sndbit_mask   = $0F			; $0F for full volume output
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 IF FORm5
 	defc sndbit_port	= $20
-    defc sndbit_bit    = 3
-    defc sndbit_mask   = $0F			; $0F for full volume output
+        defc sndbit_bit    = 3
+        defc sndbit_mask   = $0F			; $0F for full volume output
+	defc JOYSTICK_inkey = 1
 ENDIF
 
 IF FORmtx

--- a/libsrc/games/games.lst
+++ b/libsrc/games/games.lst
@@ -17,3 +17,6 @@ games/obj/${TARGET}/bit_close
 games/obj/${TARGET}/bit_close_ei
 games/obj/${TARGET}/beeper
 games/obj/${TARGET}/joystick_type
+games/obj/${TARGET}/joystick_sc
+games/obj/${TARGET}/kjoystick
+games/obj/${TARGET}/joystick_inkey

--- a/libsrc/games/games_mwr.lst
+++ b/libsrc/games/games_mwr.lst
@@ -16,3 +16,6 @@ games/obj/${TARGET}/bit_close
 games/obj/${TARGET}/bit_close_ei
 games/obj/${TARGET}/beeper_mwr
 games/obj/${TARGET}/joystick_type
+games/obj/${TARGET}/joystick_sc
+games/obj/${TARGET}/kjoystick
+games/obj/${TARGET}/joystick_inkey

--- a/libsrc/games/joystick.asm
+++ b/libsrc/games/joystick.asm
@@ -8,7 +8,10 @@
 	SECTION   code_clib
         PUBLIC    joystick
         PUBLIC    _joystick
+	EXTERN	joystick_inkey
 	EXTERN	getk
+
+	INCLUDE	"games/games.inc"
 
 .joystick
 ._joystick
@@ -16,79 +19,18 @@
 		
 	ld	a,l
 
+IF JOYSTICK_inkey = 0
 	cp	1	 ; Stick emulation 1 (qaop-mn)
 	jr	nz,j_no1
-	call	getk
-	ld	a,l
-	ld	l,0
-	or	@00100000	; TO_LOWER
-	cp	'm'
-	jr	nz,no_fire1
-	set	4,l
-	jr	j_done
-.no_fire1
-	cp	'n'
-	jr	nz,no_fire2
-	set	5,l
-	jr	j_done
-.no_fire2
-	cp	'q'
-	jr	nz,no_up
-	set	3,l
-	jr	j_done
-.no_up
-	cp	'a'
-	jr	nz,no_down
-	set	2,l
-	jr	j_done
-.no_down
-	cp	'o'
-	jr	nz,no_left
-	set	1,l
-	jr	j_done
-.no_left
-	cp	'p'
-	jr	nz,no_right
-	set	0,l
-.no_right
-	jr	j_done
+	INCLUDE	"games/joystick_qaop.as1"
 .j_no1
 	cp	2	 ; Stick emulation 2 (8246-05)
 	jr	nz,j_no2
-	call	getk
-	ld	a,l
-	ld	l,0
-	cp	'0'
-	jr	nz,no_fire1_a
-	set	4,l
-	jr	j_done
-.no_fire1_a
-	cp	'5'
-	jr	nz,no_fire2_a
-	set	5,l
-	jr	j_done
-.no_fire2_a
-	cp	'8'
-	jr	nz,no_up_a
-	set	3,l
-	jr	j_done
-.no_up_a
-	cp	'2'
-	jr	nz,no_down_a
-	set	2,l
-	jr	j_done
-.no_down_a
-	cp	'4'
-	jr	nz,no_left_a
-	set	1,l
-	jr	j_done
-.no_left_a
-	cp	'6'
-	jr	nz,no_right_a
-	set	0,l
-.no_right_a
-	jr	j_done
+	INCLUDE	"games/joystick_8246.as1"
 .j_no2
-	xor	a
-.j_done
+	ld	hl,0
 	ret
+ELSE
+	jp	joystick_inkey
+ENDIF	
+

--- a/libsrc/games/joystick_8246.as1
+++ b/libsrc/games/joystick_8246.as1
@@ -1,0 +1,34 @@
+; Snippet for 8246-05 joystick
+
+	call	getk
+	ld	a,l
+	ld	hl,0
+	cp	'0'
+	jr	nz,no_fire1_a
+	set	4,l
+	ret
+.no_fire1_a
+	cp	'5'
+	jr	nz,no_fire2_a
+	set	5,l
+	ret
+.no_fire2_a
+	cp	'8'
+	jr	nz,no_up_a
+	set	3,l
+	ret
+.no_up_a
+	cp	'2'
+	jr	nz,no_down_a
+	set	2,l
+	ret
+.no_down_a
+	cp	'4'
+	jr	nz,no_left_a
+	set	1,l
+	ret
+.no_left_a
+	cp	'6'
+	ret	nz
+	set	0,l
+	ret

--- a/libsrc/games/joystick_inkey.asm
+++ b/libsrc/games/joystick_inkey.asm
@@ -1,0 +1,29 @@
+; Keyboard joysticks based on inkey
+
+	MODULE	joystick_inkey
+	SECTION	code_clib
+
+
+	PUBLIC	joystick_inkey
+
+        EXTERN  joystick_sc
+        EXTERN  keys_qaop
+        EXTERN  keys_8246
+        EXTERN  keys_vi
+        EXTERN  keys_cursor
+
+joystick_inkey:
+        ld      hl,keys_qaop
+        cp      1
+        jp      z,joystick_sc
+        ld      hl,keys_8246
+        cp      2
+        jp      z,joystick_sc
+        ld      hl,keys_vi
+        cp      3
+        jp      z,joystick_sc
+        ld      hl,keys_cursor
+        cp      4
+        jp      z,joystick_sc
+        ld      hl,0
+        ret

--- a/libsrc/games/joystick_qaop.as1
+++ b/libsrc/games/joystick_qaop.as1
@@ -1,0 +1,36 @@
+; Snippet for QAOP-MN joystick
+
+	call	getk
+	ld	a,l
+	ld	hl,0
+	or	@00100000	; TO_LOWER
+	cp	'm'
+	jr	nz,no_fire1
+	set	4,l
+	ret
+.no_fire1
+	cp	'n'
+	jr	nz,no_fire2
+	set	5,l
+	ret
+.no_fire2
+	cp	'q'
+	jr	nz,no_up
+	set	3,l
+	ret
+.no_up
+	cp	'a'
+	jr	nz,no_down
+	set	2,l
+	ret
+.no_down
+	cp	'o'
+	jr	nz,no_left
+	set	1,l
+	ret
+.no_left
+	cp	'p'
+	ret	nz
+	set	0,l
+	ret
+

--- a/libsrc/games/joystick_sc.asm
+++ b/libsrc/games/joystick_sc.asm
@@ -1,0 +1,52 @@
+;
+;
+; uint8_t joystick_sc(uint16_t keys[...]) __z88dk_fastcall
+
+; Keys are ordered: RIGHT, LEFT, DOWN, UP, FIRE1, FIRE2, FIRE3, FIRE4
+; Terminated by \0
+;
+; Uses scancodes
+
+	MODULE	joystick_sc
+
+	SECTION	code_clib
+	PUBLIC	joystick_sc
+	PUBLIC	_joystick_sc
+
+	EXTERN	in_LookupKey
+	EXTERN	in_KeyPressed
+
+
+joystick_sc:
+_joystick_sc:
+	ld	b,8
+	ld	de,$0001
+loop:
+	push	bc
+	ld	c,(hl)
+	inc	hl
+	ld	b,(hl)	
+	inc	hl
+	ld	a,c
+	or	b
+	jr	z,finished
+	push	hl
+	ld	l,c
+	ld	h,b
+	push	de
+	call	in_KeyPressed
+	pop	de
+	jr	nc,continue
+	ld	a,d
+	or	e
+	ld	d,a
+continue:
+	sla	e	;Shift mask across
+	pop	hl
+	pop	bc
+	djnz	loop
+finished:
+	pop	bc
+	ld	l,d
+	ld	h,0
+	ret

--- a/libsrc/games/kjoystick.asm
+++ b/libsrc/games/kjoystick.asm
@@ -1,0 +1,51 @@
+;
+;
+; uint8_t kjoystick(uint8_t keys[6]) __z88dk_fastcall
+
+; Keys are ordered: RIGHT, LEFT, DOWN, UP, FIRE1, FIRE2, FIRE3, FIRE4
+; Terminated by \0
+
+	MODULE	kjoystick
+
+	SECTION	code_clib
+	PUBLIC	kjoystick
+	PUBLIC	_kjoystick
+
+	EXTERN	in_LookupKey
+	EXTERN	in_KeyPressed
+
+
+kjoystick:
+_kjoystick:
+	ld	b,8
+	ld	de,$0001
+loop:
+	ld	a,(hl)
+	and	a
+	jr	z,finished
+	push	bc
+	inc	hl
+	push	hl
+	; Map to a keycode
+	ld	l,a
+	push	de		;Save result + masks
+	call	in_LookupKey	;This is inefficient, we should do better
+	jr	c,nokeys
+	call	in_KeyPressed
+	pop	de
+	jr	nc,continue
+	ld	a,d
+	or	e
+	ld	d,a
+continue:
+	sla	e	;Shift mask across
+	pop	hl
+	pop	bc
+	djnz	loop
+finished:
+	ld	l,d
+	ld	h,0
+	ret
+nokeys:
+	pop	de
+	jr	continue

--- a/libsrc/games/laser500/joystick.asm
+++ b/libsrc/games/laser500/joystick.asm
@@ -14,14 +14,15 @@
         PUBLIC    joystick
 	PUBLIC	_joystick
 	EXTERN	get_psg
+	EXTERN	joystick_inkey
 
 
 .joystick
 ._joystick
 	;__FASTCALL__ : joystick no. in HL
 	ld	hl,0
-	cp	1
-	ret	nz
+	dec	a
+	jp	nz,joystick_inkey
 
 ; 0 = #define MOVE_RIGHT 1
 ; 1 = #define MOVE_LEFT  2

--- a/libsrc/games/laser500/keys_joystick.asm
+++ b/libsrc/games/laser500/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$4002, $0409, $0109, $0809, $1007, $0000
+
+keys_qaop:
+	defw	$0805, $0405, $2001, $2002, $0107, $0100, $0000
+
+keys_vi:
+	defw	$0406, $0101, $0106, $0206, $1001, $0801, $0000
+
+keys_8246:
+	defw	$0103, $0403, $1003, $0204, $0804, $0203, $0000

--- a/libsrc/games/lynx/keys_joystick.asm
+++ b/libsrc/games/lynx/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$2009, $0409, $2000, $1000, $0804, $0000
+
+keys_qaop:
+	defw	$0207, $0406, $2002, $0202, $0805, $1004, $0000
+
+keys_vi:
+	defw	$0407, $0404, $2005, $2006, $1002, $1001, $0000
+
+keys_8246:
+	defw	$0104, $0201, $0102, $0205, $0107, $0103, $0000

--- a/libsrc/games/m5/joystick.asm
+++ b/libsrc/games/m5/joystick.asm
@@ -8,6 +8,7 @@
 	SECTION code_clib
         PUBLIC    joystick
         PUBLIC    _joystick
+	EXTERN	joystick_inkey
 
 
 
@@ -16,6 +17,14 @@
 	;__FASTCALL__ : joystick no. in HL
 		
 	ld	a,l
+	cp	1
+	jr	z,do_joystick
+	dec	a
+	jp	joystick_inkey
+
+
+
+do_joystick:
 
 	ld	hl,0
 	dec	a
@@ -42,12 +51,12 @@
 	
 	ld	e,a
 	in a,($30)	; keyboard row scan
-	and $40	; mask the SPACE key
+	rrca
+	rrca		; FIRE
+	and $10	; mask the SPACE key
 	;FUDLR
-	rra
-	rra		; FIRE
 	or e
-	ld	l,e
+	ld	l,a
 	
 .no_cursor
 	ret

--- a/libsrc/games/m5/keys_joystick.asm
+++ b/libsrc/games/m5/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$8072, $2073, $4073, $8073, $4030, $0000
+
+keys_qaop:
+	defw	$0236, $0136, $0133, $0132, $4034, $2034, $0000
+
+keys_vi:
+	defw	$1036, $2033, $4033, $8033, $0233, $0433, $0000
+
+keys_8246:
+	defw	$2031, $0831, $0231, $8031, $0235, $1031, $0000

--- a/libsrc/games/rx78/joystick.asm
+++ b/libsrc/games/rx78/joystick.asm
@@ -3,6 +3,7 @@
 	SECTION	code_clib
 	PUBLIC	joystick
 	PUBLIC	_joystick
+	EXTERN	joystick_inkey
 
 ; 0 = #define MOVE_RIGHT 1
 ; 1 = #define MOVE_LEFT  2
@@ -14,6 +15,10 @@
 
 ; hl = 1 - player 1 joystick
 ;    = 2 - player 2 joystick
+;    = 3 - qaop
+;    = 4 - 8246
+;    = 5 - hjkl
+;    = 6 - cursors
 
 ; Ports 10, 11, 12 = J1 13, 14, 15 = J2
 
@@ -24,6 +29,10 @@ _joystick:
 	cp	1
 	jr	z,read_joystick
 	ld	h,13
+	cp	2
+	jr	z,read_joystick
+	sub	2
+	jp	joystick_inkey
 
 read_joystick:
 	ld	bc,0xf4

--- a/libsrc/games/rx78/keys_joystick.asm
+++ b/libsrc/games/rx78/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$0806, $1006, $0206, $0406, $0106, $0000
+
+keys_qaop:
+	defw	$0104, $8003, $0202, $0204, $2003, $4003, $0000
+
+keys_vi:
+	defw	$1003, $0103, $0403, $0803, $0804, $1002, $0000
+
+keys_8246:
+	defw	$4000, $1000, $0400, $0101, $0100, $2000, $0000

--- a/libsrc/games/sc3000/joystick.asm
+++ b/libsrc/games/sc3000/joystick.asm
@@ -7,6 +7,7 @@
 		SECTION	code_clib
 		PUBLIC	joystick
 		PUBLIC	_joystick
+		EXTERN	joystick_inkey
 
 
 ; Port $dd:
@@ -35,6 +36,9 @@
 
 joystick:
 _joystick:
+	ld	a,l
+	cp	3
+	jr	nc,handle_keyboard
 	ld	h,0
 	in	a,($de)		;Select row 7 (only needed on SC-3000, no effect on SG-1000)
 	and	248
@@ -92,3 +96,7 @@ not_down_j1:
 	ret	z
 	set	3,l
 	ret
+
+handle_keyboard:
+	sub	2
+	jp	joystick_inkey

--- a/libsrc/games/sc3000/keys_joystick.asm
+++ b/libsrc/games/sc3000/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$2006, $2005, $2004, $4006, $1001, $0000
+
+keys_qaop:
+	defw	$8002, $8001, $0400, $0200, $0806, $0805, $0000
+
+keys_vi:
+	defw	$4001, $0405, $0406, $4000, $0401, $0402, $0000
+
+keys_8246:
+	defw	$0105, $0103, $0101, $0120, $0122, $0104, $0000

--- a/libsrc/games/super80/keys_joystick.asm
+++ b/libsrc/games/super80/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$8004, $8005, $8006, $8007, $4000, $0000
+
+keys_qaop:
+	defw	$0400, $0207, $0101, $0401, $0205, $0206, $0000
+
+keys_vi:
+	defw	$0204, $0200, $0202, $0203, $0403, $0104, $0000
+
+keys_8246:
+	defw	$1005, $1003, $1001, $1007, $2007, $1004, $0000

--- a/libsrc/games/svi/joystick.asm
+++ b/libsrc/games/svi/joystick.asm
@@ -1,0 +1,80 @@
+;
+;	Game device library for the SVI
+;       Stefano Bodrato - 3/12/2007
+;
+;	$Id: joystick.asm,v 1.9 2016-06-16 20:23:51 dom Exp $
+;
+
+        SECTION code_clib
+        PUBLIC  joystick
+        PUBLIC  _joystick
+	EXTERN	joystick_inkey
+
+	INCLUDE	"target/svi/def/svi.def"
+
+
+.joystick
+._joystick
+	;__FASTCALL__ : joystick no. in HL
+		
+	ld	a,l
+	cp	3
+	jr	nc,try_keyboard_joystick
+
+        ld      a,14		; set PSG register #14
+        out     (PSG_ADDR),a
+        in      a,(PSG_DATAIN)		; read value
+
+	dec	l		; Joystick number
+	jr	nz,joystick_2
+
+	and	$0F
+	ld	d,a
+	in      a,(PPI_A)
+	and	$10		; Stick #1 Trigger
+	or	d
+
+	jr	continue
+
+.joystick_2
+	rra
+	rra
+	rra
+	rra
+	and	$0F
+	ld	d,a
+	in      a,(PPI_A)
+	rra
+	and	$10		; Stick #2 Trigger
+	or	d
+
+.continue
+        cpl
+        and	$1f
+
+;    00fFRLDU	..got from MSX/SVI port
+;    --fFUDLR 	..to be converted to
+
+	ld	l,a
+	and	@00110000
+	ld	d,a	; keep 'Fire buttons'
+	
+	xor	a
+	ld	h,a
+	rr	l
+	rla
+	rr	l
+	rla
+	rr	l
+	rla
+	rr	l
+	rla
+	
+	or	d
+	ld	l,a
+	
+	ret
+
+try_keyboard_joystick:
+	sub	2	
+	jp	joystick_inkey

--- a/libsrc/games/svi/keys_joystick.asm
+++ b/libsrc/games/svi/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$8008, $8006, $8007, $8005, $0108, $0000
+
+keys_qaop:
+	defw	$0104, $8003, $0202, $0204, $2003, $4003, $0000
+
+keys_vi:
+	defw	$1003, $0103, $0403, $0803, $0804, $1002, $0000
+
+keys_8246:
+	defw	$4000, $1000, $0400, $0101, $0100, $2000, $0000

--- a/libsrc/games/trs80/keys_joystick.asm
+++ b/libsrc/games/trs80/keys_joystick.asm
@@ -1,0 +1,18 @@
+
+	SECTION	rodata_clib
+	PUBLIC	keys_cursor
+	PUBLIC	keys_qaop
+	PUBLIC	keys_vi
+	PUBLIC	keys_8246
+
+keys_cursor:
+	defw	$4006, $2006, $1006, $0806, $8006, $0000
+
+keys_qaop:
+	defw	$0102, $8001, $0200, $0202, $2001, $4001, $0000
+
+keys_vi:
+	defw	$1001, $0101, $0401, $0801, $0802, $1000, $0000
+
+keys_8246:
+	defw	$4004, $1004, $0404, $0105, $0104, $2004, $0000

--- a/libsrc/input/aquarius/in_KeyPressed.asm
+++ b/libsrc/input/aquarius/in_KeyPressed.asm
@@ -18,7 +18,7 @@ EXTERN CLIB_KEYBOARD_ADDRESS
 ._in_KeyPressed
 	ld	bc,0x7fff
 	in	a,(c)
-	ld	e,@0011000
+	ld	e,@00110000
 	bit	7,l
 	jr	z,noshift
 	bit	4,a
@@ -44,8 +44,9 @@ map_loop:
 	jr	map_loop
 done:
 	in	a,(c)
+	cpl
 	and	h		;Check with mask
-	jr	nz,fail
+	jr	z,fail
 	ld	hl,1
 	scf
 	ret

--- a/libsrc/input/laser500/in_KeyPressed.asm
+++ b/libsrc/input/laser500/in_KeyPressed.asm
@@ -67,7 +67,7 @@ check_actual_key:
 	ret
 fail:
 	ld	hl,0	
-	scf
+	and	a
 	ret
 
 ; Figure out which port we should be reading from
@@ -82,7 +82,6 @@ row_0_9_loop:
 	ret	z
 	scf
 	rl	e
-	rl	h
 	dec	a
 	jr	row_0_9_loop
 ports_a_d:

--- a/libsrc/input/lynx/in_KeyPressed.asm
+++ b/libsrc/input/lynx/in_KeyPressed.asm
@@ -44,6 +44,7 @@ check_shift:
 	and	15
 	ld	b,a
 	in	a,(c)
+	cpl
 	and	h		;Check with mask
 	jr	z,fail
 	ld	hl,1

--- a/libsrc/input/rx78/in_KeyPressed.asm
+++ b/libsrc/input/rx78/in_KeyPressed.asm
@@ -25,7 +25,7 @@ PUBLIC _in_KeyPressed
 	jr	z,fail
 	res	2,c
 .nocaps
-	bit	0,l
+	bit	6,l
 	jr	z,nofunc
 	bit	0,a
 	jr	z,fail

--- a/libsrc/input/rx78/in_keytranstbl.asm
+++ b/libsrc/input/rx78/in_keytranstbl.asm
@@ -17,7 +17,7 @@ PUBLIC in_keytranstbl
 	defb	'o', 'n', 'm', 'l', 'k', 'j', 'i', 'h'	; o, n, m, l, k, j, i, h
 	defb	'w', 'v', 'u', 't', 's', 'r', 'q', 'p'	; w, v, u, t, s, r, q, p
 	defb	  9,  11, ']','\\', '[', 'z', 'y', 'x'	; RIGHTARR, UPARR, ], \, [, z, y, x
-	defb	 12, 255, 255,   8,  10,  11,   9, ' '	; DEL, -, CLR, LEFt, RIGHT, UP, DOWN, SPC
+	defb	 12, 255, 255,   8,   9,  11,  10, ' '	; DEL, -, CLR, LEFt, RIGHT, UP, DOWN, SPC
 	defb	  6, 255,  13, 255,  27, 255, 255, 255	; CAPS, -, RET, -, STOP, -, -, -
 	defb	255, 255, 255, 255, 255, 255, 255, 255	; -, -, -, -, -, SHIFT, -, CTRL
 

--- a/libsrc/input/super80/in_KeyPressed.asm
+++ b/libsrc/input/super80/in_KeyPressed.asm
@@ -42,11 +42,12 @@ noctrl:
 rotate_loop:
 	and	@00001111
 	jr	z,rotate_done
-	sla	b
+	rlc	b
 	dec	a
 	jr	nz,rotate_loop
 
 rotate_done:
+	ld	a,b
 	out	(0xf8),a
 	in	a,(0xfa)
 	cpl

--- a/libsrc/laser500.lst
+++ b/libsrc/laser500.lst
@@ -33,7 +33,7 @@ graphics/text/swapgfxbk
 games/laser500/bit_open
 games/laser500/bit_close
 games/laser500/joystick
-games/laser500/joystick
+games/laser500/keys_joystick
 @games/games_mwr.lst
 games/obj/laser500/joystick_type
 @z80.lst

--- a/libsrc/lynx.lst
+++ b/libsrc/lynx.lst
@@ -26,4 +26,6 @@ graphics/stencil_render2
 graphics/text/swapgfxbk
 @gfxbase.lst
 @video/mc6845/mc6845.lst
+games/lynx/keys_joystick
+@games/games.lst
 @z80.lst

--- a/libsrc/m5.lst
+++ b/libsrc/m5.lst
@@ -34,6 +34,7 @@ graphics/msx/surface/surface_draw
 graphics/msx/surface/surface_pixladdr
 graphics/msx/surface/surface_plotpixl
 graphics/msx/surface/surface_stencil_render
+games/m5/keys_joystick
 games/m5/joystick
 psg/sn76489/bit_open
 @games/games.lst

--- a/libsrc/rx78.lst
+++ b/libsrc/rx78.lst
@@ -32,5 +32,6 @@ graphics/clrarea
 graphics/fill
 graphics/getsprite
 games/rx78/joystick
+games/rx78/keys_joystick
 @games/games.lst
 @z80.lst

--- a/libsrc/sc3000.lst
+++ b/libsrc/sc3000.lst
@@ -34,6 +34,7 @@ graphics/msx/surface/surface_plotpixl
 graphics/msx/surface/surface_stencil_render
 psg/sn76489/bit_open
 games/sc3000/joystick
+games/sc3000/keys_joystick
 @games/games.lst
 psg/sn76489/psg_tone
 psg/sn76489/psg_volume

--- a/libsrc/super80.lst
+++ b/libsrc/super80.lst
@@ -24,5 +24,6 @@ graphics/text/swapgfxbk
 @stdio/stdio.lst
 games/super80/bit_open
 games/super80/bit_close
+games/super80/keys_joystick
 @games/games.lst
 @z80.lst

--- a/libsrc/svi.lst
+++ b/libsrc/svi.lst
@@ -35,7 +35,8 @@ graphics/msx/surface/surface_draw
 graphics/msx/surface/surface_pixladdr
 graphics/msx/surface/surface_plotpixl
 graphics/msx/surface/surface_stencil_render
-games/msx/joystick
+games/svi/joystick
+games/svi/keys_joystick
 games/msx/bit_open
 games/msx/bit_open_di
 games/msx/bit_close

--- a/libsrc/trs80.lst
+++ b/libsrc/trs80.lst
@@ -17,6 +17,7 @@ games/trs80/bit_open
 games/trs80/bit_open_di
 games/trs80/bit_close
 games/trs80/bit_close_ei
+games/trs80/keys_joystick
 @games/games.lst
 @video/mc6845/mc6845.lst
 @z80.lst


### PR DESCRIPTION
Improve and fix joystick support for: RX78, Super80, Aquarius, Alphatronic, Laser 500, Lynx Sord M5, SC3000, SVI, TRS80