### PR TITLE
Allow 32-bit addresses in z80asm (see #1287, #1292, #1290)

### DIFF
--- a/src/z80asm/codearea.c
+++ b/src/z80asm/codearea.c
@@ -663,7 +663,7 @@ void set_origin_directive(int origin)
 		CURRENTSECTION->origin_found = true;
 		if (origin == -1)					/* signal split section binary file */
 			CURRENTSECTION->section_split = true;
-		else if (origin >= 0 && origin <= 0xFFFF)
+		else if (origin >= 0)
 		{
 			if (CURRENTSECTION->origin_opts && CURRENTSECTION->origin >= 0)
 				; /* ignore ORG, as --origin from command line overrides */

--- a/src/z80asm/modlink.c
+++ b/src/z80asm/modlink.c
@@ -423,9 +423,6 @@ static void patch_exprs( ExprList *exprs )
                 break;
 
             case RANGE_WORD:
-                if ( value < -32768 || value > 65535 )
-                    warn_int_range( value );
-
 				patch_word(expr->code_pos, value); 
 
 				/* Expression contains relocatable address */
@@ -460,16 +457,10 @@ static void patch_exprs( ExprList *exprs )
                 break;
 
 			case RANGE_WORD_BE:
-				if (value < -32768 || value > 65535)
-					warn_int_range(value);
-
 				patch_word_be(expr->code_pos, value);
 				break;
 
 			case RANGE_DWORD:
-                if ( value < LONG_MIN || value > LONG_MAX )
-                    warn_int_range( value );
-
 				patch_long(expr->code_pos, value);
                 break;
 

--- a/src/z80asm/opcodes.c
+++ b/src/z80asm/opcodes.c
@@ -154,7 +154,7 @@ void add_Z88_CALL_OZ(int argument)
 		append_byte(Z80_RST(0x20));
 		append_byte(argument);
 	}
-	else if (argument > 255 && argument <= 65535)
+	else if (argument > 255)
 	{
 		append_byte(Z80_RST(0x20));
 		append_word(argument);
@@ -165,7 +165,7 @@ void add_Z88_CALL_OZ(int argument)
 
 void add_Z88_CALL_PKG(int argument)
 {
-	if (argument >= 0 && argument <= 65535)
+	if (argument >= 0)
 	{
 		append_byte(Z80_RST(0x08));
 		append_word(argument);
@@ -194,7 +194,7 @@ void add_Z88_INVOKE(int argument)
 	else
 		opcode = Z80_CALL;			/* Ti83: CALL */
 
-	if (argument >= 0 && argument <= 65535)
+	if (argument >= 0)
 	{
 		append_byte(opcode);
 		append_word(argument);

--- a/src/z80asm/scan.c
+++ b/src/z80asm/scan.c
@@ -193,10 +193,8 @@ static long scan_num ( char *text, int length, int base )
 	int digit = 0;
 	char c;
 	int i;
-	bool range_err;
 	
 	value = 0;
-	range_err = false;
 	for ( i = 0 ; i < length ; i++ ) 
 	{
 		c = *text++;					/* read each digit */
@@ -223,20 +221,8 @@ static long scan_num ( char *text, int length, int base )
 		}
 		
 		value = value * base + digit;
-
-		if ( ! range_err && value < 0 )	/* overflow to sign bit */
-		{
-			range_err = true;		
-		}
 	}
 	
-	if ( range_err )
-	{
-#if 0
-		warn_int_range( value );
-#endif
-	}
-		
 	return value;
 }
 

--- a/src/z80asm/t/32_bit_addr.t
+++ b/src/z80asm/t/32_bit_addr.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+# Z88DK Z80 Macro Assembler
+#
+# Copyright (C) Paulo Custodio, 2011-2019
+# License: The Artistic License 2.0, http://www.perlfoundation.org/artistic_license_2_0
+# Repository: https://github.com/z88dk/z88dk/
+#
+# Test https://github.com/z88dk/z88dk/issues/1077
+# z80asm: optimize for speed - replace JR by JP
+
+use Modern::Perl;
+use Test::More;
+use Path::Tiny;
+require './t/testlib.pl';
+
+path('test1.asm')->spew(<<'END');
+	section test1
+	org 	$01C000
+	public 	func1
+	func1: 	ret
+	call 	func1
+	jp   	func1
+END
+
+path('test2.asm')->spew(<<'END');
+	section test2
+	org 	$02C000
+	public 	func2
+	defb 	0
+	func2: 	ret
+	call 	func2
+	jp   	func2
+END
+
+path('test.asm')->spew(<<'END');
+	section test
+	extern func1, func2
+	banked_call: ret
+	call banked_call
+	defq func1
+	call banked_call
+	defq func2
+END
+
+run("z80asm -b -m -l test.asm test1.asm test2.asm");
+
+check_bin_file('test_test1.bin', pack("C*",
+										#	section test1
+										#	org 	$01C000
+										#	public 	func1
+				0xC9,					#	func1: 	ret
+				0xCD, 0x00, 0xC0,		#	call 	func1
+				0xC3, 0x00, 0xC0,		#	jp   	func1
+));
+
+check_bin_file('test_test2.bin', pack("C*",
+										#	section test2
+										#	org 	$02C000
+										#	public 	func2
+				0,						#	defb 	0
+				0xC9,					#	func2: 	ret
+				0xCD, 0x01, 0xC0,		#	call 	func2
+				0xC3, 0x01, 0xC0,		#	jp   	func2
+));
+
+check_bin_file('test.bin', pack("C*",
+										# 	section test
+										#	extern func1, func2
+				0xC9,					#	banked_call: ret
+				0xCD, 0, 0,				#	call banked_call
+				0x00, 0xC0, 0x01, 0x00,	#	defq func1
+				0xCD, 0, 0,				#	call banked_call
+				0x01, 0xC0, 0x02, 0x00,	#	defq func2
+));
+
+check_text_file('test.map', <<'END');
+banked_call                     = $0000 ; addr, local, , test, test, test.asm:3
+func1                           = $1C000 ; addr, public, , test1, test1, test1.asm:4
+func2                           = $2C001 ; addr, public, , test2, test2, test2.asm:5
+__head                          = $0000 ; const, public, def, , ,
+__tail                          = $2C008 ; const, public, def, , ,
+__size                          = $2C008 ; const, public, def, , ,
+__test_head                     = $0000 ; const, public, def, , ,
+__test_tail                     = $000F ; const, public, def, , ,
+__test_size                     = $000F ; const, public, def, , ,
+__test1_head                    = $1C000 ; const, public, def, , ,
+__test1_tail                    = $1C007 ; const, public, def, , ,
+__test1_size                    = $0007 ; const, public, def, , ,
+__test2_head                    = $2C000 ; const, public, def, , ,
+__test2_tail                    = $2C008 ; const, public, def, , ,
+__test2_size                    = $0008 ; const, public, def, , ,
+END
+
+unlink_testfiles();
+done_testing();

--- a/src/z80asm/t/directive_org.t
+++ b/src/z80asm/t/directive_org.t
@@ -62,11 +62,6 @@ z80asm("org -2", "", 1, "", <<'ERR');
 Error at file 'test.asm' line 1: integer '-2' out of range
 ERR
 
-unlink_testfiles();
-z80asm("org 65536", "", 1, "", <<'ERR');
-Error at file 'test.asm' line 1: integer '65536' out of range
-ERR
-
 # ORG not constant
 unlink_testfiles();
 z80asm("extern start \n org start", "", 1, "", <<'ERR');

--- a/src/z80asm/t/errors.t
+++ b/src/z80asm/t/errors.t
@@ -60,7 +60,7 @@ t_z80asm_capture("-b -d ".o_file(),
 unlink_testfiles();
 
 write_file(asm_file(), <<'ASM');
-	extern G_32769, G_32768, G_129, G_128, G0, G127, G128, G255, G256, G65535, G65536
+	extern G_129, G_128, G0, G127, G128, G255, G256
 
 ; Byte = -129
 	ld	a, L_129
@@ -102,45 +102,19 @@ write_file(asm_file(), <<'ASM');
 	ld	(ix + G128), -1
 	ld	(ix + G0 + 128), -1
 
-; Word = -32769
-	ld	bc, L_32769
-	ld	bc, G_32769
-	ld	bc, G0 - 32769
-
-; Word = -32768
-	ld	bc, L_32768
-	ld	bc, G_32768
-	ld	bc, G0 - 32768
-
-; Word = 65535
-	ld	bc, L65535
-	ld	bc, G65535
-	ld	bc, G0 + 65535
-
-; Word = 65536
-	ld	bc, L65536
-	ld	bc, G65536
-	ld	bc, G0 + 65536
-
 ; Local variables
-	defc L_32769 = -32769
-	defc L_32768 = -32768
 	defc L_129   = -129
 	defc L_128   = -128
 	defc L255    =  255
 	defc L256    =  256
 	defc L127    =  127
 	defc L128    =  128
-	defc L65535  =  65535
-	defc L65536  =  65536
 ASM
 
 write_file(asm1_file(), <<'ASM1');
 
 ; Global variables
-	public G_32769, G_32768, G_129, G_128, G0, G127, G128, G255, G256, G65535, G65536
-	defc G_32769 = -32769
-	defc G_32768 = -32768
+	public G_129, G_128, G0, G127, G128, G255, G256
 	defc G_129   = -129
 	defc G_128   = -128
 	defc G0      =  0
@@ -148,8 +122,6 @@ write_file(asm1_file(), <<'ASM1');
 	defc G128    =  128
 	defc G255    =  255
 	defc G256    =  256
-	defc G65535  =  65535
-	defc G65536  =  65536
 ASM1
 
 t_z80asm_capture("-b ".asm_file()." ".asm1_file(), "", <<'ERR', 0);
@@ -157,8 +129,6 @@ Warning at file 'test.asm' line 4: integer '-129' out of range
 Warning at file 'test.asm' line 19: integer '256' out of range
 Warning at file 'test.asm' line 24: integer '-129' out of range
 Warning at file 'test.asm' line 39: integer '128' out of range
-Warning at file 'test.asm' line 44: integer '-32769' out of range
-Warning at file 'test.asm' line 59: integer '65536' out of range
 Warning at file 'test.asm' line 5: integer '-129' out of range
 Warning at file 'test.asm' line 6: integer '-129' out of range
 Warning at file 'test.asm' line 20: integer '256' out of range
@@ -167,10 +137,6 @@ Warning at file 'test.asm' line 25: integer '-129' out of range
 Warning at file 'test.asm' line 26: integer '-129' out of range
 Warning at file 'test.asm' line 40: integer '128' out of range
 Warning at file 'test.asm' line 41: integer '128' out of range
-Warning at file 'test.asm' line 45: integer '-32769' out of range
-Warning at file 'test.asm' line 46: integer '-32769' out of range
-Warning at file 'test.asm' line 60: integer '65536' out of range
-Warning at file 'test.asm' line 61: integer '65536' out of range
 ERR
 
 t_binary(read_binfile(bin_file()), pack("C*",
@@ -198,18 +164,6 @@ t_binary(read_binfile(bin_file()), pack("C*",
 		0xDD, 0x36, 0x80, 0xFF,
 		0xDD, 0x36, 0x80, 0xFF,
 		0xDD, 0x36, 0x80, 0xFF,
-		0x01, 0xFF, 0x7F,
-		0x01, 0xFF, 0x7F,
-		0x01, 0xFF, 0x7F,
-		0x01, 0x00, 0x80,
-		0x01, 0x00, 0x80,
-		0x01, 0x00, 0x80,
-		0x01, 0xFF, 0xFF,
-		0x01, 0xFF, 0xFF,
-		0x01, 0xFF, 0xFF,
-		0x01, 0x00, 0x00,
-		0x01, 0x00, 0x00,
-		0x01, 0x00, 0x00,
 ));
 
 # defvar out of range - tested in directives.t

--- a/src/z80asm/t/opcodes.t
+++ b/src/z80asm/t/opcodes.t
@@ -77,10 +77,8 @@ END_ASM
         ld   bc,1                       ;; 01 01 00
         ld   bc,32767                   ;; 01 FF 7F
         ld   bc,65535                   ;; 01 FF FF
-        ld   bc,-32769                  ;; warn 2: integer '-32769' out of range
-                                        ;; 01 FF 7F
-        ld   bc,65536                   ;; warn 2: integer '65536' out of range
-                                        ;; 01 00 00
+        ld   bc,-32769                  ;; 01 FF 7F
+        ld   bc,65536                   ;; 01 00 00
 
 ; 32-bit arithmetic, long range is not tested on a 32bit long
         defq 0xFFFFFFFF                 ;; FF FF FF FF
@@ -92,10 +90,8 @@ END_ASM
         call 0                          ;; CD 00 00
         call 1                          ;; CD 01 00
         call 65535                      ;; CD FF FF
-        call -32769                     ;; warn 2: integer '-32769' out of range
-                                        ;; CD FF 7F
-        call 65536                      ;; warn 2: integer '65536' out of range
-                                        ;; CD 00 00
+        call -32769                     ;; CD FF 7F
+        call 65536                      ;; CD 00 00
 
 ;------------------------------------------------------------------------------
 ; Expressions
@@ -2320,16 +2316,13 @@ IF      !RABBIT
         out  N,a                        ;; error: syntax error
 ENDIF   
         call_oz 0                       ;; error: integer '0' out of range
-        call_oz 65536                   ;; error: integer '65536' out of range
 IF      !RABBIT
         call_pkg -1                     ;; error: integer '-1' out of range
-        call_pkg 65536                  ;; error: integer '65536' out of range
 ENDIF   
         fpp  0                          ;; error: integer '0' out of range
         fpp  255                        ;; error: integer '255' out of range
         fpp  256                        ;; error: integer '256' out of range
         invoke -1                       ;; error: integer '-1' out of range
-        invoke 65536                    ;; error: integer '65536' out of range
 END_ASM
 );
 z80asm(
@@ -2401,10 +2394,8 @@ END_ASM
         ld   bc,1                       ;; 01 01 00
         ld   bc,32767                   ;; 01 FF 7F
         ld   bc,65535                   ;; 01 FF FF
-        ld   bc,-32769                  ;; warn 2: integer '-32769' out of range
-                                        ;; 01 FF 7F
-        ld   bc,65536                   ;; warn 2: integer '65536' out of range
-                                        ;; 01 00 00
+        ld   bc,-32769                  ;; 01 FF 7F
+        ld   bc,65536                   ;; 01 00 00
 
 ; 32-bit arithmetic, long range is not tested on a 32bit long
         defq 0xFFFFFFFF                 ;; FF FF FF FF
@@ -2416,10 +2407,8 @@ END_ASM
         call 0                          ;; CD 00 00
         call 1                          ;; CD 01 00
         call 65535                      ;; CD FF FF
-        call -32769                     ;; warn 2: integer '-32769' out of range
-                                        ;; CD FF 7F
-        call 65536                      ;; warn 2: integer '65536' out of range
-                                        ;; CD 00 00
+        call -32769                     ;; CD FF 7F
+        call 65536                      ;; CD 00 00
 
 ;------------------------------------------------------------------------------
 ; Expressions
@@ -4646,13 +4635,11 @@ ENDIF
 IF      !RABBIT
 ENDIF   
         call_oz 0                       ;; error: integer '0' out of range
-        call_oz 65536                   ;; error: integer '65536' out of range
 IF      !RABBIT
 ENDIF   
         fpp  0                          ;; error: integer '0' out of range
         fpp  255                        ;; error: integer '255' out of range
         fpp  256                        ;; error: integer '256' out of range
         invoke -1                       ;; error: integer '-1' out of range
-        invoke 65536                    ;; error: integer '65536' out of range
 END_ASM
 );

--- a/src/z80asm/z80pass.c
+++ b/src/z80asm/z80pass.c
@@ -109,23 +109,14 @@ Z80pass2( void )
                 break;
 
 			case RANGE_WORD:
-				if (value < -32768 || value > 65535)
-					warn_int_range(value);
-
 				patch_word(expr->code_pos, (int)value);
 				break;
 
 			case RANGE_WORD_BE:
-				if (value < -32768 || value > 65535)
-					warn_int_range(value);
-
 				patch_word_be(expr->code_pos, (int)value);
 				break;
 
 			case RANGE_DWORD:
-                if ( value < LONG_MIN || value > LONG_MAX )
-                    warn_int_range( value );
-
 				patch_long(expr->code_pos, value);
                 break;
 


### PR DESCRIPTION
Extend z80asm to handle 24- or 32-bit addresses, where the lower 16-bits are the address seen by the CPU, and the upper 8- or 16-bits are the bank id (platform dependent, e.g. value to be written to the bank register). CALL, JP, ... need to accept the 32-bit address and ignore the upper 16-bits. For the Spectrum 128K (which I know better than the GameBoy), one could write

  section xxx1  ; name is not relevant
  org $00C000       ; select page 0 at address $C000

  public func1
  func1: ...

  section xxx2
  org $01C000        ; select page 1 at address $C000

  extern func1
  ...
  call banked_call   ; platform-dependent function that switches banks and calls the function
  defp func1         ; patch in a 24-bit address (Spectrum 128k); use defq for a 32-bit address

As a side-effect of this change, z80asm no longer emits warnings for 16-bit values out of range.