### PR TITLE
m32 - rounding improvements

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/readme.md
+++ b/libsrc/_DEVELOPMENT/math/float/math32/readme.md
@@ -27,8 +27,8 @@ Where not written by me, the functions were sourced from:
 
   *  The z80 multiply (without a hardware instruction) is implemented with an unrolled equivalent to the z80-zxn `mul de`, which is designed to have no side effect other than resetting the flag register.
 
-  *  Mantissa calculations are done with 24-bits and 8-bits for rounding. Rounding is simple, using the Digi International method, but can be if required expanded to the IEEE standard, with a performance penalty.
-  
+  *  Mantissa calculations are done with 24-bits and 8-bits for rounding. Rounding is a simple method, but can be if required expanded to the IEEE standard with a performance penalty.
+
   *  Derived functions are calculated with a 32-bit internal mantissa calculation path without rounding, to provide the maximum accuracy when repeated multiplications and additions are required.
 
   *  Higher functions are written in C, for maintainability, and draw upon the intrinsic functions including the square root, square, and polynomial evaluation, as well as the 4 standard arithmetic functions.
@@ -102,10 +102,10 @@ Both results are free of bias with IEEE method having a slight edge with roundin
 
 -------------------------------------------------------------------------
     This z88dk m32 library rounds the number using a single sticky bit
-    which is "ored" to with the lsb of the 32-bit result from
-    any intrinsic calculation:
+    which uses the lsb[7] of the of the 32-bit result from any
+    intrinsic calculation:
 
-    b s  (b=lsbit s=sticky)
+    b s  (b=lsbit[7] s=sticky)
     0 0		exact
     0 1		+.01
     1 0		exact

--- a/libsrc/_DEVELOPMENT/math/float/math32/readme_digifloatmath.txt
+++ b/libsrc/_DEVELOPMENT/math/float/math32/readme_digifloatmath.txt
@@ -8,10 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Rabbit Semiconductor Rabbit Floating Point Package (ZFPP)
 -------------------------------------------------------------------------
 
-            MODIFIED TO USE SCCZ80 CALLING CONVENTION
-            
-               LHS STACK - RHS DEHL -> RETURN DEHL
-
+            PROVIDED FOR HISTORICAL REFERENCE ONLY
 
 feilipu, April 2019
 -------------------------------------------------------------------------

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsadd.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsadd.asm
@@ -212,10 +212,10 @@ PUBLIC m32_fsadd, m32_fsadd_callee
     jr NC,al_5
 ; shift by 8 right, no 16 possible
     ld a,e                      ; lost bits, keep only 8
+    or a                        ; test lost bits
     ld e,d
     ld d,l
     ld hl,0                     ; upper zero
-    or a                        ; test lost bits
     jr Z,aldone
     set 0,e                     ; lost bits
     jr aldone
@@ -228,7 +228,7 @@ PUBLIC m32_fsadd, m32_fsadd_callee
 ; toss lost bits in a which are remote for 16 shift
 ; consider only lost bits in d and h
     ld a,d                      ; lost bits
-    or a,h
+    or a,h                      ; test lost bits
     ld e,l
     ld d,0
     ld h,d                      ; hl zero
@@ -239,7 +239,7 @@ PUBLIC m32_fsadd, m32_fsadd_callee
 
 ; here no 8 or 16 shift, lost bits in a-reg bits 6,5,4, other bits zero's
 .al_6
-    or a,h                      ; more lost bits
+    or a,h                      ; test lost bits
     ld h,0
     jr Z,aldone
     set 0,e

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsconv.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsconv.asm
@@ -33,6 +33,7 @@ EXTERN m32_fsnormalize
 ; now convert long in dehl to float in dehl
 .m32_float32
     ex de,hl                    ; hlde
+    res 7,b                     ; clear sign bit in b[7]
     bit 7,h                     ; test sign, negate if negative
     jr Z,dldf0
     ld b,h                      ; to hold the sign, put copy of MSB into b
@@ -43,7 +44,7 @@ EXTERN m32_fsnormalize
     ex de,hl
     ld hl,0
     sbc hl,bc
-    jp PO,dldf0                 ; number in hlde, sign in b
+    jp PO,dldf0                 ; number in hlde, sign in b[7]
 
 ; here negation of 0x80000000 = -2^31 = 0xcf000000
     ld de,0cf00h
@@ -64,13 +65,14 @@ EXTERN m32_fsnormalize
     ld b,d                      ; to hold the sign, put copy of MSB into b
                                 ; continue, with unsigned long number in dehl
     ex de,hl
+
 .dldf0
-; number in hlde, sign in b
+; number in hlde, sign in b[7]
     ld c,150                    ; exponent if no shift
     ld a,h
     or a
     jr NZ,dldfright             ; go shift right
-; exponent in c, sign in b
+; exponent in c, sign in b[7]
     ex af,af                    ; set carry off
     jp m32_fsnormalize          ; piggy back on existing code in _fsnormalize
 
@@ -132,7 +134,7 @@ EXTERN m32_fsnormalize
     rr d
     rr e
     inc c
-.dldf8                          ; pack up the floating point mantissa in lde, exponent in c, sign in b
+.dldf8                          ; pack up the floating point mantissa in lde, exponent in c, sign in b[7]
     sla l
     rl b                        ; get sign (if unsigned input, it was forced 0)
     rr c

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsconv.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsconv.asm
@@ -33,11 +33,10 @@ EXTERN m32_fsnormalize
 ; now convert long in dehl to float in dehl
 .m32_float32
     ex de,hl                    ; hlde
-    res 7,b                     ; clear sign bit in b[7]
+    ld b,h                      ; to hold the sign, put copy of ULSW into b
     bit 7,h                     ; test sign, negate if negative
     jr Z,dldf0
-    ld b,h                      ; to hold the sign, put copy of MSB into b
-    ld c,l
+    ld c,l                      ; LLSW into c
     ld hl,0
     or a                        ; clear C
     sbc hl,de                   ; least

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsnormalize.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/d32_fsnormalize.asm
@@ -267,10 +267,9 @@ PUBLIC m32_fsnormalize
     ld e,0
     ld a,-15
     jp normdone
-;
-; worst case 68 to get past this section
-; shift 0-3, l is zero , 16 bits in de
-;
+
+; shift 0-3, l is zero
+; 16 bits in de
 .S16H
     sla e
     rl d

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsadd32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsadd32.asm
@@ -175,11 +175,11 @@ PUBLIC m32_fsadd24x32, m32_fsadd32x32
     jr NC,al_5
 ; shift by 8 right, no 16 possible
     ld a,e                      ; lost bits, keep only 8
+    or a                        ; test lost bits
     ld e,d
     ld d,l
     ld l,h
     ld h,0                      ; upper zero
-    or a                        ; test lost bits
     jr Z,aldone
     set 0,e                     ; lost bits
     jr aldone
@@ -192,7 +192,7 @@ PUBLIC m32_fsadd24x32, m32_fsadd32x32
 ; toss lost bits in a which are remote for 16 shift
 ; consider only lost bits in d
     ld a,d                      ; lost bits
-    or a,a
+    or a                        ; test lost bits
     ld e,l
     ld d,h
     ld hl,0                     ; hl zero
@@ -202,7 +202,7 @@ PUBLIC m32_fsadd24x32, m32_fsadd32x32
 
 ; here no 8 or 16 shift, lost bits in a-reg bits 6,5,4, other bits zero's
 .al_6
-    or a                        ; more lost bits
+    or a                        ; test lost bits
     jr Z,aldone
     set 0,e
     

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsdiv.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsdiv.asm
@@ -181,26 +181,35 @@ PUBLIC m32_fsinv_fastcall
 
 ;-------------------------------;
 
-    ld a,l                      ; round using digi norm's method
-    or a
-    jr Z,fd0
-    set 0,h
-
-.fd0
-
-    ld l,h                      ; align 32-bit mantissa to IEEE 24-bit mantissa
-    ld h,e
-    ld e,d
-
     pop af                      ; recover D exponent and sign in C
     rr c                        ; save sign in c
     sub a,07fh                  ; calculate new exponent for 1/D
     neg
     add a,07eh   
+    ld b,a
 
+    ld a,l
+    ld l,h                      ; align 32-bit mantissa to IEEE 24-bit mantissa
+    ld h,e
+    ld e,d
+
+    or a                        ; round using feilipu method
+    jr Z,fd0
+    inc l
+    jr NZ,fd0
+    inc h
+    jr NZ,fd0
+    inc e
+    jr NZ,fd0
+    rr e
+    rr h
+    rr l
+    inc b
+
+.fd0
     sla e
     sla c                       ; recover sign from c
-    rra
+    rr b
     rr e
-    ld d,a
+    ld d,b
     ret                         ; return IEEE DEHL

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsinvsqrt.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsinvsqrt.asm
@@ -37,7 +37,7 @@ SECTION code_math
 EXTERN m32_fsmul, m32_fsmul_callee
 
 EXTERN m32_fsmul32x32, m32_fsmul24x32, m32_fsadd32x32, m32_fsadd24x32
-EXTERN m32_fsmin_fastcall, m32_fsmax_fastcall
+EXTERN m32_fsmin_fastcall
 
 PUBLIC m32_fssqrt, m32_fssqrt_fastcall, m32_fsinvsqrt_fastcall
 
@@ -61,7 +61,7 @@ PUBLIC m32_fssqrt, m32_fssqrt_fastcall, m32_fsinvsqrt_fastcall
     or a                        ; divide by zero?
     jp Z,m32_fsmin_fastcall    
     and 080h                    ; negative number?
-    jp NZ,m32_fsmax_fastcall
+    jp NZ,m32_fsmin_fastcall
     
     ld b,d                      ; retain original y sign & exponent
     set 7,d                     ; make y negative
@@ -214,7 +214,7 @@ PUBLIC m32_fssqrt, m32_fssqrt_fastcall, m32_fsinvsqrt_fastcall
 
 .fd0
     sla e
-    sla c                       ; recover sign from c
+    xor a                       ; set sign in C positive
     rr b
     rr e
     ld d,b

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsinvsqrt.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsinvsqrt.asm
@@ -194,16 +194,25 @@ PUBLIC m32_fssqrt, m32_fssqrt_fastcall, m32_fsinvsqrt_fastcall
 
 ;----------- snip ----------
 
-    ld a,l                      ; round using digi norm's method
-    or a
-    jr Z,fi0
-    set 0,h
-
-.fi0
+    ld a,l
     ld l,h                      ; align 32-bit mantissa to IEEE 24-bit mantissa
     ld h,e
     ld e,d
 
+    or a                        ; round using feilipu method
+    jr Z,fd0
+    inc l
+    jr NZ,fd0
+    inc h
+    jr NZ,fd0
+    inc e
+    jr NZ,fd0
+    rr e
+    rr h
+    rr l
+    inc b
+
+.fd0
     sla e
     sla c                       ; recover sign from c
     rr b

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul.asm
@@ -147,9 +147,11 @@ PUBLIC m32_fsmul, m32_fsmul_callee
     scf
 
 .fm1
-    ld b,0                      ; put sign bit in B
-    rr b
+    ld c,0                      ; put sign bit in C
+    rr c
+    ld b,a                      ; put exponent into B
 
+    ex af,af
     bit 7,h                     ; need to shift result left if msb!=1
     jr NZ,fm2
     sla e
@@ -158,29 +160,26 @@ PUBLIC m32_fsmul, m32_fsmul_callee
     jr fm3
 
 .fm2
-    inc a
-    jr C,mulovl
+    inc b
+    jr Z,mulovl
 
 .fm3
-    ex af,af
-    ld a,e                      ; round using digi norm's method
-    or a
-    jr Z,fm4
-    set 0,d
-
-.fm4
-    ex af,af
-
+    ld a,e
     ld e,h                      ; put 24 bit mantissa in place, HLD into EHL
     ld h,l
     ld l,d
 
+    and 080h                    ; round using feilipu method
+    jr Z,fm4
+    set 0,l
+
+.fm4
     sla e                       ; adjust mantissa for exponent
-    sla b                       ; put sign in C
-    rra                         ; put sign and 7 exp bits into place
+    sla c                       ; put sign into C
+    rr b                        ; put sign and 7 exp bits into place
     rr e                        ; put last exp bit into place
-    ld d,a                      ; put sign and exponent in D
-    ret                         ; return DEHL
+    ld d,b                      ; put sign and exponent in D
+    ret                         ; return IEEE DEHL
 
 .mulovl
     ex af,af                    ; get sign

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul.asm
@@ -147,8 +147,7 @@ PUBLIC m32_fsmul, m32_fsmul_callee
     scf
 
 .fm1
-    ld c,0                      ; put sign bit in C
-    rr c
+    rr c                        ; put sign bit in C
     ld b,a                      ; put exponent into B
 
     ex af,af

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsnormalize32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsnormalize32.asm
@@ -274,10 +274,9 @@ PUBLIC m32_fsnormalize32
     ld l,0
     ld a,-15
     jp normdone
-;
-; worst case 68 to get past this section
-; shift 0-3, l is zero , 16 bits in de
-;
+
+; shift 0-3, l is zero
+; 16 bits in de
 .S24H
     add hl,hl
     rl e

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fssqr.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fssqr.asm
@@ -103,7 +103,7 @@ PUBLIC m32_fssqr_fastcall
 
 .fs1
     inc b
-    jr C,mulovl
+    jr Z,mulovl
 
 .fs2
     ld a,e

--- a/libsrc/_DEVELOPMENT/math/float/readme.txt
+++ b/libsrc/_DEVELOPMENT/math/float/readme.txt
@@ -8,7 +8,7 @@ Each subdirectory contains an independent floating point math implementation.
    An independent 48-bit floating point package for all targets.
    
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-   ;; mathd32
+   ;; math32
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
    An independent 32-bit floating point package for all targets.


### PR DESCRIPTION
- Adjusted rounding on the `_fsinv` (`_fsdiv`), and `_fsinvsqrt` (`_fssqrt`) functions to ensure clean integer returns (where relevant).
- Adjusted rounding on the `_fsmul` function to recognise that "correct" calculation of carry in from the least significant byte has already been incorporated (unlike the digi international multiply), so only the most significant rounding bit should be considered.
- Minor whitespace, comment, and readme updates.

Noted, that the newlib has a fudge factor built into the printf `%f` conversion, so things are not always what they seem. And, also noted that this fudge factor seems to be wrong sometimes when presented with a correct representation which it wrongly interprets.