### PR TITLE
Implement named address spaces for sccz80

### DIFF
--- a/src/sccz80/ccdefs.h
+++ b/src/sccz80/ccdefs.h
@@ -95,6 +95,8 @@ extern void       declare_func_kr();
 extern int        ispointer(Type *type);
 extern void       type_describe(Type *type, UT_string *output);
 extern int        type_matches(Type *t1, Type *t2);
+extern void       parse_addressmod(void);
+extern namespace *get_namespace(const char *name);
 
 /* error.c */
 extern int        endst(void);

--- a/src/sccz80/ccdefs.h
+++ b/src/sccz80/ccdefs.h
@@ -97,6 +97,7 @@ extern void       type_describe(Type *type, UT_string *output);
 extern int        type_matches(Type *t1, Type *t2);
 extern void       parse_addressmod(void);
 extern namespace *get_namespace(const char *name);
+extern void       check_pointer_namespace(Type *lhs, Type *rhs);
 
 /* error.c */
 extern int        endst(void);

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -246,6 +246,12 @@ void outname(const char* sname, char pref)
     outstr(sname);
 }
 
+
+void reset_namespace()
+{
+    current_nspace = NULL;
+}
+
 static void switch_namespace(char *name)
 {
     namespace *ns;
@@ -490,6 +496,7 @@ void putstk(LVALUE *lval)
     char flags = 0;
     Type *ctype;
     Kind typeobj = lval->indirect_kind;
+
 
 
     //outfmt("; %s type=%d val_type=%d indirect=%d\n", lval->ltype->name, lval->type, lval->val_type, lval->indirect_kind);

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -259,7 +259,8 @@ static void switch_namespace(char *name)
         ns = get_namespace(name);
 
         if ( ns != NULL ) {
-            outfmt("\tcall\t_%s\n",ns->bank_function);
+            zcallop();
+            outname(ns->bank_function->name, dopref(ns->bank_function)); nl();
         }
     }
 
@@ -272,7 +273,6 @@ static void switch_namespace(char *name)
  */
 void getmem(SYMBOL* sym)
 {
-    printf("Getmem: ");dump_type(sym->ctype);
     switch_namespace(sym->ctype->namespace);
     if (sym->ctype->kind == KIND_CHAR) {
         if ( (sym->ctype->isunsigned) == 0 )  {

--- a/src/sccz80/codegen.h
+++ b/src/sccz80/codegen.h
@@ -134,4 +134,4 @@ extern void zconvert_to_double(Kind type, unsigned char isunsigned);
 extern void zconvert_from_double(Kind type, unsigned char isunsigned);
 extern int push_function_argument(Kind expr, Type *type, int push_sdccchar);
 extern int push_function_argument_fnptr(Kind expr, Type *type, int push_sdccchar, int is_last_argument);
-
+extern void reset_namespace();

--- a/src/sccz80/declinit.c
+++ b/src/sccz80/declinit.c
@@ -22,9 +22,9 @@ int initials(const char *dropname, Type *type)
     if ( (type->isconst && !c_double_strings) ||
         ( (ispointer(type) || type->kind == KIND_ARRAY) && 
 		(type->ptr->isconst || ((ispointer(type->ptr) || type->ptr->kind == KIND_ARRAY) && type->ptr->ptr->isconst) ) ) ) {
-        output_section(c_rodata_section);
+        output_section(get_section_name(type->namespace,c_rodata_section));
     } else {
-        output_section(c_data_section);
+        output_section(get_section_name(type->namespace,c_data_section));
     }
     prefix();
     outname(dropname, YES);

--- a/src/sccz80/declparse.c
+++ b/src/sccz80/declparse.c
@@ -834,7 +834,7 @@ int declare_local(int local_static)
                 sym->initialised = 1;
                 initials(namebuf, type);                
             } else {
-                sym->bss_section = strdup(c_bss_section);
+                sym->bss_section = strdup(get_section_name(sym->ctype->namespace, c_bss_section));
             }
         } else {
             int size = type->size;
@@ -998,11 +998,10 @@ Type *dodeclare(enum storage_type storage)
 
          if ( cmatch(';')) {
              // Maybe not right
-            sym->bss_section = strdup(c_bss_section);
-
+            sym->bss_section = strdup(get_section_name(sym->ctype->namespace, c_bss_section));
             return type;
         } else if ( cmatch(',')) {
-            sym->bss_section = strdup(c_bss_section);
+            sym->bss_section = strdup(get_section_name(sym->ctype->namespace, c_bss_section));
             continue;
         } 
 

--- a/src/sccz80/declparse.c
+++ b/src/sccz80/declparse.c
@@ -788,8 +788,7 @@ Type *parse_decl(char name[], Type *base_type)
         if ( amatch("__far"))
             base_type->isfar = 1;
         ptr = make_pointer(base_type);
-        ptr->namespace = base_type->namespace;
-        parse_namespace(ptr->ptr);
+        parse_namespace(ptr);
         return parse_decl(name, ptr);
     }
 

--- a/src/sccz80/declparse.c
+++ b/src/sccz80/declparse.c
@@ -1680,6 +1680,7 @@ static void declfunc(Type *type, enum storage_type storage)
 
 void parse_addressmod(void)
 {
+    SYMBOL    *sym;
     namespace *ns;
 
     char setter[NAMESIZE+1];
@@ -1697,9 +1698,17 @@ void parse_addressmod(void)
         return;
     }
 
+    sym = findglb(setter);
+
+    if ( sym == NULL || sym->ctype->kind != KIND_FUNC) {
+        junk();
+        errorfmt("Cannot find setter function <%s> for namespace <%s>",1, setter,nsname);
+        return;
+    }
+
     ns = CALLOC(1,sizeof(*ns));
     ns->name = STRDUP(nsname);
-    ns->bank_function = STRDUP(setter);
+    ns->bank_function = sym;
 
     LL_APPEND(namespaces, ns);
 }
@@ -1721,7 +1730,6 @@ static void parse_namespace(Type *type)
     namespace *ns;
     LL_FOREACH(namespaces, ns) {
         if (amatch(ns->name)) {
-            printf("Found namespace %s\n",ns->name);
             type->namespace = ns->name;
             return;
         }

--- a/src/sccz80/declparse.c
+++ b/src/sccz80/declparse.c
@@ -1616,6 +1616,7 @@ static void declfunc(Type *type, enum storage_type storage)
         col();
     }
     nl();
+    reset_namespace();
         
     
     if ( (type->flags & CRITICAL) == CRITICAL ) {

--- a/src/sccz80/define.h
+++ b/src/sccz80/define.h
@@ -94,6 +94,7 @@ struct type_s {
     char      isconst;
     char      isfar;  // Valid for pointers/array
     char      name[NAMESIZE]; 
+    char     *namespace; // Which namespace is this object in
     
     Type     *ptr;   // For array, or pointer
     int       len;   // Length of the array
@@ -202,6 +203,15 @@ struct symbol_s {
         int level;           /* Compound level that this variable is declared at */
         UT_hash_handle  hh;
 
+};
+
+
+typedef struct namespace_s namespace;
+
+struct namespace_s {
+    char        *name;
+    char        *bank_function;
+    namespace   *next;       
 };
 
 

--- a/src/sccz80/define.h
+++ b/src/sccz80/define.h
@@ -210,7 +210,7 @@ typedef struct namespace_s namespace;
 
 struct namespace_s {
     char        *name;
-    char        *bank_function;
+    SYMBOL      *bank_function;
     namespace   *next;       
 };
 

--- a/src/sccz80/expr.c
+++ b/src/sccz80/expr.c
@@ -124,6 +124,8 @@ int heir1(LVALUE* lval)
         if ( lval2.ltype->kind == KIND_VOID ) {
             warningfmt("void","Assigning from a void expression");
         }
+        check_pointer_namespace(lval->ltype, lval2.ltype);
+
         force(lval->val_type, lval2.val_type, lval->ltype->isunsigned, lval2.ltype->isunsigned, 0); /* 27.6.01 lval2.is_const); */
         smartstore(lval);
         return 0;

--- a/src/sccz80/main.c
+++ b/src/sccz80/main.c
@@ -316,6 +316,8 @@ void parse()
             dodeclare(TYPDEF);
         } else if (dodeclare(STATIK)) {
             ;
+        } else if ( amatch("__addressmod")) {
+            parse_addressmod();
         } else if (ch() == '#') {
             if (match("#asm")) {
                 doasm();

--- a/src/sccz80/misc.c
+++ b/src/sccz80/misc.c
@@ -48,7 +48,6 @@ Type* retrstk(char* flags)
         return (laststk = NULL);
     ptr = laststk = stkptr[--stkcount];
     *flags = flgstk[stkcount];
-    printf("Retrieve stack: "); dump_type(ptr);
 
     return (ptr);
 }
@@ -57,7 +56,6 @@ Type* retrstk(char* flags)
 
 int addstk(LVALUE* lval)
 {
-    printf("Add stack: "); dump_type(lval->ltype);
     if ((stkcount + 1) >= 99)
         return (0);
     stkptr[stkcount] = lval->ltype;

--- a/src/sccz80/misc.c
+++ b/src/sccz80/misc.c
@@ -62,3 +62,15 @@ int addstk(LVALUE* lval)
     flgstk[stkcount] = lval->flags;
     return (stkcount++);
 }
+
+const char *get_section_name(const char *namespace, const char *section)
+{
+    static char   buf[LINEMAX+1];
+
+    if ( namespace == NULL ) 
+        return section;
+
+    snprintf(buf,sizeof(buf),"%s_%s",namespace, section);
+
+    return buf;
+}

--- a/src/sccz80/misc.c
+++ b/src/sccz80/misc.c
@@ -27,7 +27,7 @@ void changesuffix(char *name, char *suffix)
  * off of stack, guess 100 is enough to be going on with?
  */
 
-SYMBOL *stkptr[100], *laststk;
+Type *stkptr[100], *laststk;
 int stkcount;
 char flgstk[100];
 
@@ -41,13 +41,15 @@ void initstack()
 
 /* Retrieve last item on the stack */
 
-SYMBOL* retrstk(char* flags)
+Type* retrstk(char* flags)
 {
-    SYMBOL* ptr;
+    Type* ptr;
     if (!stkcount)
         return (laststk = NULL);
     ptr = laststk = stkptr[--stkcount];
     *flags = flgstk[stkcount];
+    printf("Retrieve stack: "); dump_type(ptr);
+
     return (ptr);
 }
 
@@ -55,23 +57,10 @@ SYMBOL* retrstk(char* flags)
 
 int addstk(LVALUE* lval)
 {
+    printf("Add stack: "); dump_type(lval->ltype);
     if ((stkcount + 1) >= 99)
         return (0);
-    stkptr[stkcount] = lval->symbol;
+    stkptr[stkcount] = lval->ltype;
     flgstk[stkcount] = lval->flags;
     return (stkcount++);
-}
-
-/* Check if last item referenced to is this item, used when loading
- * values - saves a little bit of generated code
- */
-
-int chkstk(SYMBOL* ptr)
-{
-    if (!stkcount)
-        return (0);
-    if (laststk == ptr)
-        return (1);
-    else
-        return (0);
 }

--- a/src/sccz80/misc.h
+++ b/src/sccz80/misc.h
@@ -4,3 +4,4 @@ extern void changesuffix(char *name, char *suffix);
 extern void initstack(void);
 extern Type *retrstk(char *flags);
 extern int addstk(LVALUE *lval);
+extern const char *get_section_name(const char *namespace, const char *section);

--- a/src/sccz80/misc.h
+++ b/src/sccz80/misc.h
@@ -2,6 +2,5 @@
 extern void prefix(void);
 extern void changesuffix(char *name, char *suffix);
 extern void initstack(void);
-extern SYMBOL *retrstk(char *flags);
+extern Type *retrstk(char *flags);
 extern int addstk(LVALUE *lval);
-extern int chkstk(SYMBOL *ptr);

--- a/testsuite/Issue_1141_Namespaces.c
+++ b/testsuite/Issue_1141_Namespaces.c
@@ -1,0 +1,23 @@
+extern void set1(void);
+extern void set2(void);
+
+__addressmod set1 nspace1;
+__addressmod set2 nspace2;
+
+extern nspace1 int *nspace2 x;
+
+nspace1 int *y;
+
+void function() {
+    *x = 2;
+}
+
+void function2() {
+    *y = 2;
+}
+
+nspace2 int z = 2;
+
+void func3() {
+   z = 2;
+}

--- a/testsuite/results/Issue_1141_Namespaces.opt
+++ b/testsuite/results/Issue_1141_Namespaces.opt
@@ -1,0 +1,64 @@
+
+
+
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._function
+	call	_set2
+	ld	hl,(_x)
+	push	hl
+	ld	hl,2	;const
+	call	_set1
+	pop	de
+	call	l_pint
+	ret
+
+
+
+._function2
+	ld	hl,(_y)
+	push	hl
+	ld	hl,2	;const
+	call	_set1
+	pop	de
+	call	l_pint
+	ret
+
+
+	SECTION	nspace2_data_compiler
+._z
+	defw	2
+	SECTION	code_compiler
+
+._func3
+	ld	hl,2	;const
+	call	_set2
+	ld	(_z),hl
+	ret
+
+
+
+
+	SECTION	bss_compiler
+._y	defs	2
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_set1
+	GLOBAL	_set2
+	GLOBAL	_x
+	GLOBAL	_y
+	GLOBAL	_function
+	GLOBAL	_function2
+	GLOBAL	_z
+	GLOBAL	_func3
+
+
+
+


### PR DESCRIPTION
Should match the zsdcc implementation.

Switching address spaces inserts additional codes so will clobber some optimisations.