### PR TITLE
m32 - rework zero exits

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/sccz80/l_f32_ldexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/lm32/c/sccz80/l_f32_ldexp.asm
@@ -6,26 +6,37 @@
 
         PUBLIC  l_f32_ldexp
 
-; Entry: a = adjustment for exponent
-;       Stack: float, ret
-; Exit: dehl = adjusted float
+; Entry: dehl = float, a = adjustment for exponent
+;        stack = ret
+;
+; Exit:  dehl = adjusted float
 
-l_f32_ldexp:
+
+.l_f32_ldexp
         sla e                       ; get the exponent
         rl d
+        jr Z,zero_legal             ; return IEEE zero
         rr e                        ; save the sign in e[7]
 
         add d
         ld d,a                      ; exponent returned
-        rl e                        ; get sign back
+
+        rl e                        ; restore sign to C
         rr d
         rr e
 
-        and a                       ; check for zero exponent
+        and a                       ; check for zero exponent result
         ret NZ                      ; return IEEE in DEHL
 
-        ld e,0
-        ld h,e
-        ld l,e
+        ld e,a
+        ld h,a
+        ld l,a
         scf
         ret                         ; return IEEE underflow ZERO in DEHL
+
+.zero_legal
+        ld e,d                      ; use 0
+        ld h,d
+        ld l,d
+        rr d                        ; restore the sign
+        ret                         ; return IEEE signed ZERO in DEHL

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsdiv2.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsdiv2.asm
@@ -17,9 +17,6 @@
 
 SECTION code_fp_math32
 
-EXTERN m32_fszero_fastcall
-EXTERN m32_fsmin_fastcall
-
 PUBLIC m32_fsdiv2_fastcall
 PUBLIC _m32_div2f
 
@@ -28,12 +25,26 @@ PUBLIC _m32_div2f
 .m32_fsdiv2_fastcall
     sla e                       ; get exponent in d
     rl d                        ; put sign in C
-
-    jp Z,m32_fszero_fastcall
+    jr Z,zero_legal             ; return IEEE zero
 
     dec d                       ; divide by 2
-    jp Z,m32_fsmin_fastcall     ; capture underflow
+    jr Z,zero_underflow         ; capture underflow zero
 
     rr d                        ; return sign and exponent
     rr e
     ret                         ; return IEEE DEHL
+
+.zero_legal
+    ld e,d                      ; use 0
+    ld h,d
+    ld l,d        
+    rr d                        ; restore the sign
+    ret                         ; return IEEE signed ZERO in DEHL
+
+.zero_underflow
+    ld e,d                      ; use 0
+    ld h,d
+    ld l,d
+    rr d                        ; restore the sign
+    scf
+    ret                         ; return IEEE signed ZERO in DEHL

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsfrexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsfrexp.asm
@@ -37,7 +37,6 @@ PUBLIC _m32_frexpf
 
 ; float frexpf (float x, int *pw2);
 ._m32_frexpf
-
 .m32_fsfrexp_callee
     ; evaluation of fraction and exponent
     ;

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsldexp.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsldexp.asm
@@ -30,7 +30,6 @@
 SECTION code_clib
 SECTION code_fp_math32
 
-EXTERN m32_fszero_fastcall
 EXTERN m32_fsmin_fastcall
 
 PUBLIC m32_fsldexp_callee
@@ -39,7 +38,6 @@ PUBLIC _m32_ldexpf
 
 ; float ldexpf (float x, int16_t pw2);
 ._m32_ldexpf
-
 .m32_fsldexp_callee
     ; evaluation of fraction and exponent
     ;
@@ -58,7 +56,7 @@ PUBLIC _m32_ldexpf
 
     sla e                       ; get the exponent
     rl d
-    jp Z,m32_fszero_fastcall    ; return IEEE zero
+    jr Z,zero_legal             ; return IEEE zero
     rr e                        ; save the sign in e[7]
 
     ld a,d
@@ -71,4 +69,11 @@ PUBLIC _m32_ldexpf
 
     and a                       ; check for zero exponent
     ret NZ                      ; return IEEE DEHL
-    jp m32_fsmin_fastcall       ; otherwise return IEEE underflow zero 
+    jp m32_fsmin_fastcall       ; otherwise return IEEE underflow zero
+
+.zero_legal
+    ld e,d                      ; use 0
+    ld h,d
+    ld l,d
+    rr d                        ; restore the sign
+    ret                         ; return IEEE signed ZERO in DEHL

--- a/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul2.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/z80/f32_fsmul2.asm
@@ -17,8 +17,6 @@
 
 SECTION code_fp_math32
 
-EXTERN m32_fsmax_fastcall
-
 PUBLIC m32_fsmul2_fastcall
 PUBLIC _m32_mul2f
 
@@ -27,13 +25,31 @@ PUBLIC _m32_mul2f
 .m32_fsmul2_fastcall
     sla e                       ; get exponent in d
     rl d                        ; put sign in C
+    jr Z,zero_legal             ; return IEEE zero
 
     inc d                       ; multiply by 2
-    jp Z,m32_fsmax_fastcall     ; capture NaN
+    jr Z,infinity               ; capture NaN
     inc d
-    jp Z,m32_fsmax_fastcall     ; capture overflow
+    jr Z,infinity               ; capture overflow
     dec d
 
     rr d                        ; return sign and exponent
     rr e
     ret                         ; return IEEE DEHL
+
+.zero_legal
+    ld e,d                      ; use 0
+    ld h,d
+    ld l,d        
+    rr d                        ; restore the sign
+    ret                         ; return IEEE signed ZERO in DEHL
+
+.infinity
+    ld e,d                      ; use 0
+    ld h,d
+    ld l,d
+    dec d                       ; 0xff
+    rr d                        ; restore the sign
+    rr e
+    scf
+    ret                         ; return IEEE signed ZERO in DEHL


### PR DESCRIPTION
- try to support negative zero properly, by using sign bit properly.
- use `jr` in main-line code to save 3 cycles per non-taken test.