### PR TITLE
Gameboy - sdcc compatibility

### DIFF
--- a/include/arch/gb/cgb.h
+++ b/include/arch/gb/cgb.h
@@ -40,19 +40,19 @@
 
 /** Set bkg palette(s).
  */
-void __LIB__ set_bkg_palette(uint8_t first_palette, uint8_t nb_palettes, uint16_t *rgb_data) __smallc NONBANKED;
+void __LIB__ set_bkg_palette(uint16_t first_palette, uint16_t nb_palettes, uint16_t *rgb_data) __smallc NONBANKED;
 
 /** Set sprite palette(s).
  */
-void __LIB__ set_sprite_palette(uint8_t first_palette, uint8_t nb_palettes, uint16_t *rgb_data) __smallc NONBANKED;
+void __LIB__ set_sprite_palette(uint16_t first_palette, uint16_t nb_palettes, uint16_t *rgb_data) __smallc NONBANKED;
 
 /** Set a bkg palette entry.
  */
-void __LIB__ set_bkg_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) __smallc;
+void __LIB__ set_bkg_palette_entry(uint16_t palette, uint16_t entry, uint16_t rgb_data) __smallc;
 
 /** Set a sprite palette entry.
  */
-void __LIB__ set_sprite_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) __smallc;
+void __LIB__ set_sprite_palette_entry(uint16_t palette, uint16_t entry, uint16_t rgb_data) __smallc;
 
 /** Set CPU speed to slow operation.
     Make sure interrupts are disabled before call.

--- a/include/arch/gb/console.h
+++ b/include/arch/gb/console.h
@@ -10,7 +10,7 @@
 
 /** Move the cursor to an absolute position.
  */
-void __LIB__ gotoxy(uint8_t x, uint8_t y) __smallc;
+void __LIB__ gotoxy(uint16_t x, uint16_t y) __smallc;
 
 /** Get the current X position of the cursor.
  */

--- a/include/arch/gb/drawing.h
+++ b/include/arch/gb/drawing.h
@@ -41,60 +41,41 @@
 #define	M_NOFILL	0
 #define	M_FILL		1
 
-/** Possible values for signed_value in gprintln() and gprintn() */
-#define SIGNED   1
-#define UNSIGNED 0
-
-
-/** Print the string 'str' with no interpretation */
-void __LIB__ gprint(char *str) NONBANKED;
-
-/** Print the long number 'number' in radix 'radix'.  signed_value should
-   be set to SIGNED or UNSIGNED depending on whether the number is signed
-   or not */
-void __LIB__ gprintln(int16_t number, int8_t radix, int8_t signed_value) __smallc;
-
-/** Print the number 'number' as in 'gprintln' */
-void __LIB__	gprintn(int8_t number, int8_t radix, int8_t signed_value) __smallc;
-
-/** Print the formatted string 'fmt' with arguments '...' */
-int8_t __LIB__	gprintf(char *fmt,...) NONBANKED;
-
 /** Old style plot - try plot_point() */
-void __LIB__ plot(uint8_t x, uint8_t y, uint8_t colour, uint8_t mode) __smallc;
+void __LIB__ plot(uint16_t x, uint16_t y, uint16_t colour, uint16_t mode) __smallc;
 
 /** Plot a point in the current drawing mode and colour at (x,y) */
-void __LIB__ plot_point(uint8_t x, uint8_t y) __smallc;
+void __LIB__ plot_point(uint16_t x, uint16_t y) __smallc;
 
 /** I (MLH) have no idea what switch_data does... */
-void __LIB__ switch_data(uint8_t x, uint8_t y, unsigned char *src, unsigned char *dst) __smallc NONBANKED;
+void __LIB__ switch_data(uint16_t x, uint16_t y, unsigned char *src, unsigned char *dst) __smallc NONBANKED;
 
 /** Ditto */
 void __LIB__ draw_image(unsigned char *data) NONBANKED;
 
 /** Draw a line in the current drawing mode and colour from (x1,y1) to (x2,y2) */
-void __LIB__ line(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2) __smallc;
+void __LIB__ line(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) __smallc;
 
 /** Draw a box (rectangle) with corners (x1,y1) and (x2,y2) using fill mode
    'style' (one of NOFILL or FILL */
-void __LIB__ box(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, uint8_t style) __smallc;
+void __LIB__ box(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t style) __smallc;
 
 /** Draw a circle with centre at (x,y) and radius 'radius'.  'style' sets
    the fill mode */
-void __LIB__	circle(uint8_t x, uint8_t y, uint8_t radius, uint8_t style) __smallc;
+void __LIB__	circle(uint16_t x, uint16_t y, uint16_t radius, uint16_t style) __smallc;
 
 /** Returns the current colour of the pixel at (x,y) */
-uint8_t __LIB__	getpix(uint8_t x, uint8_t y) __smallc;
+uint16_t __LIB__	getpix(uint16_t x, uint16_t y) __smallc;
 
 /** Prints the character 'chr' in the default font at the current position */
 void __LIB__	wrtchr(char chr);
 
 /** Sets the current text position to (x,y).  Note that x and y have units
    of cells (8 pixels) */
-void __LIB__ gotogxy(uint8_t x, uint8_t y) __smallc;
+void __LIB__ gotogxy(uint16_t x, uint16_t y) __smallc;
 
 /** Set the current foreground colour (for pixels), background colour, and
    draw mode */
-void __LIB__ color(uint8_t forecolor, uint8_t backcolor, uint8_t mode) __smallc;
+void __LIB__ color(uint16_t forecolor, uint16_t backcolor, uint16_t mode) __smallc;
 
 #endif /* __DRAWING_H */

--- a/include/arch/gb/gb.h
+++ b/include/arch/gb/gb.h
@@ -365,7 +365,7 @@ void __LIB__ display_off(void) NONBANKED;
     @param src		Area to copy from
     @param n		Number of bytes to copy.
 */
-void __LIB__ hiramcpy(uint8_t dst, const void *src, uint8_t n) NONBANKED;
+void __LIB__ hiramcpy(uint16_t dst, const void *src, uint16_t n) __smallc NONBANKED;
 
 /* ************************************************************ */
 
@@ -444,7 +444,7 @@ void __LIB__ hiramcpy(uint8_t dst, const void *src, uint8_t n) NONBANKED;
     @param first_tile	Range 0 - 255
     @param nb_tiles	Range 0 - 255
 */
-void __LIB__ set_bkg_data(uint8_t first_tile, uint8_t nb_tiles, unsigned char *data) __smallc NONBANKED;
+void __LIB__ set_bkg_data(uint16_t first_tile, uint16_t nb_tiles, unsigned char *data) __smallc NONBANKED;
 
 /** Sets the tiles in the background tile table.
     Starting at position x,y in tiles and writing across for w tiles
@@ -460,21 +460,21 @@ void __LIB__ set_bkg_data(uint8_t first_tile, uint8_t nb_tiles, unsigned char *d
     @param data		Pointer to an unsigned char. Usually the 
     			first element in an array.
 */
-void __LIB__ set_bkg_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *tiles) __smallc NONBANKED;
+void __LIB__ set_bkg_tiles(uint16_t x, uint16_t y, uint16_t w, uint16_t h, unsigned char *tiles) __smallc NONBANKED;
 
-void __LIB__ get_bkg_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *tiles) __smallc NONBANKED; 
+void __LIB__ get_bkg_tiles(uint16_t x, uint16_t y, uint16_t w, uint16_t h, unsigned char *tiles) __smallc NONBANKED; 
 
 /** Moves the background layer to the position specified in x and y in pixels.
     Where 0,0 is the top left corner of the GB screen. You'll notice the screen
     wraps around in all 4 directions, and is always under the window layer.
 */
-void __LIB__ move_bkg(uint8_t x, uint8_t y) __smallc NONBANKED;
+void __LIB__ move_bkg(uint16_t x, uint16_t y) __smallc NONBANKED;
 
 /** Moves the background relative to it's current position.
 
     @see move_bkg
 */
-void __LIB__ scroll_bkg(int8_t x, int8_t y) __smallc NONBANKED;
+void __LIB__ scroll_bkg(int16_t x, int16_t y) __smallc NONBANKED;
 
 /* ************************************************************ */
 
@@ -483,7 +483,7 @@ void __LIB__ scroll_bkg(int8_t x, int8_t y) __smallc NONBANKED;
     layer share the same Tile Patterns.
     @see set_bkg_data
 */
-void __LIB__ set_win_data(uint8_t first_tile, uint8_t nb_tiles, unsigned char *data) __smallc NONBANKED;
+void __LIB__ set_win_data(uint16_t first_tile, uint16_t nb_tiles, unsigned char *data) __smallc NONBANKED;
 
 /** Sets the tiles in the win tile table. 
     Starting at position x,y in
@@ -515,21 +515,21 @@ void __LIB__ set_win_data(uint8_t first_tile, uint8_t nb_tiles, unsigned char *d
     @param w		Range 0 - 31
     @param h		Range 0 - 31
 */
-void __LIB__ set_win_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *tiles) __smallc NONBANKED;
+void __LIB__ set_win_tiles(uint16_t x, uint16_t y, uint16_t w, uint16_t h, unsigned char *tiles) __smallc NONBANKED;
 
-void __LIB__ get_win_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *tiles) __smallc NONBANKED;
+void __LIB__ get_win_tiles(uint16_t x, uint16_t y, uint16_t w, uint16_t h, unsigned char *tiles) __smallc NONBANKED;
 
 /** Moves the window layer to the position specified in x and y in pixels.
     Where 7,0 is the top left corner of the GB screen. The window is locked to
     the bottom right corner, and is always over the background layer.
     @see SHOW_WIN, HIDE_WIN
 */
-void __LIB__ move_win(uint8_t x, uint8_t y) __smallc NONBANKED;
+void __LIB__ move_win(uint16_t x, uint16_t y) __smallc NONBANKED;
 
 /** Move the window relative to its current position.
     @see move_win
 */
-void __LIB__ scroll_win(int8_t x, int8_t y) __smallc NONBANKED;
+void __LIB__ scroll_win(int16_t x, int16_t y) __smallc NONBANKED;
 
 /* ************************************************************ */
 
@@ -544,18 +544,18 @@ void __LIB__ scroll_win(int8_t x, int8_t y) __smallc NONBANKED;
     patterns are written to. VBK_REG=0 indicates the first bank, and VBK_REG=1
     indicates the second.
 */
-void __LIB__ set_sprite_data(uint8_t first_tile, uint8_t nb_tiles, unsigned char *data) __smallc NONBANKED;
+void __LIB__ set_sprite_data(uint16_t first_tile, uint16_t nb_tiles, unsigned char *data) __smallc NONBANKED;
 
-void __LIB__ get_sprite_data(uint8_t first_tile, uint8_t nb_tiles, unsigned char *data) __smallc NONBANKED;
+void __LIB__ get_sprite_data(uint16_t first_tile, uint16_t nb_tiles, unsigned char *data) __smallc NONBANKED;
 
 /** Sets sprite n to display tile number t, from the sprite tile data. 
     If the GB is in 8x16 sprite mode then it will display the next
     tile, t+1, below the first tile.
     @param nb		Sprite number, range 0 - 39
 */
-void __LIB__ set_sprite_tile(uint8_t nb, uint8_t tile) __smallc NONBANKED;
+void __LIB__ set_sprite_tile(uint16_t nb, uint16_t tile) __smallc NONBANKED;
 
-uint8_t __LIB__ get_sprite_tile(uint8_t nb) NONBANKED;
+uint8_t __LIB__ get_sprite_tile(uint16_t nb) NONBANKED;
 
 /** Sets the property of sprite n to those defined in p.
     Where the bits in p represent:
@@ -576,9 +576,9 @@ uint8_t __LIB__ get_sprite_tile(uint8_t nb) NONBANKED;
     
     @param nb		Sprite number, range 0 - 39
 */
-void __LIB__ set_sprite_prop(uint8_t nb, uint8_t prop) __smallc NONBANKED;
+void __LIB__ set_sprite_prop(uint16_t nb, uint16_t prop) __smallc NONBANKED;
 
-uint8_t __LIB__ get_sprite_prop(uint8_t nb) NONBANKED;
+uint8_t __LIB__ get_sprite_prop(uint16_t nb) NONBANKED;
 
 /** Moves the given sprite to the given position on the
     screen.
@@ -586,11 +586,11 @@ uint8_t __LIB__ get_sprite_prop(uint8_t nb) NONBANKED;
     is at (8,16).  To put sprite 0 at the top left, use
     move_sprite(0, 8, 16);
 */
-void __LIB__ move_sprite(uint8_t nb, uint8_t x, uint8_t y) __smallc NONBANKED;
+void __LIB__ move_sprite(uint16_t nb, uint16_t x, uint16_t y) __smallc NONBANKED;
 
 /** Moves the given sprite relative to its current position.
  */
-void __LIB__ scroll_sprite(int8_t nb, int8_t x, int8_t y) __smallc  NONBANKED;
+void __LIB__ scroll_sprite(int16_t nb, int16_t x, int16_t y) __smallc  NONBANKED;
 
 /* ************************************************************ */
 
@@ -598,8 +598,8 @@ void __LIB__ set_data(unsigned char *vram_addr, unsigned char *data, uint16_t le
 
 void __LIB__ get_data(unsigned char *data, unsigned char *vram_addr, uint16_t len) __smallc NONBANKED; 
 
-void __LIB__ set_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *vram_addr, unsigned char *tiles) __smallc  NONBANKED;
+void __LIB__ set_tiles(uint16_t x, uint16_t y, uint16_t w, uint16_t h, unsigned char *vram_addr, unsigned char *tiles) __smallc  NONBANKED;
 
-void __LIB__ get_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *tiles, unsigned char *vram_addr) __smallc NONBANKED;
+void __LIB__ get_tiles(uint16_t x, uint16_t y, uint16_t w, uint16_t h, unsigned char *tiles, unsigned char *vram_addr) __smallc NONBANKED;
 
 #endif /* _GB_H */

--- a/include/string.h
+++ b/include/string.h
@@ -5,14 +5,14 @@
 #include <sys/types.h>
 
 extern int __LIB__ bcmp(const void *b1,const void *b2,size_t len) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern int __LIB__ bcmp_callee(const void *b1,const void *b2,size_t len) __smallc __z88dk_callee;
 #define bcmp(a,b,c) bcmp_callee(a,b,c)
 #endif
 
 
 extern void __LIB__ bcopy(const void *src,void *dst,size_t len) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern void __LIB__ bcopy_callee(const void *src,void *dst,size_t len) __smallc __z88dk_callee; 
 #define bcopy(a,b,c) bcopy_callee(a,b,c)
 #endif
@@ -39,7 +39,7 @@ extern char __LIB__ *strset_callee(char *s,int c) __smallc __z88dk_callee;
 
 
 extern char __LIB__ *strnset(char *s,int c,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *strnset_callee(char *s,int c,size_t n) __smallc __z88dk_callee;
 #define strnset(a,b,c) strnset_callee(a,b,c)
 #endif
@@ -57,7 +57,7 @@ extern char __LIB__ *_memlwr__callee(void *p,size_t n) __smallc __z88dk_callee;
 
 
 extern char __LIB__ *_memstrcpy_(void *p,const char *s,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *_memstrcpy__callee(void *p,const char *s,size_t n) __smallc __z88dk_callee;
 #define _memstrcpy_(a,b,c) _memstrcpy__callee(a,b,c)
 #endif
@@ -83,21 +83,21 @@ extern void __LIB__ *memccpy_callee(void *dst,const void *src,int c,size_t n) __
 
 
 extern void __LIB__ *memchr(const void *s,int c,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern void __LIB__ *memchr_callee(const void *s,int c,size_t n) __smallc __z88dk_callee;
 #define memchr(a,b,c) memchr_callee(a,b,c)
 #endif
 
 
 extern int __LIB__ memcmp(const void *s1,const void *s2,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern int __LIB__ memcmp_callee(const void *s1,const void *s2,size_t n) __smallc __z88dk_callee;
 #define memcmp(a,b,c) memcmp_callee(a,b,c)
 #endif
 
 
 extern void __LIB__ *memcpy(void *dst,const void *src,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern void __LIB__ *memcpy_callee(void *dst,const void *src,size_t n) __smallc __z88dk_callee;
 #define memcpy(a,b,c) memcpy_callee(a,b,c)
 #endif
@@ -109,14 +109,14 @@ extern void __LIB__ *memmem_callee(const void *haystack,size_t haystack_len,cons
 
 
 extern void __LIB__ *memmove(void *dst,const void *src,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern void __LIB__ *memmove_callee(void *dst,const void *src,size_t n) __smallc __z88dk_callee;
 #define memmove(a,b,c) memmove_callee(a,b,c)
 #endif
 
 
 extern void __LIB__ *memrchr(const void *s,int c,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern void __LIB__ *memrchr_callee(const void *s,int c,size_t n) __smallc __z88dk_callee;
 #define memrchr(a,b,c) memrchr_callee(a,b,c)
 #endif
@@ -138,7 +138,7 @@ extern char __LIB__ *stpcpy_callee(char *dst,const char *src) __smallc __z88dk_c
 
 
 extern char __LIB__ *stpncpy(char *dst,const char *src,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *stpncpy_callee(char *dst,const char *src,size_t n) __smallc __z88dk_callee;
 #define stpncpy(a,b,c) stpncpy_callee(a,b,c)
 #endif
@@ -216,35 +216,35 @@ extern char __LIB__  *strlwr(char *s) __smallc __z88dk_fastcall;
 
 
 extern int __LIB__ strncasecmp(const char *s1,const char *s2,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern int __LIB__ strncasecmp_callee(const char *s1,const char *s2,size_t n) __smallc __z88dk_callee;
 #define strncasecmp(a,b,c) strncasecmp_callee(a,b,c)
 #endif
 
 
 extern char __LIB__ *strncat(char *dst,const char *src,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *strncat_callee(char *dst,const char *src,size_t n) __smallc __z88dk_callee;
 #define strncat(a,b,c) strncat_callee(a,b,c)
 #endif
 
 
 extern char __LIB__ *strnchr(const char *s,size_t n,int c) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *strnchr_callee(const char *s,size_t n,int c) __smallc __z88dk_callee;
 #define strnchr(a,b,c) strnchr_callee(a,b,c)
 #endif
 
 
 extern int __LIB__ strncmp(const char *s1,const char *s2,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern int __LIB__ strncmp_callee(const char *s1,const char *s2,size_t n) __smallc __z88dk_callee;
 #define strncmp(a,b,c) strncmp_callee(a,b,c)
 #endif
 
 
 extern char __LIB__ *strncpy(char *dst,const char *src,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *strncpy_callee(char *dst,const char *src,size_t n) __smallc __z88dk_callee;
 #define strncpy(a,b,c) strncpy_callee(a,b,c)
 #endif
@@ -315,7 +315,7 @@ extern char __LIB__ *strtok_callee(char *s,const char *delim) __smallc __z88dk_c
 
 
 extern char __LIB__ *strtok_r(char *s,const char *delim,char **last_s) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern char __LIB__ *strtok_r_callee(char *s,const char *delim,char **last_s) __smallc __z88dk_callee;
 #define strtok_r(a,b,c) strtok_r_callee(a,b,c)
 #endif
@@ -325,7 +325,7 @@ extern char __LIB__  *strupr(char *s) __smallc __z88dk_fastcall;
 
 
 extern size_t __LIB__ strxfrm(char *dst,const char *src,size_t n) __smallc;
-#if !__GB8080__
+#if !__GBZ80__
 extern size_t __LIB__ strxfrm_callee(char *dst,const char *src,size_t n) __smallc __z88dk_callee;
 #define strxfrm(a,b,c) strxfrm_callee(a,b,c)
 #endif

--- a/include/sys/compiler.h
+++ b/include/sys/compiler.h
@@ -25,6 +25,7 @@
 
 #if __SDCC && __GBZ80__
 #define __DISABLE_BUILTIN 
+#define __z88dk_fastcall
 #endif
 
 #define NONBANKED __nonbanked

--- a/lib/arch/gbz80/gbz80_rules.1
+++ b/lib/arch/gbz80/gbz80_rules.1
@@ -122,3 +122,49 @@
 	ld	a,(hl+)
 	ld	h,(hl)
 	ld	l,a
+
+	ld	a,(hl+)
+	ld	h,(hl)
+	ld	l,a
+	push	hl
+	ld	hl,sp+%1
+	ld	a,(hl+)
+	ld	h,(hl)
+	ld	l,a
+	pop	de
+=
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+	ld	hl,sp+%eval(%1 2 -)
+	ld	a,(hl+)
+	ld	h,(hl)
+	ld	l,a
+
+	ld	a,(hl+)
+	ld	h,(hl)
+	ld	l,a
+	ld	de,%1
+	push	hl
+	ld	l,e
+	ld	h,d
+	pop	de
+=
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+	ld	hl,%1
+
+	ld	de,_%1
+	call	l_pint
+	ld	hl,_%1
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+	ld	hl,%2
+=
+	ld	de,_%1
+	call	l_pint
+	ld	e,l
+	ld	d,h
+	ld	hl,%2

--- a/lib/config/gb.cfg
+++ b/lib/config/gb.cfg
@@ -7,7 +7,7 @@ CRT0		 DESTDIR/lib/target/gb/classic/gb_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2 -iquote.  -DZ80 -DGBZ80 -D__GAMEBOY__ -M -subtype=default -clib=default -Ca-IDESTDIR/lib/target/gb/def -IDESTDIR/include/arch
+OPTIONS		 -O2 -SO2 -iquote.  -DZ80 -D__GBZ80__ -D__GAMEBOY__ -M -subtype=default -clib=default -Ca-IDESTDIR/lib/target/gb/def -IDESTDIR/include/arch
 
 CLIB	  default -mgbz80 -Cc-standard-escape-chars -lgb_clib -startuplib=gbz80_crt0 -D__GBZ80__ -custom-copt-rules=DESTDIR/lib/arch/gbz80/gbz80_rules.1 -lndos
 

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -4534,3 +4534,17 @@
 	ld	de,_%1
 	ld	hl,_%2
 	push	de
+
+	ld	hl,_%1
+	ld	l,(hl)
+	ld	h,0
+	inc	hl
+	ld	a,l
+	ld	(_%1),a
+	dec	hl
+=
+	ld	hl,_%1
+	inc	(hl)
+	ld	l,(hl)
+	dec	l
+	ld	h,0

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isalnum.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isalnum.asm
@@ -8,6 +8,15 @@ PUBLIC isalnum
 
 EXTERN asm_isalnum, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isalnum
+_isalnum:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isalnum:
 
    inc h
@@ -18,13 +27,20 @@ isalnum:
    call asm_isalnum
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isalnum
 defc _isalnum = isalnum
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isalpha.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isalpha.asm
@@ -8,6 +8,14 @@ PUBLIC isalpha
 
 EXTERN asm_isalpha, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isalpha
+_isalpha:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
 isalpha:
 
    inc h
@@ -18,13 +26,20 @@ isalpha:
    call asm_isalpha
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isalpha
 defc _isalpha = isalpha
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isascii.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isascii.asm
@@ -8,6 +8,15 @@ PUBLIC isascii
 
 EXTERN error_znc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isascii
+_isascii:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isascii:
 
    inc h
@@ -21,16 +30,22 @@ IF __CPU_INTEL__
    ret c
 ELSE
    bit 7,l
-   
+ IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ ENDIF
    ld l,h
    ret nz
 ENDIF
 
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isascii
 defc _isascii = isascii
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isbdigit.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isbdigit.asm
@@ -8,6 +8,15 @@ PUBLIC isbdigit
 
 EXTERN asm_isbdigit, error_znc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isbdigit
+_isbdigit:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isbdigit:
 
    inc h
@@ -18,13 +27,20 @@ isbdigit:
    call asm_isbdigit
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret nz
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isbdigit
 defc _isbdigit = isbdigit
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isblank.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isblank.asm
@@ -8,6 +8,15 @@ PUBLIC isblank
 
 EXTERN asm_isblank, error_znc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isblank
+_isblank:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isblank:
 
    inc h
@@ -18,13 +27,20 @@ isblank:
    call asm_isblank
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret nz
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isblank
 defc _isblank = isblank
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/iscntrl.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/iscntrl.asm
@@ -8,6 +8,14 @@ PUBLIC iscntrl
 
 EXTERN asm_iscntrl, error_znc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _iscntrl
+_iscntrl:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
 iscntrl:
 
    inc h
@@ -18,13 +26,20 @@ iscntrl:
    call asm_iscntrl
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret nc
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _iscntrl
 defc _iscntrl = iscntrl
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isdigit.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isdigit.asm
@@ -8,6 +8,15 @@ PUBLIC isdigit
 
 EXTERN asm_isdigit, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isdigit
+_isdigit:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isdigit:
 
    inc h
@@ -18,13 +27,20 @@ isdigit:
    call asm_isdigit
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isdigit
 defc _isdigit = isdigit
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isgraph.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isgraph.asm
@@ -8,6 +8,15 @@ PUBLIC isgraph
 
 EXTERN asm_isgraph, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isgraph
+_isgraph:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isgraph:
 
    inc h
@@ -18,13 +27,20 @@ isgraph:
    call asm_isgraph
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isgraph
 defc _isgraph = isgraph
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/islower.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/islower.asm
@@ -8,6 +8,15 @@ PUBLIC islower
 
 EXTERN asm_islower, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _islower
+_islower:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 islower:
 
    inc h
@@ -18,13 +27,20 @@ islower:
    call asm_islower
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _islower
 defc _islower = islower
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isodigit.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isodigit.asm
@@ -8,6 +8,15 @@ PUBLIC isodigit
 
 EXTERN asm_isodigit, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isodigit
+_isodigit:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isodigit:
 
    inc h
@@ -18,13 +27,20 @@ isodigit:
    call asm_isodigit
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isodigit
 defc _isodigit = isodigit
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isprint.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isprint.asm
@@ -8,6 +8,15 @@ PUBLIC isprint
 
 EXTERN asm_isprint, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isprint
+_isprint:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isprint:
 
    inc h
@@ -18,13 +27,20 @@ isprint:
    call asm_isprint
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isprint
 defc _isprint = isprint
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/ispunct.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/ispunct.asm
@@ -8,6 +8,15 @@ PUBLIC ispunct
 
 EXTERN asm_ispunct, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _ispunct
+_ispunct:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 ispunct:
 
    inc h
@@ -18,13 +27,20 @@ ispunct:
    call asm_ispunct
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _ispunct
 defc _ispunct = ispunct
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isspace.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isspace.asm
@@ -8,6 +8,15 @@ PUBLIC isspace
 
 EXTERN asm_isspace, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isspace
+_isspace:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isspace:
 
    inc h
@@ -18,13 +27,20 @@ isspace:
    call asm_isspace
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isspace
 defc _isspace = isspace
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isupper.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isupper.asm
@@ -8,6 +8,15 @@ PUBLIC isupper
 
 EXTERN asm_isupper, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isupper
+_isupper:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isupper:
 
    inc h
@@ -18,14 +27,21 @@ isupper:
    call asm_isupper
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
-PUBLIC _isupper
+IF __CLASSIC && !__CPU_GBZ80__
+PUBLIC _isupper 
 defc _isupper = isupper
 ENDIF
 

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/isxdigit.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/isxdigit.asm
@@ -8,6 +8,15 @@ PUBLIC isxdigit
 
 EXTERN asm_isxdigit, error_zc
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _isxdigit
+_isxdigit:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 isxdigit:
 
    inc h
@@ -18,13 +27,20 @@ isxdigit:
    call asm_isxdigit
    
    ld l,h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret c
    
    inc l
+IF __CPU_GBZ80__
+   inc e
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _isxdigit
 defc _isxdigit = isxdigit
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/toascii.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/toascii.asm
@@ -6,6 +6,15 @@ SECTION code_ctype
 
 PUBLIC toascii
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _toascii
+_toascii:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 toascii:
 
    ld h,0
@@ -16,11 +25,14 @@ IF __CPU_INTEL__
 ELSE
    res 7,l
 ENDIF
-   
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _toascii
 defc _toascii = toascii
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/tolower.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/tolower.asm
@@ -8,20 +8,37 @@ PUBLIC tolower
 
 EXTERN asm_tolower
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _tolower
+_tolower:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 tolower:
 
    inc h
    dec h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret nz
 
    ld a,l
    call asm_tolower
    
    ld l,a
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _tolower
 defc _tolower = tolower
 ENDIF

--- a/libsrc/_DEVELOPMENT/ctype/c/sccz80/toupper.asm
+++ b/libsrc/_DEVELOPMENT/ctype/c/sccz80/toupper.asm
@@ -8,20 +8,37 @@ PUBLIC toupper
 
 EXTERN asm_toupper
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _toupper
+_toupper:
+  ld  hl,sp+2
+  ld  a,(hl+)
+  ld  h,(hl)
+  ld  l,a
+ENDIF
+
 toupper:
 
    inc h
    dec h
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret nz
 
    ld a,l
    call asm_toupper
    
    ld l,a
+IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ENDIF
    ret
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _toupper
 defc _toupper = toupper
 ENDIF

--- a/libsrc/_DEVELOPMENT/sdcc_opt.1
+++ b/libsrc/_DEVELOPMENT/sdcc_opt.1
@@ -549,3 +549,9 @@ __xinit_%0
 	ld	ix, %1 (%2)
 =
 	ld	ix,(%2 + %1)
+
+;;
+;; GBZ80 instructions
+	ldhl	sp, %2
+=
+	ld	hl,sp + %2

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memccpy.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memccpy.asm
@@ -11,40 +11,51 @@ EXTERN asm_memccpy
 memccpy:
 
 IF __CPU_INTEL__ | __CPU_GBZ80__
-	ld hl,2
-        add hl,sp
-        ld  c,(hl)
-        inc hl
-        ld  b,(hl)
-        inc hl
-        ld  a,(hl)
-        inc hl
-        inc hl
-        ld  e,(hl)
-        inc hl
-        ld  d,(hl)
-        inc hl
-        push de
-        ld  e,(hl)
-        inc hl
-        ld  d,(hl)
-        pop hl
+ IF __CPU_GBZ80__
+   ld hl,sp+2
+ ELSE  
+   ld hl,2
+   add hl,sp
+ ENDIF
+   ld  c,(hl)
+   inc hl
+   ld  b,(hl)
+   inc hl
+   ld  a,(hl)
+   inc hl
+   inc hl
+   ld  e,(hl)
+   inc hl
+   ld  d,(hl)
+   inc hl
+   push de
+   ld  e,(hl)
+   inc hl
+   ld  d,(hl)
+   pop hl
 ELSE
    pop ix
-	pop bc
-	pop de
-	ld a,e
-	pop hl
-	pop de
+   pop bc
+   pop de
+   ld a,e
+   pop hl
+   pop de
 	
-	push de
-	push hl
-	push de
-	push bc
-	push ix
+   push de
+   push hl
+   push de
+   push bc
+   push ix
 ENDIF
 
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_memccpy
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_memccpy
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memccpy_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memccpy_callee.asm
@@ -10,12 +10,12 @@ EXTERN asm_memccpy
 
 memccpy_callee:
 IF __CPU_INTEL__ | __CPU_GBZ80__
-IF __CPU_GBZ80__
+ IF __CPU_GBZ80__
    ld hl,sp+2
-ELSE
+ ELSE
    ld hl,2
    add hl,sp
-ENDIF
+ ENDIF
    ld  c,(hl)
    inc hl
    ld  b,(hl)
@@ -34,6 +34,10 @@ ENDIF
    inc hl
    pop hl
    call asm_memccpy
+ IF __CPU_GBZ80__
+   ld d,h
+   ld e,l
+ ENDIF
    pop bc ; return value
    pop af ;dump arg
    pop af ;dump arg

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memchr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memchr.asm
@@ -22,6 +22,10 @@ IF __CPU_GBZ80__
    ld a,(hl+)
    ld h,(hl)
    ld l,a
+   call l0_memchr_callee
+   ld d,h
+   ld e,l
+   ret
 ELSE
 
    pop af
@@ -33,9 +37,9 @@ ELSE
    push de
    push bc
    push af
+   jp l0_memchr_callee
 ENDIF
 
-   jp l0_memchr_callee
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memchr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memchr_callee.asm
@@ -9,18 +9,10 @@ PUBLIC memchr_callee, l0_memchr_callee
 EXTERN asm_memchr
 
 memchr_callee:
-IF __CPU_GBZ80__
-   pop af	;ret
-   pop bc
-   pop de
-   pop hl
-   push af
-ELSE
    pop hl
    pop bc
    pop de
    ex (sp),hl
-ENDIF
 
 l0_memchr_callee:
 

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memcmp.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memcmp.asm
@@ -38,8 +38,15 @@ ELSE
    push bc
    push af
 ENDIF
-   
+  
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_memcmp
+   ld d,h
+   ld e,l
+   ret
+ELSE 
    jp asm_memcmp
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memcpy.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memcpy.asm
@@ -38,8 +38,15 @@ ELSE
    push bc
    push af
 ENDIF
-   
+  
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_memcpy
+   ld d,h
+   ld e,l
+   ret
+ELSE 
    jp asm_memcpy
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memmove.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memmove.asm
@@ -37,8 +37,15 @@ ELSE
    push bc
    push af
 ENDIF
-   
+  
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_memmove
+   ld d,h
+   ld e,l
+   ret
+ELSE 
    jp asm_memmove
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memrchr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memrchr.asm
@@ -35,7 +35,14 @@ ELSE
    push af
 ENDIF
 
+IF __CLASSIC && __CPU_GBZ80__
+   call l0_memrchr_callee
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp l0_memrchr_callee
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memrchr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memrchr_callee.asm
@@ -1,7 +1,6 @@
 
 ; void *memrchr(const void *s, int c, size_t n)
 
-IF !__CPU_GBZ80__
 SECTION code_clib
 SECTION code_string
 
@@ -27,4 +26,3 @@ PUBLIC _memrchr_callee
 defc _memrchr_callee = memrchr_callee
 ENDIF
 
-ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memset.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memset.asm
@@ -34,8 +34,15 @@ ELSE
    push bc
    push af
 ENDIF
-   
+  
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_memset
+   ld d,h
+   ld e,l
+   ret
+ELSE 
    jp asm_memset
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/memswap.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/memswap.asm
@@ -34,8 +34,15 @@ ELSE
    push bc
    push af
 ENDIF
-   
+  
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_memswap
+   ld d,h
+   ld e,l
+   ret
+ELSE 
    jp asm_memswap
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcasecmp.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcasecmp.asm
@@ -17,8 +17,14 @@ strcasecmp:
    push de
    push hl
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcasecmp
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strcasecmp
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcasecmp_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcasecmp_callee.asm
@@ -14,8 +14,14 @@ strcasecmp_callee:
    pop hl
    pop de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcasecmp
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strcasecmp
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcat.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcat.asm
@@ -17,8 +17,14 @@ strcat:
    push de
    push hl
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcat
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strcat
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcat_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcat_callee.asm
@@ -14,8 +14,15 @@ strcat_callee:
    pop hl
    pop de
    push bc
-   
+
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcat
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strcat
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strchr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strchr.asm
@@ -17,8 +17,14 @@ strchr:
    push hl
    push bc
    push de
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strchr
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strchr
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strchr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strchr_callee.asm
@@ -14,13 +14,17 @@ IF __CPU_GBZ80__
    pop bc
    pop hl
    push de
+   call asm_strchr
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop bc
    ex (sp),hl
+   jp asm_strchr
 ENDIF
    
-   jp asm_strchr
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strchrnul.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strchrnul.asm
@@ -17,8 +17,14 @@ strchrnul:
    push hl
    push bc
    push de
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strchrnul
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strchrnul
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strchrnul_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strchrnul_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop bc
    pop hl
    push de
+   call asm_strchrnul
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop bc
    ex (sp),hl
+   jp asm_strchrnul
 ENDIF
    
-   jp asm_strchrnul
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcmp.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcmp.asm
@@ -17,8 +17,14 @@ strcmp:
    push de
    push hl
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcmp
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcmp
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcmp_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcmp_callee.asm
@@ -14,8 +14,14 @@ strcmp_callee:
    pop hl
    pop de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcmp
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcmp
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcoll.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcoll.asm
@@ -17,8 +17,14 @@ strcoll:
    push de
    push hl
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcoll
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcoll
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcoll_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcoll_callee.asm
@@ -14,8 +14,14 @@ strcoll_callee:
    pop hl
    pop de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcoll
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcoll
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcpy.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcpy.asm
@@ -17,8 +17,14 @@ strcpy:
    push de
    push hl
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcpy
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcpy
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcpy_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcpy_callee.asm
@@ -14,8 +14,14 @@ strcpy_callee:
    pop hl
    pop de
    push bc
-   
+IF __CLASSIC &&  __CPU_GBZ80__
+   call asm_strcpy
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcpy
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcspn.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcspn.asm
@@ -17,8 +17,15 @@ strcspn:
    push hl
    push de
    push bc
-   
+
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strcspn
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strcspn
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strcspn_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strcspn_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strcspn
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strcspn
 ENDIF
    
-   jp asm_strcspn
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strdup.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strdup.asm
@@ -10,8 +10,23 @@ EXTERN asm_strdup
 
 defc strdup = asm_strdup
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strdup
+
+_strdup:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call strdup
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
+
+
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strdup
 defc _strdup = strdup
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strerror.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strerror.asm
@@ -10,8 +10,22 @@ EXTERN asm_strerror
 
 defc strerror = asm_strerror
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strerror
+
+_strerror:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strerror
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
+
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strerror
 defc _strerror = strerror
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strlcat.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strlcat.asm
@@ -22,6 +22,10 @@ IF __CPU_GBZ80__
    ld a,(hl+)
    ld h,(hl)
    ld l,a
+   call asm_strlcat
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop af
    pop bc
@@ -32,9 +36,9 @@ ELSE
    push de
    push bc
    push af
+   jp asm_strlcat
 ENDIF
    
-   jp asm_strlcat
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strlcat_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strlcat_callee.asm
@@ -10,19 +10,10 @@ EXTERN asm_strlcat
 
 strlcat_callee:
 
-IF __CPU_GBZ80__
-   pop af
-   pop bc
-   pop de
-   pop hl
-   push af
-ELSE
    pop hl
    pop bc
    pop de
    ex (sp),hl
-ENDIF
-   
    jp asm_strlcat
 
 ; SDCC bridge for Classic

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strlcpy.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strlcpy.asm
@@ -26,9 +26,11 @@ IF __CPU_GBZ80__
    ld a,h
    ld h,d
    ld d,a
+   call asm_strlcpy
+   ld d,h
+   ld e,l
+   ret
 ELSE
-
-
    pop af
    pop bc
    pop hl
@@ -38,9 +40,9 @@ ELSE
    push hl
    push bc
    push af
+   jp asm_strlcpy
 ENDIF
    
-   jp asm_strlcpy
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strlen.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strlen.asm
@@ -10,8 +10,22 @@ EXTERN asm_strlen
 
 defc strlen = asm_strlen
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strlen
+
+_strlen:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strlen
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
+
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strlen
 defc _strlen = strlen
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strlwr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strlwr.asm
@@ -9,9 +9,22 @@ PUBLIC strlwr
 EXTERN asm_strlwr
 
 defc strlwr = asm_strlwr
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strlwr
+
+_strlwr:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strlwr
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strlwr
 defc _strlwr = strlwr
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strncasecmp.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strncasecmp.asm
@@ -26,6 +26,10 @@ IF __CPU_GBZ80__
    ld a,d
    ld d,h
    ld h,a
+   call  asm_strncasecmp
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop af
    pop bc
@@ -36,19 +40,19 @@ ELSE
    push hl
    push bc
    push af
-ENDIF
 
-IF __CLASSIC
-IF !__CPU_INTEL__ && !__CPU_GBZ80__
+ IF __CLASSIC
+  IF !__CPU_INTEL__ 
    push ix   
-ENDIF
+  ENDIF
    call  asm_strncasecmp
-IF !__CPU_INTEL__ && !__CPU_GBZ80__
+  IF !__CPU_INTEL__ 
    pop  ix
-ENDIF
+  ENDIF
    ret
-ELSE
+ ELSE
    jp asm_strncasecmp
+ ENDIF
 ENDIF
 
 ; SDCC bridge for Classic

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strncat.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strncat.asm
@@ -26,6 +26,10 @@ IF __CPU_GBZ80__
    ld a,d
    ld d,h
    ld h,a
+   call asm_strncat
+   ld d,h
+   ld e,l
+   ret
 ELSE
 
    pop af
@@ -37,9 +41,9 @@ ELSE
    push hl
    push bc
    push af
+   jp asm_strncat
 ENDIF
    
-   jp asm_strncat
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strnchr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strnchr.asm
@@ -22,6 +22,10 @@ IF __CPU_GBZ80__
    ld a,(hl+)
    ld h,(hl)
    ld l,a
+   call asm_strnchr
+   ld d,h
+   ld e,l
+   ret
 ELSE
 
    pop af
@@ -33,9 +37,9 @@ ELSE
    push bc
    push de
    push af
+   jp asm_strnchr
 ENDIF
    
-   jp asm_strnchr
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strnchr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strnchr_callee.asm
@@ -9,20 +9,11 @@ PUBLIC strnchr_callee
 EXTERN asm_strnchr
 
 strnchr_callee:
-
-IF __CPU_GBZ80__
    pop af
    pop de
    pop bc
    pop hl
    push af
-ELSE
-   pop hl
-   pop de
-   pop bc
-   ex (sp),hl
-ENDIF
-   
    jp asm_strnchr
 
 ; SDCC bridge for Classic

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strncmp.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strncmp.asm
@@ -11,21 +11,25 @@ EXTERN asm_strncmp
 strncmp:
 IF __CPU_GBZ80__
    ld hl,sp+2
-   ld c,(hl)
+   ld c,(hl)	;n
    inc hl
    ld b,(hl)
    inc hl
-   ld e,(hl)
+   ld e,(hl)	;s2
    inc hl
    ld d,(hl)
    inc hl
-   ld a,(hl+)
+   ld a,(hl+)	;s1
    ld h,(hl)
    ld l,e
    ld e,a
    ld a,d
    ld d,h
    ld h,a
+   call asm_strncmp
+   ld d,h
+   ld e,l
+   ret
 ELSE
 
    pop af
@@ -37,9 +41,9 @@ ELSE
    push hl
    push bc
    push af
+   jp asm_strncmp
 ENDIF
    
-   jp asm_strncmp
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strncpy.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strncpy.asm
@@ -26,6 +26,10 @@ IF __CPU_GBZ80__
    ld a,d
    ld d,h
    ld h,a
+   call asm_strncpy
+   ld d,h
+   ld e,l
+   ret
 ELSE
 
    pop af
@@ -37,9 +41,9 @@ ELSE
    push hl
    push bc
    push af
+   jp asm_strncpy
 ENDIF
    
-   jp asm_strncpy
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strndup.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strndup.asm
@@ -17,8 +17,14 @@ strndup:
    push hl
    push bc
    push de
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strndup
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strndup
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strndup_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strndup_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop bc
    pop hl
    push de
+   call asm_strndup
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop bc
    ex (sp),hl
+   jp asm_strndup
 ENDIF
    
-   jp asm_strndup
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strnlen.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strnlen.asm
@@ -17,8 +17,14 @@ strnlen:
    push hl
    push bc
    push de
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strnlen
+   ld d,h
+   ld e,l
+   ret
+ELSE   
    jp asm_strnlen
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strnlen_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strnlen_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop bc
    pop hl
    push de
+   call asm_strnlen
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop bc
    ex (sp),hl
+   jp asm_strnlen
 ENDIF
    
-   jp asm_strnlen
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strnset.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strnset.asm
@@ -22,6 +22,10 @@ IF __CPU_GBZ80__
    ld a,(hl+)
    ld h,(hl)
    ld l,a
+   call asm_strnset
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop af
    pop bc
@@ -32,9 +36,9 @@ ELSE
    push de
    push bc
    push af
+   jp asm_strnset
 ENDIF
    
-   jp asm_strnset
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strnset_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strnset_callee.asm
@@ -10,18 +10,10 @@ EXTERN asm_strnset
 
 strnset_callee:
 
-IF __CPU_GBZ80__
-   pop af
-   pop bc
-   pop de
-   pop hl
-   push af
-ELSE
    pop hl
    pop bc
    pop de
    ex (sp),hl
-ENDIF
    
    jp asm_strnset
 

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strpbrk.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strpbrk.asm
@@ -17,8 +17,14 @@ strpbrk:
    push hl
    push de
    push de
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strpbrk
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strpbrk
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strpbrk_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strpbrk_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strpbrk
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strpbrk
 ENDIF
    
-   jp asm_strpbrk
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrchr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrchr.asm
@@ -17,8 +17,14 @@ strrchr:
    push hl
    push bc
    push de
-   
+IF __CLASSIC && __CPU_GBZ80__   
+   call asm_strrchr
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strrchr
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrchr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrchr_callee.asm
@@ -14,13 +14,17 @@ IF __CPU_GBZ80__
    pop bc
    pop hl
    push de
+   call asm_strrchr
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop bc
    ex (sp),hl
+   jp asm_strrchr
 ENDIF
    
-   jp asm_strrchr
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrcspn.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrcspn.asm
@@ -17,8 +17,14 @@ strrcspn:
    push hl
    push de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strrcspn
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strrcspn
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrcspn_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrcspn_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strrcspn
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strrcspn
 ENDIF
    
-   jp asm_strrcspn
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrev.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrev.asm
@@ -10,8 +10,22 @@ EXTERN asm_strrev
 
 defc strrev = asm_strrev
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strrev
+
+_strrev:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strrev
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
+
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strrev
 defc _strrev = strrev
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrspn.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrspn.asm
@@ -17,8 +17,14 @@ strrspn:
    push hl
    push de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__   
+   call asm_strrspn
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strrspn
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrspn_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrspn_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strrspn
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strrspn
 ENDIF
    
-   jp asm_strrspn
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrstr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrstr.asm
@@ -16,8 +16,14 @@ strrstr:
    push hl
    push de
    push bc
-
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strrstr
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strrstr
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrstr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrstr_callee.asm
@@ -14,13 +14,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strrstr
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strrstr
 ENDIF
    
-   jp asm_strrstr
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strrstrip.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strrstrip.asm
@@ -10,8 +10,22 @@ EXTERN asm_strrstrip
 
 defc strrstrip = asm_strrstrip
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strrstrip
+
+_strrstrip:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strrstrip
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
+
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strrstrip
 defc _strrstrip = strrstrip
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strsep.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strsep.asm
@@ -17,8 +17,14 @@ strsep:
    push bc
    push de
    push hl
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strsep
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strsep
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strsep_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strsep_callee.asm
@@ -14,8 +14,14 @@ strsep_callee:
    pop de
    pop bc
    push hl
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strsep
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strsep
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strset.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strset.asm
@@ -17,8 +17,14 @@ strset:
    push hl
    push de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strset
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strset
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strset_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strset_callee.asm
@@ -15,13 +15,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strset
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strset
 ENDIF
    
-   jp asm_strset
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strspn.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strspn.asm
@@ -17,8 +17,13 @@ strspn:
    push hl
    push de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strspn
+   ld d,h
+   ld e,l
+ELSE
    jp asm_strspn
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strspn_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strspn_callee.asm
@@ -14,13 +14,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strspn
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strspn
 ENDIF
    
-   jp asm_strspn
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strstr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strstr.asm
@@ -17,8 +17,14 @@ strstr:
    push de
    push hl
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strstr
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strstr
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strstr_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strstr_callee.asm
@@ -15,7 +15,14 @@ strstr_callee:
    pop de
    push bc
    
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strstr
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strstr
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strstrip.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strstrip.asm
@@ -9,9 +9,22 @@ PUBLIC strstrip
 EXTERN asm_strstrip
 
 defc strstrip = asm_strstrip
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strstrip
+
+_strstrip:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strstrip
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
 
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strstrip
 defc _strstrip = strstrip
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strtok.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strtok.asm
@@ -17,8 +17,14 @@ strtok:
    push hl
    push de
    push bc
-   
+IF __CLASSIC && __CPU_GBZ80__
+   call asm_strtok
+   ld d,h
+   ld e,l
+   ret
+ELSE
    jp asm_strtok
+ENDIF
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strtok_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strtok_callee.asm
@@ -14,13 +14,17 @@ IF __CPU_GBZ80__
    pop de
    pop hl
    push bc
+   call asm_strtok
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop hl
    pop de
    ex (sp),hl
+   jp asm_strtok
 ENDIF
    
-   jp asm_strtok
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strtok_r.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strtok_r.asm
@@ -22,6 +22,10 @@ IF __CPU_GBZ80__
    ld a,(hl+)
    ld h,(hl)
    ld l,a
+   call asm_strtok_r
+   ld d,h
+   ld e,l
+   ret
 ELSE
    pop af
    pop bc
@@ -32,9 +36,9 @@ ELSE
    push de
    push bc
    push af
+   jp asm_strtok_r
 ENDIF
    
-   jp asm_strtok_r
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strtok_r_callee.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strtok_r_callee.asm
@@ -10,18 +10,10 @@ EXTERN asm_strtok_r
 
 strtok_r_callee:
 
-IF __CPU_GBZ80__
-   pop af
-   pop bc
-   pop de
-   pop hl
-   push af
-ELSE
    pop hl
    pop bc
    pop de
    ex (sp),hl
-ENDIF
    
    jp asm_strtok_r
 

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strupr.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strupr.asm
@@ -10,8 +10,22 @@ EXTERN asm_strupr
 
 defc strupr = asm_strupr
 
+IF __CLASSIC && __CPU_GBZ80__
+PUBLIC _strupr
+
+_strupr:
+   ld hl,sp+2
+   ld a,(hl+)
+   ld h,(hl)
+   ld l,a
+   call asm_strupr
+   ld   d,h
+   ld   e,l
+   ret
+ENDIF
+
 ; SDCC bridge for Classic
-IF __CLASSIC
+IF __CLASSIC && !__CPU_GBZ80__
 PUBLIC _strupr
 defc _strupr = strupr
 ENDIF

--- a/libsrc/_DEVELOPMENT/string/c/sccz80/strxfrm.asm
+++ b/libsrc/_DEVELOPMENT/string/c/sccz80/strxfrm.asm
@@ -26,6 +26,10 @@ IF __CPU_GBZ80__
    ld a,d
    ld d,h
    ld h,a
+   call asm_strxfrm
+   ld d,h
+   ld e,l
+   ret
 ELSE
 
    pop af
@@ -37,9 +41,9 @@ ELSE
    push hl
    push bc
    push af
+   jp asm_strxfrm
 ENDIF
    
-   jp asm_strxfrm
 
 ; SDCC bridge for Classic
 IF __CLASSIC

--- a/libsrc/gb.lst
+++ b/libsrc/gb.lst
@@ -1,5 +1,5 @@
-target/gb/**/*.asm
 target/gb/graphics/obj/gbz80/*
+target/gb/**/*.asm
 graphics/__gfx_coords
 graphics/generic_console/plotpixl
 graphics/generic_console/respixl

--- a/libsrc/setjmp/l_longjmp.c
+++ b/libsrc/setjmp/l_longjmp.c
@@ -20,7 +20,7 @@ void l_longjmp(jmp_buf *env, int val)
 	inc	bc	;cant return 0
 .longjmp1
 	pop	hl	;&env
-IF !__CPU_8080__ && !__CPU_GBZ80__
+IF !__CPU_INTEL__ && !__CPU_GBZ80__
 	ld	e,(hl)	;ix
 	inc	hl
 	ld	d,(hl)
@@ -52,6 +52,10 @@ ENDIF
 	push	de	;ret address
 	ld	l,c	;ret value
 	ld	h,b
+IF __CPU_GBZ80__
+    ld  d,h
+    ld  e,l
+ENDIF
 #pragma endasm
 }
 

--- a/libsrc/setjmp/l_longjmp.c
+++ b/libsrc/setjmp/l_longjmp.c
@@ -21,7 +21,7 @@ void l_longjmp(jmp_buf *env, int val)
 .longjmp1
 	pop	hl	;&env
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
-	ld	e,(hl)	;ix
+	ld	e,(hl)	;iy
 	inc	hl
 	ld	d,(hl)
 	inc	hl

--- a/libsrc/setjmp/l_setjmp.c
+++ b/libsrc/setjmp/l_setjmp.c
@@ -16,7 +16,7 @@ int l_setjmp(jmp_buf *env)
 #pragma asm
 	pop	bc	;return address
 	pop	hl	;&env
-IF !__CPU_8080__ && !__CPU_GBZ80__
+IF !__CPU_INTEL__ && !__CPU_GBZ80__
 	push	iy
 	pop	de	;de=iy, hl=&env
 	ld	(hl),e
@@ -33,6 +33,7 @@ ELSE
 	inc	hl
 	inc	hl
 	inc	hl
+	inc	hl
 ENDIF
 	inc	hl
 IF __CPU_GBZ80__
@@ -42,11 +43,12 @@ IF __CPU_GBZ80__
 	ld	a,h
 	ld	h,d
 	ld	d,a
+    ld  hl,sp+0
 ELSE
 	ex	de,hl	;de=&env, hl=scratch
-ENDIF
 	ld	hl,0
 	add	hl,sp	;stack pointer
+ENDIF
 	ex	de,hl	;hl=env+2, de=sp
 	ld	(hl),e	;sp
 	inc	hl
@@ -59,6 +61,10 @@ ENDIF
 	push	bc
 
 	ld	hl,0	;Have to return 0
+IF __CPU_GBZ80__
+    ld  d,h
+    ld  e,l
+ENDIF
 #pragma endasm
 }
 

--- a/libsrc/setjmp/l_setjmp.c
+++ b/libsrc/setjmp/l_setjmp.c
@@ -23,14 +23,12 @@ IF !__CPU_INTEL__ && !__CPU_GBZ80__
 	inc	hl
 	ld	(hl),d
 	inc	hl
-	inc	hl
 	push	ix
 	pop	de	;de=ix, hl=&env
 	ld	(hl),e
 	inc	hl
 	ld	(hl),d
 ELSE
-	inc	hl
 	inc	hl
 	inc	hl
 	inc	hl

--- a/libsrc/stdio/_printf.asm
+++ b/libsrc/stdio/_printf.asm
@@ -32,11 +32,15 @@ ENDIF
 	push	de	;fmt
 	push	hl	;argument
 	call	asm_printf
+IF __CPU_GBZ80__
+	add	sp,10
+ELSE
 	pop	bc
 	pop	bc
 	pop	bc	
 	pop	bc
 	pop	bc
+ENDIF
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
 	pop	ix	;restore ix
 ENDIF

--- a/libsrc/stdio/asm_printf.asm
+++ b/libsrc/stdio/asm_printf.asm
@@ -143,15 +143,15 @@ IF __CPU_INTEL__ | __CPU_GBZ80__
 	dec	hl
 	dec	hl	;-3
 	xor	a
-IF __CPU_GBZ80__
+  IF __CPU_GBZ80__
 	ld	(hl-),a
 	ld	(hl-),a
-ELSE
+  ELSE
 	ld	(hl),a	;upper case switch
 	dec	hl	;-4
 	ld	(hl),a	;flags
 	dec	hl	;-5
-ENDIF
+  ENDIF
 	dec	hl	;-6
 	dec	hl	;-7
 	dec	hl	;-8
@@ -183,6 +183,10 @@ ELSE
 	ld	sp,hl
 ENDIF
 	pop	hl		;grab the number of bytes written
+IF __CPU_GBZ80__
+	ld	d,h
+	ld	e,l
+ENDIF
 __printf_get_flags_noop:	
 	ret
 	

--- a/libsrc/stdio/conio/cvpeek.asm
+++ b/libsrc/stdio/conio/cvpeek.asm
@@ -20,40 +20,57 @@
 
 cvpeekr:
 _cvpeekr:
-	ld	a,1
-	jr	do_peek
+    ld      a,1
+    jr      do_peek
 
 cvpeek:
 _cvpeek:
-	xor	a		;Not in raw mode
+    xor     a		;Not in raw mode
 
 
 do_peek:
-	pop	hl	
-	pop	bc		;c=y
-	pop	de		;e=x
-	push	de
-	push	bc
-	push	hl
+    pop     hl	
+    pop     bc		;c=y
+    pop     de		;e=x
+    push    de
+    push    bc
+    push    hl
 
-	ld	b,e		;b = x
-	ld	e,a		;e = raw mode
+    ld      b,e		;b = x
+    ld      e,a		;e = raw mode
 
-	ld	hl,-1		;invalid charactet
-	ld	a,(__console_h)
-	cp	c
-	ret	c
-	ld	a,(__console_w)
-	cp	b
-	ret	c
-	ld	a,b		;a = x
-	ld	b,c		;b = y
-	ld	c,a		;c = x
+    ld      hl,-1		;invalid character
+    ld      a,(__console_h)
+    cp      c
+IF __CPU_GBZ80__
+    jr      c,do_peek_ret
+ELSE
+    ret     c
+ENDIF
+	ld      a,(__console_w)
+	cp      b
+IF __CPU_GBZ80__
+    jr      c,do_peek_ret
+ELSE
+    ret     c
+ENDIF
+	ld      a,b		;a = x
+	ld      b,c		;b = y
+	ld      c,a		;c = x
 
 	; b = y, c = x
-	call	generic_console_vpeek
-	ld	hl,-1
-	ret	c
-	ld	l,a
-	ld	h,0
+	call    generic_console_vpeek
+	ld      hl,-1
+IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+ENDIF
+	ret     c
+	ld      l,a
+	ld      h,0
+IF __CPU_GBZ80__
+do_peek_ret:
+    ld      d,h
+    ld      e,l
+ENDIF
 	ret

--- a/libsrc/stdio/conio/wherex.asm
+++ b/libsrc/stdio/conio/wherex.asm
@@ -10,7 +10,11 @@ EXTERN __console_x
 .wherex
 ._wherex
 
-	ld	a,(__console_x)
-	ld	l,a
-	ld	h,0
-	ret
+    ld      a,(__console_x)
+    ld      l,a
+    ld      h,0
+IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+ENDIF
+    ret

--- a/libsrc/stdio/conio/wherey.asm
+++ b/libsrc/stdio/conio/wherey.asm
@@ -10,7 +10,11 @@ EXTERN __console_y
 .wherey
 ._wherey
 
-	ld	a,(__console_y)
-	ld	l,a
-	ld	h,0
-	ret
+    ld      a,(__console_y)
+    ld      l,a
+    ld      h,0
+IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+ENDIF
+    ret

--- a/libsrc/stdio/fchkstd.c
+++ b/libsrc/stdio/fchkstd.c
@@ -29,7 +29,7 @@ IF __CPU_R2K__ | __CPU_R3K__
 	ex	de,hl
 ELIF __CPU_GBZ80__
 	ld	hl,sp+2
-	ld	d,(hl)
+	ld	e,(hl)
 	inc	hl
 	ld	d,(hl)
 ELSE

--- a/libsrc/stdio/fclose.c
+++ b/libsrc/stdio/fclose.c
@@ -78,7 +78,11 @@ fclose_check_success:
 	pop	de	;flags pointer
 	ld	a,h	; an error
 	or	l
+IF __CPU_GBZ80__
+	jr	nz,fclose_assign_ret
+ELSE
 	ret	nz
+ENDIF
 	ex	de,hl
 fclose_success:
 	ld	de,0
@@ -88,5 +92,10 @@ fclose_success:
 	dec	hl
 	ld	(hl),e
 	ex	de,hl
+IF __CPU_GBZ80__
+fclose_assign_ret:
+	ld	d,h
+	ld	e,l
+ENDIF
 #endasm
 }

--- a/libsrc/stdio/feof.c
+++ b/libsrc/stdio/feof.c
@@ -29,8 +29,17 @@ IF __CPU_INTEL__
 ELSE
 	bit	3,a	;_IOEOF
 ENDIF
+IF __CPU_GBZ80__
+	jr	nz,feof_assign_ret
+ELSE
 	ret	nz
+ENDIF
 	dec	hl	;hl = 0
+IF __CPU_GBZ80__
+feof_assign_ret:
+	ld	d,h
+	ld	e,l
+ENDIF
 	ret
 #endasm
 //	return (fp->flags&_IOEOF ? 1 : 0 );

--- a/libsrc/stdio/fflush.c
+++ b/libsrc/stdio/fflush.c
@@ -54,11 +54,19 @@ IF __CPU_R2K__ | __CPU_R3K__
 	rr	hl
 ELSE
 	ld	hl,0
+  IF __CPU_GBZ80__
+        ld      d,h
+        ld      e,l
+  ENDIF
 ENDIF
 	ret
 ENDIF
 .fflush_error
 	ld	hl,-1	; EOF
+IF __CPU_GBZ80__
+        ld      d,h
+        ld      e,l
+ENDIF
 #endasm
 }
 

--- a/libsrc/stdio/fgetc.c
+++ b/libsrc/stdio/fgetc.c
@@ -28,216 +28,239 @@ int fgetc(FILE *fp)
 {
 #asm
 IF __CPU_INTEL__ || __CPU_GBZ80__
-	pop	bc
-	pop	de	;fp
-	push	de
-	push	bc
-	ld	hl,-1	;EOF
-	inc	de	
-	inc	de
-	ld	a,(de)	;de = &fp_flags get flags
-	and	a
-	ret	z
-	and	_IOWRITE | _IOEOF	;check we`re not write/EOF
-	ret	nz
-	inc	de	;de=&fp_ungetc
-	ld	a,(de)	;check for ungot char
-	and	a
-	jr	z,no_ungetc
-	ex	de,hl
-	ld	e,a
-	ld	d,0
-	ld	(hl),d	;set no ungetc character
-	ex	de,hl
-	ret
+    pop     bc
+    pop     de  ;fp
+    push    de
+    push    bc
+    ld      hl,-1	;EOF
+    inc     de	
+    inc     de
+    ld      a,(de)	;de = &fp_flags get flags
+    and     a
+    ret     z
+    and     _IOWRITE | _IOEOF	;check we`re not write/EOF
+  IF __CPU_GBZ80__
+    jr      nz,fgetc_assign_ret
+  ELSE
+    ret     nz
+  ENDIF
+    inc     de      ;de=&fp_ungetc
+    ld      a,(de)	;check for ungot char
+    and     a
+    jr      z,no_ungetc
+    ex      de,hl
+    ld      e,a
+    ld      d,0
+    ld      (hl),d	;set no ungetc character
+    ex      de,hl
+  IF __CPU_GBZ80__
+fgetc_assign_ret:
+    ld      d,h
+    ld      e,l
+  ENDIF
+    ret
 .no_ungetc
 ; Now do strings
-	dec	de	;de=&fp_flags
-	ld	a,(de)
-	and	_IOSTRING
-	jr	z,no_string	;not a string
-	ex	de,hl
-	dec	hl		;fp_desc+1
-	ld	d,(hl)
-	dec	hl		;fp_desc
-	ld	e,(hl)
-	ld	a,(de)
-	inc	de
-	ld	(hl),e		
-	inc	hl		;fp_desc+1
-	ld	(hl),d
-	ex	de,hl
-	ld	hl,-1	;EOF
-	and	a	;test for zero
-	ret	z	;return EOF if so
-	ld	l,a	;else return character
-	ld	h,0
-	ret
+    dec     de	;de=&fp_flags
+    ld      a,(de)
+    and     _IOSTRING
+    jr      z,no_string	;not a string
+    ex      de,hl
+    dec     hl		;fp_desc+1
+    ld      d,(hl)
+    dec     hl		;fp_desc
+    ld      e,(hl)
+    ld      a,(de)
+    inc     de
+    ld      (hl),e		
+    inc     hl		;fp_desc+1
+    ld      (hl),d
+    ex      de,hl
+    ld      hl,-1	;EOF
+    and     a	;test for zero
+  IF __CPU_GBZ80__
+    jr      z,fgetc_assign_ret
+  ENDIF
+    ret     z	;return EOF if so
+    ld      l,a	;else return character
+    ld      h,0
+  IF __CPU_GBZ80__
+    jr      fgetc_assign_ret
+  ELSE
+    ret
+  ENDIF
 .no_string
-	dec	de	;fp_desc+1
-	dec	de	;fp_desc
-	push	de	;preserve fp
-	call	fchkstd	;check for stdin (stdout/err have failed already)
-	pop	de	;ix back
-	jr	c,no_stdin
-	call	fgetc_cons	;get from console
-	ret			;always succeeds - never EOF
+    dec     de	;fp_desc+1
+    dec     de	;fp_desc
+    push    de	;preserve fp
+    call    fchkstd	;check for stdin (stdout/err have failed already)
+    pop     de	;ix back
+    jr      c,no_stdin
+    call    fgetc_cons	;get from console
+    ret			;always succeeds - never EOF
 .no_stdin
-	ex	de,hl
-	ld	e,(hl)
-	inc	hl		;fp_desc+1
-	ld	d,(hl)
-	dec	hl		;fp_desc
-	ex	de,hl
-	push	de
-	call	readbyte	;readbyte sorts out stack (fastcall)
-	pop	de		;get fp back
-	ret	nc		;no error so return (make sure other
-				;implementations respect this!)
+    ex      de,hl
+    ld      e,(hl)
+    inc     hl		;fp_desc+1
+    ld      d,(hl)
+    dec     hl		;fp_desc
+    ex      de,hl
+    push    de
+    call    readbyte	;readbyte sorts out stack (fastcall)
+    pop     de		;get fp back
+  IF __GBZ80__
+    jr      nc,fgetc_assign_ret
+  ELSE
+    ret	nc		;no error so return (make sure other
+    			;implementations respect this!)
+  ENDIF
 .seteof
-	inc	de	
-	inc	de		;fp_flags
-	ld	a,(de)
-	or	_IOEOF
-	ld	(de),a	;set EOF, return with EOF
+    inc     de	
+    inc     de		;fp_flags
+    ld      a,(de)
+    or      _IOEOF
+    ld      (de),a	;set EOF, return with EOF
+  IF __CPU_GBZ80__
+    jr      fgetc_assign_ret
+  ENDIF
 ELSE
 
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	hl,(sp + 2)
-	push	ix		;save callers ix
-	ld	ix,hl
-ELSE
-	pop	bc
-	pop	hl	; fp
-	push	hl
-	push	bc
-	push	ix	; callers ix
-	push	hl
-	pop	ix
-ENDIF
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      hl,(sp + 2)
+    push    ix		;save callers ix
+    ld      ix,hl
+  ELSE
+    pop     bc
+    pop     hl	; fp
+    push    hl
+    push    bc
+    push    ix	; callers ix
+    push    hl
+    pop     ix
+  ENDIF
 
-	ld	a,(ix+fp_flags)	;get flags
-	and	a
-	jp	z, is_eof
-	and	_IOWRITE | _IOEOF	;check we`re not write/EOF
-	jp	nz, is_eof
-	ld	a,(ix+fp_ungetc)	;check for ungot char
-	and	a
-	jr	z,no_ungetc
-	ld	l,a
-	ld	h,0
-	ld	(ix+fp_ungetc),h
-	jp	fgetc_end
+    ld      a,(ix+fp_flags)	;get flags
+    and     a
+    jp      z, is_eof
+    and     _IOWRITE | _IOEOF	;check we`re not write/EOF
+    jp      nz, is_eof
+    ld      a,(ix+fp_ungetc)	;check for ungot char
+    and     a
+    jr      z,no_ungetc
+    ld      l,a
+    ld      h,0
+    ld      (ix+fp_ungetc),h
+    jp      fgetc_end
 .no_ungetc
 ; Now do strings
-	ld	a,(ix+fp_flags)
-	and	_IOSTRING
-	jr	z,no_string	;not a string
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	hl,(ix+fp_extra)	; check the length
-ELSE
-	ld	l,(ix+fp_extra)	; check the length
-	ld	h,(ix+fp_extra+1)
-ENDIF
-	ld	a,h
-	or	l
-	jp	z,is_eof
-	dec	hl
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	(ix+fp_extra),hl
-ELSE
-	ld	(ix+fp_extra),l
-	ld	(ix+fp_extra+1),h
-ENDIF
+    ld      a,(ix+fp_flags)
+    and	_IOSTRING
+    jr      z,no_string	;not a string
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      hl,(ix+fp_extra)	; check the length
+  ELSE
+    ld      l,(ix+fp_extra)	; check the length
+    ld      h,(ix+fp_extra+1)
+  ENDIF
+    ld      a,h
+    or      l
+    jp      z,is_eof
+    dec     hl
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      (ix+fp_extra),hl
+  ELSE
+    ld      (ix+fp_extra),l
+    ld      (ix+fp_extra+1),h
+  ENDIF
 
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	hl,(ix+fp_desc)
-ELSE
-	ld	l,(ix+fp_desc)
-	ld	h,(ix+fp_desc+1)
-ENDIF
-	ld	a,(hl)
-	inc	hl
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	(ix+fp_desc),hl
-ELSE
-	ld	(ix+fp_desc),l
-	ld	(ix+fp_desc+1),h
-ENDIF
-	and	a		;test for zero
-	jr	z,is_eof	;return EOF if so
-	ld	l,a		;else return character
-	ld	h,0
-	jr	fgetc_end
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      hl,(ix+fp_desc)
+  ELSE
+    ld      l,(ix+fp_desc)
+    ld      h,(ix+fp_desc+1)
+  ENDIF
+    ld      a,(hl)
+    inc     hl
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      (ix+fp_desc),hl
+  ELSE
+    ld      (ix+fp_desc),l
+    ld      (ix+fp_desc+1),h
+  ENDIF
+    and     a		;test for zero
+    jr      z,is_eof	;return EOF if so
+    ld      l,a		;else return character
+    ld      h,0
+    jr      fgetc_end
 .no_string
-	ld	a,(ix+fp_flags)
-	and	_IOEXTRA
-	jr	z,not_extra_fp
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	hl,(ix + fp_extra)
-ELSE
-	ld	l,(ix+fp_extra)
-	ld	h,(ix+fp_extra+1)
-ENDIF
-	ld	a,__STDIO_MSG_GETC
-	call	l_jphl
-	jr	nc, fgetc_end
-	jr	seteof		;EOF reached (sock closed?)
+    ld      a,(ix+fp_flags)
+    and     _IOEXTRA
+    jr      z,not_extra_fp
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      hl,(ix + fp_extra)
+  ELSE
+    ld      l,(ix+fp_extra)
+    ld      h,(ix+fp_extra+1)
+  ENDIF
+    ld      a,__STDIO_MSG_GETC
+    call	l_jphl
+    jr      nc, fgetc_end
+    jr      seteof		;EOF reached (sock closed?)
 .not_extra_fp
-	push	ix		;preserve fp
-	call	fchkstd		;check for stdin (stdout/err have failed already)
-	pop	ix		;ix back
-	jr	c,no_stdin
-	call	fgetc_cons	;get from console
+    push    ix		;preserve fp
+    call	fchkstd		;check for stdin (stdout/err have failed already)
+    pop     ix		;ix back
+    jr      c,no_stdin
+    call	fgetc_cons	;get from console
 #ifdef __STDIO_EOFMARKER
-	ld	a,l
-	cp	__STDIO_EOFMARKER
-	jr	z,is_eof
+    ld      a,l
+    cp	__STDIO_EOFMARKER
+    jr      z,is_eof
 #endif
-	push	hl
-	call	fputc_cons
-	pop	hl
-	jr	fgetc_end	; always succeeds - never EOF when EOF has not been defined.
+    push    hl
+    call	fputc_cons
+    pop     hl
+    jr      fgetc_end	; always succeeds - never EOF when EOF has not been defined.
 .no_stdin
-IF __CPU_R2K__ | __CPU_R3K__
-	ld	hl,(ix+fp_desc)
-ELSE
-	ld	l,(ix+fp_desc)
-	ld	h,(ix+fp_desc+1)
-ENDIF
-	push	ix
-	call	readbyte	; readbyte sorts out stack (fastcall)
-				; hl = byte read
-				; c = EOF
-				; nc = good
-	pop	ix		; get fp back
+  IF __CPU_R2K__ | __CPU_R3K__
+    ld      hl,(ix+fp_desc)
+  ELSE
+    ld      l,(ix+fp_desc)
+    ld      h,(ix+fp_desc+1)
+  ENDIF
+    push    ix
+    call	readbyte	; readbyte sorts out stack (fastcall)
+    			; hl = byte read
+    			; c = EOF
+    			; nc = good
+    pop     ix		; get fp back
 #ifdef __STDIO_BINARY
-	ld	a,_IOTEXT	;check for text mode
-	and	(ix+fp_flags)
-	jr	z,not_text_fp
-	ld	a,l
+    ld      a,_IOTEXT	;check for text mode
+    and     (ix+fp_flags)
+    jr      z,not_text_fp
+    ld      a,l
 #ifdef __STDIO_EOFMARKER
-	cp	__STDIO_EOFMARKER	;compare with the EOF marker
-	jr	z,is_eof
+    cp	__STDIO_EOFMARKER	;compare with the EOF marker
+    jr      z,is_eof
 #endif
 #ifdef __STDIO_CRLF
-	cp	13
-	jr	z,no_stdin		; Read again
+    cp      13
+    jr      z,no_stdin		; Read again
 #endif
 .not_text_fp
 #endif
-	; Check for value of -1
-	ld	a,h
-	inc	a
-	jr	nz,fgetc_end
+    ; Check for value of -1
+    ld      a,h
+    inc     a
+    jr      nz,fgetc_end
 .is_eof
-	ld	hl,-1		;signify EOF
+    ld      hl,-1		;signify EOF
 .seteof
-	ld	a,(ix+fp_flags)
-	or	_IOEOF
-	ld	(ix+fp_flags),a	;set EOF, return with EOF
+    ld      a,(ix+fp_flags)
+    or      _IOEOF
+    ld      (ix+fp_flags),a	;set EOF, return with EOF
 .fgetc_end
-	pop	 ix
+    pop      ix
 ENDIF
 #endasm
 }

--- a/libsrc/stdio/fputc.asm
+++ b/libsrc/stdio/fputc.asm
@@ -8,23 +8,23 @@ EXTERN asm_fputc_callee
 
 .fputc
 ._fputc
-        pop     de      ;return address
-        pop     hl      ;fp
-        pop     bc      ;c
-        push    bc
-        push    hl
-        push    de
+    pop     de      ;return address
+    pop     hl      ;fp
+    pop     bc      ;c
+    push    bc
+    push    hl
+    push    de
 
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
-        push    ix        ;callers ix
-        push    hl
-        pop     ix
+    push    ix        ;callers ix
+    push    hl
+    pop     ix
    	call    asm_fputc_callee 
-        pop     ix
+    pop     ix
 ELSE
 	call	asm_fputc_callee
 ENDIF
-        ret
+    ret
    
 
 

--- a/libsrc/stdio/fputc_callee.c
+++ b/libsrc/stdio/fputc_callee.c
@@ -27,28 +27,35 @@ static void wrapper_fputc_callee() __naked
 fputc_callee:
 _fputc_callee:
 
-	pop	de
-	pop	hl	;fp
-	pop	bc	;c
-	push 	de
+    pop     de
+    pop     hl	;fp
+    pop     bc	;c
+    push 	de
 
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
-        push	ix
-
+    push    ix
   IF __CPU_R2K__ | __CPU_R3K__
-	ld	ix,hl
+    ld      ix,hl
   ELSE
-	push	hl
-	pop	ix
+	push    hl
+	pop     ix
   ENDIF
 ENDIF
-	call	asm_fputc_callee
-
-IF !__CPU_INTEL__ && !__CPU_GBZ80__
-	pop	ix	
+    call    asm_fputc_callee
+IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+ELIF !__CPU_INTEL__ 
+    pop     ix
 ENDIF
-	ret
+    ret
+#endasm
+}
 
+
+static void wrapper_fputc_callee_z80() __naked
+{
+#asm
 	PUBLIC	asm_fputc_callee
 
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
@@ -161,55 +168,55 @@ IF __CPU_INTEL__ | __CPU_GBZ80__
 ; 		bc = character to print
 ; Exit:		hl = byte written
 asm_fputc_callee:
-	ex	de,hl
-        ld      hl,-1   ;EOF
-        inc     de
-        inc     de      ;fp_flags
-        ld      a,(de)
-        and     a       ;no thing
-        ret     z
-        and     _IOREAD
-        ret     nz      ;don`t want reading streams
-        ld      a,(de)
-        and     _IOSTRING
-        jr      z,no_string
-        ex      de,hl
-        dec     hl      ;fp_desc+1
-        ld      d,(hl)
-        dec     hl      ;&fp_desc
-        ld      e,(hl)
-        ld      a,c     ;store character
-        ld      (de),a
-        inc     de      ;inc pointer and store
-        ld      (hl),e
-        inc     hl      ;fp_desc+1
-        ld      (hl),d
-        ld      l,c     ;load char to return
-        ld      h,0
-        ret
+    ex      de,hl
+    ld      hl,-1   ;EOF
+    inc     de
+    inc     de      ;fp_flags
+    ld      a,(de)
+    and     a       ;no thing
+    ret     z
+    and     _IOREAD
+    ret     nz      ;don`t want reading streams
+    ld      a,(de)
+    and     _IOSTRING
+    jr      z,no_string
+    ex      de,hl
+    dec     hl      ;fp_desc+1
+    ld      d,(hl)
+    dec     hl      ;&fp_desc
+    ld      e,(hl)
+    ld      a,c     ;store character
+    ld      (de),a
+    inc     de      ;inc pointer and store
+    ld      (hl),e
+    inc     hl      ;fp_desc+1
+    ld      (hl),d
+    ld      l,c     ;load char to return
+    ld      h,0
+    ret
 .no_string
-        dec     de
-        dec     de      ;fp_desc
-        push    de
-        call    fchkstd ;preserves bc
-        pop     de
-        jr      c,no_cons
+    dec     de
+    dec     de      ;fp_desc
+    push    de
+    call    fchkstd ;preserves bc
+    pop     de
+    jr      c,no_cons
 ; Output to console
-        push    bc
-        call    fputc_cons
-        pop     hl
-        ret
+    push    bc
+    call    fputc_cons
+    pop     hl
+    ret
 .no_cons
 ; Output to file
-        ex      de,hl
-        ld      e,(hl)  ;fp_desc
-        inc     hl
-        ld      d,(hl)
-        push    de      ;fd
-        push    bc      ;c
-        call    writebyte
-        pop     bc      ;discard values
-        pop     bc
+    ex      de,hl
+    ld      e,(hl)  ;fp_desc
+    inc     hl
+    ld      d,(hl)
+    push    de      ;fd
+    push    bc      ;c
+    call    writebyte
+    pop     bc      ;discard values
+    pop     bc
 	ret
 ENDIF
 #endasm

--- a/libsrc/stdio/fputs.asm
+++ b/libsrc/stdio/fputs.asm
@@ -3,9 +3,11 @@
 MODULE fputs
 SECTION code_clib
 PUBLIC fputs
+PUBLIC _fputs
 EXTERN asm_fputs_callee
 
 .fputs
+._fputs
     pop     hl	;ret
     pop     bc	;fp
     pop     de	;s

--- a/libsrc/stdio/fputs.asm
+++ b/libsrc/stdio/fputs.asm
@@ -6,21 +6,24 @@ PUBLIC fputs
 EXTERN asm_fputs_callee
 
 .fputs
-
-	pop	hl	;ret
-	pop	bc	;fp
-	pop	de	;s
-	push	de
-	push	bc
-	push	hl
+    pop     hl	;ret
+    pop     bc	;fp
+    pop     de	;s
+    push    de
+    push    bc
+    push    hl
 IF __CPU_INTEL__ | __CPU_GBZ80__
-	call	asm_fputs_callee
+    call    asm_fputs_callee
+  IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+  ENDIF
 ELSE
-        push    ix  ; callers ix
-        push    bc
-        pop     ix
-   	call	asm_fputs_callee
-	pop	ix	
+    push    ix  ; callers ix
+    push    bc
+    pop     ix
+    call    asm_fputs_callee
+    pop     ix
 ENDIF
-	ret
+    ret
 

--- a/libsrc/stdio/fputs_callee.c
+++ b/libsrc/stdio/fputs_callee.c
@@ -31,7 +31,10 @@ IF !__CPU_INTEL__ && !__CPU_GBZ80__
 	pop	ix
 ENDIF
 	call	asm_fputs_callee
-IF !__CPU_INTEL__ && !__CPU_GBZ80__
+IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+ELIF !__CPU_INTEL__
 	pop	ix
 ENDIF
 	ret

--- a/libsrc/stdio/fputs_callee.c
+++ b/libsrc/stdio/fputs_callee.c
@@ -55,7 +55,7 @@ ENDIF
 	ret	z	;end of string
 	inc	de	;s++
 	push	de	;keep s
-IF __CPU_INTEL__
+IF __CPU_INTEL__ || __CPU_GBZ80__
 	push	bc
 	ld	l,c
 	ld	h,b
@@ -69,7 +69,7 @@ ENDIF
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
         pop	ix
 ENDIF
-IF __CPU_INTEL__
+IF __CPU_INTEL__ || __CPU_GBZ80__
 	pop	bc
 ENDIF
 	pop	de	;get s back

--- a/libsrc/stdio/fread.c
+++ b/libsrc/stdio/fread.c
@@ -12,7 +12,9 @@ static int wrapper() __naked
 fread:
 _fread:
 IF __CPU_INTEL__ | __CPU_GBZ80__
-	ld	hl,-1
+	ld      hl,-1
+    ld      d,h
+    ld      e,l
 	ret
 ELSE
 	push	ix	;save callers

--- a/libsrc/stdio/kbhit.asm
+++ b/libsrc/stdio/kbhit.asm
@@ -15,19 +15,22 @@
 kbhit:
 _kbhit:
 IF __CPU_GBZ80__
-	ld	hl,kbhit_key
-	ld	a,(hl+)
-	ld	h,(hl)
-	ld	l,a
-	or	h
-	ret	nz
-	call	getk
-	ld	de,kbhit_key
-	ld	a,l
-	ld	(de),a
-	inc	de
-	ld	a,h
-	ld	(de),a
+    ld      hl,kbhit_key
+    ld      a,(hl+)
+    ld      h,(hl)
+    ld      l,a
+    or      h
+    ret     nz
+    call    getk
+    ld      de,kbhit_key
+    ld      a,l
+    ld      (de),a
+    inc     de
+    ld      a,h
+    ld      (de),a
+    ld      d,h
+    ld      e,l
+    ret
 ELSE
 	ld	hl,(kbhit_key)	; check if we've got a keypress pending
 	ld	a,h

--- a/libsrc/stdio/ungetc.c
+++ b/libsrc/stdio/ungetc.c
@@ -41,6 +41,10 @@ int ungetc(int c, FILE *fp)
 	ld	(hl),c	;store the char
 	ld	l,c			;return it
 	ld	h,0
+IF __CPU_GBZ80__
+    ld      d,h
+    ld      e,l
+ENDIF
 #endasm
 #else
         if (fp == 0 || c == EOF || fp->ungetc || fp->flags&_IOWRITE ) return(EOF);

--- a/libsrc/target/gb/stdio/fgetc_cons.asm
+++ b/libsrc/target/gb/stdio/fgetc_cons.asm
@@ -21,6 +21,7 @@ _fgetc_cons:
 getchar_1:
         CALL    asm_getchar
         LD      E,A
+        ld      d,0
         ld      l,a
-        ld      h,0
+        ld      h,d
         RET

--- a/libsrc/target/gb/stdio/vpeek_MODE1.asm
+++ b/libsrc/target/gb/stdio/vpeek_MODE1.asm
@@ -50,7 +50,6 @@ vpeek_read_screen:
 
         ;hl = screen location
         pop     de
-        push    de
 
         ld      b,8
 wait_1:
@@ -63,7 +62,6 @@ wait_1:
         ld      (de),a
         inc     de
         djnz    wait_1
-        pop     hl
         ret
 
         

--- a/libsrc/z80_crt0s/crt0_gbz80.lst
+++ b/libsrc/z80_crt0s/crt0_gbz80.lst
@@ -99,4 +99,4 @@ z80/sccz80/l_push_di
 z80/sccz80/l_pop_ei
 z80/sccz80/l_graphics_cmp
 @newlib-gbz80.lst
-
+@sdcc-gbz80.lst

--- a/libsrc/z80_crt0s/crt0_gbz80.lst
+++ b/libsrc/z80_crt0s/crt0_gbz80.lst
@@ -42,7 +42,6 @@ z80/sccz80/l_gint
 z80/sccz80/l_gint7de
 z80/sccz80/l_gintsp
 z80/sccz80/l_gintspchar
-z80/sccz80/l_gintspsp
 z80/sccz80/l_gint_eq
 z80/sccz80/l_ghtonsint
 z80/sccz80/l_gt

--- a/libsrc/z80_crt0s/gbz80/sdcc/COPYING
+++ b/libsrc/z80_crt0s/gbz80/sdcc/COPYING
@@ -1,0 +1,26 @@
+;--------------------------------------------------------------------------
+;
+;  Copyright (C) 2000, Michael Hope
+;
+;  This library is free software; you can redistribute it and/or modify it
+;  under the terms of the GNU General Public License as published by the
+;  Free Software Foundation; either version 2, or (at your option) any
+;  later version.
+;
+;  This library is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;  GNU General Public License for more details.
+;
+;  You should have received a copy of the GNU General Public License
+;  along with this library; see the file COPYING. If not, write to the
+;  Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;  As a special exception, if you link this library with other files,
+;  some of which are compiled with SDCC, to produce an executable,
+;  this library does not by itself cause the resulting executable to
+;  be covered by the GNU General Public License. This exception does
+;  not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;--------------------------------------------------------------------------

--- a/libsrc/z80_crt0s/gbz80/sdcc/__divschar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__divschar.asm
@@ -1,0 +1,23 @@
+
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __divschar
+
+        GLOBAL  l_div8
+
+__divschar:
+        ld      hl,sp+3
+
+        ld      e,(hl)
+        dec     hl
+        ld      l,(hl)
+
+        ld      c,l
+
+        call    l_div8
+
+        ld      e,c
+        ld      d,b
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__divsint.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__divsint.asm
@@ -1,0 +1,29 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __divsint
+
+        GLOBAL  l_div16
+
+__divsint:
+        ld      hl,sp+5
+
+        ld      d,(hl)
+        dec     hl
+        ld      e,(hl)
+        dec     hl
+        ld      a,(hl)
+        dec     hl
+        ld      l,(hl)
+        ld      h,a
+
+        ld      b,h
+        ld      c,l
+
+        call    l_div16
+
+        ld      e,c
+        ld      d,b
+
+        ret
+

--- a/libsrc/z80_crt0s/gbz80/sdcc/__divsuchar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__divsuchar.asm
@@ -1,0 +1,25 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __divuschar
+
+        GLOBAL  l_div8_signexte
+
+__divuschar:
+        ld      hl,sp+3
+
+        ld      e,(hl)
+        dec     hl
+        ld      c,(hl)
+
+        ld      a,c             ; Sign extend
+        rlca
+        sbc     a
+        ld      b,a
+
+        call    l_div8_signexte
+
+        ld      e,c
+        ld      d,b
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__divuchar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__divuchar.asm
@@ -1,0 +1,22 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __divuchar
+
+        GLOBAL  l_divu8
+
+        ;; Unsigned
+__divuchar:
+        ld      hl,sp+3
+
+        ld      e,(hl)
+        dec     hl
+        ld      l,(hl)
+
+        ld      c,l
+        call    l_divu8
+
+        ld      e,c
+        ld      d,b
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__divuint.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__divuint.asm
@@ -1,0 +1,26 @@
+
+	SECTION	code_l_sdcc
+	PUBLIC	__divuint
+
+	GLOBAL	l_divu16
+
+__divuint:
+	ld	hl,sp + 5
+
+        ld      d,(hl)
+        dec     hl
+        ld      e,(hl)
+        dec     hl
+        ld      a,(hl)
+        dec     hl
+        ld      l,(hl)
+        ld      h,a
+
+        ld      b,h
+        ld      c,l
+        call    l_divu16
+
+        ld      e,c
+        ld      d,b
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__divuschar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__divuschar.asm
@@ -1,0 +1,26 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __divuschar
+
+        GLOBAL  l_div16
+
+__divuschar:
+        ld      hl,sp+3
+        ld      d,0
+
+        ld      e,(hl)
+        dec     hl
+        ld      c,(hl)
+
+        ld      a,c             ; Sign extend
+        rlca
+        sbc     a
+        ld      b,a
+
+        call    l_div16
+
+        ld      e,c
+        ld      d,b
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__modschar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__modschar.asm
@@ -1,0 +1,22 @@
+
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __modschar
+
+        GLOBAL  l_div8
+
+__modschar:
+        ld      hl,sp+3
+
+        ld      e,(hl)
+        dec     hl
+        ld      l,(hl)
+
+        ld      c,l
+
+        call    l_div8
+
+        ;; Already in DE
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__modsint.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__modsint.asm
@@ -1,0 +1,28 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __modsint
+
+        GLOBAL  l_div16
+
+__modsint:
+        ld      hl,sp+5
+
+        ld      d,(hl)
+        dec     hl
+        ld      e,(hl)
+        dec     hl
+        ld      a,(hl)
+        dec     hl
+        ld      l,(hl)
+        ld      h,a
+
+        ld      b,h
+        ld      c,l
+
+        call    l_div16
+
+        ;; Already in DE
+
+        ret
+

--- a/libsrc/z80_crt0s/gbz80/sdcc/__modsuchar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__modsuchar.asm
@@ -1,0 +1,17 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __modsuchar
+
+        GLOBAL  l_div8_signexte
+
+
+__modsuchar:
+        ld      hl,sp+3
+
+        ld      e,(hl)
+        dec     hl
+        ld      c,(hl)
+        ld      b,0
+
+        jp    l_div8_signexte

--- a/libsrc/z80_crt0s/gbz80/sdcc/__moduchar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__moduchar.asm
@@ -1,0 +1,20 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __moduchar
+
+        GLOBAL  l_divu8
+
+__moduchar:
+        ld      hl,sp+3
+
+        ld      e,(hl)
+        dec     hl
+        ld      l,(hl)
+
+        ld      c,l
+        call    l_divu8
+
+        ;; Already in DE
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__moduint.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__moduint.asm
@@ -1,0 +1,27 @@
+
+	SECTION	code_l_sdcc
+
+	PUBLIC	__moduint
+	GLOBAL	l_divu16
+
+
+__moduint:
+	ld	hl,sp+5
+
+        ld      d,(hl)
+        dec     hl
+        ld      e,(hl)
+        dec     hl
+        ld      a,(hl)
+        dec     hl
+        ld      l,(hl)
+        ld      h,a
+
+        ld      b,h
+        ld      c,l
+
+        call    l_divu16
+
+        ;; Already in DE
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__moduschar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__moduschar.asm
@@ -1,0 +1,23 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __moduschar
+
+        GLOBAL  l_div16
+
+__moduschar:
+        ld      hl,sp+3
+        ld      d,0
+
+        ld      e,(hl)
+        dec     hl
+        ld      c,(hl)
+
+        ld      a,c             ; Sign extend
+        rlca
+        sbc     a
+        ld      b,a
+
+        call    l_div16
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/__mulint.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__mulint.asm
@@ -1,0 +1,23 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __mulint
+
+        GLOBAL  l_mul16
+
+__mulint:
+        ld      hl,sp+2
+
+        ld      e,(hl)
+        inc     hl
+        ld      d,(hl)
+        inc     hl
+        ld      a,(hl+)
+        ld      h,(hl)
+        ld      l,a
+
+        ;; Parameters:
+        ;;      HL, DE (left, right irrelivent)
+        ld      b,h
+        ld      c,l
+        jp      l_mul16

--- a/libsrc/z80_crt0s/gbz80/sdcc/__mulschar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__mulschar.asm
@@ -1,0 +1,22 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __mulschar
+
+        GLOBAL  l_mul8_signexte
+
+__mulschar:
+        ld      hl,sp+2
+
+        ld      e,(hl)
+        inc     hl
+        ld      l,(hl)
+
+        ;; Need to sign extend before going in.
+        ld      c,l
+
+        ld      a,l
+        rla
+        sbc     a,a
+        ld      b,a
+        jp      l_mul8_signexte

--- a/libsrc/z80_crt0s/gbz80/sdcc/__mulsuchar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__mulsuchar.asm
@@ -1,0 +1,15 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __mulsuchar
+
+        GLOBAL  l_mul8_signexte
+
+__mulsuchar:
+        ld      hl,sp+3
+        ld      b, 0
+
+        ld      e,(hl)
+        dec     hl
+        ld      c,(hl)
+        jp      l_mul8_signexte

--- a/libsrc/z80_crt0s/gbz80/sdcc/__muluchar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__muluchar.asm
@@ -1,0 +1,21 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  __muluchar
+
+        GLOBAL  l_mul16
+
+__muluchar:
+        ld      hl,sp+2
+
+        ld      e,(hl)
+
+        inc     hl
+        ld      c,(hl)
+
+        ;; Clear the top
+        xor     a
+        ld      d,a
+        ld      b,a
+
+        jp      l_mul16

--- a/libsrc/z80_crt0s/gbz80/sdcc/__muluschar.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/__muluschar.asm
@@ -1,0 +1,14 @@
+        SECTION code_l_sdcc
+
+        PUBLIC  __muluschar
+
+        GLOBAL  l_mul8_signexte
+
+__muluschar:
+        ld      hl,sp+2
+        ld      b, 0
+
+        ld      e,(hl)
+        inc     hl
+        ld      c,(hl)
+        jp      l_mul8_signexte

--- a/libsrc/z80_crt0s/gbz80/sdcc/l_div16.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/l_div16.asm
@@ -1,0 +1,101 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  l_div8
+        PUBLIC  l_mod8
+        PUBLIC  l_div8_signexte
+        PUBLIC  l_div16
+        PUBLIC  l_mod16
+
+        GLOBAL  l_divu16
+
+l_div8:
+l_mod8:
+        ld      a,c             ; Sign extend
+        rlca
+        sbc     a
+        ld      b,a
+l_div8_signexte:
+        ld      a,e             ; Sign extend
+        rlca
+        sbc     a
+        ld      d,a
+
+        ; Fall through to .div16
+
+        ;; 16-bit division
+        ;;
+        ;; Entry conditions
+        ;;   BC = dividend
+        ;;   DE = divisor
+        ;;
+        ;; Exit conditions
+        ;;   BC = quotient
+        ;;   DE = remainder
+        ;;   If divisor is non-zero, carry=0
+        ;;   If divisor is 0, carry=1 and both quotient and remainder are 0
+        ;;
+        ;; Register used: AF,BC,DE,HL
+l_div16:
+l_mod16:
+        ;; Determine sign of quotient by xor-ing high bytes of dividend
+        ;;  and divisor. Quotient is positive if signs are the same, negative
+        ;;  if signs are different
+        ;; Remainder has same sign as dividend
+        ld      a,b             ; Get high byte of dividend
+        push    af              ; Save as sign of remainder
+        xor     d               ; Xor with high byte of divisor
+        push    af              ; Save sign of quotient
+
+        ;; Take absolute value of divisor
+        bit     7,d
+        jr      Z,chkde        ; Jump if divisor is positive
+        sub     a               ; Substract divisor from 0
+        sub     e
+        ld      e,a
+        sbc     a               ; Propagate borrow (A=0xFF if borrow)
+        sub     d
+        ld      d,a
+        ;; Take absolute value of dividend
+chkde:
+        bit     7,b
+        jr      Z,dodiv        ; Jump if dividend is positive
+        sub     a               ; Substract dividend from 0
+        sub     c
+        ld      c,a
+        sbc     a               ; Propagate borrow (A=0xFF if borrow)
+        sub     b
+        ld      b,a
+        ;; Divide absolute values
+dodiv:
+        call    l_divu16
+        jr      C,exit         ; Exit if divide by zero
+        ;; Negate quotient if it is negative
+        pop     af              ; recover sign of quotient
+        and     0x80
+        ;; Negate quotient if it is negative
+        pop     af              ; recover sign of quotient
+        and     0x80
+        jr      Z,dorem        ; Jump if quotient is positive
+        sub     a               ; Substract quotient from 0
+        sub     c
+        ld      c,a
+        sbc     a               ; Propagate borrow (A=0xFF if borrow)
+        sub     b
+        ld      b,a
+dorem:
+        ;; Negate remainder if it is negative
+        pop     af              ; recover sign of remainder
+        and     0x80
+        ret     Z               ; Return if remainder is positive
+        sub     a               ; Substract remainder from 0
+        sub     e
+        ld      e,a
+        sbc     a               ; Propagate remainder (A=0xFF if borrow)
+        sub     d
+        ld      d,a
+        ret
+exit:
+        pop     af
+        pop     af
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/l_divu16.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/l_divu16.asm
@@ -1,0 +1,82 @@
+
+	SECTION	code_l_sdcc
+	
+	PUBLIC	l_divu8
+	PUBLIC	l_modu8
+	PUBLIC	l_divu16
+	PUBLIC	l_modu16
+
+
+l_divu8:
+l_modu8:
+        ld      b,0x00
+        ld      d,b
+        ; Fall through to divu16
+
+l_divu16:
+l_modu16:
+        ;; Check for division by zero
+        ld      a,e
+        or      d
+        jr      NZ,divide      ; Branch if divisor is non-zero
+        ld      bc,0x00        ; Divide by zero error
+        ld      d,b
+        ld      e,c
+        scf                     ; Set carry, invalid result
+        ret
+divide:
+        ld      l,c             ; L = low byte of dividend/quotient
+        ld      h,b             ; H = high byte of dividend/quotient
+        ld      bc,0x00        ; BC = remainder
+        or      a               ; Clear carry to start
+        ld      a,16           ; 16 bits in dividend
+dvloop:
+        ;; Shift next bit of quotient into bit 0 of dividend
+        ;; Shift next MSB of dividend into LSB of remainder
+        ;; BC holds both dividend and quotient. While we shift a bit from
+        ;;  MSB of dividend, we shift next bit of quotient in from carry
+        ;; HL holds remainder
+        ;; Do a 32-bit left shift, shifting carry to L, L to H,
+        ;;  H to C, C to B
+        push    af              ; save number of bits remaining
+        rl      l               ; Carry (next bit of quotient) to bit 0
+        rl      h               ; Shift remaining bytes
+        rl      c
+        rl      b               ; Clears carry since BC was 0
+        ;; If remainder is >= divisor, next bit of quotient is 1. This
+        ;;  bit goes to carry
+        push    bc              ; Save current remainder
+        ld      a,c             ; Substract divisor from remainder
+        sbc     e
+        ld      c,a
+        ld      a,b
+        sbc     d
+        ld      b,a
+        ccf                     ; Complement borrow so 1 indicates a
+                                ;  successful substraction (this is the
+                                ;  next bit of quotient)
+        jr      C,drop         ; Jump if remainder is >= dividend
+        pop     bc              ; Otherwise, restore remainder
+        pop     af              ; recover # bits remaining, carry flag destroyed
+        dec     a
+        or      a               ; restore (clear) the carry flag
+        jr      NZ,dvloop
+        jr      nodrop
+drop:
+        inc     sp
+        inc     sp
+        pop     af              ; recover # bits remaining, carry flag destroyed
+        dec     a
+        scf                     ; restore (set) the carry flag
+        jr      NZ,dvloop
+        jr      nodrop
+nodrop:
+        ;; Shift last carry bit into quotient
+        ld      d,b             ; DE = remainder
+        ld      e,c
+        rl      l               ; Carry to L
+        ld      c,l             ; C = low byte of quotient
+        rl      h
+        ld      b,h             ; B = high byte of quotient
+        or      a               ; Clear carry, valid result
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/l_mul16.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/l_mul16.asm
@@ -1,0 +1,49 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  l_mul16
+        ;; Parameters:
+        ;;      HL, DE (left, right irrelivent)
+        ld      b,h
+        ld      c,l
+
+        ;; 16-bit multiplication
+        ;;
+        ;; Entry conditions
+        ;;   BC = multiplicand
+        ;;   DE = multiplier
+        ;;
+        ;; Exit conditions
+        ;;   DE = less significant word of product
+        ;;
+        ;; Register used: AF,BC,DE,HL
+l_mul16:
+        ld      hl,0
+        ld      a,b
+        ; ld c,c
+        ld      b,16
+
+        ;; Optimise for the case when this side has 8 bits of data or
+        ;; less.  This is often the case with support address calls.
+        or      a
+        jp      NZ,mul_1
+
+        ld      b,8
+        ld      a,c
+mul_1:
+        ;; Taken from z88dk, which originally borrowed from the
+        ;; Spectrum rom.
+        add     hl,hl
+        rl      c
+        rla                     ;DLE 27/11/98
+        jp      NC,mul_2
+        add     hl,de
+mul_2:
+        dec     b
+        jr      NZ,mul_1
+
+        ;; Return in DE
+        ld      e,l
+        ld      d,h
+
+        ret

--- a/libsrc/z80_crt0s/gbz80/sdcc/l_mul8_signexte.asm
+++ b/libsrc/z80_crt0s/gbz80/sdcc/l_mul8_signexte.asm
@@ -1,0 +1,16 @@
+
+        SECTION code_l_sdcc
+
+        PUBLIC  l_mul8_signexte
+ 
+        GLOBAL  l_mul16
+
+
+
+l_mul8_signexte:
+        ld      a,e
+        rla
+        sbc     a,a
+        ld      d,a
+
+        jp      l_mul16

--- a/libsrc/z80_crt0s/sdcc-gbz80.lst
+++ b/libsrc/z80_crt0s/sdcc-gbz80.lst
@@ -1,0 +1,1 @@
+../_DEVELOPMENT/l/sdcc/___sdcc_call_hl

--- a/libsrc/z80_crt0s/sdcc-gbz80.lst
+++ b/libsrc/z80_crt0s/sdcc-gbz80.lst
@@ -1,1 +1,2 @@
 ../_DEVELOPMENT/l/sdcc/___sdcc_call_hl
+gbz80/sdcc/*.asm

--- a/test/suites/stdio/sprintf.c
+++ b/test/suites/stdio/sprintf.c
@@ -4,7 +4,11 @@
 #include <string.h>
 #include "test.h"
 
+#ifndef __GBZ80__
 #pragma output CLIB_OPT_PRINTF=0x7fffffff
+#else
+#pragma output CLIB_OPT_PRINTF=0x40ffffff
+#endif
 
 struct sprintf_test {
     char *pattern;

--- a/test/suites/string/stricmp.c
+++ b/test/suites/string/stricmp.c
@@ -5,11 +5,7 @@
 
 #include "string_tests.h"
 
-#ifdef SCCZ80
-static int (*func)();
-#else
-static int (*func)(char *x, char *y);
-#endif
+static int (*func)(char *x, char *y) __smallc;
 
 void stricmp_equal_lower()
 {


### PR DESCRIPTION
Get classic/+gb working with sdcc.

- Add in sdcc crt0 routines for division/multiplication
- Change the prototypes so that int8_t -> int16_t - this works around #1279 
- Modify the sccz80 bridges in newlib to handle switching return registers for sdcc (conditional on `__CLASSIC && __CPU_GBZ80__`)
- General gbz80 fixups about the place

There will of course be some things that don't work, but we can whack those when we meet them