### PR TITLE
classiclib - fputc_cons reverse escape characters

### DIFF
--- a/libsrc/stdio/cpm/fputc_cons.asm
+++ b/libsrc/stdio/cpm/fputc_cons.asm
@@ -26,9 +26,10 @@
 IF STANDARDESCAPECHARS
 	cp	10	; LF ?
 	jr	nz,nocrlf
+	ld	de,13
 	ld	c,2
 	call	5
-	ld	de,13
+	ld	de,10
 ELSE
         cp      13      ; CR ?
         jr      nz,nocrlf


### PR DESCRIPTION
swap the `STANDARDESCAPECHARS` to produce `CR LF`.