### PR TITLE
[doc/z80asm.txt] Update directives definitions

### DIFF
--- a/doc/z80asm.txt
+++ b/doc/z80asm.txt
@@ -1744,7 +1744,15 @@ Some of the symbols will look like this:
     JJJ = $40D4
 
 
-7.12. FPP <8-bit expression>
+7.12. EXTERN name {, name}
+--------------------------
+
+This declares symbols as external to the current module. Such a symbol must have
+been defined as PUBLIC in another module for the current module to be able to
+use the symbol (it will be linked during the linking phase).
+
+
+7.13. FPP <8-bit expression>
 ----------------------------
 
 Interface call to the Z88 operating systems' floating point library. This is
@@ -1758,7 +1766,14 @@ the specified parameter. All Z88 floating point call mnemonics are defined in th
 "fpp.def" file.
 
 
-7.13. IF <logical expression> ... [ELSE] ... ENDIF
+7.14. GLOBAL name {, name}
+--------------------------
+
+The GLOBAL directive defines a symbol PUBLIC if it has been defined locally or
+EXTERN otherwise.
+
+
+7.15. IF <logical expression> ... [ELSE] ... ENDIF
 --------------------------------------------------
 
 This structure evaluates the logical expression as a constant, and compiles the
@@ -1767,7 +1782,7 @@ lines from ELSE to ENDIF if is is false (i.e. zero). The ELSE clause is optional
 This structure may be nested.
 
 
-7.14. IFDEF <name> ... [ELSE] ... ENDIF
+7.16. IFDEF <name> ... [ELSE] ... ENDIF
 ---------------------------------------
 
 This structure checks if the give symbol name is defined, and compiles the lines
@@ -1776,7 +1791,7 @@ false (i.e. not defined). The ELSE clause is optional. This structure may be
 nested.
 
 
-7.15. IFNDEF <name> ... [ELSE] ... ENDIF
+7.17. IFNDEF <name> ... [ELSE] ... ENDIF
 ----------------------------------------
 
 This structure checks if the give symbol name is not defined, and compiles the
@@ -1785,7 +1800,7 @@ ENDIF if false (i.e. defined). The ELSE clause is optional. This structure may b
 nested.
 
 
-7.16. INCLUDE "filename"
+7.18. INCLUDE "filename"
 ------------------------
 
 Another component that is frequently used is to 'link' an additional source file
@@ -1809,7 +1824,7 @@ after the INCLUDE directive when the included file has been parsed to the end of
 file.
 
 
-7.17. INVOKE <16-bit expression>
+7.19. INVOKE <16-bit expression>
 --------------------------------
 
 Special CALL instruction for the Ti83 calculator; it is coded as a RST 28H
@@ -1818,17 +1833,14 @@ line (for the Ti83Plus), or as a normal CALL instruction if the option is not
 passed.
 
 
-7.18. LIB name {,name}
+7.20. LIB name {,name}
 ----------------------
 
-LIB declares symbol as external to the current module. The symbol name will be
-defined as the name of a library routine which will be automatically linked into
-the application code from a library during the linking/relocation phase of the
-compilation process (if a library has been specified at the command line with the
--i option).
+This directive is obsolete. It has been replaced by the EXTERN directive (See
+changelog.txt at the root of the z88dk project).
 
 
-7.19. LINE <32-bit expr>
+7.21. LINE <32-bit expr>
 ------------------------
 
 Used when the assembler is used as the back-end of a compiler to synchronize the
@@ -1836,13 +1848,13 @@ line numbers in error messages to the lines from the compiled source. Needs the
 -C option to enable.
 
 
-7.20. LSTOFF
+7.22. LSTOFF
 ------------
 
 Switches listing output to file off temporarily. The listing file is not closed.
 
 
-7.21. LSTON
+7.23. LSTON
 -----------
 
 Enables listing output (usually from a previous LSTOFF). Both directives may be
@@ -1850,7 +1862,7 @@ useful when information from INCLUDE files is redundant in the listing file, e.g
 operating system definitions.
 
 
-7.22. MODULE name
+7.24. MODULE name
 -----------------
 
 This defines the name of the current module. This may be defined only once for a
@@ -1863,7 +1875,7 @@ sense to put it at the top. The syntax is simple - specify a legal identifier
 name after the MODULE directive, e.g. MODULE main_module
 
 
-7.23. ORG <16-bit expression>
+7.25. ORG <16-bit expression>
 -----------------------------
 
 Define address origin of compiled machine code - the position in memory where the
@@ -1882,29 +1894,32 @@ A section may contain ORG -1 to tell the linker to split the binary file of this
 section, but continue the addresses sequence from the previous section.
 
 
-7.24. XDEF name {, name}
+7.26. PUBLIC name {, name}
+--------------------------
+
+This directive declares symbols publicly available for other modules during the
+linking phase of the compilation process.
+
+
+7.27. XDEF name {, name}
 ------------------------
 
-This declares symbol globally available to other specified source file modules
-during the linking phase of the compilation process.
+This directive is obsolete. It has been replaced by the PUBLIC directive (See
+changelog.txt at the root of the z88dk project).
 
 
-7.25. XLIB name
+7.28. XLIB name
 ---------------
 
-When you need to create a library routine, it is necessary to declare the routine
-with XLIB. In functionality it declares the name globally available to all other
-modules in project, but also serves as a searchable item in libraries. A library
-routine does not contain a MODULE directive, since the XLIB name is also
-identified as the module name (you only specify one library routine per module).
+This directive is obsolete. It has been replaced by the PUBLIC directive (See
+changelog.txt at the root of the z88dk project).
 
 
-7.26. XREF name {, name}
+7.29. XREF name {, name}
 ------------------------
 
-This declares symbol as external to the current module. The name must have been
-defined as XDEF in another module to let this module reach the value of the
-symbol during the linking phase.
+This directive is obsolete. It has been replaced by the EXTERN directive (See
+changelog.txt at the root of the z88dk project).
 
 
 


### PR DESCRIPTION
Update the description the following directives based on the changelog:
* XDEF: obsolete in favor of PUBLIC
* XLIB: obsolete in favor of PUBLIC
* XREF: obsolete if favor of EXTERN
* LIB: obsolete in favor of EXTERN
* PUBLIC: replaces XDEF and XLIB
* EXTERN: replaces XREF and LIB
* GLOBAL: can be used instead of PUBLIC or EXTERN