### PR TITLE
m32 - use zsdcc r11276 to fix fastcall

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/c/Makefile
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/Makefile
@@ -7,4 +7,4 @@ CFLAGS += -I.
 all: $(addprefix asm/,$(AFILES))
 
 asm/%.asm: %.c
-	zcc +z80 -clib=sdcc_ix --max-allocs-per-node200000 -SO3 $(CFLAGS) -a $^ -o $@
+	zcc +z80 -clib=sdcc_ix --reserve-regs-iy --max-allocs-per-node200000 -SO3 $(CFLAGS) -a $^ -o $@

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_acosf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_acosf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -205,9 +205,13 @@
 ; Externals used
 ;--------------------------------------------------------
 	GLOBAL _m32_polyf
+	GLOBAL _m32_hypotf
 	GLOBAL _m32_invsqrtf
+	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -216,12 +220,10 @@
 	GLOBAL _m32_ldexpf
 	GLOBAL _m32_frexpf
 	GLOBAL _m32_fabsf
-	GLOBAL _m32_hypotf
 	GLOBAL _m32_powf
 	GLOBAL _m32_log10f
 	GLOBAL _m32_logf
 	GLOBAL _m32_expf
-	GLOBAL _m32_sqrtf
 	GLOBAL _m32_atanhf
 	GLOBAL _m32_acoshf
 	GLOBAL _m32_asinhf
@@ -282,6 +284,12 @@ _m32_acosf:
 	ld	(ix-3),h
 	ld	(ix-2),e
 	ld	(ix-1),d
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_sqrf
 	push	de
 	push	hl

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_acoshf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_acoshf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -278,22 +278,25 @@ _m32_acoshf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
-	ld	hl, -8
-	add	hl, sp
-	ld	sp, hl
+	push	af
+	push	af
+	push	af
+	push	af
 	ld	(ix-4),l
 	ld	(ix-3),h
 	ld	(ix-2),e
 	ld	(ix-1),d
-	call	_m32_mul2f
-	ld	(ix-5),d
-	ld	(ix-6),e
-	ld	(ix-7),h
-	ld	(ix-8),l
 	ld	l,(ix-4)
 	ld	h,(ix-3)
+	call	_m32_mul2f
+	ld	(ix-8),l
+	ld	(ix-7),h
+	ld	(ix-6),e
+	ld	(ix-5),d
 	ld	e,(ix-2)
 	ld	d,(ix-1)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	call	_m32_sqrf
 	ld	bc,0x3f80
 	push	bc

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_asinf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_asinf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -284,6 +284,12 @@ _m32_asinf:
 	ld	(ix-3),h
 	ld	(ix-2),e
 	ld	(ix-1),d
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_sqrf
 	push	de
 	push	hl

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_asinhf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_asinhf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -278,23 +278,27 @@ _m32_asinhf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
+	ld	c, l
+	ld	b, h
 	ld	hl, -12
 	add	hl, sp
 	ld	sp, hl
-	ld	(ix-4),l
-	ld	(ix-3),h
+	ld	(ix-4),c
+	ld	(ix-3),b
 	ld	(ix-2),e
 	ld	(ix-1),d
-	call	_m32_fabsf
-	call	_m32_mul2f
-	ld	(ix-9),d
-	ld	(ix-10),e
-	ld	(ix-11),h
-	ld	(ix-12),l
 	ld	l,(ix-4)
 	ld	h,(ix-3)
+	call	_m32_fabsf
+	call	_m32_mul2f
+	ld	(ix-12),l
+	ld	(ix-11),h
+	ld	(ix-10),e
+	ld	(ix-9),d
 	ld	e,(ix-2)
 	ld	d,(ix-1)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	call	_m32_sqrf
 	ld	bc,0x3f80
 	push	bc
@@ -304,14 +308,14 @@ _m32_asinhf:
 	push	hl
 	call	___fsadd_callee
 	call	_m32_sqrtf
-	ld	(ix-5),d
-	ld	(ix-6),e
-	ld	(ix-7),h
 	ld	(ix-8),l
-	ld	l,(ix-4)
-	ld	h,(ix-3)
+	ld	(ix-7),h
+	ld	(ix-6),e
+	ld	(ix-5),d
 	ld	e,(ix-2)
 	ld	d,(ix-1)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	call	_m32_fabsf
 	push	de
 	push	hl

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atan2f.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atan2f.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -276,22 +278,22 @@ _m32_atan2f:
 	push	ix
 	ld	ix,0
 	add	ix,sp
-	ld	hl, -9
-	add	hl, sp
-	ld	sp, hl
-	ld	l,(ix+8)
-	ld	h,(ix+9)
+	push	af
+	push	af
+	dec	sp
 	ld	e,(ix+10)
 	ld	d,(ix+11)
+	ld	l,(ix+8)
+	ld	h,(ix+9)
 	call	_m32_fabsf
-	ld	(ix-1),d
-	ld	(ix-2),e
-	ld	(ix-3),h
 	ld	(ix-4),l
-	ld	l,(ix+4)
-	ld	h,(ix+5)
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 	ld	e,(ix+6)
 	ld	d,(ix+7)
+	ld	l,(ix+4)
+	ld	h,(ix+5)
 	call	_m32_fabsf
 	push	hl
 	push	de
@@ -318,7 +320,7 @@ _m32_atan2f:
 	push	hl
 	call	___fslt_callee
 	bit	0,l
-	jp	NZ,l_m32_atan2f_00107
+	jp	NZ, l_m32_atan2f_00107
 	ld	l,(ix+10)
 	ld	h,(ix+11)
 	push	hl
@@ -352,7 +354,7 @@ _m32_atan2f:
 	call	___fslt_callee
 	pop	de
 	pop	bc
-	bit	0, l
+	bit	0,l
 	jr	NZ,l_m32_atan2f_00102
 	ld	hl,0x4049
 	push	hl
@@ -377,7 +379,7 @@ l_m32_atan2f_00102:
 l_m32_atan2f_00105:
 	ld	l, c
 	ld	h, b
-	jr	l_m32_atan2f_00111
+	jp	l_m32_atan2f_00111
 l_m32_atan2f_00107:
 	ld	l,(ix+6)
 	ld	h,(ix+7)
@@ -393,13 +395,13 @@ l_m32_atan2f_00107:
 	push	hl
 	call	___fsdiv_callee
 	call	_m32_atanf
-	ld	a, d
+	ld	a,d
 	xor	a,0x80
-	ld	c, a
-	ld	(ix-9),l
-	ld	(ix-8),h
-	ld	(ix-7),e
-	ld	(ix-6),c
+	ld	d,a
+	ld	(ix-4),l
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 	ld	a,(ix-5)
 	or	a, a
 	jr	Z,l_m32_atan2f_00109
@@ -407,27 +409,33 @@ l_m32_atan2f_00107:
 	push	hl
 	ld	hl,0x0fdb
 	push	hl
-	ld	l,(ix-7)
-	ld	h,(ix-6)
+	ld	l,(ix-2)
+	ld	h,(ix-1)
 	push	hl
-	ld	l,(ix-9)
-	ld	h,(ix-8)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	push	hl
 	call	___fssub_callee
+	ld	c, l
+	ld	b, h
 	jr	l_m32_atan2f_00110
 l_m32_atan2f_00109:
 	ld	hl,0x3fc9
 	push	hl
 	ld	hl,0x0fdb
 	push	hl
-	ld	l,(ix-7)
-	ld	h,(ix-6)
+	ld	l,(ix-2)
+	ld	h,(ix-1)
 	push	hl
-	ld	l,(ix-9)
-	ld	h,(ix-8)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	push	hl
 	call	___fsadd_callee
+	ld	c, l
+	ld	b, h
 l_m32_atan2f_00110:
+	ld	l, c
+	ld	h, b
 l_m32_atan2f_00111:
 	ld	sp, ix
 	pop	ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atanf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atanf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -278,18 +280,22 @@ _m32_atanf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
+	ld	c, l
+	ld	b, h
 	ld	hl, -14
 	add	hl, sp
 	ld	sp, hl
-	ld	(ix-4),l
-	ld	(ix-3),h
+	ld	(ix-4),c
+	ld	(ix-3),b
 	ld	(ix-2),e
 	ld	(ix-1),d
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	call	_m32_fabsf
-	ld	(ix-8),l
-	ld	(ix-7),h
-	ld	(ix-6),e
-	ld	(ix-5),d
+	ld	(ix-14),l
+	ld	(ix-13),h
+	ld	(ix-12),e
+	ld	(ix-11),d
 	ld	a,d
 	and	a,0x7f
 	or	a,e
@@ -301,37 +307,42 @@ _m32_atanf:
 	ld	d,h
 	jp	l_m32_atanf_00107
 l_m32_atanf_00102:
+	ld	l,(ix-12)
+	ld	h,(ix-11)
+	push	hl
+	ld	l,(ix-14)
+	ld	h,(ix-13)
+	push	hl
 	ld	hl,0x3f80
 	push	hl
 	ld	hl,0x0000
 	push	hl
-	ld	l,(ix-6)
-	ld	h,(ix-5)
-	push	hl
-	ld	l,(ix-8)
-	ld	h,(ix-7)
-	push	hl
-	call	___fsgt_callee
-	ld	c,0x00
-	ld	(ix-10),l
-	ld	(ix-9),c
-	ld	a, c
-	or	a,l
+	call	___fslt_callee
+	ld	c, l
+	ld	b,0x00
+	ld	(ix-10),c
+	ld	(ix-9),b
+	ld	a, b
+	or	a, c
 	jr	Z,l_m32_atanf_00104
-	ld	l,(ix-8)
-	ld	h,(ix-7)
-	ld	e,(ix-6)
-	ld	d,(ix-5)
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_invf
-	ld	(ix-8),l
-	ld	(ix-7),h
-	ld	(ix-6),e
-	ld	(ix-5),d
+	ld	(ix-14),l
+	ld	(ix-13),h
+	ld	(ix-12),e
+	ld	(ix-11),d
 l_m32_atanf_00104:
-	ld	l,(ix-8)
-	ld	h,(ix-7)
-	ld	e,(ix-6)
-	ld	d,(ix-5)
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_sqrf
 	push	hl
 	ld	c,l
@@ -344,10 +355,10 @@ l_m32_atanf_00104:
 	push	de
 	push	bc
 	call	_m32_polyf
-	ld	(ix-11),d
-	ld	(ix-12),e
-	ld	(ix-13),h
-	ld	(ix-14),l
+	ld	(ix-8),l
+	ld	(ix-7),h
+	ld	(ix-6),e
+	ld	(ix-5),d
 	pop	de
 	pop	bc
 	ld	hl,0x0004
@@ -359,20 +370,20 @@ l_m32_atanf_00104:
 	call	_m32_polyf
 	push	de
 	push	hl
-	ld	l,(ix-12)
-	ld	h,(ix-11)
-	push	hl
-	ld	l,(ix-14)
-	ld	h,(ix-13)
-	push	hl
-	call	___fsdiv_callee
-	push	de
-	push	hl
 	ld	l,(ix-6)
 	ld	h,(ix-5)
 	push	hl
 	ld	l,(ix-8)
 	ld	h,(ix-7)
+	push	hl
+	call	___fsdiv_callee
+	push	de
+	push	hl
+	ld	l,(ix-12)
+	ld	h,(ix-11)
+	push	hl
+	ld	l,(ix-14)
+	ld	h,(ix-13)
 	push	hl
 	call	___fsmul_callee
 	ld	a,(ix-9)
@@ -404,7 +415,7 @@ l_m32_atanf_00106:
 	call	___fslt_callee
 	pop	de
 	pop	bc
-	ld	a, l
+	ld	a,l
 	or	a, a
 	jr	Z,l_m32_atanf_00109
 	ld	a, d

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atanhf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_atanhf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -291,10 +291,10 @@ _m32_atanhf:
 	push	de
 	push	bc
 	call	___fsadd_callee
-	ld	(ix-1),d
-	ld	(ix-2),e
-	ld	(ix-3),h
 	ld	(ix-4),l
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 	pop	de
 	pop	bc
 	push	de

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_cosf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_cosf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_coshf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_coshf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -281,27 +281,25 @@ _m32_coshf:
 	push	af
 	push	af
 	call	_m32_expf
-	push	hl
-	ld	c,l
-	ld	b,h
-	push	de
-	ld	l, c
-	ld	h, b
-	call	_m32_invf
-	ld	(ix-1),d
-	ld	(ix-2),e
-	ld	(ix-3),h
 	ld	(ix-4),l
-	pop	de
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
+	call	_m32_invf
+	push	de
+	push	hl
 	ld	l,(ix-2)
 	ld	h,(ix-1)
 	push	hl
 	ld	l,(ix-4)
 	ld	h,(ix-3)
 	push	hl
-	push	de
-	push	bc
 	call	___fsadd_callee
 	call	_m32_div2f
 	ld	sp, ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_expf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_expf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -277,14 +279,20 @@ _m32_expf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
+	ld	c, l
+	ld	b, h
 	ld	hl, -14
 	add	hl, sp
 	ld	sp, hl
-	ld	(ix-8),l
-	ld	(ix-7),h
-	ld	(ix-6),e
-	ld	(ix-5),d
-	push	de
+	ld	(ix-12),c
+	ld	(ix-11),b
+	ld	(ix-10),e
+	ld	l, e
+	ld	(ix-9),d
+	ld	h,d
+	push	hl
+	ld	l,(ix-12)
+	ld	h,(ix-11)
 	push	hl
 	ld	hl,0x3fb8
 	push	hl
@@ -302,14 +310,14 @@ _m32_expf:
 	push	de
 	push	hl
 	call	___fs2sint_callee
-	pop	bc
+	pop	de
 	push	hl
 	push	hl
 	call	___sint2fs_callee
-	ld	(ix-9),d
-	ld	(ix-10),e
-	ld	(ix-11),h
-	ld	(ix-12),l
+	ld	(ix-8),l
+	ld	(ix-7),h
+	ld	(ix-6),e
+	ld	(ix-5),d
 	push	de
 	push	hl
 	ld	hl,0x3f31
@@ -319,22 +327,22 @@ _m32_expf:
 	call	___fsmul_callee
 	push	de
 	push	hl
-	ld	l,(ix-6)
-	ld	h,(ix-5)
+	ld	l,(ix-10)
+	ld	h,(ix-9)
 	push	hl
-	ld	l,(ix-8)
-	ld	h,(ix-7)
+	ld	l,(ix-12)
+	ld	h,(ix-11)
 	push	hl
 	call	___fssub_callee
 	ld	(ix-4),l
 	ld	(ix-3),h
 	ld	(ix-2),e
 	ld	(ix-1),d
-	ld	l,(ix-10)
-	ld	h,(ix-9)
+	ld	l,(ix-6)
+	ld	h,(ix-5)
 	push	hl
-	ld	l,(ix-12)
-	ld	h,(ix-11)
+	ld	l,(ix-8)
+	ld	h,(ix-7)
 	push	hl
 	ld	hl,0xb95e
 	push	hl
@@ -354,11 +362,15 @@ _m32_expf:
 	ld	(ix-11),h
 	ld	(ix-10),e
 	ld	(ix-9),d
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
 	call	_m32_sqrf
-	ld	(ix-5),d
-	ld	(ix-6),e
-	ld	(ix-7),h
 	ld	(ix-8),l
+	ld	(ix-7),h
+	ld	(ix-6),e
+	ld	(ix-5),d
 	ld	hl,0x0005
 	push	hl
 	ld	hl,_m32_coeff_exp
@@ -397,11 +409,13 @@ _m32_expf:
 	push	de
 	push	hl
 	call	___fsadd_callee
-	pop	bc
-	push	bc
-	push	bc
-	push	de
+	ld	c, l
+	ld	b, h
+	pop	hl
 	push	hl
+	push	hl
+	push	de
+	push	bc
 	call	_m32_ldexpf
 	ld	sp, ix
 	pop	ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_fmodf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_fmodf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_modff
 	GLOBAL _m32_floorf
@@ -341,7 +343,7 @@ l_m32_fmodf_00102:
 	call	___fslt_callee
 	pop	de
 	pop	bc
-	bit	0, l
+	bit	0,l
 	jr	NZ,l_m32_fmodf_00105
 	ld	l,(ix+10)
 	ld	h,(ix+11)
@@ -353,11 +355,10 @@ l_m32_fmodf_00102:
 	push	bc
 	call	___fssub_callee
 	ld	c, l
-	jr	l_m32_fmodf_00106
+	ld	b, h
 l_m32_fmodf_00105:
-	ld	h, b
-l_m32_fmodf_00106:
 	ld	l, c
+	ld	h, b
 l_m32_fmodf_00103:
 	pop	ix
 	ret

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_log10f.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_log10f.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_logf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_logf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -279,151 +279,117 @@ _m32_logf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
-	ld	hl, -22
+	ld	c, l
+	ld	b, h
+	ld	hl, -17
 	add	hl, sp
 	ld	sp, hl
-	ld	(ix-13),l
-	ld	(ix-12),h
-	ld	(ix-11),e
-	ld	(ix-10),d
+	ld	(ix-5),c
+	ld	(ix-4),b
+	ld	(ix-3),e
+	ld	l, e
+	ld	(ix-2),d
+	ld	h,d
+	push	hl
+	ld	l,(ix-5)
+	ld	h,(ix-4)
+	push	hl
 	ld	hl,0x0000
 	push	hl
 	push	hl
-	ld	l,(ix-11)
-	ld	h,(ix-10)
-	push	hl
-	ld	l,(ix-13)
-	ld	h,(ix-12)
-	push	hl
-	call	___fsgt_callee
-	ld	(ix-5),l
+	call	___fslt_callee
 	bit	0,l
 	jr	NZ,l_m32_logf_00102
 	ld	de,0xc2b1
 	ld	hl,0x7218
 	jp	l_m32_logf_00110
 l_m32_logf_00102:
-	ld	hl,0x0000
+	ld	hl,16
 	add	hl, sp
 	push	hl
-	ld	l,(ix-11)
-	ld	h,(ix-10)
+	ld	l,(ix-3)
+	ld	h,(ix-2)
 	push	hl
-	ld	l,(ix-13)
-	ld	h,(ix-12)
+	ld	l,(ix-5)
+	ld	h,(ix-4)
 	push	hl
 	call	_m32_frexpf
-	ld	(ix-10),d
-	ld	(ix-11),e
-	ld	(ix-12),h
-	ld	(ix-13),l
-	ld	hl,18
-	add	hl, sp
-	ex	de, hl
-	ld	hl,9
-	add	hl, sp
-	ld	bc,4
-	ldir
+	push	hl
+	ld	c,l
+	ld	b,h
+	push	de
 	ld	hl,0x3f35
 	push	hl
 	ld	hl,0x04f3
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
+	push	de
+	push	bc
 	call	___fslt_callee
-	ld	(ix-5),l
-	ld	a, l
+	pop	de
+	pop	bc
+	ld	a,l
 	or	a, a
 	jr	Z,l_m32_logf_00104
-	dec	(ix-22)
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
+	dec	(ix-1)
+	push	de
+	push	bc
+	push	de
+	push	bc
 	call	___fsadd_callee
-	ld	(ix-10),d
-	ld	(ix-11),e
-	ld	(ix-12),h
-	ld	(ix-13),l
-	ld	hl,0x3f80
-	push	hl
-	ld	hl,0x0000
-	push	hl
-	ld	l,(ix-11)
-	ld	h,(ix-10)
-	push	hl
-	ld	l,(ix-13)
-	ld	h,(ix-12)
+	ld	bc,0x3f80
+	push	bc
+	ld	bc,0x0000
+	push	bc
+	push	de
 	push	hl
 	call	___fssub_callee
-	ld	(ix-10),d
-	ld	(ix-11),e
-	ld	(ix-12),h
-	ld	(ix-13),l
+	ld	(ix-17),l
+	ld	(ix-16),h
+	ld	(ix-15),e
+	ld	(ix-14),d
 	jr	l_m32_logf_00105
 l_m32_logf_00104:
 	ld	hl,0x3f80
 	push	hl
 	ld	hl,0x0000
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
+	push	de
+	push	bc
 	call	___fssub_callee
-	ld	(ix-14),d
-	ld	(ix-15),e
-	ld	(ix-16),h
 	ld	(ix-17),l
-	ld	hl,9
-	add	hl, sp
-	ex	de, hl
-	ld	hl,5
-	add	hl, sp
-	ld	bc,4
-	ldir
+	ld	(ix-16),h
+	ld	(ix-15),e
+	ld	(ix-14),d
 l_m32_logf_00105:
-	ld	l,(ix-13)
-	ld	h,(ix-12)
-	ld	e,(ix-11)
-	ld	d,(ix-10)
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_sqrf
-	ld	(ix-17),l
-	ld	(ix-16),h
-	ld	(ix-15),e
-	ld	(ix-14),d
+	ld	(ix-13),l
+	ld	(ix-12),h
+	ld	(ix-11),e
+	ld	(ix-10),d
 	ld	hl,0x0009
 	push	hl
 	ld	hl,_m32_coeff_log
 	push	hl
-	ld	l,(ix-11)
-	ld	h,(ix-10)
-	push	hl
-	ld	l,(ix-13)
-	ld	h,(ix-12)
-	push	hl
-	call	_m32_polyf
-	ld	c, l
 	ld	l,(ix-15)
-	ld	b,h
 	ld	h,(ix-14)
 	push	hl
 	ld	l,(ix-17)
 	ld	h,(ix-16)
+	push	hl
+	call	_m32_polyf
+	ld	c, l
+	ld	l,(ix-11)
+	ld	b,h
+	ld	h,(ix-10)
+	push	hl
+	ld	l,(ix-13)
+	ld	h,(ix-12)
 	push	hl
 	push	de
 	push	bc
@@ -432,17 +398,21 @@ l_m32_logf_00105:
 	ld	(ix-8),h
 	ld	(ix-7),e
 	ld	(ix-6),d
-	ld	a,(ix-22)
+	ld	a,(ix-1)
 	or	a, a
 	jr	Z,l_m32_logf_00107
 	push	af
 	inc	sp
 	call	___schar2fs_callee
-	ld	(ix-21),l
-	ld	(ix-20),h
-	ld	(ix-19),e
-	ld	(ix-18),d
-	push	de
+	ld	(ix-5),l
+	ld	(ix-4),h
+	ld	(ix-3),e
+	ld	l, e
+	ld	(ix-2),d
+	ld	h,d
+	push	hl
+	ld	l,(ix-5)
+	ld	h,(ix-4)
 	push	hl
 	ld	hl,0xb95e
 	push	hl
@@ -463,10 +433,10 @@ l_m32_logf_00105:
 	ld	(ix-7),e
 	ld	(ix-6),d
 l_m32_logf_00107:
-	ld	l,(ix-17)
-	ld	h,(ix-16)
-	ld	e,(ix-15)
-	ld	d,(ix-14)
+	ld	e,(ix-11)
+	ld	d,(ix-10)
+	ld	l,(ix-13)
+	ld	h,(ix-12)
 	call	_m32_div2f
 	push	de
 	push	hl
@@ -479,48 +449,42 @@ l_m32_logf_00107:
 	call	___fssub_callee
 	push	de
 	push	hl
-	ld	l,(ix-11)
-	ld	h,(ix-10)
+	ld	l,(ix-15)
+	ld	h,(ix-14)
 	push	hl
-	ld	l,(ix-13)
-	ld	h,(ix-12)
+	ld	l,(ix-17)
+	ld	h,(ix-16)
 	push	hl
 	call	___fsadd_callee
-	ld	(ix-6),d
-	ld	(ix-7),e
-	ld	(ix-8),h
-	ld	(ix-9),l
-	ld	e,(ix-7)
-	ld	d,(ix-6)
-	ld	a,(ix-22)
+	ld	a,(ix-1)
 	or	a,a
 	ld	c,l
 	ld	b,h
 	jr	Z,l_m32_logf_00109
 	push	bc
 	push	de
-	ld	l,(ix-19)
-	ld	h,(ix-18)
+	ld	l,(ix-3)
+	ld	h,(ix-2)
 	push	hl
-	ld	l,(ix-21)
-	ld	h,(ix-20)
+	ld	l,(ix-5)
+	ld	h,(ix-4)
 	push	hl
 	ld	hl,0x3f31
 	push	hl
 	ld	hl,0x8000
 	push	hl
 	call	___fsmul_callee
-	ld	(ix-6),d
-	ld	(ix-7),e
-	ld	(ix-8),h
-	ld	(ix-9),l
+	ld	(ix-5),l
+	ld	(ix-4),h
+	ld	(ix-3),e
+	ld	(ix-2),d
 	pop	de
 	pop	bc
-	ld	l,(ix-7)
-	ld	h,(ix-6)
+	ld	l,(ix-3)
+	ld	h,(ix-2)
 	push	hl
-	ld	l,(ix-9)
-	ld	h,(ix-8)
+	ld	l,(ix-5)
+	ld	h,(ix-4)
 	push	hl
 	push	de
 	push	bc

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_modff.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_modff.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -205,9 +205,13 @@
 ; Externals used
 ;--------------------------------------------------------
 	GLOBAL _m32_polyf
+	GLOBAL _m32_hypotf
 	GLOBAL _m32_invsqrtf
+	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_floorf
@@ -215,12 +219,10 @@
 	GLOBAL _m32_ldexpf
 	GLOBAL _m32_frexpf
 	GLOBAL _m32_fabsf
-	GLOBAL _m32_hypotf
 	GLOBAL _m32_powf
 	GLOBAL _m32_log10f
 	GLOBAL _m32_logf
 	GLOBAL _m32_expf
-	GLOBAL _m32_sqrtf
 	GLOBAL _m32_atanhf
 	GLOBAL _m32_acoshf
 	GLOBAL _m32_asinhf
@@ -292,6 +294,7 @@ _m32_modff:
 	ld	c, l
 	ld	b, h
 	pop	hl
+	push	hl
 	ld	(hl), c
 	inc	hl
 	ld	(hl), b
@@ -307,7 +310,8 @@ _m32_modff:
 	ld	l,(ix+4)
 	ld	h,(ix+5)
 	push	hl
-	call	___fssub_callee
+	call	___fssub
+	ld	sp,ix
 	pop	ix
 	ret
 	SECTION IGNORE

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_powf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_powf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -205,9 +205,13 @@
 ; Externals used
 ;--------------------------------------------------------
 	GLOBAL _m32_polyf
+	GLOBAL _m32_hypotf
 	GLOBAL _m32_invsqrtf
+	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -216,11 +220,9 @@
 	GLOBAL _m32_ldexpf
 	GLOBAL _m32_frexpf
 	GLOBAL _m32_fabsf
-	GLOBAL _m32_hypotf
 	GLOBAL _m32_log10f
 	GLOBAL _m32_logf
 	GLOBAL _m32_expf
-	GLOBAL _m32_sqrtf
 	GLOBAL _m32_atanhf
 	GLOBAL _m32_acoshf
 	GLOBAL _m32_asinhf
@@ -335,10 +337,10 @@ l_m32_powf_00106:
 	ld	d,(ix+7)
 	jr	l_m32_powf_00109
 l_m32_powf_00108:
-	ld	l,(ix+4)
-	ld	h,(ix+5)
 	ld	e,(ix+6)
 	ld	d,(ix+7)
+	ld	l,(ix+4)
+	ld	h,(ix+5)
 	call	_m32_logf
 	ld	c, l
 	ld	l,(ix+10)

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_roundf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_roundf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
 	GLOBAL _m32_floorf
@@ -276,13 +278,15 @@ _m32_roundf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
+	ld	c, l
+	ld	b, h
 	ld	hl, -22
 	add	hl, sp
 	ld	sp, hl
-	ld	c, l
-	ld	b, h
-	ld	hl,0x0008
+	ld	hl,0
 	add	hl, sp
+	ld	(ix-2),l
+	ld	(ix-1),h
 	ld	(hl), c
 	inc	hl
 	ld	(hl), b
@@ -290,107 +294,115 @@ _m32_roundf:
 	ld	(hl), e
 	inc	hl
 	ld	(hl), d
-	ld	hl,0x0008
+	ld	hl,0
 	add	hl, sp
-	ld	(ix-6),l
-	ld	(ix-5),h
+	ld	(ix-18),l
+	ld	(ix-17),h
 	push	de
 	push	bc
-	ld	e,(ix-6)
-	ld	d,(ix-5)
-	ld	hl,0x0010
+	ld	e,(ix-18)
+	ld	d,(ix-17)
+	ld	hl,0x0016
 	add	hl, sp
 	ex	de, hl
 	ld	bc,0x0004
 	ldir
 	pop	bc
 	pop	de
+	ld	a,(ix-4)
+	ld	(ix-16),a
+	ld	a,(ix-3)
+	ld	(ix-15),a
+	ld	a,(ix-2)
+	ld	(ix-14),a
+	ld	a,(ix-1)
+	ld	(ix-13),a
 	ld	(ix-4),0x00
 	ld	(ix-3),0x00
-	ld	a,(ix-8)
+	ld	a,(ix-14)
 	and	a,0x80
 	ld	(ix-2),a
-	ld	a,(ix-7)
+	ld	a,(ix-13)
 	and	a,0x7f
 	ld	(ix-1),a
 	ld	a,0x17
-l_m32_roundf_00136:
+l_m32_roundf_00141:
 	srl	(ix-1)
 	rr	(ix-2)
 	rr	(ix-3)
 	rr	(ix-4)
 	dec	a
-	jr	NZ, l_m32_roundf_00136
+	jr	NZ, l_m32_roundf_00141
 	ld	h,(ix-3)
 	ld	a,(ix-4)
 	add	a,0x81
-	ld	(ix-20),a
+	ld	(ix-12),a
 	ld	a, h
 	adc	a,0xff
-	ld	(ix-19),a
-	ld	a,(ix-20)
+	ld	(ix-11),a
+	ld	a,(ix-12)
 	sub	a,0x17
-	ld	a,(ix-19)
+	ld	a,(ix-11)
 	rla
 	ccf
 	rra
 	sbc	a,0x80
 	jp	NC, l_m32_roundf_00112
-	bit	7,(ix-19)
+	bit	7,(ix-11)
 	jr	Z,l_m32_roundf_00106
 	ld	bc,0x0000
 	ld	e,0x00
-	ld	a,(ix-7)
+	ld	a,(ix-13)
 	and	a,0x80
 	ld	d, a
-	ld	a,(ix-20)
+	ld	a,(ix-12)
 	inc	a
 	jp	NZ,l_m32_roundf_00113
-	ld	a,(ix-19)
+	ld	a,(ix-11)
 	inc	a
 	jp	NZ,l_m32_roundf_00113
 	set	7, e
-	ld	a,d
+	ld	a, d
 	or	a,0x3f
 	ld	d, a
 	jp	l_m32_roundf_00113
 l_m32_roundf_00106:
-	ld	a,(ix-20)
+	ld	a,(ix-12)
 	ld	(ix-4),0xff
 	ld	(ix-3),0xff
 	ld	(ix-2),0x7f
 	ld	(ix-1),0x00
 	inc	a
-	jr	l_m32_roundf_00141
-l_m32_roundf_00140:
+	jr	l_m32_roundf_00146
+l_m32_roundf_00145:
 	sra	(ix-1)
 	rr	(ix-2)
 	rr	(ix-3)
 	rr	(ix-4)
-l_m32_roundf_00141:
+l_m32_roundf_00146:
 	dec	a
-	jr	NZ, l_m32_roundf_00140
+	jr	NZ, l_m32_roundf_00145
 	ld	a,(ix-4)
-	ld	(ix-22),a
+	ld	(ix-10),a
 	ld	a,(ix-3)
-	ld	(ix-21),a
-	ld	a,(ix-22)
-	ld	(ix-4),a
-	ld	a,(ix-21)
-	ld	(ix-3),a
-	ld	(ix-2),0x00
-	ld	(ix-1),0x00
-	ld	a,(ix-4)
-	and	a,(ix-10)
-	ld	(ix-4),a
-	ld	a,(ix-3)
-	and	a,(ix-9)
-	ld	(ix-3),a
-	ld	a,(ix-2)
+	ld	(ix-9),a
+	ld	a,(ix-10)
+	ld	(ix-8),a
+	ld	a,(ix-9)
+	ld	(ix-7),a
+	ld	(ix-6),0x00
+	ld	(ix-5),0x00
+	ld	a,(ix-16)
 	and	a,(ix-8)
-	ld	(ix-2),a
-	ld	a,(ix-1)
+	ld	(ix-4),a
+	ld	a,(ix-15)
 	and	a,(ix-7)
+	ld	(ix-3),a
+	ld	a,(ix-14)
+	and	a,(ix-6)
+	ld	(ix-2),a
+	ld	a,(ix-13)
+	and	a,(ix-5)
 	ld	(ix-1),a
 	or	a,(ix-2)
 	or	a,(ix-3)
@@ -400,59 +412,58 @@ l_m32_roundf_00141:
 	ld	h, b
 	jp	l_m32_roundf_00114
 l_m32_roundf_00104:
-	ld	b,(ix-20)
-	ld	c,0x00
-	ld	e,c
+	ld	b,(ix-12)
+	ld	de,0x0000
 	inc	b
 	ld	hl,0x0040
-	jr	l_m32_roundf_00143
-l_m32_roundf_00142:
+	jr	l_m32_roundf_00148
+l_m32_roundf_00147:
 	sra	h
 	rr	l
+	rr	d
 	rr	e
-	rr	c
-l_m32_roundf_00143:
-	djnz	l_m32_roundf_00142
-	ld	a,(ix-10)
-	add	a, c
+l_m32_roundf_00148:
+	djnz	l_m32_roundf_00147
+	ld	a,(ix-16)
+	add	a, e
 	ld	c, a
-	ld	a,(ix-9)
-	adc	a, e
+	ld	a,(ix-15)
+	adc	a, d
 	ld	b, a
-	ld	a,(ix-8)
+	ld	a,(ix-14)
 	adc	a, l
 	ld	e, a
-	ld	a,(ix-7)
+	ld	a,(ix-13)
 	adc	a, h
 	ld	d, a
-	ld	(ix-18),c
-	ld	(ix-17),b
-	ld	(ix-16),e
-	ld	(ix-15),d
-	ld	a,(ix-22)
+	ld	(ix-4),c
+	ld	(ix-3),b
+	ld	(ix-2),e
+	ld	(ix-1),d
+	ld	a,(ix-10)
 	cpl
 	ld	c, a
-	ld	a,(ix-21)
+	ld	a,(ix-9)
 	cpl
 	ld	b, a
 	ld	de,0x0000
 	ld	a, c
-	and	a,(ix-18)
+	and	a,(ix-4)
 	ld	c, a
 	ld	a, b
-	and	a,(ix-17)
+	and	a,(ix-3)
 	ld	b, a
 	ld	a, e
-	and	a,(ix-16)
+	and	a,(ix-2)
 	ld	e, a
 	ld	a, d
-	and	a,(ix-15)
+	and	a,(ix-1)
 	ld	d, a
 	jr	l_m32_roundf_00113
 l_m32_roundf_00112:
-	ld	a,(ix-20)
+	ld	a,(ix-12)
 	sub	a,0x80
-	or	a,(ix-19)
+	or	a,(ix-11)
 	jr	NZ,l_m32_roundf_00109
 	push	de
 	push	bc
@@ -465,8 +476,8 @@ l_m32_roundf_00109:
 	ld	h, b
 	jr	l_m32_roundf_00114
 l_m32_roundf_00113:
-	ld	l,(ix-6)
-	ld	h,(ix-5)
+	ld	l,(ix-18)
+	ld	h,(ix-17)
 	ld	(hl), c
 	inc	hl
 	ld	(hl), b
@@ -474,7 +485,7 @@ l_m32_roundf_00113:
 	ld	(hl), e
 	inc	hl
 	ld	(hl), d
-	ld	hl,0x0008
+	ld	hl,0
 	add	hl, sp
 	ld	c, (hl)
 	inc	hl

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_sinf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_sinf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -280,12 +280,12 @@ _m32_sinf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
+	ld	c, l
+	ld	b, h
 	ld	hl, -14
 	add	hl, sp
 	ld	sp, hl
-	push	hl
-	ld	c,l
-	ld	b,h
+	push	bc
 	push	de
 	ld	hl,0x0000
 	push	hl
@@ -295,18 +295,18 @@ _m32_sinf:
 	call	___fslt_callee
 	pop	de
 	pop	bc
-	ld	a, l
+	ld	a,l
 	or	a, a
 	jr	Z,l_m32_sinf_00102
 	ld	a, d
 	xor	a,0x80
 	ld	d, a
-	ld	(ix-10),0x02
-	ld	(ix-9),0x00
+	ld	(ix-6),0x02
+	ld	(ix-5),0x00
 	jr	l_m32_sinf_00103
 l_m32_sinf_00102:
-	ld	(ix-10),0x00
-	ld	(ix-9),0x00
+	ld	(ix-6),0x00
+	ld	(ix-5),0x00
 l_m32_sinf_00103:
 	push	de
 	push	bc
@@ -315,28 +315,28 @@ l_m32_sinf_00103:
 	ld	hl,0xf983
 	push	hl
 	call	___fsmul_callee
-	ld	(ix-4),l
-	ld	(ix-3),h
-	ld	(ix-2),e
-	ld	(ix-1),d
+	ld	(ix-10),l
+	ld	(ix-9),h
+	ld	(ix-8),e
+	ld	l, e
+	ld	(ix-7),d
+	ld	h,d
+	push	hl
+	ld	l,(ix-10)
+	ld	h,(ix-9)
+	push	hl
 	ld	hl,0x4080
 	push	hl
 	ld	hl,0x0000
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
-	call	___fsgt_callee
+	call	___fslt_callee
 	ld	a, l
 	or	a, a
 	jr	Z,l_m32_sinf_00105
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	ld	e,(ix-2)
-	ld	d,(ix-1)
+	ld	e,(ix-8)
+	ld	d,(ix-7)
+	ld	l,(ix-10)
+	ld	h,(ix-9)
 	call	_m32_div2f
 	call	_m32_div2f
 	call	_m32_floorf
@@ -344,29 +344,29 @@ l_m32_sinf_00103:
 	call	_m32_mul2f
 	push	de
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
+	ld	l,(ix-8)
+	ld	h,(ix-7)
 	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
+	ld	l,(ix-10)
+	ld	h,(ix-9)
 	push	hl
 	call	___fssub_callee
-	ld	(ix-4),l
-	ld	(ix-3),h
-	ld	(ix-2),e
-	ld	(ix-1),d
+	ld	(ix-10),l
+	ld	(ix-9),h
+	ld	(ix-8),e
+	ld	(ix-7),d
 l_m32_sinf_00105:
+	ld	l,(ix-8)
+	ld	h,(ix-7)
+	push	hl
+	ld	l,(ix-10)
+	ld	h,(ix-9)
+	push	hl
 	ld	hl,0x4000
 	push	hl
 	ld	hl,0x0000
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
-	call	___fsgt_callee
+	call	___fslt_callee
 	ld	a, l
 	or	a, a
 	jr	Z,l_m32_sinf_00107
@@ -374,87 +374,88 @@ l_m32_sinf_00105:
 	push	hl
 	ld	hl,0x0000
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
+	ld	l,(ix-8)
+	ld	h,(ix-7)
 	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
+	ld	l,(ix-10)
+	ld	h,(ix-9)
+	push	hl
+	call	___fssub_callee
+	ld	(ix-10),l
+	ld	(ix-9),h
+	ld	(ix-8),e
+	ld	(ix-7),d
+	ld	a,0x02
+	sub	a,(ix-6)
+	ld	(ix-6),a
+	ld	a,0x00
+	sbc	a,(ix-5)
+	ld	(ix-5),a
+l_m32_sinf_00107:
+	ld	l,(ix-8)
+	ld	h,(ix-7)
+	push	hl
+	ld	l,(ix-10)
+	ld	h,(ix-9)
+	push	hl
+	call	___fs2sint_callee
+	ld	(ix-12),l
+	ld	(ix-11),h
+	push	hl
+	call	___sint2fs_callee
+	push	de
+	push	hl
+	ld	l,(ix-8)
+	ld	h,(ix-7)
+	push	hl
+	ld	l,(ix-10)
+	ld	h,(ix-9)
 	push	hl
 	call	___fssub_callee
 	ld	(ix-4),l
 	ld	(ix-3),h
 	ld	(ix-2),e
 	ld	(ix-1),d
-	ld	a,0x02
-	sub	a,(ix-10)
-	ld	(ix-10),a
-	ld	a,0x00
-	sbc	a,(ix-9)
-	ld	(ix-9),a
-l_m32_sinf_00107:
-	ld	l,(ix-2)
-	ld	h,(ix-1)
+	ld	a,(ix-12)
+	add	a,(ix-6)
+	ld	c, a
+	ld	a,(ix-11)
+	adc	a,(ix-5)
+	ld	b, a
+	ld	hl,0x0004
 	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
-	call	___fs2sint_callee
-	push	hl
-	push	hl
-	call	___sint2fs_callee
-	push	de
-	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
-	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
-	push	hl
-	call	___fssub_callee
-	pop	bc
-	ld	(ix-14),l
-	ld	(ix-13),h
-	ld	(ix-12),e
-	ld	(ix-11),d
-	ld	l,(ix-10)
-	ld	h,(ix-9)
-	add	hl, bc
-	ld	bc,0x0004
 	push	bc
-	push	hl
 	call	__modsint_callee
-	ld	c, l
-	ld	b, h
-	bit	0, c
+	ld	(ix-6),l
+	ld	(ix-5),h
+	bit	0,(ix-6)
 	jr	Z,l_m32_sinf_00109
-	push	bc
-	ld	l,(ix-12)
-	ld	h,(ix-11)
+	ld	l,(ix-2)
+	ld	h,(ix-1)
 	push	hl
-	ld	l,(ix-14)
-	ld	h,(ix-13)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	push	hl
 	ld	hl,0x3f80
 	push	hl
 	ld	hl,0x0000
 	push	hl
 	call	___fssub_callee
-	pop	bc
-	ld	(ix-14),l
-	ld	(ix-13),h
-	ld	(ix-12),e
-	ld	(ix-11),d
+	ld	(ix-4),l
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 l_m32_sinf_00109:
-	bit	1, c
+	bit	1,(ix-6)
 	jr	Z,l_m32_sinf_00111
-	ld	a,(ix-11)
+	ld	a,(ix-1)
 	xor	a,0x80
-	ld	(ix-11),a
+	ld	(ix-1),a
 l_m32_sinf_00111:
-	ld	l,(ix-14)
-	ld	h,(ix-13)
-	ld	e,(ix-12)
-	ld	d,(ix-11)
+	ld	e,(ix-2)
+	ld	d,(ix-1)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	call	_m32_sqrf
 	push	hl
 	ld	c,l
@@ -467,23 +468,23 @@ l_m32_sinf_00111:
 	push	de
 	push	bc
 	call	_m32_polyf
-	ld	(ix-5),d
-	ld	(ix-6),e
-	ld	(ix-7),h
-	ld	(ix-8),l
+	ld	(ix-14),l
+	ld	(ix-13),h
+	ld	(ix-12),e
+	ld	(ix-11),d
 	push	de
 	push	hl
-	ld	l,(ix-12)
-	ld	h,(ix-11)
+	ld	l,(ix-2)
+	ld	h,(ix-1)
 	push	hl
-	ld	l,(ix-14)
-	ld	h,(ix-13)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	push	hl
 	call	___fsmul_callee
-	ld	(ix-5),d
-	ld	(ix-6),e
-	ld	(ix-7),h
-	ld	(ix-8),l
+	ld	(ix-4),l
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 	pop	de
 	pop	bc
 	ld	hl,0x0004
@@ -495,11 +496,11 @@ l_m32_sinf_00111:
 	call	_m32_polyf
 	push	de
 	push	hl
-	ld	l,(ix-6)
-	ld	h,(ix-5)
+	ld	l,(ix-2)
+	ld	h,(ix-1)
 	push	hl
-	ld	l,(ix-8)
-	ld	h,(ix-7)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	push	hl
 	call	___fsdiv
 	ld	sp,ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_sinhf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_sinhf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -281,27 +281,25 @@ _m32_sinhf:
 	push	af
 	push	af
 	call	_m32_expf
-	push	hl
-	ld	c,l
-	ld	b,h
-	push	de
-	ld	l, c
-	ld	h, b
-	call	_m32_invf
-	ld	(ix-1),d
-	ld	(ix-2),e
-	ld	(ix-3),h
 	ld	(ix-4),l
-	pop	de
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
 	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
+	call	_m32_invf
+	push	de
+	push	hl
 	ld	l,(ix-2)
 	ld	h,(ix-1)
 	push	hl
 	ld	l,(ix-4)
 	ld	h,(ix-3)
 	push	hl
-	push	de
-	push	bc
 	call	___fssub_callee
 	call	_m32_div2f
 	ld	sp, ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_tanf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_tanf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -205,9 +205,13 @@
 ; Externals used
 ;--------------------------------------------------------
 	GLOBAL _m32_polyf
+	GLOBAL _m32_hypotf
 	GLOBAL _m32_invsqrtf
+	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -216,12 +220,10 @@
 	GLOBAL _m32_ldexpf
 	GLOBAL _m32_frexpf
 	GLOBAL _m32_fabsf
-	GLOBAL _m32_hypotf
 	GLOBAL _m32_powf
 	GLOBAL _m32_log10f
 	GLOBAL _m32_logf
 	GLOBAL _m32_expf
-	GLOBAL _m32_sqrtf
 	GLOBAL _m32_atanhf
 	GLOBAL _m32_acoshf
 	GLOBAL _m32_asinhf
@@ -278,23 +280,31 @@ _m32_tanf:
 	add	ix,sp
 	push	af
 	push	af
-	push	hl
-	push	de
-	call	_m32_sinf
-	ld	(ix-1),d
-	ld	(ix-2),e
-	ld	(ix-3),h
+	push	af
+	push	af
 	ld	(ix-4),l
-	pop	de
-	pop	hl
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
+	ld	l,(ix-4)
+	ld	h,(ix-3)
+	call	_m32_sinf
+	ld	(ix-8),l
+	ld	(ix-7),h
+	ld	(ix-6),e
+	ld	(ix-5),d
+	ld	e,(ix-2)
+	ld	d,(ix-1)
+	ld	l,(ix-4)
+	ld	h,(ix-3)
 	call	_m32_cosf
 	push	de
 	push	hl
-	ld	l,(ix-2)
-	ld	h,(ix-1)
+	ld	l,(ix-6)
+	ld	h,(ix-5)
 	push	hl
-	ld	l,(ix-4)
-	ld	h,(ix-3)
+	ld	l,(ix-8)
+	ld	h,(ix-7)
 	push	hl
 	call	___fsdiv
 	ld	sp,ix

--- a/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_tanhf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/asm/m32_tanhf.asm
@@ -1,6 +1,6 @@
 ;--------------------------------------------------------
 ; File Created by SDCC : free open source ANSI-C Compiler
-; Version 3.6.9 #9958 (Linux)
+; Version 3.9.1 #11276 (Linux)
 ;--------------------------------------------------------
 ; Processed by Z88DK
 ;--------------------------------------------------------
@@ -210,6 +210,8 @@
 	GLOBAL _m32_sqrtf
 	GLOBAL _m32_invf
 	GLOBAL _m32_sqrf
+	GLOBAL _m32_div2f
+	GLOBAL _m32_mul2f
 	GLOBAL _m32_roundf
 	GLOBAL _m32_fmodf
 	GLOBAL _m32_modff
@@ -276,14 +278,21 @@ _m32_tanhf:
 	push	ix
 	ld	ix,0
 	add	ix,sp
-	ld	hl, -8
-	add	hl, sp
-	ld	sp, hl
+	push	af
+	push	af
+	push	af
+	push	af
 	call	_m32_expf
 	ld	(ix-8),l
 	ld	(ix-7),h
 	ld	(ix-6),e
 	ld	(ix-5),d
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_invf
 	push	de
 	push	hl
@@ -294,14 +303,16 @@ _m32_tanhf:
 	ld	h,(ix-7)
 	push	hl
 	call	___fssub_callee
-	ld	(ix-1),d
-	ld	(ix-2),e
-	ld	(ix-3),h
 	ld	(ix-4),l
-	ld	l,(ix-8)
-	ld	h,(ix-7)
-	ld	e,(ix-6)
-	ld	d,(ix-5)
+	ld	(ix-3),h
+	ld	(ix-2),e
+	ld	(ix-1),d
+	pop	bc
+	pop	de
+	push	de
+	ld	l,c
+	ld	h,b
+	push	hl
 	call	_m32_invf
 	push	de
 	push	hl


### PR DESCRIPTION
There is an issue with the zsdcc r9958 version (old faithful), in that it overwrites the `hl` register parameter with `__z88dk_fastcall` functions with the stack adjustment, before `hl` can be saved. Discussed in #1149.

To be seen in `asinhf()`, `atanf()`, `acoshf()`, `sinf()`, and others.

This is fixed with the r11276 (and other earlier versions). But, somehow the code quality is otherwise worse. Perhaps there's some new peephole optimisation rules resulting.