### PR TITLE
m32 - internal c functions to callee with linkage

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atan2f.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atan2f.asm
@@ -284,10 +284,10 @@ _m32_atan2f:
 	ld	e,(ix+10)
 	ld	d,(ix+11)
 	call	_m32_fabsf
-	ld	(ix-2),d
-	ld	(ix-3),e
-	ld	(ix-4),h
-	ld	(ix-5),l
+	ld	(ix-1),d
+	ld	(ix-2),e
+	ld	(ix-3),h
+	ld	(ix-4),l
 	ld	l,(ix+4)
 	ld	h,(ix+5)
 	ld	e,(ix+6)
@@ -305,20 +305,20 @@ _m32_atan2f:
 	ld	h,(ix+9)
 	push	hl
 	call	___fslt_callee
-	ld	(ix-1),l
+	ld	(ix-5),l
 	pop	de
 	pop	bc
 	push	de
 	push	bc
-	ld	l,(ix-3)
-	ld	h,(ix-2)
+	ld	l,(ix-2)
+	ld	h,(ix-1)
 	push	hl
-	ld	l,(ix-5)
-	ld	h,(ix-4)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	push	hl
 	call	___fslt_callee
-	bit	0, l
-	jp	NZ, l_m32_atan2f_00107
+	bit	0,l
+	jp	NZ,l_m32_atan2f_00107
 	ld	l,(ix+10)
 	ld	h,(ix+11)
 	push	hl
@@ -333,7 +333,7 @@ _m32_atan2f:
 	push	hl
 	call	___fsdiv_callee
 	call	_m32_atanf
-	ld	a,(ix-1)
+	ld	a,(ix-5)
 	or	a,a
 	ld	c,l
 	ld	b,h
@@ -400,7 +400,7 @@ l_m32_atan2f_00107:
 	ld	(ix-8),h
 	ld	(ix-7),e
 	ld	(ix-6),c
-	ld	a,(ix-1)
+	ld	a,(ix-5)
 	or	a, a
 	jr	Z,l_m32_atan2f_00109
 	ld	hl,0x3fc9

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atanf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atanf.asm
@@ -286,10 +286,10 @@ _m32_atanf:
 	ld	(ix-2),e
 	ld	(ix-1),d
 	call	_m32_fabsf
-	ld	(ix-8),l
-	ld	(ix-7),h
-	ld	(ix-6),e
-	ld	(ix-5),d
+	ld	(ix-12),l
+	ld	(ix-11),h
+	ld	(ix-10),e
+	ld	(ix-9),d
 	ld	a,d
 	and	a,0x7f
 	or	a,e
@@ -305,33 +305,33 @@ l_m32_atanf_00102:
 	push	hl
 	ld	hl,0x0000
 	push	hl
-	ld	l,(ix-6)
-	ld	h,(ix-5)
+	ld	l,(ix-10)
+	ld	h,(ix-9)
 	push	hl
-	ld	l,(ix-8)
-	ld	h,(ix-7)
+	ld	l,(ix-12)
+	ld	h,(ix-11)
 	push	hl
 	call	___fsgt_callee
 	ld	c,0x00
-	ld	(ix-10),l
-	ld	(ix-9),c
+	ld	(ix-14),l
+	ld	(ix-13),c
 	ld	a, c
 	or	a,l
 	jr	Z,l_m32_atanf_00104
-	ld	l,(ix-8)
-	ld	h,(ix-7)
-	ld	e,(ix-6)
-	ld	d,(ix-5)
+	ld	l,(ix-12)
+	ld	h,(ix-11)
+	ld	e,(ix-10)
+	ld	d,(ix-9)
 	call	_m32_invf
-	ld	(ix-8),l
-	ld	(ix-7),h
-	ld	(ix-6),e
-	ld	(ix-5),d
+	ld	(ix-12),l
+	ld	(ix-11),h
+	ld	(ix-10),e
+	ld	(ix-9),d
 l_m32_atanf_00104:
-	ld	l,(ix-8)
-	ld	h,(ix-7)
-	ld	e,(ix-6)
-	ld	d,(ix-5)
+	ld	l,(ix-12)
+	ld	h,(ix-11)
+	ld	e,(ix-10)
+	ld	d,(ix-9)
 	call	_m32_sqrf
 	push	hl
 	ld	c,l
@@ -344,14 +344,10 @@ l_m32_atanf_00104:
 	push	de
 	push	bc
 	call	_m32_polyf
-	pop	af
-	pop	af
-	pop	af
-	pop	af
-	ld	(ix-11),d
-	ld	(ix-12),e
-	ld	(ix-13),h
-	ld	(ix-14),l
+	ld	(ix-5),d
+	ld	(ix-6),e
+	ld	(ix-7),h
+	ld	(ix-8),l
 	pop	de
 	pop	bc
 	ld	hl,0x0004
@@ -361,19 +357,6 @@ l_m32_atanf_00104:
 	push	de
 	push	bc
 	call	_m32_polyf
-	pop	af
-	pop	af
-	pop	af
-	pop	af
-	push	de
-	push	hl
-	ld	l,(ix-12)
-	ld	h,(ix-11)
-	push	hl
-	ld	l,(ix-14)
-	ld	h,(ix-13)
-	push	hl
-	call	___fsdiv_callee
 	push	de
 	push	hl
 	ld	l,(ix-6)
@@ -382,11 +365,20 @@ l_m32_atanf_00104:
 	ld	l,(ix-8)
 	ld	h,(ix-7)
 	push	hl
+	call	___fsdiv_callee
+	push	de
+	push	hl
+	ld	l,(ix-10)
+	ld	h,(ix-9)
+	push	hl
+	ld	l,(ix-12)
+	ld	h,(ix-11)
+	push	hl
 	call	___fsmul_callee
-	ld	a,(ix-9)
+	ld	a,(ix-13)
 	ld	c,l
 	ld	b,h
-	or	a,(ix-10)
+	or	a,(ix-14)
 	jr	Z,l_m32_atanf_00106
 	push	de
 	push	bc

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_expf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_expf.asm
@@ -345,19 +345,12 @@ l_m32_expf_00104:
 	push	de
 	push	hl
 	call	_m32_polyf
-	pop	af
-	pop	af
-	pop	af
-	pop	af
 	pop	bc
 	push	bc
 	push	bc
 	push	de
 	push	hl
 	call	_m32_ldexpf
-	pop	af
-	pop	af
-	pop	af
 	ld	a,(ix-1)
 	or	a, a
 	jr	Z,l_m32_expf_00106

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_fmodf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_fmodf.asm
@@ -352,11 +352,12 @@ l_m32_fmodf_00102:
 	push	de
 	push	bc
 	call	___fssub_callee
+	ld	c, l
 	jr	l_m32_fmodf_00106
 l_m32_fmodf_00105:
-	ld	l, c
 	ld	h, b
 l_m32_fmodf_00106:
+	ld	l, c
 l_m32_fmodf_00103:
 	pop	ix
 	ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_logf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_logf.asm
@@ -297,7 +297,7 @@ _m32_logf:
 	ld	hl,0x0000
 	ld	e,l
 	ld	d,h
-	jp	l_m32_logf_00103
+	jr	l_m32_logf_00103
 l_m32_logf_00102:
 	ld	hl,0x0000
 	add	hl, sp
@@ -305,9 +305,6 @@ l_m32_logf_00102:
 	push	de
 	push	bc
 	call	_m32_frexpf
-	pop	af
-	pop	af
-	pop	af
 	push	de
 	push	hl
 	ld	hl,0x4000
@@ -332,10 +329,6 @@ l_m32_logf_00102:
 	push	de
 	push	bc
 	call	_m32_polyf
-	pop	af
-	pop	af
-	pop	af
-	pop	af
 	ld	(ix-4),l
 	ld	(ix-3),h
 	ld	(ix-2),e

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_roundf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_roundf.asm
@@ -292,37 +292,37 @@ _m32_roundf:
 	ld	(hl), d
 	ld	hl,0x0008
 	add	hl, sp
-	ld	(ix-10),l
-	ld	(ix-9),h
+	ld	(ix-6),l
+	ld	(ix-5),h
 	push	de
 	push	bc
-	ld	e,(ix-10)
-	ld	d,(ix-9)
-	ld	hl,0x0016
+	ld	e,(ix-6)
+	ld	d,(ix-5)
+	ld	hl,0x0010
 	add	hl, sp
 	ex	de, hl
 	ld	bc,0x0004
 	ldir
 	pop	bc
 	pop	de
-	ld	(ix-8),0x00
-	ld	(ix-7),0x00
-	ld	a,(ix-2)
+	ld	(ix-4),0x00
+	ld	(ix-3),0x00
+	ld	a,(ix-8)
 	and	a,0x80
-	ld	(ix-6),a
-	ld	a,(ix-1)
+	ld	(ix-2),a
+	ld	a,(ix-7)
 	and	a,0x7f
-	ld	(ix-5),a
+	ld	(ix-1),a
 	ld	a,0x17
 l_m32_roundf_00136:
-	srl	(ix-5)
-	rr	(ix-6)
-	rr	(ix-7)
-	rr	(ix-8)
+	srl	(ix-1)
+	rr	(ix-2)
+	rr	(ix-3)
+	rr	(ix-4)
 	dec	a
 	jr	NZ, l_m32_roundf_00136
-	ld	h,(ix-7)
-	ld	a,(ix-8)
+	ld	h,(ix-3)
+	ld	a,(ix-4)
 	add	a,0x81
 	ld	(ix-20),a
 	ld	a, h
@@ -340,7 +340,7 @@ l_m32_roundf_00136:
 	jr	Z,l_m32_roundf_00106
 	ld	bc,0x0000
 	ld	e,0x00
-	ld	a,(ix-1)
+	ld	a,(ix-7)
 	and	a,0x80
 	ld	d, a
 	ld	a,(ix-20)
@@ -356,45 +356,45 @@ l_m32_roundf_00136:
 	jp	l_m32_roundf_00113
 l_m32_roundf_00106:
 	ld	a,(ix-20)
-	ld	(ix-8),0xff
-	ld	(ix-7),0xff
-	ld	(ix-6),0x7f
-	ld	(ix-5),0x00
+	ld	(ix-4),0xff
+	ld	(ix-3),0xff
+	ld	(ix-2),0x7f
+	ld	(ix-1),0x00
 	inc	a
 	jr	l_m32_roundf_00141
 l_m32_roundf_00140:
-	sra	(ix-5)
-	rr	(ix-6)
-	rr	(ix-7)
-	rr	(ix-8)
+	sra	(ix-1)
+	rr	(ix-2)
+	rr	(ix-3)
+	rr	(ix-4)
 l_m32_roundf_00141:
 	dec	a
 	jr	NZ, l_m32_roundf_00140
-	ld	a,(ix-8)
+	ld	a,(ix-4)
 	ld	(ix-22),a
-	ld	a,(ix-7)
+	ld	a,(ix-3)
 	ld	(ix-21),a
 	ld	a,(ix-22)
-	ld	(ix-8),a
+	ld	(ix-4),a
 	ld	a,(ix-21)
-	ld	(ix-7),a
-	ld	(ix-6),0x00
-	ld	(ix-5),0x00
-	ld	a,(ix-8)
-	and	a,(ix-4)
-	ld	(ix-8),a
-	ld	a,(ix-7)
-	and	a,(ix-3)
-	ld	(ix-7),a
-	ld	a,(ix-6)
-	and	a,(ix-2)
-	ld	(ix-6),a
-	ld	a,(ix-5)
-	and	a,(ix-1)
-	ld	(ix-5),a
-	or	a,(ix-6)
-	or	a,(ix-7)
-	or	a,(ix-8)
+	ld	(ix-3),a
+	ld	(ix-2),0x00
+	ld	(ix-1),0x00
+	ld	a,(ix-4)
+	and	a,(ix-10)
+	ld	(ix-4),a
+	ld	a,(ix-3)
+	and	a,(ix-9)
+	ld	(ix-3),a
+	ld	a,(ix-2)
+	and	a,(ix-8)
+	ld	(ix-2),a
+	ld	a,(ix-1)
+	and	a,(ix-7)
+	ld	(ix-1),a
+	or	a,(ix-2)
+	or	a,(ix-3)
+	or	a,(ix-4)
 	jr	NZ,l_m32_roundf_00104
 	ld	l, c
 	ld	h, b
@@ -413,16 +413,16 @@ l_m32_roundf_00142:
 	rr	c
 l_m32_roundf_00143:
 	djnz	l_m32_roundf_00142
-	ld	a,(ix-4)
+	ld	a,(ix-10)
 	add	a, c
 	ld	c, a
-	ld	a,(ix-3)
+	ld	a,(ix-9)
 	adc	a, e
 	ld	b, a
-	ld	a,(ix-2)
+	ld	a,(ix-8)
 	adc	a, l
 	ld	e, a
-	ld	a,(ix-1)
+	ld	a,(ix-7)
 	adc	a, h
 	ld	d, a
 	ld	(ix-18),c
@@ -465,8 +465,8 @@ l_m32_roundf_00109:
 	ld	h, b
 	jr	l_m32_roundf_00114
 l_m32_roundf_00113:
-	ld	l,(ix-10)
-	ld	h,(ix-9)
+	ld	l,(ix-6)
+	ld	h,(ix-5)
 	ld	(hl), c
 	inc	hl
 	ld	(hl), b

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_sinf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_sinf.asm
@@ -299,12 +299,12 @@ _m32_sinf:
 	ld	a, d
 	xor	a,0x80
 	ld	d, a
-	ld	(ix-6),0x02
-	ld	(ix-5),0x00
+	ld	(ix-10),0x02
+	ld	(ix-9),0x00
 	jr	l_m32_sinf_00103
 l_m32_sinf_00102:
-	ld	(ix-6),0x00
-	ld	(ix-5),0x00
+	ld	(ix-10),0x00
+	ld	(ix-9),0x00
 l_m32_sinf_00103:
 	push	de
 	push	bc
@@ -394,11 +394,11 @@ l_m32_sinf_00105:
 	ld	(ix-2),e
 	ld	(ix-1),d
 	ld	a,0x02
-	sub	a,(ix-6)
-	ld	(ix-6),a
+	sub	a,(ix-10)
+	ld	(ix-10),a
 	ld	a,0x00
-	sbc	a,(ix-5)
-	ld	(ix-5),a
+	sbc	a,(ix-9)
+	ld	(ix-9),a
 l_m32_sinf_00107:
 	ld	l,(ix-2)
 	ld	h,(ix-1)
@@ -424,8 +424,8 @@ l_m32_sinf_00107:
 	ld	(ix-13),h
 	ld	(ix-12),e
 	ld	(ix-11),d
-	ld	l,(ix-6)
-	ld	h,(ix-5)
+	ld	l,(ix-10)
+	ld	h,(ix-9)
 	add	hl, bc
 	ld	bc,0x0004
 	push	bc
@@ -475,14 +475,10 @@ l_m32_sinf_00111:
 	push	de
 	push	bc
 	call	_m32_polyf
-	pop	af
-	pop	af
-	pop	af
-	pop	af
-	ld	(ix-7),d
-	ld	(ix-8),e
-	ld	(ix-9),h
-	ld	(ix-10),l
+	ld	(ix-5),d
+	ld	(ix-6),e
+	ld	(ix-7),h
+	ld	(ix-8),l
 	push	de
 	push	hl
 	ld	l,(ix-12)
@@ -492,10 +488,10 @@ l_m32_sinf_00111:
 	ld	h,(ix-13)
 	push	hl
 	call	___fsmul_callee
-	ld	(ix-7),d
-	ld	(ix-8),e
-	ld	(ix-9),h
-	ld	(ix-10),l
+	ld	(ix-5),d
+	ld	(ix-6),e
+	ld	(ix-7),h
+	ld	(ix-8),l
 	pop	de
 	pop	bc
 	ld	hl,0x0004
@@ -505,17 +501,13 @@ l_m32_sinf_00111:
 	push	de
 	push	bc
 	call	_m32_polyf
-	pop	af
-	pop	af
-	pop	af
-	pop	af
 	push	de
+	push	hl
+	ld	l,(ix-6)
+	ld	h,(ix-5)
 	push	hl
 	ld	l,(ix-8)
 	ld	h,(ix-7)
-	push	hl
-	ld	l,(ix-10)
-	ld	h,(ix-9)
 	push	hl
 	call	___fsdiv
 	ld	sp,ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/m32_math.h
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/m32_math.h
@@ -96,8 +96,8 @@ float m32_hypotf(float x, float y);
 
 /* Nearest integer, absolute value, and remainder functions */
 float m32_fabsf(float x) __z88dk_fastcall;
-float m32_frexpf(float x, int8_t *pw2);
-float m32_ldexpf(float x, int16_t pw2);
+float m32_frexpf(float x, int8_t *pw2) __z88dk_callee;
+float m32_ldexpf(float x, int16_t pw2) __z88dk_callee;
 float m32_ceilf(float x) __z88dk_fastcall;
 float m32_floorf(float x) __z88dk_fastcall;
 float m32_modff(float x, float * y);
@@ -108,6 +108,6 @@ float m32_roundf(float x) __z88dk_fastcall;
 float m32_sqrf(float a) __z88dk_fastcall;
 float m32_invf(float a) __z88dk_fastcall;
 float m32_invsqrtf(float a) __z88dk_fastcall;
-float m32_polyf(const float x, const float d[], uint16_t n);
+float m32_polyf(const float x, const float d[], uint16_t n) __z88dk_callee;
 
 #endif  /* _INC_MATH */

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsfrexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsfrexp.asm
@@ -3,20 +3,27 @@ SECTION code_fp_math32
 
 PUBLIC cm32_sccz80_frexp
 
-EXTERN m32_fsfrexp
+EXTERN m32_fsfrexp_callee
 
 ; float frexpf(float x, int8_t *pw2);
-cm32_sccz80_frexp:
-	; Entry:
-	; Stack: float left, ptr right, ret
+.cm32_sccz80_frexp
+    ; Entry:
+    ; Stack: float left, ptr right, ret
 
-	; Reverse the stack
-	pop	af	;ret
-	pop	bc	;ptr
-	pop	hl	;float
-	pop	de
-	push	bc	;ptr
-	push	de	;float
-	push	hl
-	push	af	;ret
-	jp	m32_fsfrexp
+    ; Reverse the stack
+    pop af                      ;my return
+    pop bc                      ;ptr
+    pop hl                      ;float
+    pop de
+    push af                     ; my return
+    push bc                     ;ptr
+    push de                     ;float
+    push hl
+    call m32_fsfrexp_callee
+
+    pop bc                      ;my return
+    push bc
+    push bc
+    push bc
+    push bc
+    ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsfrexp_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsfrexp_callee.asm
@@ -6,17 +6,17 @@ PUBLIC cm32_sccz80_frexp_callee
 EXTERN m32_fsfrexp_callee
 
 ; float frexpf(float x, int8_t *pw2);
-cm32_sccz80_frexp_callee:
-	; Entry:
-	; Stack: float left, ptr right, ret
+.cm32_sccz80_frexp_callee
+    ; Entry:
+    ; Stack: float left, ptr right, ret
 
-	; Reverse the stack
-	pop	af	;ret
-	pop	bc	;ptr
-	pop	hl	;float
-	pop	de
-	push	bc	;ptr
-	push	de	;float
-	push	hl
-	push	af	;ret
-	jp  m32_fsfrexp_callee
+    ; Reverse the stack
+    pop af                      ;my return
+    pop bc                      ;ptr
+    pop hl                      ;float
+    pop de
+    push bc                     ;ptr
+    push de                     ;float
+    push hl
+    push af                     ;my return
+    jp  m32_fsfrexp_callee

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsldexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsldexp.asm
@@ -3,21 +3,27 @@ SECTION code_fp_math32
 
 PUBLIC cm32_sccz80_ldexp
 
-EXTERN m32_fsldexp
+EXTERN m32_fsldexp_callee
 
 ; float ldexpf(float x, int16_t pw2);
-cm32_sccz80_ldexp:
+
+.cm32_sccz80_ldexp
 	; Entry:
 	; Stack: float left, int right, ret
 
 	; Reverse the stack
-	pop	af	;ret
-	pop	bc	;int
-	pop	hl	;float
+	pop	af	                    ;my return
+	pop	bc	                    ;int
+	pop	hl	                    ;float
 	pop	de
-	push	bc	;int
-	push	de	;float
+	push	af	                ;my return
+	push	bc	                ;int
+	push	de	                ;float
 	push	hl
-	push	af	;ret
-	jp	m32_fsldexp
-	
+    call m32_fsldexp_callee
+    pop bc                      ;my return
+    push bc
+    push bc
+    push bc
+    push bc
+    ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsldexp_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsldexp_callee.asm
@@ -6,18 +6,19 @@ PUBLIC cm32_sccz80_ldexp_callee
 EXTERN m32_fsldexp_callee
 
 ; float ldexpf(float x, int16_t pw2);
-cm32_sccz80_ldexp_callee:
+
+.cm32_sccz80_ldexp_callee
 	; Entry:
 	; Stack: float left, int right, ret
 
 	; Reverse the stack
-	pop	af	;ret
-	pop	bc	;int
-	pop	hl	;float
+	pop	af	                    ;my return
+	pop	bc	                    ;int
+	pop	hl	                    ;float
 	pop	de
-	push	bc	;int
-	push	de	;float
+	push	bc	                ;int
+	push	de	                ;float
 	push	hl
-	push	af	;ret
+	push	af	                ;my return
 	jp	m32_fsldexp_callee
 	

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fspoly.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fspoly.asm
@@ -8,11 +8,12 @@ PUBLIC cm32_sccz80_fspoly
 
 EXTERN m32_fspoly_callee
 
+
 .cm32_sccz80_fspoly
 
     ; evaluation of a polynomial function
     ;
-    ; enter : stack = uint16_t n, float d[], float x, ret
+    ; enter : stack = float x, float d[], uint16_t n, ret
     ;
     ; exit  : dehl  = 32-bit product
     ;         carry reset
@@ -20,28 +21,27 @@ EXTERN m32_fspoly_callee
     ; uses  : af, bc, de, hl, af', bc', de', hl'
 
     pop af                      ; my return
+    pop hl                      ; (uint16_t)n
+    pop de                      ; (float*)d
+
+    exx
     pop hl                      ; (float)x
-    pop de
+    pop de 
 
     exx
-    pop hl                      ; (float*)d
-    pop de                      ; (uint16_t)n
-
     push af                     ; my return
-    push de                     ; (uint16_t)n
-    push hl                     ; (float*)d
+    push hl                     ; (uint16_t)n
+    push de                     ; (float*)d
 
     exx
-    push de                      ; (float)x
+    push de                     ; (float)x
     push hl
 
     call m32_fspoly_callee
     
-    pop hl                      ; my return
-    xor a
-    push af
-    push af
-    push af
-    push af  
-    jp (hl)
-
+    pop bc                      ; my return
+    push bc
+    push bc
+    push bc
+    push bc  
+    ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fspoly_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fspoly_callee.asm
@@ -8,13 +8,33 @@ PUBLIC cm32_sccz80_fspoly_callee
 
 EXTERN m32_fspoly_callee
 
+
+.cm32_sccz80_fspoly_callee
+
     ; evaluation of a polynomial function
     ;
-    ; enter : stack = uint16_t n, float d[], float x, ret
+    ; enter : stack = float x, float d[], uint16_t n, ret
     ;
     ; exit  : dehl  = 32-bit product
     ;         carry reset
     ;
     ; uses  : af, bc, de, hl, af', bc', de', hl'
 
-DEFC cm32_sccz80_fspoly_callee = m32_fspoly_callee
+    pop af                      ; my return
+    pop hl                      ; (uint16_t)n
+    pop de                      ; (float*)d
+
+    exx
+    pop hl                      ; (float)x
+    pop de 
+
+    exx
+    push af                     ; my return
+    push hl                     ; (uint16_t)n
+    push de                     ; (float*)d
+
+    exx
+    push de                     ; (float)x
+    push hl
+
+    jp m32_fspoly_callee

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fsfrexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fsfrexp.asm
@@ -3,11 +3,25 @@ SECTION code_fp_math32
 
 PUBLIC cm32_sdcc_frexp
 
-EXTERN m32_fsfrexp
+EXTERN m32_fsfrexp_callee
 
 ; float frexpf(float x, int8_t *pw2);
-
+.cm32_sdcc_frexp
     ; Entry:
     ; Stack: ptr right, float left, ret
     
-defc cm32_sdcc_frexp = m32_fsfrexp
+    pop af                      ; my return
+    pop hl                      ; (float)x
+    pop de
+    pop bc                      ; (float*)pw2
+    push af                     ; my return   
+    push bc                     ; (float*)pw2
+    push de                     ; (float)x
+    push hl
+    call m32_fsfrexp_callee
+    pop bc                      ; my return
+    push bc
+    push bc
+    push bc
+    push bc
+    ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fsldexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fsldexp.asm
@@ -3,11 +3,28 @@ SECTION code_fp_math32
 
 PUBLIC cm32_sccz80_ldexp
 
-EXTERN m32_fsldexp
+EXTERN m32_fsldexp_callee
 
 ; float ldexpf(float x, int16_t pw2);
+
+.cm32_sccz80_ldexp
 
     ; Entry:
     ; Stack: int right, float left, ret
 
-defc cm32_sccz80_ldexp = m32_fsldexp    
+    pop af                      ; my return
+    pop hl                      ; (float)x
+    pop de
+    pop bc                      ; pw2
+    push af                     ; my return   
+    push bc                     ; pw2
+    push de                     ; (float)x
+    push hl
+    call m32_fsldexp_callee
+    pop bc                      ; my return
+    push bc
+    push bc
+    push bc
+    push bc
+    ret
+    

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fspoly.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fspoly.asm
@@ -37,11 +37,9 @@ EXTERN m32_fspoly_callee
 
     call m32_fspoly_callee
     
-    pop hl                      ; my return
-    xor a
-    push af
-    push af
-    push af
-    push af  
-    jp (hl)
-
+    pop bc                      ; my return
+    push bc
+    push bc
+    push bc
+    push bc  
+    ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fspoly_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fspoly_callee.asm
@@ -8,8 +8,6 @@ PUBLIC cm32_sdcc_fspoly_callee
 
 EXTERN m32_fspoly_callee
 
-.cm32_sdcc_dpoly
-
     ; evaluation of a polynomial function
     ;
     ; enter : stack = uint16_t n, float d[], float x, ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsfrexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsfrexp.asm
@@ -31,29 +31,11 @@
 SECTION code_clib
 SECTION code_fp_math32
 
-PUBLIC m32_fsfrexp, m32_fsfrexp_callee
+PUBLIC m32_fsfrexp_callee
 PUBLIC _m32_frexpf
 
 
 ._m32_frexpf
-.m32_fsfrexp
-    pop af                      ; my return
-    pop hl                      ; (float)x
-    pop de
-    pop bc                      ; (float*)pw2
-    push af                     ; my return   
-    push bc                     ; (float*)pw2
-    push de                     ; (float)x
-    push hl
-    call m32_fsfrexp_callee
-    pop bc                      ; my return
-    push af
-    push af
-    push af
-    push bc
-    ret
-
-
 .m32_fsfrexp_callee
     ; evaluation of fraction and exponent
     ;

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsldexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsldexp.asm
@@ -30,29 +30,11 @@
 SECTION code_clib
 SECTION code_fp_math32
 
-PUBLIC m32_fsldexp, m32_fsldexp_callee
+PUBLIC m32_fsldexp_callee
 PUBLIC _m32_ldexpf
 
 
 ._m32_ldexpf
-.m32_fsldexp
-    pop af                      ; my return
-    pop hl                      ; (float)x
-    pop de
-    pop bc                      ; pw2
-    push af                     ; my return   
-    push bc                     ; pw2
-    push de                     ; (float)x
-    push hl
-    call m32_fsldexp_callee
-    pop bc                      ; my return
-    push af
-    push af
-    push af
-    push bc
-    ret
-
-
 .m32_fsldexp_callee
     ; evaluation of fraction and exponent
     ;

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fspoly.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fspoly.asm
@@ -49,33 +49,6 @@ PUBLIC _m32_polyf
 
 
 ._m32_polyf
-    pop af                      ; my return
-    pop hl                      ; (float)x
-    pop de
-
-    exx
-    pop hl                      ; (float*)d
-    pop de                      ; (uint16_t)n
-
-    push af                     ; my return
-    push de                     ; (uint16_t)n
-    push hl                     ; (float*)d
-
-    exx
-    push de                      ; (float)x
-    push hl
-
-    call m32_fspoly_callee
-    
-    pop hl                      ; my return
-    xor a
-    push af
-    push af
-    push af
-    push af
-    jp (hl)
-
-
 .m32_fspoly_callee
     ; evaluation of a polynomial function
     ;


### PR DESCRIPTION
- [x] converted three internal functions `frexpf()`, `ldexpf()`, and `polyf()` to callee
- [x] added sccz80 stack reversal, and normal function sccz80 and sdcc stack management.