### PR TITLE
+msx: Add fcntl library for msxdos2

### DIFF
--- a/lib/config/msx.cfg
+++ b/lib/config/msx.cfg
@@ -15,6 +15,7 @@ SUBTYPE		disk -Cz+msx -Cz--disk -startup=1 -lndos
 SUBTYPE		wav -Cz+msx -Cz--fmsx -Cz--audio -Cz--fast -startup=1 -lndos
 SUBTYPE		rom	-Cz+rom -Cz--romsize=0x8000 -Cz--rombase=0x4000 -startup=3 -lndos
 SUBTYPE		msxdos  -Cz+fat -Cz-f -Czmsxdos -startup=2
+SUBTYPE		msxdos2  -Cz+fat -Cz-f -Czmsxdos -startup=2 -lmsxdos2
 
 CLIB      default -lmsx_clib
 CLIB	  ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lmsx_clib

--- a/lib/target/msx/classic/msxdos.asm
+++ b/lib/target/msx/classic/msxdos.asm
@@ -9,6 +9,12 @@
                 defc CRT_ORG_CODE = $100   ; MSXDOS
         ENDIF
 
+	IF !DEFINED_MSXDOS
+		defc MSXDOS = 5
+	ENDIF
+	PUBLIC MSXDOS
+
+
 	org CRT_ORG_CODE
 
 ;----------------------
@@ -63,15 +69,6 @@ ENDIF
         call    _main		;Call user code
 	pop	bc	;kill argv
 	pop	bc	;kill argc
-
-	ld	a,(defltdsk)	;Restore default disc
-	ld	($F306),a
-	;ld	e,a
-	;ld	c,14
-	;call	5
-	ld	ix,$d2	; TOTEXT - force text mode on exit
-	call	msxbios
-;**
 	
 cleanup:
 ;
@@ -84,8 +81,7 @@ IF CRT_ENABLE_STDIO = 1
 ENDIF
 
 start1:
-        ld      sp,0
-        ret
+	jp	0
 
 l_dcal:
         jp      (hl)

--- a/lib/target/msx/classic/msxdos.asm
+++ b/lib/target/msx/classic/msxdos.asm
@@ -81,6 +81,7 @@ IF CRT_ENABLE_STDIO = 1
 ENDIF
 
 start1:
+	ld	sp,0
 	jp	0
 
 l_dcal:

--- a/lib/target/msx/def/msxdos2.def
+++ b/lib/target/msx/def/msxdos2.def
@@ -1,0 +1,116 @@
+; MSX-DOS2 command and error codes
+; Source: http://map.grauw.nl/resources/dos2_environment.php
+;         http://map.grauw.nl/resources/dos2_functioncalls.php
+
+	; Error codes
+	defc	_FFIRST = $40
+	defc	_FNEXT  = $41
+	defc	_FNEW	= $42
+	defc	_OPEN	= $43
+	defc	_CREATE = $44
+	defc	_CLOSE	= $45
+	defc	_ENSURE = $46
+	defc	_DUP	= $47
+	defc	_READ	= $48
+	defc	_WRITE	= $49
+	defc	_SEEK	= $4a
+	defc	_IOCTL	= $4b
+	defc	_HTEST	= $4c
+	defc	_DELETE	= $4d
+	defc	_RENAME	= $4e
+	defc	_MOVE	= $4f
+	defc	_ATTR	= $50
+	defc	_FTIME	= $51
+	defc	_HDELETE = $52
+	defc	_HRENAME = $53
+	defc	_HMOVE	= $54
+	defc	_HATTR	= $55
+	defc	_HFTIME = $56
+	defc	_GETDTA	= $57
+	defc	_GETVFY = $58
+	defc	_GETCD	= $59
+	defc	_CHDIR	= $5a
+	defc	_PARSE	= $5b
+	defc	_PFILE	= $5c
+	defc	_CHLCHR	= $5d
+	defc	_WPATH	= $5e
+	defc	_FLUSH	= $5f
+	defc	_FORK	= $60
+	defc	_JOIN	= $61
+	defc	_TERM	= $62
+	defc	_DEFAB	= $63
+	defc	_DEFER	= $64
+	defc	_ERROR	= $65
+	defc	_EXPLAIN = $66
+	defc	_FORMAT	= $67
+	defc	_RAMD	= $68
+	defc	_BUFFER	= $69
+	defc	_ASSIGN	= $6a
+	defc	_GENV	= $6b
+	defc	_SENV	= $6c
+	defc	_FENV	= $6d
+	defc	_DSKCHK	= $6e
+	defc	_DOSVER	= $6f
+	defc	_REDIR	= $70
+
+	; Error codes
+
+	; Disk errors
+	defc	E_NCOMP	= $ff
+	defc	E_WRERR	= $fe
+	defc	E_DISK	= $fd
+	defc	E_NRDY	= $fc
+	defc	E_VERFY	= $fb
+	defc	E_DATA	= $fa
+	defc	E_RNF	= $f9
+	defc	E_WPROT	= $f8
+	defc	E_UFORM	= $f7
+	defc	E_NDOS	= $f6
+	defc	E_WDISK	= $f5
+	defc	E_WFILE	= $f4
+	defc	E_SEEK	= $f3
+	defc	E_IFAT	= $f2
+	defc	E_NOUPB	= $f1
+	defc	E_IFORM	= $f0
+
+	; MSX-DOS function errors
+	defc	E_INTER	= $df
+	defc	E_NORAM	= $de
+	defc	E_IBDOS	= $dc
+	defc	E_IDRV	= $db
+	defc	E_IFNM	= $da
+	defc	E_IPATH	= $d9
+	defc	E_PLONG	= $d8
+	defc	E_NOFIL	= $d7
+	defc	E_NODIR	= $d6
+	defc	E_DRFUL	= $d5
+	defc	E_DKFUL = $d4
+	defc	E_DUPF	= $d3
+	defc	E_DIRE	= $d2
+	defc	E_FILRO	= $d1
+	defc	E_DIRNE	= $d0
+	defc	E_IATTR	= $cf
+	defc	E_DOT	= $ce
+	defc	E_SYSX	= $cd
+	defc	E_DIRX	= $cc
+	defc	E_FILEX	= $cb
+	defc	E_FOPEN	= $ca
+	defc	E_OV64K	= $c9
+	defc	E_FILE	= $c8
+	defc	E_EOF	= $c7
+	defc	E_ACCV	= $c6
+	defc	E_IPROC	= $c5
+	defc	E_NHAND	= $c4
+	defc	E_IHAND	= $c3
+	defc	E_NOPEN	= $c2
+	defc	E_IDEV	= $c1
+	defc	E_IENV	= $c0
+	defc	E_ELONG	= $bf
+	defc	E_IDATE	= $be
+	defc	E_ITIME	= $bd
+	defc	E_RAMDX	= $bc
+	defc	E_NRAMD	= $bb
+	defc	E_HDEAD	= $ba
+	defc	E_EOL	= $b9
+	defc	E_ISBFN	= $b8
+

--- a/libsrc/fcntl/Makefile
+++ b/libsrc/fcntl/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = cpc cpm dummy gen_rnd nc100 newbrain osca spectrum sprinter z88 zxvgs
+SUBDIRS = cpc cpm dummy gen_rnd msxdos2 nc100 newbrain osca spectrum sprinter z88 zxvgs 
 CLEANDIRS = $(SUBDIRS:%=clean-%)
 
 include ../Make.config

--- a/libsrc/fcntl/msxdos2/Makefile
+++ b/libsrc/fcntl/msxdos2/Makefile
@@ -1,0 +1,14 @@
+
+include ../../Make.config
+
+ASM = $(wildcard *.asm)
+
+all: $(OUTPUT_DIRECTORY)/msxdos2.lib
+
+
+$(OUTPUT_DIRECTORY)/msxdos2.lib: $(ASM)
+	@$(ASSEMBLER) -I$(Z88DK_LIB) -x$(OUTPUT_DIRECTORY)/msxdos2.lib $(ASM)
+
+clean:
+	$(RM) -f *.o
+	$(RM) $(OUTPUT_DIRECTORY)/msxdos2.lib

--- a/libsrc/fcntl/msxdos2/chdir.asm
+++ b/libsrc/fcntl/msxdos2/chdir.asm
@@ -1,0 +1,26 @@
+	SECTION	code_clib
+
+	INCLUDE	"target/msx/def/msxdos2.def"
+
+	PUBLIC	chdir
+	PUBLIC	_chdir
+
+	EXTERN	MSXDOS
+	EXTERN	msxdos_error
+
+; (char *)
+chdir:
+_chdir:
+	pop	bc
+	pop	de	;directory
+	push	de
+	push	bc
+	ld	c,_CHDIR
+	call	MSXDOS
+	ld	(msxdos_error),a
+	ld	hl,0
+	and	a
+	ret	z
+	dec	hl
+	ret
+	

--- a/libsrc/fcntl/msxdos2/close.asm
+++ b/libsrc/fcntl/msxdos2/close.asm
@@ -1,0 +1,23 @@
+
+		SECTION	code_clib
+		INCLUDE	"target/msx/def/msxdos2.def"
+
+		PUBLIC	close
+		PUBLIC	_close
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+
+.close
+._close
+	pop	hl
+	pop	bc
+	push	bc
+	push	hl
+	ld	c,_CLOSE
+	call	MSXDOS
+	ld	(msxdos_error),a
+	ld	hl,0
+	and	a
+	ret	z
+	dec	hl
+	ret

--- a/libsrc/fcntl/msxdos2/creat.asm
+++ b/libsrc/fcntl/msxdos2/creat.asm
@@ -1,0 +1,38 @@
+; creat(const char *name, mode_t mode)
+
+                SECTION code_clib
+
+		PUBLIC	creat
+		PUBLIC	_creat
+
+		INCLUDE	"target/msx/def/msxdos2.def"
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+
+.creat
+._creat
+	push	ix
+	ld	ix,2
+	add	ix,sp
+
+	ld	e,(ix+4)	;Filename
+	ld	d,(ix+5)
+        ld      c,_DELETE
+        call    MSXDOS          ;We don't care about the result
+        ; And now create it
+        ld      e,(ix+4)        ;Filename
+        ld      d,(ix+5)
+	ld	a,1		;O_WRONLY
+        ld      b,@10000000     ;Create new
+        ld      c,_CREATE
+        call    MSXDOS
+	ld	(msxdos_error),a
+	pop	ix
+	ld	hl,0
+	ld	h,b
+	and	a
+	ret	z
+	ld	hl,-1
+	ret
+
+	

--- a/libsrc/fcntl/msxdos2/fdgetpos.asm
+++ b/libsrc/fcntl/msxdos2/fdgetpos.asm
@@ -1,0 +1,9 @@
+                SECTION code_clib
+
+	PUBLIC	fdgetpos
+	PUBLIC	_fdgetpos
+
+.fdgetpos
+._fdgetpos
+	ld	hl,1	;non zero is error
+	ret

--- a/libsrc/fcntl/msxdos2/fdtell.asm
+++ b/libsrc/fcntl/msxdos2/fdtell.asm
@@ -1,0 +1,29 @@
+        SECTION code_clib
+
+	PUBLIC	fdtell
+	PUBLIC	_fdtell
+
+	INCLUDE	"target/msx/def/msxdos2.def"
+	EXTERN	MSXDOS
+	EXTERN	msxdos_error
+
+.fdtell
+._fdtell
+	pop	af
+	pop	bc	;File handler
+	push	bc
+	push	af
+
+	ld	hl,0
+	ld	de,0
+	ld	a,1
+	ld	c,_SEEK
+	call	MSXDOS
+	ld	(msxdos_error),a
+	and	a
+	ret	z
+	ld	hl,-1	;return -1
+	ld	d,h
+	ld	e,l
+	ret
+

--- a/libsrc/fcntl/msxdos2/getcwd.asm
+++ b/libsrc/fcntl/msxdos2/getcwd.asm
@@ -1,0 +1,45 @@
+	SECTION	code_clib
+
+	INCLUDE	"target/msx/def/msxdos2.def"
+
+	PUBLIC	getwd
+	PUBLIC	_getwd
+
+	EXTERN	MSXDOS
+	EXTERN	msxdos_error
+
+; (char *,size_t len)
+getwd:
+_getwd:
+	push	ix
+	ld	ix,0
+	add	ix,sp
+	ld	hl,-64
+	add	hl,sp
+	ld	sp,hl
+	ex	de,hl	;de = buffer
+	push	ix
+	ld	c,_GETCD
+	call	MSXDOS
+	ld	(msxdos_error),a
+	pop	ix
+	and	a
+	jr	nz,skip_copy
+	ld	c,(ix+4)	;length
+	ld	b,(ix+5)
+	ld	e,(ix+6)	;destination
+	ld	d,(ix+7)
+	ld	hl,0
+	add	hl,sp
+	ldir
+skip_copy:
+	ld	hl,64
+	add	hl,sp
+	ld	sp,hl
+	pop	ix
+	ld	hl,0
+	and	a	
+	ret	z
+	dec	hl
+	ret
+

--- a/libsrc/fcntl/msxdos2/getwd.asm
+++ b/libsrc/fcntl/msxdos2/getwd.asm
@@ -1,0 +1,26 @@
+	SECTION	code_clib
+
+	INCLUDE	"target/msx/def/msxdos2.def"
+
+	PUBLIC	getwd
+	PUBLIC	_getwd
+
+	EXTERN	MSXDOS
+	EXTERN	msxdos_error
+
+; (char *)
+getwd:
+_getwd:
+	pop	bc
+	pop	de	;64 byte buffer
+	push	de
+	push	bc
+	ld	c,_GETCD
+	call	MSXDOS
+	ld	(msxdos_error),a
+	ld	hl,0
+	and	a
+	ret	z
+	dec	hl
+	ret
+	

--- a/libsrc/fcntl/msxdos2/lseek.asm
+++ b/libsrc/fcntl/msxdos2/lseek.asm
@@ -1,0 +1,31 @@
+
+        SECTION code_clib
+
+
+	INCLUDE "target/msx/def/msxdos2.def"
+
+	PUBLIC	lseek
+	PUBLIC	_lseek
+
+	EXTERN	MSXDOS
+	EXTERN	msxdos_error
+
+; fd, where, whence
+.lseek
+._lseek
+        push    ix              ;save callers
+        ld      ix,2
+        add     ix,sp
+
+	ld	a, (ix + 2)	;whence
+	ld	b, (ix + 9)	;fd
+
+	ld	l, (ix + 4)
+	ld	h, (ix + 5)
+	ld	e, (ix + 6)
+	ld	d, (ix + 7)
+	ld	c,_SEEK
+	call	MSXDOS
+	ld	(msxdos_error),a
+	pop	ix
+	ret

--- a/libsrc/fcntl/msxdos2/mkdir.asm
+++ b/libsrc/fcntl/msxdos2/mkdir.asm
@@ -1,0 +1,29 @@
+	SECTION	code_clib
+
+	INCLUDE	"target/msx/def/msxdos2.def"
+
+	PUBLIC	mkdir
+	PUBLIC	_mkdir
+
+	EXTERN	MSXDOS
+	EXTERN	msxdos_error
+
+; (char *)
+mkdir:
+_mkdir:
+	pop	bc
+	pop	de	;directory name
+	push	de
+	push	bc
+	xor	a		;open mode
+	ld	b,@00010000	;Directory
+	ld	c,_CREATE
+	call	MSXDOS
+	ld	(msxdos_error),a
+	ld	hl,0
+	and	a
+	ret	z
+	dec	hl
+	ret
+
+	

--- a/libsrc/fcntl/msxdos2/msxdos_variables.asm
+++ b/libsrc/fcntl/msxdos2/msxdos_variables.asm
@@ -1,0 +1,7 @@
+
+
+	SECTION	bss_clib
+
+	PUBLIC	msxdos_error
+
+msxdos_error:	defb	0

--- a/libsrc/fcntl/msxdos2/open.asm
+++ b/libsrc/fcntl/msxdos2/open.asm
@@ -1,0 +1,77 @@
+;       int open(char *name,int access, mode_t mode)
+; 
+;       Flags is one of: O_RDONLY, O_WRONLY, O_RDWR
+;       Or'd with any of: O_CREAT, O_TRUNC, O_APPEND
+;#define O_RDONLY  0
+;#define O_WRONLY  1
+;#define O_RDWR    2
+;#define O_APPEND  256
+;#define O_TRUNC   512
+;#define O_CREAT   1024
+
+                SECTION code_clib
+		INCLUDE	"target/msx/def/msxdos2.def"
+
+		PUBLIC	open
+		PUBLIC	_open
+
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+
+; char *name, int flags, mode_t mode)
+.open
+._open
+	push	ix
+	ld	ix,2
+	add	ix,sp
+	ld	e,(ix+6)	;Filename
+	ld	d,(ix+7)
+	ld	a,(ix+5)	;High byte flags
+	and	2
+	jr	z,no_truncate
+	; Delete the file
+	ld	c,_DELETE
+	call	MSXDOS		;We don't care about the result
+	; And now create it
+create_file:
+	ld	e,(ix+6)	;Filename
+	ld	d,(ix+7)
+	call	get_mode	;Mode in c
+	ld	a,c
+	ld	b,@10000000	;Create new
+	ld	c,_CREATE
+	call	MSXDOS
+	jr	return
+
+no_truncate:
+	; We don't want to truncate, try top open it
+	call	get_mode	;Mode in c
+	ld	a,c
+	ld	c,_OPEN
+	call	MSXDOS
+	and	a
+	jr	z,return
+	; We failed to open it, check for O_CREAT
+	bit	2,(ix+5)
+	jr	nz,create_file
+return:
+	ld	(msxdos_error),a
+	pop	ix	;Return callers
+	ld	hl,0
+	ld	h,b
+	and	a
+	ret	z
+	ld	hl,-1
+	ret
+
+
+get_mode:
+        ld      a,(ix+4)	;Low byte flags
+        ld      c,1
+        and     a               ;O_RDONLY
+	ret	z
+        ld      c,2
+        dec     a               ;O_WRONLY
+	ret	z
+        ld      c,0		;O_RDWR
+	ret

--- a/libsrc/fcntl/msxdos2/read.asm
+++ b/libsrc/fcntl/msxdos2/read.asm
@@ -18,7 +18,6 @@
 	push	de
 	push	hl
 	push	af
-	ld	b,c
 	ld	c,_READ
 	call	MSXDOS
 	ld	(msxdos_error),a

--- a/libsrc/fcntl/msxdos2/read.asm
+++ b/libsrc/fcntl/msxdos2/read.asm
@@ -1,0 +1,28 @@
+                SECTION code_clib
+                INCLUDE "target/msx/def/msxdos2.def"
+
+		PUBLIC	read
+		PUBLIC	_read
+                EXTERN  MSXDOS
+                EXTERN  msxdos_error
+
+
+; (fd, buf,len)
+.read
+._read
+	pop	af	;ret
+	pop	hl	;len
+	pop	de	;buf
+	pop	bc	;b = fd
+	push	bc
+	push	de
+	push	hl
+	push	af
+	ld	b,c
+	ld	c,_READ
+	call	MSXDOS
+	ld	(msxdos_error),a
+	and	a
+	ret	z
+	ld	hl,-1
+	ret

--- a/libsrc/fcntl/msxdos2/readbyte.asm
+++ b/libsrc/fcntl/msxdos2/readbyte.asm
@@ -1,0 +1,26 @@
+                SECTION code_clib
+
+		INCLUDE "target/msx/def/msxdos2.def"
+
+		PUBLIC	readbyte
+		PUBLIC	_readbyte
+
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+		
+.readbyte
+._readbyte
+	ld	b,h		;fd
+	ld	hl,0
+	push	hl
+	add	hl,sp
+	ex	de,hl
+	ld	hl,1
+	ld	c,_READ
+	call	MSXDOS
+	ld	(msxdos_error),a
+	pop	hl
+	and	a
+	ret	z
+	ld	hl,-1
+	ret

--- a/libsrc/fcntl/msxdos2/remove.asm
+++ b/libsrc/fcntl/msxdos2/remove.asm
@@ -1,0 +1,20 @@
+                SECTION code_clib
+
+
+		INCLUDE	"target/msx/def/msxdos2.def"
+		PUBLIC	remove
+		PUBLIC	_remove
+
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+
+.remove
+._remove
+	ex	de,hl
+	ld	c,$4d
+	call	MSXDOS
+	ld	(msxdos_error),a
+	ld	hl,0
+	and	a
+	ret	z
+	dec	hl

--- a/libsrc/fcntl/msxdos2/rename.asm
+++ b/libsrc/fcntl/msxdos2/rename.asm
@@ -1,0 +1,27 @@
+                SECTION code_clib
+
+		INCLUDE "target/msx/def/msxdos2.def"
+		PUBLIC	rename
+		PUBLIC	_rename
+
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+
+; (char *s, char *d)
+.rename
+._rename
+	pop	bc
+	pop	hl	;dest
+	pop	de	;src
+	push	de
+	push	hl
+	push	bc
+
+	ld	c,_RENAME
+	call	MSXDOS
+	ld	(msxdos_error),a
+	ld	hl,0
+	and	a
+	ret	z
+	dec	hl
+	ret

--- a/libsrc/fcntl/msxdos2/write.asm
+++ b/libsrc/fcntl/msxdos2/write.asm
@@ -1,0 +1,28 @@
+                SECTION code_clib
+                INCLUDE "target/msx/def/msxdos2.def"
+
+		PUBLIC	write
+		PUBLIC	_write
+                EXTERN  MSXDOS
+                EXTERN  msxdos_error
+
+
+; (fd, buf,len)
+.write
+._write
+	pop	af	;ret
+	pop	hl	;len
+	pop	de	;buf
+	pop	bc	;b = fd
+	push	bc
+	push	de
+	push	hl
+	push	af
+	ld	b,c
+	ld	c,_WRITE
+	call	MSXDOS
+	ld	(msxdos_error),a
+	and	a
+	ret	z
+	ld	hl,-1
+	ret

--- a/libsrc/fcntl/msxdos2/write.asm
+++ b/libsrc/fcntl/msxdos2/write.asm
@@ -18,7 +18,6 @@
 	push	de
 	push	hl
 	push	af
-	ld	b,c
 	ld	c,_WRITE
 	call	MSXDOS
 	ld	(msxdos_error),a

--- a/libsrc/fcntl/msxdos2/writebyte.asm
+++ b/libsrc/fcntl/msxdos2/writebyte.asm
@@ -1,0 +1,33 @@
+                SECTION code_clib
+
+		INCLUDE	"target/msx/def/msxdos2.def"
+		PUBLIC	writebyte
+		PUBLIC	_writebyte
+
+		EXTERN	MSXDOS
+		EXTERN	msxdos_error
+
+
+;(int fd, int b)
+.writebyte
+._writebyte
+	push	ix
+	ld	ix,4
+	add	ix,sp
+
+	ld	b,(ix+3)
+	ld	hl,4
+	add	hl,sp
+	ex	de,hl
+	ld	hl,1
+	ld	c,_WRITE
+	call	MSXDOS
+	ld	(msxdos_error),a
+	pop	ix
+	ld	l,(ix+0)
+	ld	h,(ix+1)
+	and	a
+	ret	z
+	ld	hl,-1
+	ret
+


### PR DESCRIPTION
New library for +msx - msxdos2.lib. 

Add a new subtype -subtype=msxdos2 to allow creating of apps where file operations use the MSXDOS2 API.