### PR TITLE
m32 - mulu_de zero exit optimisation

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
@@ -29,12 +29,12 @@ PUBLIC m32_z80_mulu_de
 
 .m32_z80_mulu_de
 
-   inc d
-   dec d
-   jr Z,zerod               ; multiply by 0
    inc e
    dec e
    jr Z,zeroe               ; multiply by 0
+   inc d
+   dec d
+   jr Z,zerod               ; multiply by 0
 
    push hl
    ex de,hl
@@ -59,13 +59,13 @@ PUBLIC m32_z80_mulu_de
    sla h
    jr C,branch_17
    jr exit1                ; multiply by 1
-   
-.zerod
-   ld e,d
-   ret
-   
+
 .zeroe
    ld d,e
+   ret
+
+.zerod
+   ld e,d
    ret
 
    ; multiplication tree


### PR DESCRIPTION
Simple PR to swap the zero exit for `z80_mulu_de`.

This is based on the info in @suborb initial benchmarking.

```
34595525	138382100 m32_z80_mulu_de:                  inc     d
34595525	138382100		                    dec     d
34595525	264303830		                    jr      z,zerod
30168494	120673976		                    inc     e
30168494	120673976		                    dec     e
30168494	235882743		                    jr      z,zeroe
25227837	277506207		                    push    hl
25227837	100911348		                    ex      de,hl
25227837	100911348		                    ld      e,l
25227837	176594859		                    ld      d,$00
25227837	201822696		                    sla     h
25227837	277552494		                    jr      c,branch_11
```
(138382100 - 120673976)/4 = 4,427,031 (12.8%) exit to `zerod`
(120673976 - 100911348)/4 = 4,940,657 (14.3%) exit to `zeroe`
Of a total of 138382100/4 = 34,595,525 cases.

And specifically since cases with both `zerod` and `zeroe` would have been caught by the first `zerod` exit, yet the `zeroe` case still wins by a substantial margin.

So, it seems to be better to put the `zeroe` test first.
