### PR TITLE
m32 - provide independent z80, z180, & z80-zxn multiply functions

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/math32_z180_asm.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/math32_z180_asm.lst
@@ -21,10 +21,9 @@ math/float/math32/z80/f32_fssqr
 math/float/math32/z80/f32_fssqrt
 math/float/math32/z80/f32_fsunity
 
-math/float/math32/z80/f32_z80_mulu_32h_24x24
-math/float/math32/z80/f32_z80_sqr_32h_24x24
-
+math/float/math32/z80/f32_z180_mulu_32h_24x24
 math/float/math32/z80/f32_z180_mulu_32h_32x32
+math/float/math32/z80/f32_z180_sqr_32h_24x24
 
 math/float/math32/z80/h32_coeff_atan
 math/float/math32/z80/h32_coeff_exp

--- a/libsrc/_DEVELOPMENT/math/float/math32/math32_z80_asm.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/math32_z80_asm.lst
@@ -21,11 +21,10 @@ math/float/math32/z80/f32_fssqr
 math/float/math32/z80/f32_fssqrt
 math/float/math32/z80/f32_fsunity
 
-math/float/math32/z80/f32_z80_mulu_32h_24x24
-math/float/math32/z80/f32_z80_sqr_32h_24x24
-
 math/float/math32/z80/f32_z80_mulu_de
+math/float/math32/z80/f32_z80_mulu_32h_24x24
 math/float/math32/z80/f32_z80_mulu_32h_32x32
+math/float/math32/z80/f32_z80_sqr_32h_24x24
 
 math/float/math32/z80/h32_coeff_atan
 math/float/math32/z80/h32_coeff_exp

--- a/libsrc/_DEVELOPMENT/math/float/math32/math32_z80_zxn_asm.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/math32_z80_zxn_asm.lst
@@ -21,10 +21,9 @@ math/float/math32/z80/f32_fssqr
 math/float/math32/z80/f32_fssqrt
 math/float/math32/z80/f32_fsunity
 
-math/float/math32/z80/f32_z80_mulu_32h_24x24
-math/float/math32/z80/f32_z80_sqr_32h_24x24
-
+math/float/math32/z80/f32_z80_zxn_mulu_32h_24x24
 math/float/math32/z80/f32_z80_zxn_mulu_32h_32x32
+math/float/math32/z80/f32_z80_zxn_sqr_32h_24x24
 
 math/float/math32/z80/h32_coeff_atan
 math/float/math32/z80/h32_coeff_exp

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul.asm
@@ -132,9 +132,8 @@ PUBLIC m32_fsmul, m32_fsmul_callee
 
     ex af,af
     ld a,b
-    ex af,af                    ; save sum of exponents a', and xor sign of exponents in f'
+    push af                     ; stack: sum of exponents a, and xor sign of exponents in f
 
-                                ; a' = sum of exponents, f' = Sign of result
                                 ; first  h  = eeeeeeee, lde  = 1mmmmmmm mmmmmmmm mmmmmmmm
                                 ; second h' = eeeeeeee, lde' = 1mmmmmmm mmmmmmmm mmmmmmmm
                                 ; sum of exponents in a', xor of exponents in sign f'
@@ -142,15 +141,8 @@ PUBLIC m32_fsmul, m32_fsmul_callee
                                 ; multiplication of two 24-bit numbers into a 32-bit product
     call m32_mulu_32h_24x24     ; exit  : HLDE  = 32-bit product
 
-    ex af,af                    ; retrieve sign and exponent from af'
-    jp P,fm1
-    scf
+    pop bc                      ; retrieve sign and exponent from stack = b,c[7]
 
-.fm1
-    rr c                        ; put sign bit in C
-    ld b,a                      ; put exponent into B
-
-    ex af,af
     bit 7,h                     ; need to shift result left if msb!=1
     jr NZ,fm2
     sla e

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul32.asm
@@ -115,7 +115,7 @@ PUBLIC m32_fsmul24x32, m32_fsmul32x32
 
     ex af,af
     ld a,b
-    push af                     ; stack: sum of exponents a', and xor sign of exponents in f'
+    push af                     ; stack: sum of exponents a, and xor sign of exponents in f
 
                                 ; first  dehl  = 1mmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm
                                 ; second dehl' = 1mmmmmmm mmmmmmmm mmmmmmmm mmmmmmmm

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fssqr.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fssqr.asm
@@ -74,10 +74,8 @@ PUBLIC _m32_sqrf
 .fsnouf
     or a
     jp Z,m32_fszero_fastcall
-    ld b,a
-    ex af,af
-    ld a,b
-    ex af,af                    ; save sum of exponents a'
+
+    push af                     ; stack: sum of exponents a
 
                                 ; square of two 24-bit numbers into a 32-bit product
                                 ;
@@ -92,8 +90,7 @@ PUBLIC _m32_sqrf
 
     call m32_sqr_32h_24x24      ; exit  : HLDE  = 32-bit product
 
-    ex af,af                    ; retrieve exponent from af'
-    ld b,a                      ; put exponent into B
+    pop bc                      ; retrieve exponent from stack
 
     bit 7,h                     ; need to shift result left if msb!=1
     jr NZ,fs1

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z180_mulu_32h_24x24.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z180_mulu_32h_24x24.asm
@@ -33,12 +33,10 @@
 ;
 ; uses  : af, bc, de, hl, bc', de', hl'
 
-IF __CPU_Z80__
+IF __CPU_Z180__
 
 SECTION code_clib
 SECTION code_fp_math32
-
-EXTERN m32_z80_mulu_de
 
 PUBLIC m32_mulu_32h_24x24
 
@@ -71,9 +69,8 @@ PUBLIC m32_mulu_32h_24x24
     ld a,h
     ld h,e
     ld e,a
-    call m32_z80_mulu_de        ; b*e 2^8
-    ex de,hl
-    call m32_z80_mulu_de        ; c*f 2^8
+    mlt hl                      ; b*e 2^8
+    mlt de                      ; c*f 2^8
 
     xor a
     add hl,de
@@ -87,9 +84,8 @@ PUBLIC m32_mulu_32h_24x24
     ld a,d
     ld d,h
     ld h,a
-    call m32_z80_mulu_de        ; a*f 2^16
-    ex de,hl
-    call m32_z80_mulu_de        ; e*b 2^16
+    mlt hl                      ; a*f 2^16
+    mlt de                      ; e*b 2^16
 
     xor a
     add hl,bc
@@ -98,7 +94,7 @@ PUBLIC m32_mulu_32h_24x24
     adc a,0
 
     pop de                      ; dc
-    call m32_z80_mulu_de        ; d*c 2^16
+    mlt de                      ; d*c 2^16
 
     add hl,de
     adc a,0
@@ -115,9 +111,8 @@ PUBLIC m32_mulu_32h_24x24
     ld a,d
     ld d,h
     ld h,a
-    call m32_z80_mulu_de        ; d*b 2^24
-    ex de,hl
-    call m32_z80_mulu_de        ; a*e 2^24
+    mlt hl                      ; d*b 2^24
+    mlt de                      ; a*e 2^24
 
     xor a
     add hl,bc
@@ -132,7 +127,7 @@ PUBLIC m32_mulu_32h_24x24
     ld h,a
 
     pop de                      ; ad
-    call m32_z80_mulu_de        ; a*d 2^32
+    mlt de                      ; a*d 2^32
 
     add hl,de
 

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z180_mulu_32h_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z180_mulu_32h_32x32.asm
@@ -11,6 +11,7 @@
 ;
 ; NOTE THIS IS NOT A TRUE MULTIPLY.
 ; Carry in from low bytes is not calculated.
+; Rounding is done at 2^16.
 ;
 ; enter : dehl  = 32-bit multiplier   = x
 ;         dehl' = 32-bit multiplicand = y
@@ -19,6 +20,8 @@
 ;         carry reset
 ;
 ; uses  : af, bc, de, hl, af', bc', de', hl'
+
+IF __CPU_Z180__
 
 SECTION code_clib
 SECTION code_fp_math32
@@ -181,3 +184,4 @@ PUBLIC m32_mulu_32h_32x32
     ex de,hl                    ; p7 p6 <-> p5 p4
     ret                         ; exit  : DEHL = 32-bit product
 
+ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z180_sqr_32h_24x24.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z180_sqr_32h_24x24.asm
@@ -33,12 +33,10 @@
 ;
 ; uses  : af, bc, de, hl
 
-IF __CPU_Z80__
+IF __CPU_Z180__
 
 SECTION code_clib
 SECTION code_fp_math32
-
-EXTERN m32_z80_mulu_de
 
 PUBLIC m32_sqr_32h_24x24
 
@@ -55,9 +53,7 @@ PUBLIC m32_sqr_32h_24x24
     push de                     ; ac on stack
     ld l,e                      ; bc:ac
 
-    ex de,hl                    ; ac:bc
-    call m32_z80_mulu_de        ; b*c 2^8
-    ex de,hl
+    mlt hl                      ; b*c 2^8
 
     xor a
     add hl,hl                   ; 2*b*c 2^8
@@ -66,11 +62,10 @@ PUBLIC m32_sqr_32h_24x24
     ld c,h                      ; put 2^8 in bc
     ld b,a
 
-    pop de                      ; ac
-    pop hl                      ; bb
-    call m32_z80_mulu_de        ; a*c 2^16
-    ex de,hl
-    call m32_z80_mulu_de        ; b*b 2^16
+    pop hl                      ; ac
+    pop de                      ; bb
+    mlt hl                      ; a*c 2^16
+    mlt de                      ; b*b 2^16
 
     xor a
     add hl,hl                   ; 2*a*c 2^16
@@ -84,7 +79,7 @@ PUBLIC m32_sqr_32h_24x24
     ld b,a
 
     pop de                      ; ab
-    call m32_z80_mulu_de        ; a*b 2^24
+    mlt de                      ; a*b 2^24
 
     ex de,hl                    ; l into e
     
@@ -100,7 +95,7 @@ PUBLIC m32_sqr_32h_24x24
     ld h,a
 
     pop de                      ; aa
-    call m32_z80_mulu_de        ; a*a 2^32
+    mlt de                      ; a*a 2^32
 
     add hl,de
     ld d,b

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_24x24.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_24x24.asm
@@ -31,7 +31,7 @@
 ;
 ; exit  : hlde  = 32-bit product
 ;
-; uses  : af, bc, de, hl, bc', de', hl'
+; uses  : af, bc, de, hl, af', bc', de', hl'
 
 IF __CPU_Z80__
 
@@ -47,7 +47,7 @@ PUBLIC m32_mulu_32h_24x24
 
     ld h,l                      ; ab:bc
     ld l,d
-    ld a,h                      ; a in a             
+    ld a,h                      ; a in a
     
     exx
     ld h,a
@@ -79,49 +79,60 @@ PUBLIC m32_mulu_32h_24x24
     add hl,de
     adc a,a
 
-    ld c,h                      ; put 2^8 in bc
-    ld b,a
+    ld l,h                      ; put 2^8 in hl
+    ld h,a
 
     pop de                      ; ef
-    pop hl                      ; ab
+    pop bc                      ; ab
     ld a,d
-    ld d,h
-    ld h,a
+    ld d,b
+    ld b,a
+    push bc                     ; eb
     call m32_z80_mulu_de        ; a*f 2^16
-    ex de,hl
-    call m32_z80_mulu_de        ; e*b 2^16
 
     xor a
-    add hl,bc
+    add hl,de
     adc a,a
+    ex af,af
+
+    pop de                      ; eb
+    call m32_z80_mulu_de        ; e*b 2^16
+
+    ex af,af
     add hl,de
     adc a,0
+    ex af,af
 
     pop de                      ; dc
     call m32_z80_mulu_de        ; d*c 2^16
 
+    ex af,af
     add hl,de
     adc a,0
 
-    ld c,h                      ; put 2^16 in bca
-    ld b,a
-    ld a,l
+    ld b,l                      ; put 2^16 in hla
+    ld l,h
+    ld h,a
+    ld a,b
 
     pop de                      ; ab
-    pop hl                      ; de
-
+    pop bc                      ; de
     push af                     ; l on stack
-
     ld a,d
-    ld d,h
-    ld h,a
+    ld d,b
+    ld b,a
+    push bc                     ; ae
     call m32_z80_mulu_de        ; d*b 2^24
-    ex de,hl
-    call m32_z80_mulu_de        ; a*e 2^24
 
     xor a
-    add hl,bc
+    add hl,de
     adc a,a
+    ex af,af
+
+    pop de                      ; ae
+    call m32_z80_mulu_de        ; a*e 2^24
+
+    ex af,af
     add hl,de
     adc a,0
 
@@ -132,12 +143,11 @@ PUBLIC m32_mulu_32h_24x24
     ld h,a
 
     pop de                      ; ad
+    push bc
     call m32_z80_mulu_de        ; a*d 2^32
 
     add hl,de
-
-    ld d,b
-    ld e,c                      ; exit  : HLDE  = 32-bit product
+    pop de                      ; exit  : HLDE  = 32-bit product
     ret
 
 ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
@@ -26,166 +26,20 @@ IF __CPU_Z80__
 SECTION code_clib
 SECTION code_fp_math32
 
-EXTERN m32_z80_mulu_de
+EXTERN l_mulu_64_32x32
 
 PUBLIC m32_mulu_32h_32x32
 
-
 .m32_mulu_32h_32x32
-
-    ld c,l
-    ld b,h
-    push de
-    exx
-    pop bc
-    push hl
-    exx
-    pop de
-
-    ; multiplication of two 32-bit numbers into a 32-bit product
-    ;
-    ; enter : de'de = 32-bit multiplier    = x
-    ;         bc'bc = 32-bit multiplicand  = y
-    ;
-    ; exit  : dehl = 32-bit product
-    ;         carry reset
-    ;
-    ; uses  : af, bc, de, hl, af', bc', de', hl'
-
-    ; save material for the byte p7 p6 = x3*y3 + p5 carry
-    exx                         ;'
-    ld h,d
-    ld l,b
-    push hl                     ;'x3 y3
-
-    ; save material for the byte p5 = x3*y2 + x2*y3 + p4 carry
-    ld l,c
-    push hl                     ;'x3 y2
-    ld h,b
-    ld l,e
-    push hl                     ;'y3 x2
-
-    ; save material for the byte p4 = x3*y1 + x2*y2 + x1*y3 + p3 carry
-    ld h,e
-    ld l,c
-    push hl                     ;'x2 y2
-    ld h,d
-    ld l,b
-    push hl                     ;'x3 y3
-    exx                         ;
-    ld l,b
-    ld h,d
-    push hl                     ; x1 y1
-
-    ; save material for the byte p3 = x3*y0 + x2*y1 + x1*y2 + x0*y3
-    push bc                     ; y1 y0
-    exx                         ;'
-    push de                     ;'x3 x2
-    push bc                     ;'y3 y2
-    exx                         ;
-;   push de                     ; x1 x0
-
-    ; start doing the p3 byte
-
-    pop hl                      ; y3 y2
-    ld a,h
-    ld h,d
-    ld d,a
-    call m32_z80_mulu_de        ; y3*x0
-    ex de,hl
-    call m32_z80_mulu_de        ; x1*y2
-
-    xor a                       ; zero A
-    add hl,de                   ; p4 p3
-    adc a,a                     ; p5
-    ld b,h
-    ld c,l
-    ex af,af
-
-    pop hl                      ; x3 x2
-    pop de                      ; y1 y0
-    ld a,h
-    ld h,d
-    ld d,a
-    call m32_z80_mulu_de        ; x3*y0
-    ex de,hl
-    call m32_z80_mulu_de        ; y1*x2
-
-    ex af,af
-    add hl,de                   ; p4 p3
-    adc a,0                     ; p5
-    add hl,bc                   ; p4 p3
-    adc a,0                     ; p5
-
-    ex af,af
-    ld a,l                      ; preserve p3 byte for rounding
-    ex af,af
-
-    ld c,h                      ; prepare BC for next cycle
-    ld b,a                      ; promote BC p5 p4
-
-    ; start doing the p4 byte
-
-    pop hl                      ; x1 y1
-    pop de                      ; x3 y3
-    ld a,h
-    ld h,d
-    ld d,a
-    call m32_z80_mulu_de        ; x1*y3
-    ex de,hl
-    call m32_z80_mulu_de        ; x3*y1
-
-
-    xor a                       ; zero A
-    add hl,de                   ; p5 p4
-    adc a,a                     ; p6
-    add hl,bc                   ; p5 p4
-    adc a,0                     ; p6
-
-    pop de                      ; x2 y2
-    call m32_z80_mulu_de        ; x2*y2
-
-    add hl,de                   ; p5 p4
-    adc a,0                     ; p6
-
-    ld c,l                      ; final p4 byte in C
-    ld l,h                      ; prepare HL for next cycle
-    ld h,a                      ; promote HL p6 p5
-
-    ex af,af
-    or a
-    jr Z,mul0                   ; use p3 to round p4
-    set 0,c
-
-.mul0
     
-    ; start doing the p5 byte
+    call l_mulu_64_32x32
+    exx
+    ld a,d
+    exx
 
-    pop de                      ; y3 x2
-    call m32_z80_mulu_de        ; y3*x2
-
-    xor a                       ; zero A
-    add hl,de                   ; p6 p5
-    adc a,a                     ; p7
-
-    pop de                      ; x3 y2
-    call m32_z80_mulu_de        ; x3*y2
-
-    add hl,de                   ; p6 p5
-    adc a,0                     ; p7
-
-    ld b,l                      ; final p5 byte in B
-    ld l,h                      ; prepare HL for next cycle
-    ld h,a                      ; promote HL p7 p6
-
-    ; start doing the p6 p7 bytes
-    pop de                      ; y3 x3
-    call m32_z80_mulu_de        ; y3*x3
-
-    add hl,de                   ; p7 p6
-    ex de,hl                    ; p7 p6
-    ld h,b                      ; p5
-    ld l,c                      ; p4
+    or a
+    ret Z                       ; exit  : use p3 to round p4 DEHL = 32-bit product
+    set 0,l
     ret                         ; exit  : DEHL = 32-bit product
-
+    
 ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
@@ -98,53 +98,63 @@ PUBLIC m32_mulu_32h_32x32
     xor a                       ; zero A
     add hl,de                   ; p4 p3
     adc a,a                     ; p5
-    ld b,h
-    ld c,l
     ex af,af
 
-    pop hl                      ; x3 x2
+    pop bc                      ; x3 x2
     pop de                      ; y1 y0
-    ld a,h
-    ld h,d
+    ld a,b
+    ld b,d
     ld d,a
+    push bc                     ; y1 x2
     call m32_z80_mulu_de        ; x3*y0
-    ex de,hl
+
+    ex af,af
+    add hl,de                   ; p4 p3
+    adc a,0                     ; p5
+    ex af,af
+
+    pop de                      ; y1 x2
     call m32_z80_mulu_de        ; y1*x2
 
     ex af,af
     add hl,de                   ; p4 p3
     adc a,0                     ; p5
-    add hl,bc                   ; p4 p3
-    adc a,0                     ; p5
 
-    ex af,af
-    ld a,l                      ; preserve p3 byte for rounding
-    ex af,af
-
-    ld c,h                      ; prepare BC for next cycle
-    ld b,a                      ; promote BC p5 p4
+    ld b,l                      ; preserve p3 byte for rounding
+    ld l,h                      ; prepare HL for next cycle
+    ld h,a                      ; promote HL p5 p4
+    ld a,b                      ; preserve p3 byte for rounding
 
     ; start doing the p4 byte
 
-    pop hl                      ; x1 y1
+    pop bc                      ; x1 y1
     pop de                      ; x3 y3
-    ld a,h
-    ld h,d
+    push af                     ; preserve p3 byte for rounding
+    ld a,b
+    ld b,d
     ld d,a
+    push bc                     ; x3 y1
     call m32_z80_mulu_de        ; x1*y3
-    ex de,hl
-    call m32_z80_mulu_de        ; x3*y1
-
 
     xor a                       ; zero A
     add hl,de                   ; p5 p4
     adc a,a                     ; p6
-    add hl,bc                   ; p5 p4
-    adc a,0                     ; p6
+    ex af,af
 
+    pop de                      ; x3 y1
+    call m32_z80_mulu_de        ; x3*y1
+
+    ex af,af
+    add hl,de                   ; p5 p4
+    adc a,0                     ; p6
+    ex af,af
+
+    pop af                      ; preserve p3 byte for rounding
     pop de                      ; x2 y2
+    push af                     ; preserve p3 byte for rounding
     call m32_z80_mulu_de        ; x2*y2
 
+    ex af,af
     add hl,de                   ; p5 p4
     adc a,0                     ; p6
 
@@ -152,40 +162,45 @@ PUBLIC m32_mulu_32h_32x32
     ld l,h                      ; prepare HL for next cycle
     ld h,a                      ; promote HL p6 p5
 
-    ex af,af
+    pop af                      ; p3 byte for rounding
     or a
     jr Z,mul0                   ; use p3 to round p4
     set 0,c
 
 .mul0
-    
     ; start doing the p5 byte
 
     pop de                      ; y3 x2
+    push bc                     ; save p4 byte
     call m32_z80_mulu_de        ; y3*x2
 
     xor a                       ; zero A
     add hl,de                   ; p6 p5
     adc a,a                     ; p7
+    ex af,af
 
+    pop bc                      ; save p4 byte
     pop de                      ; x3 y2
+    push bc                     ; save p4 byte
     call m32_z80_mulu_de        ; x3*y2
 
+    ex af,af
     add hl,de                   ; p6 p5
     adc a,0                     ; p7
 
+    pop bc                      ; save p4 byte in C
     ld b,l                      ; final p5 byte in B
     ld l,h                      ; prepare HL for next cycle
     ld h,a                      ; promote HL p7 p6
 
     ; start doing the p6 p7 bytes
     pop de                      ; y3 x3
+    push bc                     ; save p5 p4 byte in BC
     call m32_z80_mulu_de        ; y3*x3
 
-    add hl,de                   ; p7 p6
-    ex de,hl                    ; p7 p6
-    ld h,b                      ; p5
-    ld l,c                      ; p4
+    add hl,de                   ; p7 p6 in HL
+    pop de                      ; save p5 p4 byte in DE
+    ex de,hl                    ; p7 p6 p5 p4
     ret                         ; exit  : DEHL = 32-bit product
 
 ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
@@ -26,20 +26,166 @@ IF __CPU_Z80__
 SECTION code_clib
 SECTION code_fp_math32
 
-EXTERN l_mulu_64_32x32
+EXTERN m32_z80_mulu_de
 
 PUBLIC m32_mulu_32h_32x32
 
-.m32_mulu_32h_32x32
-    
-    call l_mulu_64_32x32
-    exx
-    ld a,d
-    exx
 
+.m32_mulu_32h_32x32
+
+    ld c,l
+    ld b,h
+    push de
+    exx
+    pop bc
+    push hl
+    exx
+    pop de
+
+    ; multiplication of two 32-bit numbers into a 32-bit product
+    ;
+    ; enter : de'de = 32-bit multiplier    = x
+    ;         bc'bc = 32-bit multiplicand  = y
+    ;
+    ; exit  : dehl = 32-bit product
+    ;         carry reset
+    ;
+    ; uses  : af, bc, de, hl, af', bc', de', hl'
+
+    ; save material for the byte p7 p6 = x3*y3 + p5 carry
+    exx                         ;'
+    ld h,d
+    ld l,b
+    push hl                     ;'x3 y3
+
+    ; save material for the byte p5 = x3*y2 + x2*y3 + p4 carry
+    ld l,c
+    push hl                     ;'x3 y2
+    ld h,b
+    ld l,e
+    push hl                     ;'y3 x2
+
+    ; save material for the byte p4 = x3*y1 + x2*y2 + x1*y3 + p3 carry
+    ld h,e
+    ld l,c
+    push hl                     ;'x2 y2
+    ld h,d
+    ld l,b
+    push hl                     ;'x3 y3
+    exx                         ;
+    ld l,b
+    ld h,d
+    push hl                     ; x1 y1
+
+    ; save material for the byte p3 = x3*y0 + x2*y1 + x1*y2 + x0*y3
+    push bc                     ; y1 y0
+    exx                         ;'
+    push de                     ;'x3 x2
+    push bc                     ;'y3 y2
+    exx                         ;
+;   push de                     ; x1 x0
+
+    ; start doing the p3 byte
+
+    pop hl                      ; y3 y2
+    ld a,h
+    ld h,d
+    ld d,a
+    call m32_z80_mulu_de        ; y3*x0
+    ex de,hl
+    call m32_z80_mulu_de        ; x1*y2
+
+    xor a                       ; zero A
+    add hl,de                   ; p4 p3
+    adc a,a                     ; p5
+    ld b,h
+    ld c,l
+    ex af,af
+
+    pop hl                      ; x3 x2
+    pop de                      ; y1 y0
+    ld a,h
+    ld h,d
+    ld d,a
+    call m32_z80_mulu_de        ; x3*y0
+    ex de,hl
+    call m32_z80_mulu_de        ; y1*x2
+
+    ex af,af
+    add hl,de                   ; p4 p3
+    adc a,0                     ; p5
+    add hl,bc                   ; p4 p3
+    adc a,0                     ; p5
+
+    ex af,af
+    ld a,l                      ; preserve p3 byte for rounding
+    ex af,af
+
+    ld c,h                      ; prepare BC for next cycle
+    ld b,a                      ; promote BC p5 p4
+
+    ; start doing the p4 byte
+
+    pop hl                      ; x1 y1
+    pop de                      ; x3 y3
+    ld a,h
+    ld h,d
+    ld d,a
+    call m32_z80_mulu_de        ; x1*y3
+    ex de,hl
+    call m32_z80_mulu_de        ; x3*y1
+
+
+    xor a                       ; zero A
+    add hl,de                   ; p5 p4
+    adc a,a                     ; p6
+    add hl,bc                   ; p5 p4
+    adc a,0                     ; p6
+
+    pop de                      ; x2 y2
+    call m32_z80_mulu_de        ; x2*y2
+
+    add hl,de                   ; p5 p4
+    adc a,0                     ; p6
+
+    ld c,l                      ; final p4 byte in C
+    ld l,h                      ; prepare HL for next cycle
+    ld h,a                      ; promote HL p6 p5
+
+    ex af,af
     or a
-    ret Z                       ; exit  : use p3 to round p4 DEHL = 32-bit product
-    set 0,l
-    ret                         ; exit  : DEHL = 32-bit product
+    jr Z,mul0                   ; use p3 to round p4
+    set 0,c
+
+.mul0
     
+    ; start doing the p5 byte
+
+    pop de                      ; y3 x2
+    call m32_z80_mulu_de        ; y3*x2
+
+    xor a                       ; zero A
+    add hl,de                   ; p6 p5
+    adc a,a                     ; p7
+
+    pop de                      ; x3 y2
+    call m32_z80_mulu_de        ; x3*y2
+
+    add hl,de                   ; p6 p5
+    adc a,0                     ; p7
+
+    ld b,l                      ; final p5 byte in B
+    ld l,h                      ; prepare HL for next cycle
+    ld h,a                      ; promote HL p7 p6
+
+    ; start doing the p6 p7 bytes
+    pop de                      ; y3 x3
+    call m32_z80_mulu_de        ; y3*x3
+
+    add hl,de                   ; p7 p6
+    ex de,hl                    ; p7 p6
+    ld h,b                      ; p5
+    ld l,c                      ; p4
+    ret                         ; exit  : DEHL = 32-bit product
+
 ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
@@ -16,9 +16,7 @@
 ; exit  : de = 16-bit product
 ;         carry reset
 
-
-;IF __CLIB_OPT_IMATH <= 50
-IF 1
+IF __CLIB_OPT_IMATH <= 50
 
 ;-------------------------------------------------------------------------
 ;
@@ -118,8 +116,7 @@ PUBLIC m32_z80_mulu_de
 
 ENDIF
 
-;IF __CLIB_OPT_IMATH > 50
-IF 0
+IF __CLIB_OPT_IMATH > 50
 
 ;-------------------------------------------------------------------------
 ;
@@ -143,7 +140,7 @@ PUBLIC m32_z80_mulu_de
     ld d,e
     ld e,a
 
-.lnc                        ; largest in d
+.lnc                        ; with largest in d
     xor a
     or e
     jr Z,lzeroe             ; multiply by 0

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
@@ -17,7 +17,8 @@
 ;         carry reset
 
 
-IF __CLIB_OPT_IMATH <= 50
+;IF __CLIB_OPT_IMATH <= 50
+IF 0
 
 ;-------------------------------------------------------------------------
 ;
@@ -33,10 +34,10 @@ PUBLIC m32_z80_mulu_de
 
    inc e
    dec e
-   jr Z,zeroe               ; multiply by 0
+   jr Z,lzeroe              ; multiply by 0
    inc d
    dec d
-   jr Z,zerod               ; multiply by 0
+   jr Z,lzerod              ; multiply by 0
 
    push hl
    ex de,hl
@@ -62,11 +63,11 @@ PUBLIC m32_z80_mulu_de
    jr C,branch_17
    jr exit1                ; multiply by 1
 
-.zeroe
+.lzeroe
    ld d,e
    ret
 
-.zerod
+.lzerod
    ld e,d
    ret
 
@@ -115,7 +116,8 @@ PUBLIC m32_z80_mulu_de
 
 ENDIF
 
-IF __CLIB_OPT_IMATH > 50
+;IF __CLIB_OPT_IMATH > 50
+IF 1
 
 ;-------------------------------------------------------------------------
 ;

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_sqr_32h_24x24.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_sqr_32h_24x24.asm
@@ -31,7 +31,7 @@
 ;
 ; exit  : hlde  = 32-bit product
 ;
-; uses  : af, bc, de, hl
+; uses  : af, bc, de, hl, af'
 
 IF __CPU_Z80__
 
@@ -63,48 +63,53 @@ PUBLIC m32_sqr_32h_24x24
     add hl,hl                   ; 2*b*c 2^8
     adc a,a
 
-    ld c,h                      ; put 2^8 in bc
-    ld b,a
+    ld l,h                      ; put 2^8 in hl
+    ld h,a
 
     pop de                      ; ac
-    pop hl                      ; bb
     call m32_z80_mulu_de        ; a*c 2^16
-    ex de,hl
-    call m32_z80_mulu_de        ; b*b 2^16
 
     xor a
-    add hl,hl                   ; 2*a*c 2^16
+    add hl,de                   ; 2*a*c 2^16
     adc a,a
     add hl,de
     adc a,0
-    add hl,bc
+    ex af,af
+
+    pop de                      ; bb
+    call m32_z80_mulu_de        ; b*b 2^16
+
+    ex af,af
+    add hl,de
     adc a,0
 
-    ld c,h                      ; put 2^16 in bc
-    ld b,a
+    ld b,l                      ; put 2^16 in hla
+    ld l,h
+    ld h,a
+    ld a,b
 
     pop de                      ; ab
+    push af                     ; l on stack
     call m32_z80_mulu_de        ; a*b 2^24
-
-    ex de,hl                    ; l into e
     
     xor a
-    add hl,hl                   ; 2*a*b 2^24
+    add hl,de                   ; 2*a*b 2^24
     adc a,a
-    add hl,bc
+    add hl,de
     adc a,0
 
-    ld c,e                      ; l into c
+    pop bc                      ; l in b
+    ld c,b                      ; l into c
     ld b,l
     ld l,h
     ld h,a
 
     pop de                      ; aa
+    push bc
     call m32_z80_mulu_de        ; a*a 2^32
 
     add hl,de
-    ld d,b
-    ld e,c                      ; exit  : HLDE  = 32-bit product
+    pop de                      ; exit  : HLDE  = 32-bit product
     ret
 
 ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_mulu_32h_24x24.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_mulu_32h_24x24.asm
@@ -33,12 +33,10 @@
 ;
 ; uses  : af, bc, de, hl, bc', de', hl'
 
-IF __CPU_Z80__
+IF __CPU_Z80_ZXN__
 
 SECTION code_clib
 SECTION code_fp_math32
-
-EXTERN m32_z80_mulu_de
 
 PUBLIC m32_mulu_32h_24x24
 
@@ -71,9 +69,9 @@ PUBLIC m32_mulu_32h_24x24
     ld a,h
     ld h,e
     ld e,a
-    call m32_z80_mulu_de        ; b*e 2^8
+    mul de                      ; b*e 2^8
     ex de,hl
-    call m32_z80_mulu_de        ; c*f 2^8
+    mul de                      ; c*f 2^8
 
     xor a
     add hl,de
@@ -87,9 +85,9 @@ PUBLIC m32_mulu_32h_24x24
     ld a,d
     ld d,h
     ld h,a
-    call m32_z80_mulu_de        ; a*f 2^16
+    mul de                      ; a*f 2^16
     ex de,hl
-    call m32_z80_mulu_de        ; e*b 2^16
+    mul de                      ; e*b 2^16
 
     xor a
     add hl,bc
@@ -98,7 +96,7 @@ PUBLIC m32_mulu_32h_24x24
     adc a,0
 
     pop de                      ; dc
-    call m32_z80_mulu_de        ; d*c 2^16
+    mul de                      ; d*c 2^16
 
     add hl,de
     adc a,0
@@ -115,9 +113,9 @@ PUBLIC m32_mulu_32h_24x24
     ld a,d
     ld d,h
     ld h,a
-    call m32_z80_mulu_de        ; d*b 2^24
+    mul de                      ; d*b 2^24
     ex de,hl
-    call m32_z80_mulu_de        ; a*e 2^24
+    mul de                      ; a*e 2^24
 
     xor a
     add hl,bc
@@ -132,7 +130,7 @@ PUBLIC m32_mulu_32h_24x24
     ld h,a
 
     pop de                      ; ad
-    call m32_z80_mulu_de        ; a*d 2^32
+    mul de                      ; a*d 2^32
 
     add hl,de
 

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_mulu_32h_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_mulu_32h_32x32.asm
@@ -11,6 +11,7 @@
 ;
 ; NOTE THIS IS NOT A TRUE MULTIPLY.
 ; Carry in from low bytes is not calculated.
+; Rounding is done at 2^16.
 ;
 ; enter : dehl  = 32-bit multiplier   = x
 ;         dehl' = 32-bit multiplicand = y
@@ -19,6 +20,8 @@
 ;         carry reset
 ;
 ; uses  : af, bc, de, hl, af', bc', de', hl'
+
+IF __CPU_Z80_ZXN__
 
 SECTION code_clib
 SECTION code_fp_math32
@@ -183,3 +186,4 @@ PUBLIC m32_mulu_32h_32x32
     ld l,c                      ; p4
     ret                         ; exit  : DEHL = 32-bit product
 
+ENDIF

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_sqr_32h_24x24.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_sqr_32h_24x24.asm
@@ -33,12 +33,10 @@
 ;
 ; uses  : af, bc, de, hl
 
-IF __CPU_Z80__
+IF __CPU_Z80_ZXN__
 
 SECTION code_clib
 SECTION code_fp_math32
-
-EXTERN m32_z80_mulu_de
 
 PUBLIC m32_sqr_32h_24x24
 
@@ -56,7 +54,7 @@ PUBLIC m32_sqr_32h_24x24
     ld l,e                      ; bc:ac
 
     ex de,hl                    ; ac:bc
-    call m32_z80_mulu_de        ; b*c 2^8
+    mul de                      ; b*c 2^8
     ex de,hl
 
     xor a
@@ -68,9 +66,9 @@ PUBLIC m32_sqr_32h_24x24
 
     pop de                      ; ac
     pop hl                      ; bb
-    call m32_z80_mulu_de        ; a*c 2^16
+    mul de                      ; a*c 2^16
     ex de,hl
-    call m32_z80_mulu_de        ; b*b 2^16
+    mul de                      ; b*b 2^16
 
     xor a
     add hl,hl                   ; 2*a*c 2^16
@@ -84,7 +82,7 @@ PUBLIC m32_sqr_32h_24x24
     ld b,a
 
     pop de                      ; ab
-    call m32_z80_mulu_de        ; a*b 2^24
+    mul de                      ; a*b 2^24
 
     ex de,hl                    ; l into e
     
@@ -100,7 +98,7 @@ PUBLIC m32_sqr_32h_24x24
     ld h,a
 
     pop de                      ; aa
-    call m32_z80_mulu_de        ; a*a 2^32
+    mul de                      ; a*a 2^32
 
     add hl,de
     ld d,b

--- a/libsrc/math/math32/newlibfiles_z180.lst
+++ b/libsrc/math/math32/newlibfiles_z180.lst
@@ -1,2 +1,4 @@
+../../_DEVELOPMENT/math/float/math32/z80/f32_z180_mulu_32h_24x24.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z180_mulu_32h_32x32.asm
+../../_DEVELOPMENT/math/float/math32/z80/f32_z180_sqr_32h_24x24.asm
 @newlibfiles_z80.lst

--- a/libsrc/math/math32/newlibfiles_z80.lst
+++ b/libsrc/math/math32/newlibfiles_z80.lst
@@ -139,7 +139,6 @@
 ../../_DEVELOPMENT/math/float/math32/z80/f32_fssqr.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_fssqrt.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_fsunity.asm
-../../_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_24x24.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_sqr_32h_24x24.asm

--- a/libsrc/math/math32/newlibfiles_z80.lst
+++ b/libsrc/math/math32/newlibfiles_z80.lst
@@ -139,6 +139,7 @@
 ../../_DEVELOPMENT/math/float/math32/z80/f32_fssqr.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_fssqrt.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_fsunity.asm
+../../_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_de.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_24x24.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_mulu_32h_32x32.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_sqr_32h_24x24.asm

--- a/libsrc/math/math32/newlibfiles_zxn.lst
+++ b/libsrc/math/math32/newlibfiles_zxn.lst
@@ -1,2 +1,4 @@
+../../_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_mulu_32h_24x24.asm
 ../../_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_mulu_32h_32x32.asm
+../../_DEVELOPMENT/math/float/math32/z80/f32_z80_zxn_sqr_32h_24x24.asm
 @newlibfiles_z80.lst

--- a/test/suites/math/math.c
+++ b/test/suites/math/math.c
@@ -57,7 +57,7 @@ void test_integer_constant_longform_lhs()
      Assert ( a == 4, "addition: a == 4");
      a = 2 * a;
      Assert ( a == 8, "multiply: a == 8");
-     a = 32. / a;
+     a = 32 / a;
      Assert ( a == 4, "divide: a == 4");
      a = 6 - a;
      Assert ( a == 2, "subtract: a == 2");


### PR DESCRIPTION
- Provide a separate mantissa multiply system for each CPU variant.
- Optimise the z80 `mulu_de` function table lookup option and convert to caller preserves.
- Fix `math.c` test typo.