### PR TITLE
Bugfix/issue 1266

### DIFF
--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -230,6 +230,7 @@ zx_clib.lib:
 	@echo ''
 	@echo '--- Building ZX Spectrum Library ---'
 	@echo ''
+	$(RM) stdio/spectrum/*.o
 	$(MAKE) gfxdeps
 	$(call buildgeneric,zx)
 	$(MAKE) -C target/zx
@@ -251,6 +252,7 @@ ts2068_clib.lib:
 	@echo ''
 	@echo '--- Building TS2068 (Spectrum clone) Library ---'
 	@echo ''
+	$(RM) stdio/spectrum/*.o
 	$(MAKE) gfxdeps
 	$(call buildgeneric,zx)
 	$(MAKE) -C target/zx

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -2494,19 +2494,19 @@ void zor_const(LVALUE *lval, int32_t value)
             return;
         } else if ( (value & 0xFFFFFF00) == 0 ) {
             ol("ld\ta,l");
-            ot("or\t"); outdec(value % 256); nl();
+            ot("or\t"); outdec((value & 0xff)); nl();
             ol("ld\tl,a");
         } else if ( ( value & 0xFFFF00FF) == 0 ) {
             ol("ld\ta,h");
-            ot("or\t"); outdec((value % 65536)/256); nl();
+            ot("or\t"); outdec((value & 0xff00) >> 8); nl();
             ol("ld\th,a");            
        } else if ( ( value & 0xFF00FFFF) == 0 ) {
             ol("ld\ta,e");
-            ot("or\t"); outdec((value / 65536)%256); nl();
+            ot("or\t"); outdec((value & 0xff0000) >> 16); nl();
             ol("ld\te,a");            
        } else if ( ( value & 0x00FFFFFF) == 0 ) {
             ol("ld\ta,d");
-            ot("or\t"); outdec((value / 65536)/256); nl();
+            ot("or\t"); outdec((value & 0xff000000) >> 24); nl();
             ol("ld\td,a");            
         } else if ( value != 0 ) {
             lpush();
@@ -2518,11 +2518,11 @@ void zor_const(LVALUE *lval, int32_t value)
             return;
         } else if ( ((value % 65536) & 0xff00) == 0 ) {
             ol("ld\ta,l");
-            ot("or\t"); outdec(value % 256); nl();
+            ot("or\t"); outdec(value & 0xff); nl();
             ol("ld\tl,a");    
         } else if ( ((value % 65536) & 0x00ff) == 0 ) {
             ol("ld\ta,h");
-            ot("or\t"); outdec((value % 65536) / 256); nl();
+            ot("or\t"); outdec((value & 0xff00) >> 8); nl();
             ol("ld\th,a");    
         } else if ( value != 0 ) {
             const2(value & 0xffff);
@@ -2555,15 +2555,15 @@ void zxor_const(LVALUE *lval, int32_t value)
             ol("ld\tl,a");
         } else if ( ( value & 0xFFFF00FF) == 0 ) {
             ol("ld\ta,h");
-            ot("xor\t"); outdec((value % 65536)/256); nl();
+            ot("xor\t"); outdec((value & 0xff00) >> 8); nl();
             ol("ld\th,a");            
        } else if ( ( value & 0xFF00FFFF) == 0 ) {
             ol("ld\ta,e");
-            ot("xor\t"); outdec((value / 65536)%256); nl();
+            ot("xor\t"); outdec((value & 0xff0000) >> 16); nl();
             ol("ld\te,a");            
        } else if ( ( value & 0x00FFFFFF) == 0 ) {
             ol("ld\ta,d");
-            ot("xor\t"); outdec((value / 65536)/256); nl();
+            ot("xor\t"); outdec((value & 0xff000000) >> 24); nl();
             ol("ld\td,a");  
         } else if ( ( value & 0xffffffff) == 0xffffffff ) {
             com(lval);          
@@ -2575,11 +2575,11 @@ void zxor_const(LVALUE *lval, int32_t value)
     } else {
         if ( ((value % 65536) & 0xff00) == 0 ) {
             ol("ld\ta,l");
-            ot("xor\t"); outdec(value % 256); nl();
+            ot("xor\t"); outdec(value & 0xff); nl();
             ol("ld\tl,a");    
         } else if ( ((value % 65536) & 0x00ff) == 0 ) {
             ol("ld\ta,h");
-            ot("xor\t"); outdec((value % 65536) / 256); nl();
+            ot("xor\t"); outdec((value & 0xff00) >> 8); nl();
             ol("ld\th,a");   
         } else if ( ( value & 0xffff) == 0xffff ) {
             com(lval);
@@ -2672,7 +2672,7 @@ void zand_const(LVALUE *lval, int32_t value)
             ol("ld\th,0");
         } else if ( value % 256 == 0 ) {
             ol("ld\ta,h");
-            outfmt("\tand\t+(%d %% 256)\n",(value % 65536) / 256);
+            outfmt("\tand\t+(%d %% 256)\n",(value & 0xff00) >> 8);
             ol("ld\th,a");
             ol("ld\tl,0");            
         } else if ( value == (uint16_t)0xffff ) {

--- a/testsuite/Issue_1266_ranges.c
+++ b/testsuite/Issue_1266_ranges.c
@@ -1,0 +1,58 @@
+
+long land_test1(long t) {
+   return t & 0x7000;
+}
+
+long land_test2(long t) {
+   return t & 0x70;
+}
+
+long land_test3(long t) {
+   return t & 0x700000;
+}
+
+long land_test4(long t) {
+   return t & 0x70000000;
+}
+
+int iand_test1(int t) {
+   return t & 0x7000;
+}
+
+int iand_test2(int t) {
+   return t & 0x70;
+}
+
+
+long lor_test1(long t) {
+   return t | 0x7000;
+}
+
+long lor_test2(long t) {
+   return t | 0x70;
+}
+
+long lor_test3(long t) {
+   return t | 0x700000;
+}
+
+long lor_test4(long t) {
+   return t | 0x70000000;
+}
+
+long lxor_test1(long t) {
+   return t ^ 0x7000;
+}
+
+long lxor_test2(long t) {
+   return t ^ 0x70;
+}
+
+long lxor_test3(long t) {
+   return t ^ 0x700000;
+}
+
+long lxor_test4(long t) {
+   return t ^ 0x70000000;
+}
+

--- a/testsuite/results/Issue_1266_ranges.opt
+++ b/testsuite/results/Issue_1266_ranges.opt
@@ -1,0 +1,196 @@
+
+
+
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._land_test1
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,h
+	and	+(112 % 256)
+	ld	h,a
+	ld	l,0
+	ld	de,0
+	ret
+
+
+
+._land_test2
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,l
+	and	112
+	ld	l,a
+	ld	h,0
+	ld	de,0
+	ret
+
+
+
+._land_test3
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong2sp
+	ld	hl,0	;const
+	ld	de,112
+	call	l_long_and
+	ret
+
+
+
+._land_test4
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong2sp
+	ld	hl,0	;const
+	ld	de,28672
+	call	l_long_and
+	ret
+
+
+
+._iand_test1
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	ld	a,h
+	and	+(112 % 256)
+	ld	h,a
+	ld	l,0
+	ret
+
+
+
+._iand_test2
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	ld	a,l
+	and	+(112 % 256)
+	ld	l,a
+	ld	h,0
+	ret
+
+
+
+._lor_test1
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,h
+	or	112
+	ld	h,a
+	ret
+
+
+
+._lor_test2
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,l
+	or	112
+	ld	l,a
+	ret
+
+
+
+._lor_test3
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,e
+	or	112
+	ld	e,a
+	ret
+
+
+
+._lor_test4
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,d
+	or	112
+	ld	d,a
+	ret
+
+
+
+._lxor_test1
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,h
+	xor	112
+	ld	h,a
+	ret
+
+
+
+._lxor_test2
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,l
+	xor	112
+	ld	l,a
+	ret
+
+
+
+._lxor_test3
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,e
+	xor	112
+	ld	e,a
+	ret
+
+
+
+._lxor_test4
+	ld	hl,2	;const
+	add	hl,sp
+	call	l_glong
+	ld	a,d
+	xor	112
+	ld	d,a
+	ret
+
+
+
+
+	SECTION	bss_compiler
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_land_test1
+	GLOBAL	_land_test2
+	GLOBAL	_land_test3
+	GLOBAL	_land_test4
+	GLOBAL	_iand_test1
+	GLOBAL	_iand_test2
+	GLOBAL	_lor_test1
+	GLOBAL	_lor_test2
+	GLOBAL	_lor_test3
+	GLOBAL	_lor_test4
+	GLOBAL	_lxor_test1
+	GLOBAL	_lxor_test2
+	GLOBAL	_lxor_test3
+	GLOBAL	_lxor_test4
+
+
+
+


### PR DESCRIPTION
Fix up a few issues spotted when compiling clisp for +zx:

- zand_const() would output a negative number which went out or range (also fixed up or, xor)
- ZX library was ending up with ts2068 code and creating large binaries (clisp was too big)