### PR TITLE
Toshiba Pasopia7 support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Concise Record of Changes to Z88DK Releases
 
 z88dk vx.x.x - xx.xx.xxxx
 
+- [appmake] Autobooting +3 discs can now be created
+- [classic] Sony SMC-70/SMC-777 support added via +cpm -subtype=smc777
+- [classic] Toshiba Pasopia 7 support added
+- [zsdcc] Upgraded to 3.8.5 r10892
 
 z88dk v1.99C - 19.01.2019
 

--- a/include/games.h
+++ b/include/games.h
@@ -201,6 +201,14 @@ extern const unsigned char *joystick_type[];
 	#define GAME_DEVICES 5
 #endif
 
+#ifdef __PASOPIA7__
+#ifdef DEFINE_JOYSTICK_TYPE
+	const unsigned char *joystick_type[] = {"Joystick 1", "Joystick 2"};
+#endif
+	#define GAME_DEVICES 2
+#endif
+
+
 #ifdef __SUPER80__
 #ifdef DEFINE_JOYSTICK_TYPE
 	const unsigned char *joystick_type[] = {"QAOP-MN", "8246-05", "hjkl-sd", "Cursor"};

--- a/include/psg.h
+++ b/include/psg.h
@@ -99,6 +99,11 @@
 #define psgT(hz)		((int)(118750.0 / (hz)))
 #endif
 
+#ifdef __PASOPIA7__
+// 1996800 / 16 ?
+#define psgT(hz)		((int)(125000.0 / (hz)))
+#endif
+
 #ifdef __PC88__
 // 3.9936 Mhz, but is sounded bad when split as suggested.
 //   This value was chosen by trial and error.

--- a/lib/config/pasopia7.cfg
+++ b/lib/config/pasopia7.cfg
@@ -1,0 +1,16 @@
+#
+# Target configuration file for z88dk
+#
+
+# Asm file which contains the startup code (without suffix)
+CRT0		 DESTDIR/lib/target/pasopia7/classic/pasopia7_crt0
+
+# Any default options you want - these are options to zcc which are fed
+# through to compiler, assembler etc as necessary
+OPTIONS		 -O2 -SO2 -iquote. -DZ80 -D__PASOPIA7__ -M -subtype=default -clib=default
+
+CLIB		default -lpasopia7_clib -lndos -Cc-standard-escape-chars 
+
+SUBTYPE     none 
+SUBTYPE		default -Cz+pasopia7
+

--- a/lib/target/pasopia7/classic/bootstrap.asm
+++ b/lib/target/pasopia7/classic/bootstrap.asm
@@ -1,0 +1,88 @@
+; 
+; Bootstrap for Pasopia7
+;
+; Loads track by track until it's all in memory
+;
+
+	SECTION	BOOTSTRAP
+	EXTERN	__DATA_END_tail
+
+	org	$f000
+	
+	di
+	ld	hl,$d000
+	ld	de,$f000
+	ld	bc,512
+	ldir
+	jp	entry
+entry:
+	push	af
+	ld	hl,banner
+	call	print_msg
+	pop	af
+	ld	b, +(__DATA_END_tail / 2048) + 1
+	ld	hl,0		;Destination 
+	ld	de, $0201	;Start track 2
+load_track:
+	push	af		;drive
+	push	bc		;number of tracks to read
+	push	de		;sector
+	push	hl		;address
+        ld      bc,$1012
+        call    $41f9
+        ld      c,$13
+        call    $41f9
+        jr      c,load_failure
+	ld	hl,dot
+	call	print_msg
+	pop	hl
+	ld	a,h		;Step up address
+	add	8
+	ld	h,a
+	pop	de
+	inc	d		;Move to next track
+	pop	bc
+	pop	af
+	djnz	load_track
+	ld	a,2		;All RAM mode
+        out     ($3c),a
+jump_to_start:
+	jp	0		;And start
+
+	
+
+
+load_failure:
+	ld	hl,failed
+	call	print_msg
+loop:
+	jr	loop
+
+print_msg:
+	xor	a
+        out    ($3c),a
+msg1:
+	ld	a,(hl)
+	and	a
+	jr	z,done
+	rst	$18
+	inc	hl
+	jr	msg1
+done:
+	ld	a,1
+	out	($3c),a
+	ret
+
+failed:
+	defm	"Error loading from disc"
+	defb	0
+
+banner:
+	defm	"z88dk bootstrap loader, loading"
+	defb	10,13
+	defb	0
+
+dot:
+	defm	"."
+	defb	0
+

--- a/lib/target/pasopia7/classic/pasopia7_crt0.asm
+++ b/lib/target/pasopia7/classic/pasopia7_crt0.asm
@@ -1,0 +1,64 @@
+;
+;	Startup for test emulator
+;
+;	$Id: test_crt0.asm,v 1.12 2016-06-21 20:49:07 dom Exp $
+
+
+	module pasopia7_crt0
+	org	  0xd000
+
+
+;--------
+; Include zcc_opt.def to find out some info
+;--------
+
+        defc    crt0 = 1
+        INCLUDE "zcc_opt.def"
+
+;--------
+; Some scope definitions
+;--------
+
+        EXTERN    _main           ;main() is always external to crt0 code
+
+        PUBLIC    cleanup         ;jp'd to by exit()
+        PUBLIC    l_dcal          ;jp(hl)
+
+
+        defc    TAR__clib_exit_stack_size = 32
+        defc    TAR__register_sp = 65280
+	defc	CRT_KEY_DEL = 127
+	defc	__CPU_CLOCK = 4000000
+        INCLUDE "crt/classic/crt_rules.inc"
+
+	di
+
+program:
+        INCLUDE "crt/classic/crt_init_sp.asm"
+        INCLUDE "crt/classic/crt_init_atexit.asm"
+	call    crt0_init_bss
+	ld	(exitsp),sp
+IF !__CPU_R2K__
+    	ei
+ENDIF
+; Optional definition for auto MALLOC init
+; it assumes we have free space between the end of
+; the compiled program and the stack pointer
+IF DEFINED_USING_amalloc
+    INCLUDE "crt/classic/crt_init_amalloc.asm"
+ENDIF
+	call	_main
+cleanup:
+	jp	0
+
+
+l_dcal: jp      (hl)            ;Used for function pointer calls
+
+
+
+	INCLUDE "crt/classic/crt_runtime_selection.asm" 
+	
+	INCLUDE	"crt/classic/crt_section.asm"
+
+	SECTION rodata_clib
+end:            defb    0               ; null file name

--- a/lib/target/pasopia7/classic/pasopia7_crt0.asm
+++ b/lib/target/pasopia7/classic/pasopia7_crt0.asm
@@ -27,11 +27,17 @@
 
         defc    TAR__clib_exit_stack_size = 32
         defc    TAR__register_sp = 65280
+        defc    TAR__fputc_cons_generic = 1
 	defc	CRT_KEY_DEL = 127
 	defc	CRT_ORG_CODE = 0xd000
         defc    CONSOLE_COLUMNS = 40
-        defc    CONSOLE_ROWS = 24
+        defc    CONSOLE_ROWS = 25
 	defc	__CPU_CLOCK = 4000000
+
+	defc	GRAPHICS_CHAR_SET = 135
+	defc	GRAPHICS_CHAR_UNSET = 32
+	PUBLIC	GRAPHICS_CHAR_SET
+	PUBLIC	GRAPHICS_CHAR_UNSET
         INCLUDE "crt/classic/crt_rules.inc"
 
 	org	CRT_ORG_CODE	

--- a/lib/target/pasopia7/classic/pasopia7_crt0.asm
+++ b/lib/target/pasopia7/classic/pasopia7_crt0.asm
@@ -1,8 +1,5 @@
 ;
 ;	Startup for Pasopia 7
-;
-;	Just limited to 4k at the moment for experimentation
-;	Will have a 64k loading mode as well
 
 
 	MODULE pasopia7_crt0
@@ -28,11 +25,12 @@
         defc    TAR__clib_exit_stack_size = 32
         defc    TAR__register_sp = 65280
         defc    TAR__fputc_cons_generic = 1
-	defc	CRT_KEY_DEL = 127
-	defc	CRT_ORG_CODE = 0xd000
+	defc	CRT_KEY_DEL = 12
+	defc	CRT_ORG_CODE = 0
         defc    CONSOLE_COLUMNS = 40
         defc    CONSOLE_ROWS = 25
 	defc	__CPU_CLOCK = 4000000
+	defc	CLIB_FGETC_CONS_DELAY = 150
 
 	defc	GRAPHICS_CHAR_SET = 135
 	defc	GRAPHICS_CHAR_UNSET = 32
@@ -42,30 +40,79 @@
 
 	org	CRT_ORG_CODE	
 
-	di
-	ld	hl,$d000	;Just read 2k into d000 to give us a bit extra
-	ld	de,$0101
-	ld	bc,$4012
-	call	$41f9
-	ld	c,$13
-	call	$41f9
-	ld	hl,$d800	;Just read 2k into d000 to give us a bit extra
-	ld	de,$0201
-	ld	bc,$4012
-	call	$41f9
-	ld	c,$13
-	call	$41f9
+if (ASMPC<>$0000)
+        defs    CODE_ALIGNMENT_ERROR
+endif
 
+        jp      program
 
-	ld	a,0
-	ld	(__pasopia_page),a
-	out	($3c),a
+        defs    $0008-ASMPC
+if (ASMPC<>$0008)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart08
+
+        defs    $0010-ASMPC
+if (ASMPC<>$0010)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart10
+        defs    $0018-ASMPC
+if (ASMPC<>$0018)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart18
+
+        defs    $0020-ASMPC
+if (ASMPC<>$0020)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart20
+
+    defs        $0028-ASMPC
+if (ASMPC<>$0028)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart28
+
+        defs    $0030-ASMPC
+if (ASMPC<>$0030)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+        jp      restart30
+
+        defs    $0038-ASMPC
+if (ASMPC<>$0038)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+	ei
+	ret
+
+; NMI routine
+        defs    $0066-ASMPC
+if (ASMPC<>$0066)
+        defs    CODE_ALIGNMENT_ERROR
+endif
+	ret
+
+restart08:
+restart10:
+restart18:
+restart20:
+restart28:
+restart30:
+        ret
+
 
 program:
+	di
+
         INCLUDE "crt/classic/crt_init_sp.asm"
         INCLUDE "crt/classic/crt_init_atexit.asm"
 	call    crt0_init_bss
 	ld	(exitsp),sp
+	ld	a,2
+	ld	(__pasopia_page),a
     	ei
 ; Optional definition for auto MALLOC init
 ; it assumes we have free space between the end of
@@ -75,7 +122,7 @@ IF DEFINED_USING_amalloc
 ENDIF
 	call	_main
 cleanup:
-	jp	0
+	jp	cleanup
 
 
 l_dcal: jp      (hl)            ;Used for function pointer calls
@@ -90,5 +137,5 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 	PUBLIC	__pasopia_page
 __pasopia_page:	defb	0
 
-	;INCLUDE	"target/pasopia7/classic/bootstrap.asm"
+	INCLUDE	"target/pasopia7/classic/bootstrap.asm"
 

--- a/lib/target/pasopia7/classic/pasopia7_crt0.asm
+++ b/lib/target/pasopia7/classic/pasopia7_crt0.asm
@@ -113,6 +113,7 @@ program:
 	ld	(exitsp),sp
 	ld	a,2
 	ld	(__pasopia_page),a
+	im	1
     	ei
 ; Optional definition for auto MALLOC init
 ; it assumes we have free space between the end of

--- a/lib/target/pasopia7/def/pasopia7.def
+++ b/lib/target/pasopia7/def/pasopia7.def
@@ -16,9 +16,14 @@
 	defc	MEM_CTRL	= $22
 	defc	VRAM_PLANE	= $0c	;V-RAM Plane selection
 	defc	DISP_CTRL	= $0d	;Display control 1
+					;xPPPxxxx PPP = text page
 	defc	CTL_PORT	= $0f	;8255 Control port
 	defc	KEY_SCAN	= $30	;Keyboard row scan
 	defc	KEY_DATA	= $31	;And read keyboard data from here
-	defc	SCR_MODE	= $0a	;ppi0 port A, screen mode
+	defc	SCR_MODE	= $08	;ppi0 port A, screen mode
+					;G.W.Cccc
+					;G = graphics mode
+					;W = 80/40 column mode
+					;C = take colour from ccc instead of attr
 	defc	CRTC_CTRL	= $0b	;ppi0 port B, vsync, raster/lcd, disp bit
 	defc	VIDEO_MISC	= $0e	;ppi1, port C, blinking attribute wrap, palette

--- a/lib/target/pasopia7/def/pasopia7.def
+++ b/lib/target/pasopia7/def/pasopia7.def
@@ -1,0 +1,24 @@
+; Toshiba Posopia 7
+
+
+	; Port definitions
+	; ppi0 = 0x08, 0x09, 0x0a + 0x0b	- (8255) screen mode + config
+	; ppi1 = 0x0c, 0x0d, 0x0e + 0x0f	- (8255) video
+	; pac2 = 0x18, 0x19, 0x1a, 0x1b
+	; ppi2 = 0x20, 0x21, 0x22 + 0x23	- (8255) nmi
+	; 6845 = 0x28, 0x29, 0x2a, 0x2b
+	; pio  = 0x30, 0x31, 0x32 +  0x33A	- (z80), keyboard
+	; PSG1 = 0x3a
+	; PSG2 = 0x3b
+	; flopy  0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6
+
+	defc	MEM_MODE	= $3c
+	defc	MEM_CTRL	= $22
+	defc	VRAM_PLANE	= $0c	;V-RAM Plane selection
+	defc	DISP_CTRL	= $0d	;Display control 1
+	defc	CTL_PORT	= $0f	;8255 Control port
+	defc	KEY_SCAN	= $30	;Keyboard row scan
+	defc	KEY_DATA	= $31	;And read keyboard data from here
+	defc	SCR_MODE	= $0a	;ppi0 port A, screen mode
+	defc	CRTC_CTRL	= $0b	;ppi0 port B, vsync, raster/lcd, disp bit
+	defc	VIDEO_MISC	= $0e	;ppi1, port C, blinking attribute wrap, palette

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -977,6 +977,7 @@ pasopia7_clib.lib:
 	@echo '--- Building Toshiba Pasopia7 Library ---'
 	@echo ''
 	$(MAKE) gfxdeps
+	@$(RM) -f video/mc6845/*.o
 	$(call buildgeneric,pasopia7)
 	TARGET=pasopia7 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORpasopia7 -x$(OUTPUT_DIRECTORY)/pasopia7_clib @$(LISTFILE_DIRECTORY)/pasopia7.lst
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -979,6 +979,7 @@ pasopia7_clib.lib:
 	$(MAKE) gfxdeps
 	@$(RM) -f video/mc6845/*.o
 	$(call buildgeneric,pasopia7)
+	$(MAKE) -C games TARGET=pasopia7
 	TARGET=pasopia7 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORpasopia7 -x$(OUTPUT_DIRECTORY)/pasopia7_clib @$(LISTFILE_DIRECTORY)/pasopia7.lst
 
 # VTech VZ700- dom

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -28,7 +28,7 @@ all: genlibs rs232libs z88libs tilibs zxlibs eplibs c128libs nclibs cpclibs \
 	embedded_clib.lib test_clib.lib testrcm_clib.lib z1013_clib.lib z9001_clib.lib kc_clib.lib \
 	pv1000_clib.lib pv2000_clib.lib coleco_clib.lib multi8_clib.lib alphatro_clib.lib  spc1000_clib.lib \
 	laser500_clib.lib super80_clib.lib super80_vduem_clib.lib \
-	adam.lib z80tvgame_clib.lib smc777.lib \
+	adam.lib z80tvgame_clib.lib smc777.lib pasopia7_clib.lib \
 	preempt.lib zx80_clib.lib zx81libs sp1-all rcmx000_clib.lib 
 
 genlibs: z80_crt0.lib math48.lib gen_math.lib gendos.lib ndos.lib  \
@@ -970,6 +970,15 @@ multi8_clib.lib:
 	$(MAKE) gfxdeps
 	$(call buildgeneric,multi8)
 	TARGET=multi8 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORmulti8 -x$(OUTPUT_DIRECTORY)/multi8_clib @$(LISTFILE_DIRECTORY)/multi8.lst
+
+# Pasopia7 Multi8 - dom
+pasopia7_clib.lib:
+	@echo ''
+	@echo '--- Building Toshiba Pasopia7 Library ---'
+	@echo ''
+	$(MAKE) gfxdeps
+	$(call buildgeneric,pasopia7)
+	TARGET=pasopia7 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORpasopia7 -x$(OUTPUT_DIRECTORY)/pasopia7_clib @$(LISTFILE_DIRECTORY)/pasopia7.lst
 
 # VTech VZ700- dom
 laser500_clib.lib:

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -259,6 +259,12 @@ IF FORpc6001
         defc sndbit_mask   = 0
 ENDIF
 
+IF FORsmc777
+    defc sndbit_port	= $1d
+    defc sndbit_bit    = 4
+    defc sndbit_mask   = $15
+ENDIF
+
 ; ********************************************************
 ;  SN76489 PSG chip definitions
 ; ********************************************************
@@ -309,11 +315,6 @@ IF FORrx78
 	defc JOYSTICK_inkey = 1
 ENDIF
 
-IF FORsmc777
-    defc sndbit_port	= $53		; possibly valid also for Sony SMC 70
-    defc sndbit_bit    = 3
-    defc sndbit_mask   = $0F			; $0F for full volume output
-ENDIF
 
 
 IF FORcoleco
@@ -326,7 +327,7 @@ ENDIF
 ;   This last part refers to NOT YET supported hardware
 ; ********************************************************
 
-IF FORpasopia
+IF FORpasopia7
 	defc sndbit_port	= $3A		; Pasopia has also a second PSG on port $3B
     defc sndbit_bit    = 3
     defc sndbit_mask   = $0F			; $0F for full volume output

--- a/libsrc/games/games.inc
+++ b/libsrc/games/games.inc
@@ -189,6 +189,12 @@ IF FORaussie
         defc sndbit_mask   = 128	; bit 6 should stay 'on'
 ENDIF
 
+IF FORpasopia7
+    defc sndbit_port	= $30	
+    defc sndbit_bit    = 7
+    defc sndbit_mask   = $80	
+ENDIF
+
 IF FORsuper80
 	defc	sndbit_port = $F0
 	defc	sndbit_bit = 3
@@ -265,6 +271,7 @@ IF FORsmc777
     defc sndbit_mask   = $15
 ENDIF
 
+
 ; ********************************************************
 ;  SN76489 PSG chip definitions
 ; ********************************************************
@@ -318,20 +325,16 @@ ENDIF
 
 
 IF FORcoleco
-	defc sndbit_port	= $E0		; also valid for Coleco Adam and Pencil II
+    defc sndbit_port	= $E0		; also valid for Coleco Adam and Pencil II
     defc sndbit_bit    = 3
     defc sndbit_mask   = $0F			; $0F for full volume output
 ENDIF
+
 
 ; ********************************************************
 ;   This last part refers to NOT YET supported hardware
 ; ********************************************************
 
-IF FORpasopia7
-	defc sndbit_port	= $3A		; Pasopia has also a second PSG on port $3B
-    defc sndbit_bit    = 3
-    defc sndbit_mask   = $0F			; $0F for full volume output
-ENDIF
 
 
 

--- a/libsrc/games/pasopia7/joystick.asm
+++ b/libsrc/games/pasopia7/joystick.asm
@@ -1,0 +1,44 @@
+;
+;	Game device library for the Pasopia7
+;
+
+	SECTION code_clib
+        PUBLIC    joystick
+	PUBLIC	_joystick
+	EXTERN	get_psg
+
+.joystick
+._joystick
+	;__FASTCALL__ : joystick no. in HL
+	ld	bc,0x1a
+	dec	l
+	jr	z,got_port
+	ld	bc,0x19
+	dec	l
+	jr	z,got_port
+	ld	hl,0	
+	ret
+
+got_port:
+	ld	a,1		;Select the joystick
+	out	($1b),a
+	in	a,(c)
+	ld	hl,0
+	cpl
+	rra		;UP
+	rl	l
+	rra		;DOWN
+	rl	l	
+	rra		;LEFT
+	rl	l
+	rra		;RIGHT
+	rl	l
+	rra		;FIRE1
+	jr	nc,not_fire1
+	set	4,l
+not_fire1:
+	rra		;FIRE2
+	ret	nc
+	set	5,l
+	ret
+

--- a/libsrc/graphics/generic_console/getmaxx1.asm
+++ b/libsrc/graphics/generic_console/getmaxx1.asm
@@ -1,0 +1,14 @@
+
+	SECTION	code_clib
+	PUBLIC	getmaxx
+	PUBLIC	_getmaxx
+
+	EXTERN	__console_w
+
+
+getmaxx:
+_getmaxx:
+	ld	hl,(__console_w)
+	ld	h,0
+	dec	hl
+	ret

--- a/libsrc/graphics/generic_console/getmaxy1.asm
+++ b/libsrc/graphics/generic_console/getmaxy1.asm
@@ -1,0 +1,14 @@
+
+	SECTION	code_clib
+	PUBLIC	getmaxy
+	PUBLIC	_getmaxy
+
+	EXTERN	__console_h
+
+
+getmaxy:
+_getmaxy:
+	ld	hl,(__console_h)
+	ld	h,0
+	dec	hl
+	ret

--- a/libsrc/graphics/generic_console/pixel1.asm
+++ b/libsrc/graphics/generic_console/pixel1.asm
@@ -1,0 +1,65 @@
+
+	INCLUDE	"graphics/grafix.inc"
+
+
+	EXTERN	generic_console_printc
+	EXTERN	generic_console_plotc
+	EXTERN	generic_console_vpeek
+	EXTERN	generic_console_pointxy
+	EXTERN	textpixl
+	EXTERN	__console_w
+	EXTERN	__console_h
+	EXTERN	GRAPHICS_CHAR_SET
+	EXTERN	GRAPHICS_CHAR_UNSET
+
+		ld	a,(__console_w)
+		dec	a
+		cp	h
+		ret	c
+
+		ld	a,(__console_h)
+		dec	a
+		cp	l
+		ret	c
+
+		push	bc		;save entry bc	
+		ld	c,h
+		ld	b,l
+		push	bc
+IF USEplotc
+		call	generic_console_pointxy
+ELSE
+		ld	e,1		;raw mode
+		call	generic_console_vpeek
+ENDIF
+
+IF NEEDplot
+		ld	a,GRAPHICS_CHAR_SET
+ENDIF
+IF NEEDunplot
+		ld	a,GRAPHICS_CHAR_UNSET
+ENDIF
+IF NEEDxor
+		ld	b,GRAPHICS_CHAR_SET
+		cp	GRAPHICS_CHAR_UNSET
+		jr	z,xor_done
+		ld	b,GRAPHICS_CHAR_UNSET
+xor_done:	ld	a,b
+ENDIF
+IF NEEDpoint
+		cp	GRAPHICS_CHAR_UNSET
+		pop	bc
+ELSE
+		pop	bc		;original coordinates
+IF USEplotc
+		ld	d,a
+                ld      e,0             ;pixel4 mode
+                call    generic_console_plotc
+ELSE
+		ld	d,a
+		ld	e,1		;raw mode
+		call	generic_console_printc
+ENDIF
+ENDIF
+		pop	bc
+		ret

--- a/libsrc/graphics/generic_console/plotpixl1.asm
+++ b/libsrc/graphics/generic_console/plotpixl1.asm
@@ -1,0 +1,14 @@
+;
+;       Generic pseudo graphics routines for text-only platforms
+;
+;       Plot pixel1 at (x,y) coordinate.
+;
+
+
+	SECTION code_clib
+	PUBLIC	plotpixel
+
+
+.plotpixel
+	defc	NEEDplot = 1
+	INCLUDE	"pixel1.asm"

--- a/libsrc/graphics/generic_console/pointxy1.asm
+++ b/libsrc/graphics/generic_console/pointxy1.asm
@@ -1,0 +1,15 @@
+;
+;       Generic pseudo graphics routines for text-only platforms
+;
+;       Get pixel at (x,y) coordinate.
+;
+
+
+
+	SECTION code_clib
+	PUBLIC	pointxy
+
+
+.pointxy
+	defc	NEEDpoint = 1
+	INCLUDE	"pixel1.asm"

--- a/libsrc/graphics/generic_console/respixl1.asm
+++ b/libsrc/graphics/generic_console/respixl1.asm
@@ -1,0 +1,11 @@
+;
+;       Generic pseudo graphics routines for text-only platforms
+;
+
+	SECTION code_clib
+	PUBLIC	respixel
+
+
+.respixel			
+	defc	NEEDunplot = 1
+	INCLUDE	"pixel1.asm"

--- a/libsrc/graphics/generic_console/xorpixl1.asm
+++ b/libsrc/graphics/generic_console/xorpixl1.asm
@@ -1,0 +1,12 @@
+;
+;       Generic pseudo graphics routines for text-only platforms
+;
+
+
+
+	SECTION code_clib
+	PUBLIC	xorpixel
+
+.xorpixel			
+	defc	NEEDxor = 1
+	INCLUDE	"pixel1.asm"

--- a/libsrc/input/pasopia7/in_Inkey.asm
+++ b/libsrc/input/pasopia7/in_Inkey.asm
@@ -12,6 +12,8 @@ EXTERN in_rowtable
 EXTERN	l_push_di
 EXTERN	l_pop_ei
 
+INCLUDE "target/pasopia7/def/pasopia7.def"
+
 ; exit : carry set and HL = 0 for no keys registered
 ;        else HL = ASCII character code
 ; uses : AF,BC,DE,HL
@@ -27,8 +29,8 @@ read_loop:
 	ld	a,(hl)
 	ld	c,a
 	inc	hl
-	out	($30),a
-	in	a,($31)
+	out	(KEY_SCAN),a
+	in	a,(KEY_DATA)
 	cpl
 	and	a
 	jr	nz,gotkey
@@ -57,8 +59,8 @@ doneinc:
 	; Check for shift and control
 	ld	bc, 96 * 2
         ld      a,@00010001             ;Modifer row
-        out     ($30),a
-        in      a,($31)
+        out     (KEY_SCAN),a
+        in      a,(KEY_DATA)
 	bit	0,a		;Control
 	jr	z, got_modifier
 	ld	bc, 96

--- a/libsrc/input/pasopia7/in_Inkey.asm
+++ b/libsrc/input/pasopia7/in_Inkey.asm
@@ -1,0 +1,81 @@
+; uint in_Inkey(void)
+; 06.2018 suborb
+
+; Read current state of keyboard but only return
+; keypress if a single key is pressed.
+
+SECTION code_clib
+PUBLIC in_Inkey
+PUBLIC _in_Inkey
+EXTERN in_keytranstbl
+EXTERN in_rowtable
+EXTERN	l_push_di
+EXTERN	l_pop_ei
+
+; exit : carry set and HL = 0 for no keys registered
+;        else HL = ASCII character code
+; uses : AF,BC,DE,HL
+;
+
+.in_Inkey
+._in_Inkey
+	call	l_push_di
+	ld	b,12
+	ld	hl,in_rowtable
+	ld	de,0
+read_loop:
+	ld	a,(hl)
+	ld	c,a
+	inc	hl
+	out	($30),a
+	in	a,($31)
+	cpl
+	and	a
+	jr	nz,gotkey
+	ld	a,e
+	add	8
+	ld	e,a
+	djnz	read_loop
+nokey:
+	ld	hl,0	
+	call	l_pop_ei
+	scf
+	ret
+
+gotkey:
+    ; a = key pressed
+    ; e = offset
+	ld	c,8
+hitkey_loop:
+	rrca
+	jr	c,doneinc
+	inc	e
+	dec	c
+	jr	nz,hitkey_loop
+doneinc:
+
+	; Check for shift and control
+	ld	bc, 96 * 2
+        ld      a,@00010001             ;Modifer row
+        out     ($30),a
+        in      a,($31)
+	bit	0,a		;Control
+	jr	z, got_modifier
+	ld	bc, 96
+	bit	1,a		;shift key
+	jr	z,got_modifier
+	ld	bc,0
+got_modifier:
+	ld	hl,in_keytranstbl
+	add	hl,bc
+	add	hl,de
+	ld	a,(hl)
+	cp	255
+	jr	z, nokey
+	ld	l,a
+	ld	h,0
+	call	l_pop_ei
+	and	a
+	ret
+
+

--- a/libsrc/input/pasopia7/in_KeyPressed.asm
+++ b/libsrc/input/pasopia7/in_KeyPressed.asm
@@ -4,6 +4,7 @@ SECTION code_clib
 PUBLIC in_KeyPressed
 PUBLIC _in_KeyPressed
 EXTERN in_getrow
+INCLUDE "target/pasopia7/def/pasopia7.def"
 
 ; Determines if a key is pressed using the scan code
 ; returned by in_LookupKey.
@@ -17,8 +18,8 @@ EXTERN in_getrow
 .in_KeyPressed
 ._in_KeyPressed
 	ld	a,@00010001		;Shift row
-	out	(30),a
-	in	a,($31)
+	out	(KEY_SCAN),a
+	in	a,(KEY_DATA)
 	bit	7,l
 	jr	nz,check_shift
 	bit	1,a
@@ -41,8 +42,8 @@ check_shift:
 
 .nofunc
 	call	in_getrow
-	out	($30),a
-	in	a,($31)
+	out	(KEY_SCAN),a
+	in	a,(KEY_DATA)
 	cpl
 	and	h		;Check with mask
 	jr	z,fail

--- a/libsrc/input/pasopia7/in_KeyPressed.asm
+++ b/libsrc/input/pasopia7/in_KeyPressed.asm
@@ -1,0 +1,57 @@
+; uint in_KeyPressed(uint scancode)
+
+SECTION code_clib
+PUBLIC in_KeyPressed
+PUBLIC _in_KeyPressed
+EXTERN in_getrow
+
+; Determines if a key is pressed using the scan code
+; returned by in_LookupKey.
+
+; enter : l = scan row
+;         h = key mask
+; exit  : carry = key is pressed & HL = 1
+;         no carry = key not pressed & HL = 0
+; used  : AF,BC,HL
+
+.in_KeyPressed
+._in_KeyPressed
+	ld	a,@00010001		;Shift row
+	out	(30),a
+	in	a,($31)
+	bit	7,l
+	jr	nz,check_shift
+	bit	1,a
+	jr	z,fail
+	jr	consider_ctrl
+
+check_shift:
+	bit	1,a
+	jr	nz,fail		;Shift not pressed
+ 
+.consider_ctrl
+	bit	6,l
+	jr	nz,check_ctrl
+	bit	0,a
+	jr	z,fail
+	jr	nofunc
+.check_ctrl
+	bit	0,a		;CTRL
+	jr	nz,fail
+
+.nofunc
+	call	in_getrow
+	out	($30),a
+	in	a,($31)
+	cpl
+	and	h		;Check with mask
+	jr	z,fail
+	ld	hl,1
+	scf
+	ret
+fail:
+	ld	hl,0
+	and	a
+	ret
+
+

--- a/libsrc/input/pasopia7/in_LookupKey.asm
+++ b/libsrc/input/pasopia7/in_LookupKey.asm
@@ -1,0 +1,77 @@
+; uint in_LookupKey(uchar c)
+; 06.2018 suborb
+
+SECTION code_clib
+PUBLIC in_LookupKey
+PUBLIC _in_LookupKey
+EXTERN in_keytranstbl
+
+; Given the ascii code of a character, returns the scan row and mask
+; corresponding to the key that needs to be pressed to generate the
+; character.  
+;
+; The scan row returned will have bit 7 set and bit 6 set to
+; indicate if CAPS, SYM SHIFTS also have to be pressed to generate the
+; ascii code, respectively.
+
+; enter: L = ascii character code
+; exit : L = scan row 
+;        H = mask
+;        else: L = scan row, H = mask
+;              bit 7 of L set if SHIFT needs to be pressed
+;              bit 6 of L set if FUNC needs to be pressed
+; uses : AF,BC,HL
+
+; The 16-bit value returned is a scan code understood by
+; in_KeyPressed.
+
+.in_LookupKey
+._in_LookupKey
+	ld	a,l
+	ld	hl,in_keytranstbl
+	ld	bc,96 * 3
+	cpir
+	jr	nz,notfound
+
+	; Try and find the position with the table here
+	ld	de,0		; Out resulting flags
+	ld	hl, 96 * 3 - 1
+	and	a
+	sbc	hl,bc		; hl = position within table
+	ld	bc,96
+	and	a
+	sbc	hl,bc
+	jr	c, got_table
+	; Now try shifted
+	set	7,e
+	and	a
+	sbc	hl,bc
+	jr	c,got_table
+	; It must be control
+	res	7,e
+	set	6,e
+	and	a
+	sbc	hl,de
+got_table:
+	add	hl,bc		;Add the 96 back on
+	ld	a,l
+	ld	h,a
+	srl	a		;divide by 8
+	srl	a
+	srl	a
+	or	e
+	ld	l,a		; l = flags + row
+	; Now get the mask
+	ld	a,h
+	ld	h,1
+shift_loop:
+	and	7
+	ret	z		; nc
+	rl	h
+	dec	a
+	jr	shift_loop
+
+notfound:
+	ld	hl,0
+	scf
+	ret

--- a/libsrc/input/pasopia7/in_keytranstbl.asm
+++ b/libsrc/input/pasopia7/in_keytranstbl.asm
@@ -1,0 +1,104 @@
+
+; This table translates key presses into ascii codes.
+
+; Write to Z80PIO port a on port $30 to specify which bit of keyboard to read,
+;		-CCCRRRR
+;	C = bit set for chunks (0-3 = 1 << 4, 4-7 = 2 << 4,8-11 = 4 << 4)
+;	R = bit set for row wihtin chunk
+; Read via Z80PIO port b on port $31
+
+SECTION code_clib
+PUBLIC in_getrow
+PUBLIC in_rowtable
+
+; Map between row number and the value needed to poke into the PIO
+; Entry a = scan row
+; Exit  a: high nibble = chunk, low nibble = row
+in_getrow:
+	push	hl
+	and	15
+	ld	c,a
+	ld	b,0
+	ld	hl,in_rowtable
+	add	hl,bc
+	ld	a,(hl)
+	pop	hl
+	ret
+
+	SECTION	rodata_clib
+in_rowtable:
+	defb	@01000001
+	defb	@01000010
+	defb	@01000100
+	defb	@01001000
+
+	defb	@00100001
+	defb	@00100010
+	defb	@00100100
+	defb	@00101000
+
+	defb	@00010001
+	defb	@00010010
+	defb	@00010100
+	defb	@00011000
+
+
+
+SECTION rodata_clib
+PUBLIC in_keytranstbl
+
+.in_keytranstbl
+
+	; 96 bytes per table
+	; Chunk 3
+	defb	'-', '5', '6', 'f', 'h', '9', ':', '}'	;- 5 6 F H 9 : }
+	defb	'q', 'w', 'e', 'g', 'j', 'i', 'o', 'p'	;Q W E G J I O P
+	defb	'a', 's', 'd', 'v', 'n', 'k', 'l', ';'	;A S D V N K L ;
+	defb	'z', 'x', 'c', 'b', 'm', ',', '.', '/'	;Z X C B M , . / 
+	;Chunk	2
+	defb	255, 255, 255, 255,   8, 255, 255, ' '	;END, UNK, UNK, UNK, LEFT, UNK, SPC
+	defb	128, 129, 130, 131, 132, 133, 134, 135	;F1, F2, F3, F4, F5, F6, F7, F8
+	defb	'1', '0', '4', 'r', 'y', '=','\\', 255	;1 0 4 R Y = \ YEN
+	defb	'2', '3', '8', 't', 'u', '7', '@', '{'	;2 3 8 T U 7 @ {
+	;Chunk 1
+	defb	255, 255,   6, 255, 255, 255, 255, 255	;CTRL, SHIFT, CAPS, UNK, UNK, KANA, UNK, UNK
+	defb	255, 255, 255, 255, 255, 255, 255, 255	;KP0, KP1, KP2, KP3, KP4, KP5, KP6, KP7
+	defb	255, 255, 255,  10,  11, 255, 255,  13	;KP8, KP8, KP-, DOWN, UP, HOME, KPDEL, KPENTER
+	defb	  9, 255,  12,   7, 255, 255, 255, 255	;RIGHT, STATUS?, BACKSPACE, TAB, UNK, UNK, UNK, UNK
+
+
+;Shifted
+	; Chunk 3
+	defb	'=', '%', '&', 'F', 'H', ')', '*', ']'	;- 5 6 F H 9 : }
+	defb	'Q', 'W', 'E', 'G', 'J', 'I', 'O', 'P'	;Q W E G J I O P
+	defb	'A', 'S', 'D', 'V', 'N', 'K', 'L', '+'	;A S D V N K L ;
+	defb	'Z', 'X', 'C', 'B', 'M', '<', '>', '?'	;Z X C B M , . / 
+	;Chunk	2
+	defb	255, 255, 255, 255,   8, 255, 255, ' '	;END, UNK, UNK, UNK, LEFT, UNK, SPC
+	defb	128, 129, 130, 131, 132, 133, 134, 135	;F1, F2, F3, F4, F5, F6, F7, F8
+	defb	'!', '_', '$', 'R', 'Y', '-', '^', 255	;1 0 4 R Y = \ YEN
+	defb   '\"', '#', '(', 'T', 'U','\'', '@', '['	;2 3 8 T U 7 @ {
+	;Chunk 1
+	defb	255, 255,   6, 255, 255, 255, 255, 255	;CTRL, SHIFT, CAPS, UNK, UNK, KANA, UNK, UNK
+	defb	255, 255, 255, 255, 255, 255, 255, 255	;KP0, KP1, KP2, KP3, KP4, KP5, KP6, KP7
+	defb	255, 255, 255,  10,  11, 255, 255,  13	;KP8, KP8, KP-, DOWN, UP, HOME, KPDEL, KPENTER
+	defb	  9, 255, 127,   7, 255, 255, 255, 255	;RIGHT, STATUS?, BACKSPACE, TAB, UNK, UNK, UNK, UNK
+
+
+;(control)
+	; 96 bytes per table
+	; Chunk 3
+	defb	'-', '5', '6',   6,   8, '9', ':', '}'	;- 5 6 F H 9 : }
+	defb	 17,  23,   5,   7,  10,   9,  15,  16	;Q W E G J I O P
+	defb	  1,  19,   4,  22,  14,  11,  12, ';'	;A S D V N K L ;
+	defb	 26,  24,   3,   2,  13, ',', '.', '/'	;Z X C B M , . / 
+	;Chunk	2
+	defb	255, 255, 255, 255,   8, 255, 255, ' '	;END, UNK, UNK, UNK, LEFT, UNK, SPC
+	defb	128, 129, 130, 131, 132, 133, 134, 135	;F1, F2, F3, F4, F5, F6, F7, F8
+	defb	'1', '0', '4',  18,  25, '=','\\', 255	;1 0 4 R Y = \ YEN
+	defb	'2', '3', '8',  20,  21, '7', '@', '{'	;2 3 8 T U 7 @ {
+	;Chunk 1
+	defb	255, 255,   6, 255, 255, 255, 255, 255	;CTRL, SHIFT, CAPS, UNK, UNK, KANA, UNK, UNK
+	defb	255, 255, 255, 255, 255, 255, 255, 255	;KP0, KP1, KP2, KP3, KP4, KP5, KP6, KP7
+	defb	255, 255, 255,  10,  11, 255, 255,  13	;KP8, KP8, KP-, DOWN, UP, HOME, KPDEL, KPENTER
+	defb	  9, 255,  12,   7, 255, 255, 255, 255	;RIGHT, STATUS?, BACKSPACE, TAB, UNK, UNK, UNK, UNK

--- a/libsrc/pasopia7.lst
+++ b/libsrc/pasopia7.lst
@@ -1,6 +1,11 @@
+stdio/inkey/fgetc_cons
+stdio/inkey/getk
 stdio/pasopia7/fputc_cons_native
 stdio/pasopia7/generic_console
 @font/font_8x8/font_8x8.lst
 @stdio/stdio.lst
+@input/input_keyboard.lst
+games/pasopia7/joystick
+@games/games.lst
 @z80.lst
 @video/mc6845/mc6845.lst

--- a/libsrc/pasopia7.lst
+++ b/libsrc/pasopia7.lst
@@ -1,0 +1,4 @@
+stdio/multi8/fputc_cons_native
+@font/font_8x8/font_8x8.lst
+@stdio/stdio.lst
+@z80.lst

--- a/libsrc/pasopia7.lst
+++ b/libsrc/pasopia7.lst
@@ -1,7 +1,9 @@
 stdio/inkey/fgetc_cons
 stdio/inkey/getk
 stdio/pasopia7/fputc_cons_native
+stdio/pasopia7/CRT_FONT
 stdio/pasopia7/generic_console
+stdio/pasopia7/generic_console_ioctl
 @font/font_8x8/font_8x8.lst
 @stdio/stdio.lst
 @input/input_keyboard.lst

--- a/libsrc/pasopia7.lst
+++ b/libsrc/pasopia7.lst
@@ -19,5 +19,13 @@ graphics/generic_console/swapgfxbk.asm
 graphics/dcircle2
 graphics/__gfx_coords
 @gfxbase.lst
+psg/sn76489/bit_open
+psg/sn76489/psg_tone
+psg/sn76489/psg_volume
+psg/sn76489/psg_envelope
+psg/sn76489/psg_init.asm
+psg/sn76489/set_psg.asm
+psg/sn76489/set_psg_callee.asm
+@psg/psg.lst
 @video/mc6845/mc6845.lst
 @z80.lst

--- a/libsrc/pasopia7.lst
+++ b/libsrc/pasopia7.lst
@@ -7,5 +7,15 @@ stdio/pasopia7/generic_console
 @input/input_keyboard.lst
 games/pasopia7/joystick
 @games/games.lst
-@z80.lst
+graphics/generic_console/getmaxx1
+graphics/generic_console/getmaxy1
+graphics/generic_console/plotpixl1
+graphics/generic_console/respixl1
+graphics/generic_console/xorpixl1
+graphics/generic_console/pointxy1
+graphics/generic_console/swapgfxbk.asm
+graphics/dcircle2
+graphics/__gfx_coords
+@gfxbase.lst
 @video/mc6845/mc6845.lst
+@z80.lst

--- a/libsrc/pasopia7.lst
+++ b/libsrc/pasopia7.lst
@@ -1,4 +1,6 @@
-stdio/multi8/fputc_cons_native
+stdio/pasopia7/fputc_cons_native
+stdio/pasopia7/generic_console
 @font/font_8x8/font_8x8.lst
 @stdio/stdio.lst
 @z80.lst
+@video/mc6845/mc6845.lst

--- a/libsrc/psg/sn76489.inc
+++ b/libsrc/psg/sn76489.inc
@@ -51,4 +51,8 @@ IF FORsmc777
 	defc HAVE16bitbus = 1
 ENDIF
 
+IF FORpasopia7
+	defc psgport 	= $3a		; There's a second one on 3b
+ENDIF
+
 

--- a/libsrc/stdio/pasopia7/CRT_FONT.asm
+++ b/libsrc/stdio/pasopia7/CRT_FONT.asm
@@ -1,0 +1,6 @@
+
+		SECTION		rodata_clib
+
+		PUBLIC		CRT_FONT
+
+		defc		CRT_FONT = 0

--- a/libsrc/stdio/pasopia7/fputc_cons_native.asm
+++ b/libsrc/stdio/pasopia7/fputc_cons_native.asm
@@ -1,0 +1,16 @@
+
+		SECTION	code_clib
+		PUBLIC	fputc_cons_native
+
+
+; (char to print)
+fputc_cons_native:
+        ld      hl,2
+        add     hl,sp
+	ld	a,(hl)
+	cp	10
+	jr	nz,not_lf
+	ld	a,13
+not_lf:
+	rst	$18
+	ret

--- a/libsrc/stdio/pasopia7/generic_console.asm
+++ b/libsrc/stdio/pasopia7/generic_console.asm
@@ -13,6 +13,7 @@
                 PUBLIC          generic_console_set_paper
                 PUBLIC          generic_console_set_inverse
 
+		EXTERN		generic_console_flags
 		EXTERN		CONSOLE_COLUMNS
 		EXTERN		CONSOLE_ROWS
 		EXTERN		__pasopia_page
@@ -21,7 +22,20 @@
 
 generic_console_ioctl:
 	scf
+	ret
+
 generic_console_set_inverse:
+	ld	a,(generic_console_flags)
+	rrca
+	rrca
+	rrca
+	rrca
+	and	8
+	ld	e,a
+	ld	a,(__pasopia7_attr)
+	and	@11110111
+	or	e
+	ld	(__pasopia7_attr),a
 	ret
 
 generic_console_set_ink:

--- a/libsrc/stdio/pasopia7/generic_console.asm
+++ b/libsrc/stdio/pasopia7/generic_console.asm
@@ -19,6 +19,7 @@
 		EXTERN		__pasopia_page
 		EXTERN		__console_w
 
+		INCLUDE		"target/pasopia7/def/pasopia7.def"
 
 generic_console_ioctl:
 	scf
@@ -54,12 +55,12 @@ generic_console_set_paper:
 generic_console_cls:
 	ld	a,(__pasopia_page)
 	or	4		; Page VRAM in
-	out	($3c),a
+	out	(MEM_MODE),a
 	ld	a,$44
-	out	($0c),a
+	out	(VRAM_PLANE),a
 
 	ld	a,(__pasopia7_attr)
-	out	($0d),a		;Set attribute data	
+	out	(DISP_CTRL),a		;Set attribute data	
 	ld	bc, 80 * 25
 	ld	hl, $8000
 	ld	de,8
@@ -72,7 +73,7 @@ cls_loop:
 	jr	nz,cls_loop
 
 	ld	a,(__pasopia_page)
-	out	($3c),a
+	out	(MEM_MODE),a
 
 	ret
 
@@ -85,14 +86,14 @@ generic_console_printc:
 	ld	d,a		;Save attribute
 	ld	a,(__pasopia_page)
 	or	4		; Page VRAM in
-	out	($3c),a
+	out	(MEM_MODE),a
 	ld	a,(__pasopia7_attr)
-	out	($0d),a		;Set attribute
+	out	(DISP_CTRL),a		;Set attribute
 	ld	a,$44		;Select text VRAM
-	out	($0c),a
+	out	(VRAM_PLANE),a
 	ld	(hl),d
 	ld	a,(__pasopia_page)
-	out	($3c),a
+	out	(MEM_MODE),a
 	ret
 
 
@@ -105,10 +106,10 @@ generic_console_vpeek:
         call    xypos
 	ld	a,(__pasopia_page)
 	or	4		; Page VRAM in
-	out	($3c),a
+	out	(MEM_MODE),a
         ld      d,(hl)
 	xor	4
-	out	($3c),a
+	out	(MEM_MODE),a
 	ld	a,d
         and     a
         ret
@@ -144,9 +145,9 @@ generic_console_scrollup:
 	push	bc
 	ld	a,(__pasopia_page)
 	or	4		; Page VRAM in
-	out	($3c),a
+	out	(MEM_MODE),a
 	ld	a,$44
-	out	($0c),a
+	out	(VRAM_PLANE),a
 
 	ld	hl,(__console_w)
 	ld	h,0
@@ -160,7 +161,7 @@ generic_console_scrollup:
 	ld	e,l
 	add	hl,bc
 
-	ld	bc, 40 * 24
+	ld	bc, 40 * 25
 scrollup_loop:
 	push	bc
 	ld	a,(hl)
@@ -194,7 +195,7 @@ scroll_1:
 
 
 	ld	a,(__pasopia_page)
-	out	($3c),a
+	out	(MEM_MODE),a
 
 	pop	bc
 	pop	de
@@ -210,7 +211,7 @@ __pasopia7_attr:
 
 	ld	a,0			;Disable cursor blinking (bit 5)
 					;No attribute wrap (bit 4)
-	out	($0a),a		;Video PIO, port C
+	out	(VIDEO_MISC),a		;Video PIO, port C
         ld      l,$20
         call    asm_set_cursor_state
 	

--- a/libsrc/stdio/pasopia7/generic_console.asm
+++ b/libsrc/stdio/pasopia7/generic_console.asm
@@ -154,15 +154,15 @@ generic_console_scrollup:
 	add	hl,hl
 	add	hl,hl
 	add	hl,hl
-	ld	c,l
-	ld	b,h
-	ld	hl, $8000
-	ld	d,h
-	ld	e,l
+	ld	bc,$8000
 	add	hl,bc
+	ld	de,$8000
 
-	ld	bc, 40 * 25
-scrollup_loop:
+	ld	c,24
+scroll_row:
+	ld	a,(__console_w)
+	ld	b,a
+scroll_char:
 	push	bc
 	ld	a,(hl)
 	ld	(de),a
@@ -172,10 +172,9 @@ scrollup_loop:
 	add	hl,bc
 	ex	de,hl
 	pop	bc
-	dec	bc
-	ld	a,b
-	or	c
-	jr	nz,scrollup_loop
+	djnz	scroll_char
+	dec	c
+	jr	nz,scroll_row
 
 	; And we have to clear the bottom line
 	ld	a,(__console_w)

--- a/libsrc/stdio/pasopia7/generic_console.asm
+++ b/libsrc/stdio/pasopia7/generic_console.asm
@@ -8,7 +8,6 @@
 		PUBLIC		generic_console_vpeek
 		PUBLIC		generic_console_scrollup
 		PUBLIC		generic_console_printc
-		PUBLIC		generic_console_ioctl
                 PUBLIC          generic_console_set_ink
                 PUBLIC          generic_console_set_paper
                 PUBLIC          generic_console_set_inverse
@@ -20,10 +19,6 @@
 		EXTERN		__console_w
 
 		INCLUDE		"target/pasopia7/def/pasopia7.def"
-
-generic_console_ioctl:
-	scf
-	ret
 
 generic_console_set_inverse:
 	ld	a,(generic_console_flags)

--- a/libsrc/stdio/pasopia7/generic_console.asm
+++ b/libsrc/stdio/pasopia7/generic_console.asm
@@ -1,0 +1,148 @@
+;
+;
+
+
+		SECTION		code_clib
+
+		PUBLIC		generic_console_cls
+		PUBLIC		generic_console_vpeek
+		PUBLIC		generic_console_scrollup
+		PUBLIC		generic_console_printc
+		PUBLIC		generic_console_ioctl
+                PUBLIC          generic_console_set_ink
+                PUBLIC          generic_console_set_paper
+                PUBLIC          generic_console_set_inverse
+
+		EXTERN		CONSOLE_COLUMNS
+		EXTERN		CONSOLE_ROWS
+		EXTERN		__pasopia_page
+		EXTERN		__console_w
+
+
+generic_console_ioctl:
+	scf
+generic_console_set_inverse:
+	ret
+
+generic_console_set_ink:
+	and	15
+	ld	e,a
+	ld	a,(__pasopia7_attr)
+	and	@11111000
+	or	e
+	ld	(__pasopia7_attr),a
+	ret
+
+	
+generic_console_set_paper:
+	ret
+
+generic_console_cls:
+	ld	a,(__pasopia_page)
+	or	4		; Page VRAM in
+	out	($3c),a
+	ld	a,$44
+	out	($0c),a
+
+	ld	bc, CONSOLE_COLUMNS * CONSOLE_ROWS
+	ld	hl, $8000
+	ld	de,8
+cls_loop:
+	ld	a,(__pasopia7_attr)
+	out	($0d),a		;Set attribute data	
+	ld	(hl),' '
+	add	hl,de
+	dec	bc
+	ld	a,b
+	or	c
+	jr	nz,cls_loop
+
+	ld	a,(__pasopia_page)
+	out	($3c),a
+
+	ret
+
+; c = x
+; b = y
+; a = character to print
+; e = raw
+generic_console_printc:
+	call	xypos
+	ld	d,a		;Save attribute
+	ld	a,(__pasopia_page)
+	or	4		; Page VRAM in
+	out	($3c),a
+	ld	a,(__pasopia7_attr)
+	out	($0d),a		;Set attribute
+	ld	a,$44		;Select text VRAM
+	out	($0c),a
+	ld	(hl),d
+	ld	a,(__pasopia_page)
+	out	($3c),a
+	ret
+
+
+;Entry: c = x,
+;       b = y
+;Exit:  nc = success
+;        a = character,
+;        c = failure
+generic_console_vpeek:
+        call    xypos
+	ld	a,(__pasopia_page)
+	or	4		; Page VRAM in
+	out	($3c),a
+        ld      d,(hl)
+	xor	4
+	out	($3c),a
+	ld	a,d
+        and     a
+        ret
+
+
+xypos:
+	ld	hl,(__console_w)
+	ld	h,0
+	add	hl,hl
+	add	hl,hl
+	add	hl,hl
+	ex	de,hl
+	ld	hl,$8000 
+	and	a
+	sbc	hl,de
+	inc	b
+generic_console_printc_1:
+	add	hl,de
+	djnz	generic_console_printc_1
+generic_console_printc_3:
+	ex	de,hl
+	ld	l,c
+	ld	h,0
+	add	hl,hl
+	add	hl,hl
+	add	hl,hl
+	add	hl,de
+	ret
+
+
+generic_console_scrollup:
+	push	de
+	push	bc
+	pop	bc
+	pop	de
+	ret
+
+	SECTION		data_clib
+
+__pasopia7_attr:
+	defb		7
+
+	SECTION		code_crt_init
+	EXTERN		asm_set_cursor_state
+
+	ld	a,0			;Disable cursor blinking (bit 5)
+					;No attribute wrap (bit 4)
+	out	($0a),a		;Video PIO, port C
+        ld      l,$20
+        call    asm_set_cursor_state
+	

--- a/libsrc/stdio/pasopia7/generic_console_ioctl.asm
+++ b/libsrc/stdio/pasopia7/generic_console_ioctl.asm
@@ -1,0 +1,84 @@
+
+	MODULE	generic_console_ioctl
+	PUBLIC	generic_console_ioctl
+
+	SECTION	code_clib
+	INCLUDE	"ioctl.def"
+
+	EXTERN	generic_console_cls
+	EXTERN	generic_console_font32
+	EXTERN	generic_console_udg32
+	EXTERN	__console_h
+	EXTERN	__console_w
+
+	INCLUDE	"target/pasopia7/def/pasopia7.def"
+
+
+; a = ioctl
+; de = arg
+generic_console_ioctl:
+	ex	de,hl
+	ld	c,(hl)	;bc = where we point to
+	inc	hl
+	ld	b,(hl)
+	cp	IOCTL_GENCON_SET_FONT32
+	jr	nz,check_set_udg
+	ld	(generic_console_font32),bc
+success:
+	and	a
+	ret
+check_set_udg:
+	cp	IOCTL_GENCON_SET_UDGS
+	jr	nz,check_mode
+	ld	(generic_console_udg32),bc
+	jr	success
+check_mode:
+	cp	IOCTL_GENCON_SET_MODE
+	jr	nz,failure
+	ld	a,c
+	ld	e,40
+	ld	d,@00000000
+	ld	hl,mode40
+	and	a
+	jr	z,set_mode
+	ld	e,80
+	ld	d,@00100000
+	ld	hl,mode80
+	cp	1
+	jr	nz,failure
+set_mode:
+	; e = number of columns
+	; d = value to write to mode port
+	; hl = 6845 registers to write
+	ld	a,e
+	ld	(__console_w),a
+	ld	a,d
+	out	(SCR_MODE),a
+	; Values are written at 4dcd in bios.rom
+        ld      c,0
+        ld      b,16
+vduloop:
+        ld      a,c
+        out     ($10),a
+        ld      a,(hl)
+        out     ($11),a
+        inc     hl
+        inc     c
+        djnz    vduloop
+        call    generic_console_cls
+        jr      success
+failure:
+	scf
+	ret
+
+
+mode80:
+	defb	$71, $50, $5c, $38, $1f, $06, $19, $1c
+	defb	$40, $07, $20, $07, $00, $00, $00, $50
+
+mode40:
+	defb	$38, $28, $2f, $34, $1f, $06, $19, $1c
+	defb	$40, $07, $20, $07, $00, $00, $00, $43
+
+else:
+	defb	$5d, $50, $52, $1e, $03, $00, $04, $00

--- a/libsrc/video/mc6845/mc6845.inc
+++ b/libsrc/video/mc6845/mc6845.inc
@@ -57,3 +57,11 @@ IF FORsmc777
 	defc	register_r = 0x19
 	defc	register_w = 0x19
 ENDIF
+
+IF FORpasopia7
+	defc	address_r = 0x10
+	defc	status_r = 0 
+	defc	address_w = 0x10
+	defc	register_r = 0x11
+	defc	register_w = 0x11
+ENDIF

--- a/src/appmake/Makefile
+++ b/src/appmake/Makefile
@@ -6,7 +6,7 @@ OBJS = appmake.o z88.o zxvgs.o zx.o z88shell.o abc80.o zx81.o msx.o mtx.o mz.o n
 	aquarius.o c7420.o rom.o sorcerer.o sos.o svi.o sc3000.o ace-tap.o hex.o lynx.o rex6000.o tixx.o nascom.o \
 	cpc.o m5.o mc.o newbrain.o newext.o sms.o trs80.o c128.o galaksija.o vz.o enterprise.o x07.o residos.o \
 	inject.o vg5k.o z1013.o extract.o z9001.o kc.o glue.o zxn.o zx-util.o x1.o multi8.o spc1000.o mz2500.o \
-	d88.o fp1100.o cpmdisk.o cpm2.o mameql.o
+	d88.o fp1100.o cpmdisk.o cpm2.o mameql.o pasopia7.o
 
 
 all: appmake$(EXESUFFIX)

--- a/src/appmake/appmake.h
+++ b/src/appmake/appmake.h
@@ -126,6 +126,9 @@ extern option_t  nascom_options;
 extern int       nec_exec(char *target);
 extern option_t  nec_options;
 
+extern int       pasopia7_exec(char *target);
+extern option_t  pasopia7_options;
+
 extern int       pc88_exec(char *target);
 extern option_t  pc88_options;
 
@@ -337,6 +340,10 @@ struct {
       "PC-6001 (and others) CAS format conversion utility",
       NULL,
       nec_exec,    &nec_options },
+    { "bin2pas",   "pasopia7",  "(C) 2019 z88dk",
+      "Convert binary file to .wav",
+      NULL,
+      pasopia7_exec,    &pasopia7_options },
     { "bin2t88",   "pc88",       "(C) 2018 Stefano Bodrato",
       "PC-8801 T88 format conversion utility",
       NULL,


### PR DESCRIPTION
Import initial support for the Pasopia7.

Provides:

* 64k RAM model with bootable disc
* 40x25 + 80x25 console
* Hardware keyboard
* 1 bit sound
* PSG support
* 40x25 + 80x25 super lores graphics