### PR TITLE
m32 - powf callee

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_pow_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_pow_callee.asm
@@ -1,0 +1,27 @@
+
+SECTION code_fp_math32
+PUBLIC cm32_sccz80_pow_callee
+
+EXTERN _m32_powf
+
+
+cm32_sccz80_pow_callee:
+	pop	af	; return
+	pop	hl	; RHS
+	pop de
+	exx
+	pop hl  ; LHS
+	pop de
+	push af ; return
+	exx
+	push de ; RHS
+	push hl
+	exx
+	push de ; LHS
+	push hl
+	call _m32_powf
+	pop bc
+	pop bc
+	pop bc
+	pop bc
+	ret     ; return

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_pow_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_pow_callee.asm
@@ -6,22 +6,22 @@ EXTERN _m32_powf
 
 
 cm32_sccz80_pow_callee:
-	pop	af	; return
-	pop	hl	; RHS
-	pop de
-	exx
-	pop hl  ; LHS
-	pop de
-	push af ; return
-	exx
-	push de ; RHS
-	push hl
-	exx
-	push de ; LHS
-	push hl
-	call _m32_powf
-	pop bc
-	pop bc
-	pop bc
-	pop bc
-	ret     ; return
+    pop af  ; return
+    pop hl  ; RHS
+    pop de
+    exx
+    pop hl  ; LHS
+    pop de
+    push af ; return
+    exx
+    push de ; RHS
+    push hl
+    exx
+    push de ; LHS
+    push hl
+    call _m32_powf
+    pop bc
+    pop bc
+    pop bc
+    pop bc
+    ret     ; return

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fssub.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fssub.asm
@@ -1,5 +1,5 @@
 
-; float __fsadd (float left, float right)
+; float __fssub (float left, float right)
 
 SECTION code_clib
 SECTION code_fp_math32

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fssub_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fssub_callee.asm
@@ -1,5 +1,5 @@
 
-; float __fsadd_callee (float left, float right)
+; float __fssub_callee (float left, float right)
 
 SECTION code_clib
 SECTION code_fp_math32

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_pow_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_pow_callee.asm
@@ -6,21 +6,21 @@ EXTERN _m32_powf
 
 
 cm32_sdcc_pow_callee:
-	pop	af	; return
-	pop	hl	; LHS
-	pop de
-	exx
-	pop hl  ; RHS
-	pop de
-	push af ; return
-	push de ; RHS
-	push hl
-	exx
-	push de ; LHS
-	push hl
-	call _m32_powf
-	pop bc
-	pop bc
-	pop bc
-	pop bc
-	ret     ; return
+    pop af  ; return
+    pop hl  ; LHS
+    pop de
+    exx
+    pop hl  ; RHS
+    pop de
+    push af ; return
+    push de ; RHS
+    push hl
+    exx
+    push de ; LHS
+    push hl
+    call _m32_powf
+    pop bc
+    pop bc
+    pop bc
+    pop bc
+    ret     ; return

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_pow_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_pow_callee.asm
@@ -1,0 +1,26 @@
+
+SECTION code_fp_math32
+PUBLIC cm32_sdcc_pow_callee
+
+EXTERN _m32_powf
+
+
+cm32_sdcc_pow_callee:
+	pop	af	; return
+	pop	hl	; LHS
+	pop de
+	exx
+	pop hl  ; RHS
+	pop de
+	push af ; return
+	push de ; RHS
+	push hl
+	exx
+	push de ; LHS
+	push hl
+	call _m32_powf
+	pop bc
+	pop bc
+	pop bc
+	pop bc
+	ret     ; return

--- a/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/m32_sccz80.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/m32_sccz80.lst
@@ -53,6 +53,7 @@ math/float/math32/lm32/c/sccz80/log10_fastcall
 math/float/math32/lm32/c/sccz80/log_fastcall
 math/float/math32/lm32/c/sccz80/modf
 math/float/math32/lm32/c/sccz80/pow
+math/float/math32/lm32/c/sccz80/pow_callee
 math/float/math32/lm32/c/sccz80/round
 math/float/math32/lm32/c/sccz80/round_fastcall
 math/float/math32/lm32/c/sccz80/sin

--- a/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/m32_sdcc.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/m32_sdcc.lst
@@ -63,6 +63,7 @@ math/float/math32/lm32/c/sdcc/log10_fastcall
 math/float/math32/lm32/c/sdcc/log_fastcall
 math/float/math32/lm32/c/sdcc/modf
 math/float/math32/lm32/c/sdcc/pow
+math/float/math32/lm32/c/sdcc/pow_callee
 math/float/math32/lm32/c/sdcc/round
 math/float/math32/lm32/c/sdcc/round_fastcall
 math/float/math32/lm32/c/sdcc/___schar2fs

--- a/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/sccz80/pow_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/sccz80/pow_callee.asm
@@ -1,0 +1,14 @@
+
+	SECTION	code_fp_math32
+	PUBLIC	pow_callee
+	EXTERN	cm32_sccz80_pow_callee
+
+	defc	pow_callee = cm32_sccz80_pow_callee
+
+
+; SDCC bridge for Classic
+IF __CLASSIC
+PUBLIC _pow_callee
+defc _pow_callee = pow_callee
+ENDIF
+

--- a/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/sdcc/pow_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/sdcc/pow_callee.asm
@@ -1,0 +1,6 @@
+
+	SECTION	code_fp_math32
+	PUBLIC	_pow_callee
+	EXTERN	cm32_sdcc_pow_callee
+
+	defc	_pow_callee = cm32_sdcc_pow_callee

--- a/libsrc/_DEVELOPMENT/math/float/math32/math32_sccz80.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/math32_sccz80.lst
@@ -51,6 +51,7 @@ math/float/math32/c/sccz80/cm32_sccz80_log
 math/float/math32/c/sccz80/cm32_sccz80_log10
 math/float/math32/c/sccz80/cm32_sccz80_modf
 math/float/math32/c/sccz80/cm32_sccz80_pow
+math/float/math32/c/sccz80/cm32_sccz80_pow_callee
 math/float/math32/c/sccz80/cm32_sccz80_round
 math/float/math32/c/sccz80/cm32_sccz80_sin
 math/float/math32/c/sccz80/cm32_sccz80_sinh

--- a/libsrc/_DEVELOPMENT/math/float/math32/math32_sdcc.lst
+++ b/libsrc/_DEVELOPMENT/math/float/math32/math32_sdcc.lst
@@ -54,6 +54,7 @@ math/float/math32/c/sdcc/cm32_sdcc_fssub_callee
 math/float/math32/c/sdcc/cm32_sdcc_fszero
 math/float/math32/c/sdcc/cm32_sdcc_log
 math/float/math32/c/sdcc/cm32_sdcc_log10
+math/float/math32/c/sdcc/cm32_sdcc_pow_callee
 math/float/math32/c/sdcc/cm32_sdcc_round
 math/float/math32/c/sdcc/cm32_sdcc___schar2fs
 math/float/math32/c/sdcc/cm32_sdcc___schar2fs_callee

--- a/libsrc/math/math32/newlibfiles_z80.lst
+++ b/libsrc/math/math32/newlibfiles_z80.lst
@@ -101,6 +101,7 @@
 ../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/frexp.asm
 ../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/l_f32_swap.asm
 ../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/pow.asm
+../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/pow_callee.asm
 ../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/exp_fastcall.asm
 ../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/ldexp.asm
 ../../_DEVELOPMENT/math/float/math32/lm32/c/sccz80/ceil_fastcall.asm
@@ -209,6 +210,7 @@
 ../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_fspoly.asm
 ../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc___fs2uint.asm
 ../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_log10.asm
+../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_pow_callee.asm
 ../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc___fs2slong.asm
 ../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_ceil.asm
 ../../_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc_cosh.asm
@@ -283,6 +285,7 @@
 ../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fspoly.asm
 ../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_atan2.asm
 ../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_pow.asm
+../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_pow_callee.asm
 ../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fsmin_callee.asm
 ../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_cos.asm
 ../../_DEVELOPMENT/math/float/math32/c/sccz80/cm32_sccz80_fssub_callee.asm


### PR DESCRIPTION
Related to #1155, add the `powf(x,y) __z88dk_callee` linkages.