### PR TITLE
(math) Implement and fix frexp for all maths libraries

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -14,6 +14,8 @@
 #include <math/math_mbf32.h>
 #elif __MATH_ZX
 #include <math/math_zx.h>
+#elif __MATH_CPC
+#include <math/math_cpc.h>
 #else
 #include <math/math_genmath.h>
 #endif

--- a/include/math/math_cpc.h
+++ b/include/math/math_cpc.h
@@ -1,5 +1,5 @@
-#ifndef __MATH_GENMATH_H__
-#define __MATH_GENMATH_H__
+#ifndef __MATH_ZXMATH_H__
+#define __MATH_ZXMATH_H__
 
 #include <sys/compiler.h>
 #include <sys/types.h>
@@ -8,28 +8,29 @@
 #define FLT_ROUNDS 1
 #define FLT_RADIX  2
 
-#define FLT_MANT_DIG 39
-#define DBL_MANT_DIG 39
-#define FLT_DIG      9
-#define DBL_DIG      9
+#define FLT_MANT_DIG 31
+#define DBL_MANT_DIG 31
+#define FLT_DIG      7
+#define DBL_DIG      7
 
-#define FLT_EPSILON  0.000000000001
-#define DBL_EPSILON  0.000000000001
-#define MAXFLOAT     9.995e37
-#define HUGE_VAL     9.990e37
-#define INFINITY     9.999e37
-#define FLT_MAX      9.995e37
-#define DBL_MAX      9.995e37
+#define FLT_EPSILON  0.000000001
+#define DBL_EPSILON  0.000000001
+#define MAXFLOAT     1.5e32
+#define HUGE_VAL     1.0e32
+#define INFINITY     1.7e32
+#define FLT_MAX      1.5e32
+#define DBL_MAX      1.5e32
 #define FLT_MIN      1.0e-38
 #define DBL_MIN      1.0e-38
 #define FLT_MIN_EXP    -38
 #define DBL_MIN_EXP    -38
 #define FLT_MIN_10_EXP -38
 #define DBL_MIN_10_EXP -38
-#define FLT_MAX_EXP     37
-#define DBL_MAX_EXP     37
-#define FLT_MAX_10_EXP  36
-#define DBL_MAX_10_EXP  36
+#define FLT_MAX_EXP     32
+#define DBL_MAX_EXP     32
+#define FLT_MAX_10_EXP  31
+#define DBL_MAX_10_EXP  31
+
 
 
 #define M_E        2.718282
@@ -69,9 +70,9 @@ extern double_t __LIB__ atan2(double_t,double_t) __smallc; /* atan2(a,b) = arc t
 extern double_t __LIB__ cosh(double_t);  /* hyperbolic cosine */
 extern double_t __LIB__ sinh(double_t);  /* hyperbolic sine */
 extern double_t __LIB__ tanh(double_t);  /* hyperbolic tangent */
-extern double_t __LIB__ asinh(double_t); /* arc hyberbolic sine */
-extern double_t __LIB__ acosh(double_t); /* arc hyberbolic cosine */
-extern double_t __LIB__ atanh(double_t); /* arc hyberbolic tangent */
+#define asinh(x) log(2.*fabs(x)+1./(sqrt(x*x+1.)+fabs(x)))
+#define acosh(x) log(2.*x-1./(x+sqrt(x*x-1.)))
+#define atanh(x) (log((1.+x)/(1.-x))*.5)
 
 /* Power functions */
 extern double_t __LIB__ pow(double_t,double_t) __smallc;   /* pow(x,y) = x**y */
@@ -96,7 +97,6 @@ extern double_t __LIB__ ceil(double_t) __smallc;
 #define rint(a) ceil(a)
 
 /* Manipulation */
-extern double_t __LIB__ modf(double_t, double_t *) __smallc; /* decomposes a number into integer and fractional parts */
 extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
 #define scalbn(x,pw2) ldexp(x,pw2)
 extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
@@ -125,10 +125,10 @@ extern double_t __LIB__ atof(char *) __smallc;
 extern void __LIB__ ftoa(double_t, int, char *) __smallc;
 extern void __LIB__ ftoe(double_t, int, char *) __smallc;
 
-/* Random numbers */
-extern double_t __LIB__ fprand(void); /* Generic only */
-extern int __LIB__ fpseed(double_t);  /* Seed random number */
-
+/* CPC Only function */
+extern double_t __LIB__ pow10(int x);         /* pow(10,x) - CPC only */
+extern void __LIB__ deg();
+extern void __LIB__ rad();
 
 /* Classification */
 #define isinf(x) 0
@@ -150,4 +150,4 @@ extern int __LIB__ fpclassify(double_t );
 #define fma(x,y,z) (x*y+z)
 
 
-#endif /* _MATH_GENMATH_H */
+#endif /* _MATH_ZXMATH_H */

--- a/include/math/math_genmath.h
+++ b/include/math/math_genmath.h
@@ -98,6 +98,7 @@ extern double_t __LIB__ ceil(double_t) __smallc;
 /* Manipulation */
 extern double_t __LIB__ modf(double_t, double_t *) __smallc; /* decomposes a number into integer and fractional parts */
 extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
+extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
 #define copysign(a,b) (b<.0?-fabs(a):fabs(a))
 #define signbit(x) (x != fabs(x))
 

--- a/include/math/math_math32.h
+++ b/include/math/math_math32.h
@@ -97,6 +97,7 @@ extern double_t __LIB__ round(double_t x);
 
 /* Manipulation */
 extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
+#define scalbn(x,pw2) ldexp(x,pw2)
 extern double_t __LIB__ modf(double_t x, double_t * y) __smallc;
 extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
 

--- a/include/math/math_mbf32.h
+++ b/include/math/math_mbf32.h
@@ -79,6 +79,7 @@ extern double_t __LIB__ ceil(double_t) __smallc;
 /* Manipulation */
 extern double_t __LIB__ modf(double_t, double_t *) __smallc; /* decomposes a number into integer and fractional parts */
 extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
+extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
 #define copysign(a,b) (b<.0?-fabs(a):fabs(a))
 #define signbit(x) (x != fabs(x))
 

--- a/include/math/math_mbf32.h
+++ b/include/math/math_mbf32.h
@@ -79,6 +79,7 @@ extern double_t __LIB__ ceil(double_t) __smallc;
 /* Manipulation */
 extern double_t __LIB__ modf(double_t, double_t *) __smallc; /* decomposes a number into integer and fractional parts */
 extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
+#define scalbn(x,pw2) ldexp(x,pw2)
 extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
 #define copysign(a,b) (b<.0?-fabs(a):fabs(a))
 #define signbit(x) (x != fabs(x))

--- a/include/math/math_zx.h
+++ b/include/math/math_zx.h
@@ -97,7 +97,8 @@ extern double_t __LIB__ ceil(double_t) __smallc;
 #define rint(a) ceil(a)
 
 /* Manipulation */
-#define ldexp(x,y) (pow(2.,(int)(y))*x)
+extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
+extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
 #define copysign(a,b) (b<.0?-fabs(a):fabs(a))
 #define signbit(x) (x != fabs(x))
 

--- a/include/math/math_zx.h
+++ b/include/math/math_zx.h
@@ -98,6 +98,7 @@ extern double_t __LIB__ ceil(double_t) __smallc;
 
 /* Manipulation */
 extern double_t __LIB__ ldexp(double_t x, int pw2) __smallc;
+#define scalbn(x,pw2) ldexp(x,pw2)
 extern double_t __LIB__ frexp(double_t x, int *pw2) __smallc;
 #define copysign(a,b) (b<.0?-fabs(a):fabs(a))
 #define signbit(x) (x != fabs(x))
@@ -136,6 +137,7 @@ extern void __LIB__ ftoe(double_t, int, char *) __smallc;
 #define FP_NAN      2
 #define FP_INFINITE 3
 #define FP_SUBNORMAL 4
+extern int __LIB__ fpclassify(double_t x);
 
 
 

--- a/lib/config/cpc.cfg
+++ b/lib/config/cpc.cfg
@@ -3,7 +3,7 @@
 #
 
 # CPC has a native maths library
-Z88MATHFLG	-D__NATIVE_MATH__
+Z88MATHFLG	-D__NATIVE_MATH__ -D__MATH_CPC
 Z88MATHLIB      cpc_math
 
 # Asm file which contains the startup code (without suffix)

--- a/lib/config/z88.cfg
+++ b/lib/config/z88.cfg
@@ -1,7 +1,7 @@
 
 
 # z88 has a native maths library
-Z88MATHFLG      -math-z88 -D__NATIVE_MATH__
+Z88MATHFLG      -math-z88 -D__NATIVE_MATH__ -D__MATH_Z88
 Z88MATHLIB      z88_math
 
 COPTRULESTARGET	DESTDIR/lib/target/z88/coptrules.z88

--- a/lib/config/zx.cfg
+++ b/lib/config/zx.cfg
@@ -3,7 +3,7 @@
 #
 
 # ZX has a custom maths library
-Z88MATHFLG      -D__NATIVE_MATH__
+Z88MATHFLG      -D__NATIVE_MATH__ -D__MATH_ZX
 Z88MATHLIB      mzx
 
 # Asm file which contains the startup code (without suffix)

--- a/lib/config/zx81.cfg
+++ b/lib/config/zx81.cfg
@@ -3,7 +3,7 @@
 #
 
 # ZX81 has custom library requirements
-Z88MATHFLG      -D__NATIVE_MATH__
+Z88MATHFLG      -D__NATIVE_MATH__ -D__MATH_ZX
 Z88MATHLIB      m81
 STARTUPLIB      z80iy_crt0
 GENMATHLIB      genmath_zx81

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsfrexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsfrexp.asm
@@ -9,7 +9,7 @@
 ; m32_frexp - z80, z180, z80-zxn fraction and exponent
 ;-------------------------------------------------------------------------
 ;
-;   float m32_frexpf (float x, int8_t *pw2)
+;   float m32_frexpf (float x, int *pw2)
 ;   {
 ;       union float_long fl;
 ;       int8_t i;
@@ -35,7 +35,7 @@ PUBLIC m32_fsfrexp_callee
 PUBLIC _m32_frexpf
 
 
-; float frexpf (float x, int8_t *pw2);
+; float frexpf (float x, int *pw2);
 ._m32_frexpf
 
 .m32_fsfrexp_callee
@@ -59,9 +59,17 @@ PUBLIC _m32_frexpf
     rr e                        ; save the sign in e[7]
 
     ld a,d
+    ld d,0
+    and a
+    jr  z,zero
     ld d,$7e                    ; remove exponent excess (bias-1)
     sub d                       ; mantissa between 0.5 and 1
+zero:
     ld (bc),a                   ; and store in pw2
+    inc bc
+    rlca
+    sbc  a
+    ld  (bc),a
 
     rl e                        ; get sign back
     rr d

--- a/libsrc/_DEVELOPMENT/math/float/math48/c/sccz80/cm48_sccz80_frexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math48/c/sccz80/cm48_sccz80_frexp.asm
@@ -19,6 +19,7 @@ cm48_sccz80_frexp:
    exx
    
    ld hl,4
+   add hl,sp
    call cm48_sccz80p_dload
    
    jp am48_frexp

--- a/libsrc/math/cpcmath/Makefile
+++ b/libsrc/math/cpcmath/Makefile
@@ -10,7 +10,7 @@ AFILES  = $(notdir $(wildcard c/sccz80/*.asm)) $(notdir $(wildcard z80/*.asm))
 CFILES  = amax.c amin.c ceil.c fmod.c ftoa.c ftoe.c cosh.c sinh.c tanh.c atan2.c atof.c
 OBJECTS = $(AFILES:.asm=.o) $(CFILES:.c=.o)
 
-CFLAGS += -D__CPC__ -D__NATIVE_MATH__
+CFLAGS += -D__CPC__ -D__NATIVE_MATH__ -D__MATH_CPC
 
 all: dirs $(OUTPUT_DIRECTORY)/cpc_math.lib $(OUTPUT_DIRECTORY)/464_math.lib $(OUTPUT_DIRECTORY)/664_math.lib $(OUTPUT_DIRECTORY)/6128_math.lib
 

--- a/libsrc/math/cpcmath/c/sccz80/fpclassify.asm
+++ b/libsrc/math/cpcmath/c/sccz80/fpclassify.asm
@@ -1,0 +1,20 @@
+
+
+SECTION code_fp
+
+PUBLIC fpclassify
+
+EXTERN fa
+
+; Return 0 = normal
+;	 1 = zero
+;	 2 = nan
+;	 3 = infinite
+
+fpclassify:
+	ld	a,(fa+5)	;exponent
+	ld	hl,1
+	and	a
+	ret	z
+	dec	hl
+	ret

--- a/libsrc/math/cpcmath/z80/frexp.asm
+++ b/libsrc/math/cpcmath/z80/frexp.asm
@@ -1,0 +1,30 @@
+
+SECTION code_fp
+
+PUBLIC frexp
+EXTERN fa
+EXTERN dload
+
+; float frexpf (float x, int *pw2);
+frexp:
+	ld	hl,4
+	add	hl,sp
+	call	dload
+	pop	bc	;Ret
+	pop	de	;pw2
+	pop	de
+	push	bc
+	ld	hl,fa+5
+	ld	a,(hl)
+	and	a
+	ld	(hl),0
+	jr	z,zero
+	sub	$80
+	ld	(hl),128
+zero:
+	ld	(de),a
+	rlca
+	sbc	a
+	inc	de
+	ld	(de),a
+	ret

--- a/libsrc/math/genmath/c/sccz80/frexp.asm
+++ b/libsrc/math/genmath/c/sccz80/frexp.asm
@@ -1,0 +1,31 @@
+
+SECTION code_fp
+
+PUBLIC frexp
+EXTERN fa
+EXTERN dload
+
+; float frexpf (float x, int8_t *pw2);
+frexp:
+        ld      hl,4
+        add     hl,sp
+        call    dload
+        pop     bc      ;Ret
+        pop     de      ;pw2
+        pop     de
+        push    bc
+        ld      hl,fa+5
+        ld      a,(hl)
+        and     a
+        ld      (hl),0
+        jr      z,zero
+        sub     $80
+        ld      (hl),128
+zero:
+        ld      (de),a
+        rlca
+        sbc     a
+        inc     de
+        ld      (de),a
+        ret
+

--- a/libsrc/math/mbf32/c/sccz80/frexp.asm
+++ b/libsrc/math/mbf32/c/sccz80/frexp.asm
@@ -1,0 +1,29 @@
+
+SECTION code_fp
+
+PUBLIC frexp
+
+; float frexpf (float x, int8_t *pw2);
+frexp:
+	pop	af	;Return
+	pop	bc	;pw2
+	pop	hl	;float
+	pop	de
+	push	de
+	push	hl
+	push	bc
+	push	af
+
+	ld	a,d
+	and	a
+	ld	d,0
+	jr	z,zero
+	sub	$80
+	ld	d,$80	;And set to non-scaled
+zero:
+	ld	(bc),a
+	inc	bc
+	rlca
+	sbc	a
+	ld	(bc),a
+	ret

--- a/libsrc/math/mbf64/c/sccz80/fpclassify.asm
+++ b/libsrc/math/mbf64/c/sccz80/fpclassify.asm
@@ -1,0 +1,19 @@
+        SECTION code_fp_mbf64
+
+        PUBLIC  fpclassify
+	INCLUDE	"mbf64.def"
+
+	EXTERN	___mbf64_FA
+
+; Return 0 = normal
+;        1 = zero
+;        2 = nan
+;        3 = infinite
+
+fpclassify:
+        ld      a,(___mbf64_FA+7)        ;exponent
+        ld      hl,1
+        and     a
+        ret     z
+        dec     hl
+        ret

--- a/libsrc/math/mbf64/c/sccz80/frexp.asm
+++ b/libsrc/math/mbf64/c/sccz80/frexp.asm
@@ -1,0 +1,30 @@
+
+SECTION code_fp
+
+PUBLIC frexp
+EXTERN l_f64_load
+EXTERN  ___mbf64_FA
+
+; float frexpf (float x, int *pw2);
+frexp:
+	ld	hl,4
+	add	hl,sp
+	call	l_f64_load
+	pop	bc	;Ret
+	pop	de	;pw2
+	pop	de
+	push	bc
+	ld	hl,___mbf64_FA + 7
+	ld	a,(hl)
+	and	a
+	ld	(hl),0
+	jr	z,zero
+	sub	$80
+	ld	(hl),128
+zero:
+	ld	(de),a
+	inc	de
+	rlca
+	sbc	a
+	ld	(de),a
+	ret

--- a/libsrc/math/z88math/c/sccz80/fpclassify.asm
+++ b/libsrc/math/z88math/c/sccz80/fpclassify.asm
@@ -1,0 +1,20 @@
+
+
+SECTION code_fp
+
+PUBLIC fpclassify
+
+EXTERN fa
+
+; Return 0 = normal
+;	 1 = zero
+;	 2 = nan
+;	 3 = infinite
+
+fpclassify:
+	ld	a,(fa+5)	;exponent
+	ld	hl,1
+	and	a
+	ret	z
+	dec	hl
+	ret

--- a/libsrc/math/z88math/c/sccz80/frexp.asm
+++ b/libsrc/math/z88math/c/sccz80/frexp.asm
@@ -1,0 +1,30 @@
+
+SECTION code_fp
+
+PUBLIC frexp
+EXTERN fa
+EXTERN dload
+
+; float frexpf (float x, int8_t *pw2);
+frexp:
+        ld      hl,4
+        add     hl,sp
+        call    dload
+        pop     bc      ;Ret
+        pop     de      ;pw2
+        pop     de
+        push    bc
+        ld      hl,fa+5
+        ld      a,(hl)
+        and     a
+        ld      (hl),0
+        jr      z,zero
+        sub     $7f
+        ld      (hl),$7f
+zero:
+        ld      (de),a
+        rlca
+        sbc     a
+        inc     de
+        ld      (de),a
+        ret

--- a/libsrc/math/zxmath/fpclassify.asm
+++ b/libsrc/math/zxmath/fpclassify.asm
@@ -1,0 +1,20 @@
+
+
+SECTION code_fp
+
+PUBLIC fpclassify
+
+EXTERN fa
+
+; Return 0 = normal
+;	 1 = zero
+;	 2 = nan
+;	 3 = infinite
+
+fpclassify:
+	ld	a,(fa+5)	;exponent
+	ld	hl,1
+	and	a
+	ret	z
+	dec	hl
+	ret

--- a/libsrc/math/zxmath/frexp.asm
+++ b/libsrc/math/zxmath/frexp.asm
@@ -1,0 +1,30 @@
+
+SECTION code_fp
+
+PUBLIC frexp
+EXTERN fa
+EXTERN dload
+
+; float frexpf (float x, int *pw2);
+frexp:
+	ld	hl,4
+	add	hl,sp
+	call	dload
+	pop	bc	;Ret
+	pop	de	;pw2
+	pop	de
+	push	bc
+	ld	hl,fa+5
+	ld	a,(hl)
+	and	a
+        ld      (hl),0
+	jr	z,zero
+	sub	$80
+        ld      (hl),128
+zero:
+	ld	(de),a
+	rlca
+	sbc	a
+	inc	de
+	ld	(de),a
+	ret

--- a/libsrc/math/zxmath/zxmlist
+++ b/libsrc/math/zxmath/zxmlist
@@ -45,3 +45,4 @@ pi
 init_floatpack
 ldexp
 l_f48_ldexp
+frexp

--- a/libsrc/math/zxmath/zxmlist
+++ b/libsrc/math/zxmath/zxmlist
@@ -46,3 +46,4 @@ init_floatpack
 ldexp
 l_f48_ldexp
 frexp
+fpclassify


### PR DESCRIPTION
Handle the 0 case in math32, actually use the float in math48.

Implement for the other libraries (mbf32, genmath actually tested)