### PR TITLE
m32 - add _m32_fabsf label

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fabs.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fabs.asm
@@ -1,13 +1,17 @@
 
 SECTION code_fp_math32
 PUBLIC  m32_fabs
+PUBLIC _m32_fabsf
 
-m32_fabs:
+
+.m32_fabs
 	pop	bc
 	pop	hl
 	pop	de
 	push	de
 	push	hl
 	push	bc
+
+._m32_fabsf	
 	res	7,d
 	ret


### PR DESCRIPTION
Somehow, `_m32_fabsf` label was missed.