### PR TITLE
[make] - remove unused sdcc architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,10 @@ bin/zsdcc$(EXESUFFIX):
 				       --disable-avr-port --disable-ds390-port \
 				       --disable-ds400-port --disable-hc08-port \
 				       --disable-pic-port --disable-pic14-port \
-                       		       --disable-pic16-port --disable-stm8-port \
+				       --disable-pic16-port --disable-stm8-port \
 				       --disable-tlcs90-port --disable-s08-port \
-                       		       --disable-ucsim --disable-device-lib \
+				       --disable-pdk14-port --disable-pdk15-port \
+				       --disable-ucsim --disable-device-lib \
 				       --disable-packihx
 	cd $(SDCC_PATH) && $(MAKE)
 	cd $(SDCC_PATH) && mv ./bin/sdcc  $(Z88DK_PATH)/bin/zsdcc


### PR DESCRIPTION
- --disable-pdk14-port
- --disable-pdk15-port