### PR TITLE
(zcc) Support INCLUDE in config files

### DIFF
--- a/lib/config/abc80.cfg
+++ b/lib/config/abc80.cfg
@@ -17,3 +17,5 @@ SUBTYPE		default -Cz+abc80
 SUBTYPE		wav  -Cz+abc80 -Cz--audio
 SUBTYPE		hex -Cz+hex
 
+
+INCLUDE alias.inc

--- a/lib/config/abc800.cfg
+++ b/lib/config/abc800.cfg
@@ -13,3 +13,5 @@ CLIB      default -Cc-standard-escape-chars -labc800_clib
 
 SUBTYPE   none 
 SUBTYPE		hex -Cz+hex
+
+INCLUDE alias.inc

--- a/lib/config/ace.cfg
+++ b/lib/config/ace.cfg
@@ -16,3 +16,4 @@ SUBTYPE   none
 SUBTYPE   default -Cz+ace
 SUBTYPE   rom -startup=2 -Cz+rom -Cz-s -Cz8192
 
+INCLUDE alias.inc

--- a/lib/config/alias.inc
+++ b/lib/config/alias.inc
@@ -1,0 +1,23 @@
+
+
+#
+# Aliases used by the classic library
+#
+ALIAS   --generic-console -pragma-redirect:fputc_cons=fputc_cons_generic
+ALIAS   --hardware-keyboard -pragma-redirect:fgetc_cons=fgetc_cons_inkey
+
+
+#
+# Math library aliases (classic)
+#
+ALIAS   --math-mbf32    -Cc-fp-mode=mbf32 -lmbf32
+ALIAS   --math-mbf64    -Cc-fp-mode=mbf64 -lmbf64
+ALIAS   --math-bbc      -Cc-fp-mode=z88 -lbbc_math
+
+#
+# Math library aliases (classic + newlib)
+#
+ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
+ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
+ALIAS   --math32_z180   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_z180 -pragma-define:CLIB_32BIT_FLOAT=1
+ALIAS   --math32_z80n   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_z80n -pragma-define:CLIB_32BIT_FLOAT=1

--- a/lib/config/alphatro.cfg
+++ b/lib/config/alphatro.cfg
@@ -14,3 +14,4 @@ CLIB		default -lalphatro_clib -lndos -Cc-standard-escape-chars
 SUBTYPE     none 
 SUBTYPE		default -Cz+rom -Cz--romsize=16384 -Cz--rombase=0xa000
 
+INCLUDE alias.inc

--- a/lib/config/aquarius.cfg
+++ b/lib/config/aquarius.cfg
@@ -16,4 +16,4 @@ SUBTYPE     none -startup=1
 SUBTYPE		default -Cz+aquarius -startup=1
 SUBTYPE		rom -Cz+rom -Cz--romsize=8192 -startup=2 -Cz--rombase=0xe000
 
-ALIAS   --math-mbf32  -Cc-fp-mode=mbf32 -lmbf32
+INCLUDE alias.inc

--- a/lib/config/bee.cfg
+++ b/lib/config/bee.cfg
@@ -18,3 +18,4 @@ SUBTYPE     wav -Cz+srr -Cz--audio -Cz--bee -Cz--bee1200
 SUBTYPE     wav300 -Cz+srr -Cz--audio -Cz--bee -Cz--300bps
 SUBTYPE     default  -Cz+newext -Cz-e -Cz.BEE
 
+INCLUDE alias.inc

--- a/lib/config/c128.cfg
+++ b/lib/config/c128.cfg
@@ -16,3 +16,4 @@ SUBTYPE   none
 SUBTYPE   default -Cz+c128
 SUBTYPE   disk -Cz+c128 -Cz--disk
 
+INCLUDE alias.inc

--- a/lib/config/c7420.cfg
+++ b/lib/config/c7420.cfg
@@ -13,3 +13,5 @@ CLIB      default -Cc-standard-escape-chars -lc7420_clib -lndos
 
 SUBTYPE        none 
 SUBTYPE        default -Cz+c7420
+
+INCLUDE alias.inc

--- a/lib/config/coleco.cfg
+++ b/lib/config/coleco.cfg
@@ -12,3 +12,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lcoleco_clib -lndos -DZ80 -D__COLECO__ -M -Cc-stand
 SUBTYPE   default -Cz+rom -Cz--romsize=32768 -Cz--rombase=32768
 
 CLIB      default -lcoleco_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/cpc.cfg
+++ b/lib/config/cpc.cfg
@@ -23,3 +23,4 @@ SUBTYPE		wav -Cz+cpc -Cz--audio
 SUBTYPE   fastwav -Cz+cpc -Cz--audio -Cz--rate -Cz10240
 SUBTYPE		noint -startup=2 -Cz+cpc
 
+INCLUDE alias.inc

--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -50,6 +50,5 @@ SUBTYPE		x1  -Cz+cpmdisk -Cz-f -Czsharpx1 -Cz--container=d88 -D__SHARPX1__ -prag
 SUBTYPE		rc700	-Cz+cpmdisk -Cz-f -Czrc700 -Cz--container=imd -D__RC700__ -pragma-define:CONSOLE_ROWS=25 -pragma-define:CONSOLE_COLUMNS=80 -lrc700 -pragma-export:GRAPHICS_CHAR_SET=127 -pragma-export:GRAPHICS_CHAR_UNSET=32
 SUBTYPE		fp1100  -Cz+cpmdisk -Cz-f -Czfp1100 -Cz--container=d88 -D__FP1100__ -pragma-define:CONSOLE_ROWS=24 -pragma-define:CONSOLE_COLUMNS=40 
 
-ALIAS       --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS       --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
+INCLUDE alias.inc
 

--- a/lib/config/embedded.cfg
+++ b/lib/config/embedded.cfg
@@ -18,3 +18,5 @@ CLIB     clang_iy -compiler=clang --reserve-regs-iy -D__SDCC -D__SDCC_IY -Ca-D__
 
 SUBTYPE  none 
 SUBTYPE  default -Cz+rom
+
+INCLUDE alias.inc

--- a/lib/config/enterprise.cfg
+++ b/lib/config/enterprise.cfg
@@ -13,3 +13,5 @@ SUBTYPE     none
 SUBTYPE		default  -Cz+enterprise
 SUBTYPE		com  -startup=2 -Cz+enterprise  -Cz-e -Cz.com
 
+
+INCLUDE alias.inc

--- a/lib/config/excali64.cfg
+++ b/lib/config/excali64.cfg
@@ -15,3 +15,5 @@ CLIB		ansi40 -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100
 
 SUBTYPE     none
 SUBTYPE     default -Cz+srr -Cz--audio -Cz--excalibur
+
+INCLUDE alias.inc

--- a/lib/config/fp1100.cfg
+++ b/lib/config/fp1100.cfg
@@ -14,3 +14,4 @@ CLIB		default -lfp1100_clib -lndos -Cc-standard-escape-chars
 SUBTYPE     none 
 SUBTYPE		default -Cz+fp1100
 
+INCLUDE alias.inc

--- a/lib/config/g800.cfg
+++ b/lib/config/g800.cfg
@@ -13,3 +13,5 @@ SUBTYPE   default  -Cz"+rom --ihex"
 CLIB      default -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=4 -pragma-export:ansicolumns=24 -lg800_clib -lndos
 CLIB      g850   -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=8 -pragma-export:ansicolumns=36 -pragma-redirect:ansifont=_font_3x5_850 -pragma-define:ansifont_is_packed=0 -lg850_clib -lndos
 CLIB      g850b   -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=6 -pragma-export:ansicolumns=24 -lg850b -lg800_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/gal.cfg
+++ b/lib/config/gal.cfg
@@ -17,3 +17,4 @@ SUBTYPE   galaxyp -Cz+gal -Cz--audio -D__GALPLUSHIRES__
 CLIB      default -lgal_clib -lndos
 CLIB      ansi -pragma-need=ansiterminal -D__CONIO_VT100 -lgal_clib -lndos
 
+INCLUDE alias.inc

--- a/lib/config/gb.cfg
+++ b/lib/config/gb.cfg
@@ -13,3 +13,5 @@ CLIB	  default -mgbz80 -Cc-standard-escape-chars -lgb_clib -startuplib=gbz80_crt
 
 
 SUBTYPE   default -Cz+gb
+
+INCLUDE alias.inc

--- a/lib/config/kc.cfg
+++ b/lib/config/kc.cfg
@@ -19,3 +19,5 @@ CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lkc_clib -lndos
 SUBTYPE     none 
 SUBTYPE		default -Cz+kc
 SUBTYPE		tap -Cz+z9001
+
+INCLUDE alias.inc

--- a/lib/config/lambda.cfg
+++ b/lib/config/lambda.cfg
@@ -21,3 +21,4 @@ SUBTYPE     none
 SUBTYPE		default -startup=102 -Cz+zx81 -Cz--lambda
 SUBTYPE		fast -startup=101 -Cz+zx81 -Cz--lambda
 
+INCLUDE alias.inc

--- a/lib/config/laser500.cfg
+++ b/lib/config/laser500.cfg
@@ -14,5 +14,4 @@ CLIB		default -llaser500_clib -lndos -Cc-standard-escape-chars
 SUBTYPE		default -Cz+laser500  -startup=1 
 SUBTYPE		rom -Cz+rom -Cz-s -Cz32768 -Cz--rombase=0 -startup-2
 
-ALIAS   --math-mbf32  -Cc-fp-mode=mbf32 -lmbf32
-ALIAS   --math-mbf64  -Cc-fp-mode=mbf64 -lmbf64
+INCLUDE alias.inc

--- a/lib/config/lynx.cfg
+++ b/lib/config/lynx.cfg
@@ -14,3 +14,4 @@ CLIB      default -llynx_clib -Cc-standard-escape-chars -lndos
 SUBTYPE   none 
 SUBTYPE   default -Cz+lynx
 
+INCLUDE alias.inc

--- a/lib/config/m5.cfg
+++ b/lib/config/m5.cfg
@@ -14,3 +14,5 @@ CLIB	  ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lm5_clib
 
 SUBTYPE   tape -Cz+m5
 SUBTYPE   rom -startup=2 -Cz+rom -Cz-s -Cz16384 -Cz--rombase=8192
+
+INCLUDE alias.inc

--- a/lib/config/mc1000.cfg
+++ b/lib/config/mc1000.cfg
@@ -16,4 +16,4 @@ SUBTYPE   none
 SUBTYPE   default -Cz+mc
 SUBTYPE   gaming -startup=2 -Cz+mc
 
-ALIAS   --math-mbf32  -Cc-fp-mode=mbf32 -lmbf32
+INCLUDE alias.inc

--- a/lib/config/msx.cfg
+++ b/lib/config/msx.cfg
@@ -20,3 +20,4 @@ SUBTYPE		msxdos2  -Cz+fat -Cz-f -Czmsxdos -startup=2 -lmsxdos2
 CLIB      default -lmsx_clib
 CLIB	  ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lmsx_clib
 
+INCLUDE alias.inc

--- a/lib/config/mtx.cfg
+++ b/lib/config/mtx.cfg
@@ -17,3 +17,5 @@ SUBTYPE   rom -startup=2 -Cz+rom -Cz-s -Cz16384 -Cz--rombase -Cz16384
 
 CLIB      default -lmtx_clib
 CLIB	  ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lmtx_clib
+
+INCLUDE alias.inc

--- a/lib/config/multi8.cfg
+++ b/lib/config/multi8.cfg
@@ -15,4 +15,4 @@ SUBTYPE     none
 SUBTYPE		default -Cz+multi8 -startup=1
 SUBTYPE		64k -Cz+multi8 -startup=2
 
-ALIAS   --math-mbf32  -Cc-fp-mode=mbf32 -lmbf32
+INCLUDE alias.inc

--- a/lib/config/myvision.cfg
+++ b/lib/config/myvision.cfg
@@ -12,3 +12,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lmyvision_clib -lndos -DZ80 -D__MYVISION__ -M -Cc-s
 SUBTYPE   default -Cz+rom -Cz--romsize=24576 -Cz--rombase=0
 
 CLIB      default -lmyvision_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/mz.cfg
+++ b/lib/config/mz.cfg
@@ -15,3 +15,5 @@ CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lmz_clib -lndos
 SUBTYPE     none 
 SUBTYPE     default -Cz+mz
 SUBTYPE     wav -Cz+mz -Cz--audio
+
+INCLUDE alias.inc

--- a/lib/config/mz2500.cfg
+++ b/lib/config/mz2500.cfg
@@ -14,3 +14,4 @@ CLIB		default -Cc-standard-escape-chars -lmz2500_clib -lndos
 SUBTYPE     none 
 SUBTYPE		default -startup=1 -Cz+mz2500
 
+INCLUDE alias.inc

--- a/lib/config/nascom.cfg
+++ b/lib/config/nascom.cfg
@@ -15,3 +15,4 @@ CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lnascom_clib -lndos -Cc-s
 SUBTYPE     none 
 SUBTYPE		default -Cz+nas
 
+INCLUDE alias.inc

--- a/lib/config/nc.cfg
+++ b/lib/config/nc.cfg
@@ -15,4 +15,4 @@ SUBTYPE		card8k  -startup=1 -Cz"+rom -s 8192 --rombase 49152"
 SUBTYPE		card4k  -startup=1 -Cz"+rom -s 4096 --rombase 49152"
 SUBTYPE		ram -startup=2  -Cz"+newext -e .COM"
 
-
+INCLUDE alias.inc

--- a/lib/config/newbrain.cfg
+++ b/lib/config/newbrain.cfg
@@ -8,3 +8,5 @@ CRT0		 DESTDIR/lib/target/newbrain/classic/newbrain_crt0
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote. -lnewbrain_clib -DZ80 -DNEWBRAIN -D__NEWBRAIN__ -M -Cc-standard-escape-chars -Cz+newbrain
+
+INCLUDE alias.inc

--- a/lib/config/osca.cfg
+++ b/lib/config/osca.cfg
@@ -15,3 +15,4 @@ CLIB		ansi -pragma-need=ansiterminal -D__CONIO_VT100 -losca_clib
 SUBTYPE     none 
 SUBTYPE		default  -Cz+newext -Cz-e -Cz.exe
 
+INCLUDE alias.inc

--- a/lib/config/oz.cfg
+++ b/lib/config/oz.cfg
@@ -8,3 +8,5 @@ CRT0		 DESTDIR/lib/target/oz/classic/oz_crt0
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote. -lozansi_clib -lndos -Cc-standard-escape-chars -DZ80 -DOZ -D__OZ__ -M -pragma-need=ansiterminal -D__CONIO_VT100
+
+INCLUDE alias.inc

--- a/lib/config/p2000.cfg
+++ b/lib/config/p2000.cfg
@@ -16,3 +16,4 @@ SUBTYPE     none
 SUBTYPE		default -Cz+p2000
 
 
+INCLUDE alias.inc

--- a/lib/config/pacman.cfg
+++ b/lib/config/pacman.cfg
@@ -13,3 +13,5 @@ CLIB         default -lpacman_clib -lndos
 
 SUBTYPE      none 
 SUBTYPE      default -create-app -Cz"+rom --chipsize 4096 --romsize 16384"
+
+INCLUDE alias.inc

--- a/lib/config/pasopia7.cfg
+++ b/lib/config/pasopia7.cfg
@@ -14,3 +14,4 @@ CLIB		default -lpasopia7_clib -lndos -Cc-standard-escape-chars
 SUBTYPE     none 
 SUBTYPE		default -Cz+pasopia7
 
+INCLUDE alias.inc

--- a/lib/config/pc6001.cfg
+++ b/lib/config/pc6001.cfg
@@ -18,3 +18,5 @@ SUBTYPE		16k -Cz+nec -startup=1
 SUBTYPE		32k -startup=2 -Cz+nec
 SUBTYPE		n60m -startup=3 -Cz+nec
 SUBTYPE     rom  -startup=4 -Cz+rom -Cz--rombase -Cz16384
+
+INCLUDE alias.inc

--- a/lib/config/pc88.cfg
+++ b/lib/config/pc88.cfg
@@ -14,3 +14,5 @@ CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lpc88_clib -lndos
 
 SUBTYPE		default -Cz+pc88 -startup=1
 SUBTYPE		wav -Cz+pc88 -Cz--audio -startup=1
+
+INCLUDE alias.inc

--- a/lib/config/pencil2.cfg
+++ b/lib/config/pencil2.cfg
@@ -12,3 +12,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lpencil2_clib -lndos -DZ80 -D__PENCIL2__ -M -Cc-sta
 SUBTYPE   default -Cz+rom -Cz--romsize=32768 -Cz--rombase=32768
 
 CLIB      default -lpencil2_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/pps.cfg
+++ b/lib/config/pps.cfg
@@ -13,3 +13,4 @@ OPTIONS		 -O2 -SO2 -iquote. -DZ80 -DSPRINTER -D__SPRINTER__ -M -clib=default -Cc
 CLIB            default -lpps_clib
 CLIB            ansi -pragma-need=ansiterminal -D__CONIO_VT100 -lpps_clib
 
+INCLUDE alias.inc

--- a/lib/config/pv1000.cfg
+++ b/lib/config/pv1000.cfg
@@ -16,3 +16,5 @@ SUBTYPE   8k -Cz+rom -Cz--romsize=8192
 
 # 32k ROMs may not be supported by the emulators
 SUBTYPE   32k -Cz+rom -Cz--romsize=32768
+
+INCLUDE alias.inc

--- a/lib/config/pv2000.cfg
+++ b/lib/config/pv2000.cfg
@@ -12,3 +12,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lpv2000_clib -lndos -DZ80 -D__PV2000__ -M -Cc-stand
 SUBTYPE   default -Cz+rom -Cz--romsize=16384 -Cz--rombase=49152
 
 CLIB      default -lpv2000_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/rc2014.cfg
+++ b/lib/config/rc2014.cfg
@@ -24,6 +24,5 @@ SUBTYPE   basic       -startup=16           -Cz"+hex --ihex"
 SUBTYPE   cpm         -startup=64           -Cz"+hex --ihex"
 SUBTYPE   none        -startup=256          -Cz"+rom --ihex"
 
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
+INCLUDE alias.inc
 

--- a/lib/config/rcmx000.cfg
+++ b/lib/config/rcmx000.cfg
@@ -13,3 +13,5 @@ CRT0		 DESTDIR/lib/target/rcmx000/classic/rcmx000_crt0
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote. -lrcmx000_clib -lndos -DZ80 -DRCMX000 -D__RCMX000__ -M -Cz+rcmx000 -Ca-mr2k -mr2k -Cc-standard-escape-chars
+
+INCLUDE alias.inc

--- a/lib/config/rex.cfg
+++ b/lib/config/rex.cfg
@@ -14,3 +14,5 @@ CLIB      default  -lrex_clib
 SUBTYPE   none 
 SUBTYPE   default  -Cz+rex -Cc-standard-escape-chars
 SUBTYPE   lib  -startup=2  -Cz+rex -Cc-standard-escape-chars
+
+INCLUDE alias.inc

--- a/lib/config/rx78.cfg
+++ b/lib/config/rx78.cfg
@@ -12,3 +12,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lrx78_clib -lndos -DZ80 -D__RX78__ -M -Cc-standard-
 SUBTYPE   default -Cz+rom -Cz--romsize=24576 -Cz--rombase=8192
 
 CLIB      default -lrx78_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/s1mp3.cfg
+++ b/lib/config/s1mp3.cfg
@@ -13,3 +13,5 @@ CLIB	  default -mz80 -Cc-standard-escape-chars -ls1mp3_clib -lndos
 
 
 SUBTYPE   default 
+
+INCLUDE alias.inc

--- a/lib/config/sam.cfg
+++ b/lib/config/sam.cfg
@@ -11,3 +11,5 @@ OPTIONS		 -O2 -SO2 -iquote. -DZ80 -DSAM -D__SAM__ -M -clib=default -Cc-standard-
 
 CLIB		default -lsam_clib -lndos
 CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lsam_clib -lndos
+
+INCLUDE alias.inc

--- a/lib/config/sc3000.cfg
+++ b/lib/config/sc3000.cfg
@@ -16,3 +16,5 @@ SUBTYPE   rom -startup=2 -Cz+rom -Cz-s -Cz32768
 
 CLIB      default -lsc3000_clib
 CLIB	  ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lsc3000_clib
+
+INCLUDE alias.inc

--- a/lib/config/sms.cfg
+++ b/lib/config/sms.cfg
@@ -21,6 +21,5 @@ CLIB         clang_iy -compiler=clang --reserve-regs-iy -D__SDCC -D__SDCC_IY -Ca
 SUBTYPE      none 
 SUBTYPE      default -Cz+sms
 
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
 
+INCLUDE alias.inc

--- a/lib/config/sos.cfg
+++ b/lib/config/sos.cfg
@@ -12,3 +12,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lsos_clib -DZ80 -DSOS -D__SOS__ -M -Cc-standard-esc
 SUBTYPE     none 
 SUBTYPE		default -Cz+sos
 SUBTYPE		mz -Cz+mz
+
+INCLUDE alias.inc

--- a/lib/config/spc1000.cfg
+++ b/lib/config/spc1000.cfg
@@ -14,3 +14,4 @@ CLIB		default -lspc1000_clib -lndos -Cc-standard-escape-chars
 SUBTYPE     none 
 SUBTYPE		default -Cz+spc1000
 
+INCLUDE alias.inc

--- a/lib/config/srr.cfg
+++ b/lib/config/srr.cfg
@@ -11,3 +11,5 @@ OPTIONS		 -O2 -SO2 -iquote. -lsorcerer_clib -DZ80 -DSORCERER -D__SORCERER__ -M -
 
 
 CLIB	default 
+
+INCLUDE alias.inc

--- a/lib/config/super80.cfg
+++ b/lib/config/super80.cfg
@@ -15,3 +15,5 @@ CLIB		vduem   -lsuper80_vduem_clib -lndos -Cc-standard-escape-chars -pragma-defi
 SUBTYPE     none 
 SUBTYPE		default -Cz+mameql
 
+
+INCLUDE alias.inc

--- a/lib/config/sv8000.cfg
+++ b/lib/config/sv8000.cfg
@@ -17,3 +17,5 @@ SUBTYPE   default -Cz+rom -Cz--romsize=4096
 SUBTYPE   8k -Cz+rom -Cz--romsize=8192
 SUBTYPE   16k -Cz+rom -Cz--romsize=16384
 SUBTYPE   32k -Cz+rom -Cz--romsize=32768
+
+INCLUDE alias.inc

--- a/lib/config/svi.cfg
+++ b/lib/config/svi.cfg
@@ -17,3 +17,4 @@ SUBTYPE		disk -startup=2 -Cz+svi -Cz--disk
 CLIB      default -lsvi_clib -lndos
 CLIB	  ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lsvi_clib -lndos
 
+INCLUDE alias.inc

--- a/lib/config/test.cfg
+++ b/lib/config/test.cfg
@@ -22,7 +22,4 @@ CLIB	  gbz80 -mgbz80 -Cc-standard-escape-chars -ltestgbz80_clib -startuplib=gbz8
 
 SUBTYPE   default -Cz+test
 
-ALIAS   --math-mbf32    -Cc-fp-mode=mbf32 -lmbf32
-ALIAS	--math-bbc      -Cc-fp-mode=z88 -lbbc_math
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
+INCLUDE alias.inc

--- a/lib/config/ti82.cfg
+++ b/lib/config/ti82.cfg
@@ -14,3 +14,6 @@ CLIB		ansi -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100 -
 
 SUBTYPE     none 
 SUBTYPE		default -Cz+ti82
+
+INCLUDE alias.inc
+

--- a/lib/config/ti83.cfg
+++ b/lib/config/ti83.cfg
@@ -36,3 +36,5 @@ SUBTYPE		sos -startup=7 -Cz+ti83
 SUBTYPE		venusexp -startup=8 -Cz+ti83
 SUBTYPE		ion -startup=9 -Cz+ti83
 SUBTYPE		asm -startup=10 -Cz+ti83
+
+INCLUDE alias.inc

--- a/lib/config/ti85.cfg
+++ b/lib/config/ti85.cfg
@@ -14,3 +14,5 @@ CLIB		ansi -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100 -
 
 SUBTYPE     none 
 SUBTYPE		default -Cz+ti85
+
+INCLUDE alias.inc

--- a/lib/config/ti86.cfg
+++ b/lib/config/ti86.cfg
@@ -28,3 +28,5 @@ SUBTYPE		zap2000 -startup=3 -Cz+ti86
 SUBTYPE		emanon -startup=4 -Cz+ti86
 SUBTYPE		largeld -startup=5 -Cz+ti86
 SUBTYPE		asm -startup=10 -Cz+ti86
+
+INCLUDE alias.inc

--- a/lib/config/ti8x.cfg
+++ b/lib/config/ti8x.cfg
@@ -25,3 +25,5 @@ SUBTYPE		ion -Cz+ti8x
 SUBTYPE		mirage -startup=2 -Cz+ti8x
 SUBTYPE		tse -startup=3 -Cz+ti8x
 SUBTYPE		asm -startup=10 -Cz+ti8x
+
+INCLUDE alias.inc

--- a/lib/config/trs80.cfg
+++ b/lib/config/trs80.cfg
@@ -18,5 +18,4 @@ SUBTYPE		eg2000disk -startup=2 -lgfxeg2000 -Cz--cmd -D__EG2000__
 CLIB      default -ltrs80_clib
 
 
-ALIAS   --math-mbf32  -Cc-fp-mode=mbf32 -lmbf32
-ALIAS   --math-mbf64  -Cc-fp-mode=mbf64 -lmbf64
+INCLUDE alias.inc

--- a/lib/config/ts2068.cfg
+++ b/lib/config/ts2068.cfg
@@ -19,3 +19,5 @@ CLIB      ansi -pragma-need=ansiterminal -D__CONIO_VT100 -lts2068_clib -lndos
 SUBTYPE   none 
 SUBTYPE   default -Cz+zx -lgfx2068hr -Cz--ts2068 -pragma-define:CRT_TS2068_HRG=1
 SUBTYPE   nohrg -Cz+zx -Cz--ts2068 
+
+INCLUDE alias.inc

--- a/lib/config/tvc.cfg
+++ b/lib/config/tvc.cfg
@@ -12,3 +12,4 @@ OPTIONS		 -O2 -SO2 -iquote. -Cc-standard-escape-chars -ltvc_clib -lndos -DZ80 -D
 SUBTYPE     none 
 SUBTYPE		default  -Cz+tvc
 
+INCLUDE alias.inc

--- a/lib/config/vg5k.cfg
+++ b/lib/config/vg5k.cfg
@@ -21,3 +21,4 @@ SUBTYPE        default -Cz+vg5k
 SUBTYPE        wav -Cz+vg5k -Cz--audio -Cz--fast
 SUBTYPE        fastwav -Cz+vg5k -Cz--audio -Cz--fast
 
+INCLUDE alias.inc

--- a/lib/config/vz.cfg
+++ b/lib/config/vz.cfg
@@ -16,3 +16,5 @@ SUBTYPE     none
 SUBTYPE		default -Cz+vz
 SUBTYPE		basic -startup=2 -Cz+vz
 SUBTYPE		bin -startup=3
+
+INCLUDE alias.inc

--- a/lib/config/x07.cfg
+++ b/lib/config/x07.cfg
@@ -8,3 +8,5 @@ CRT0		 DESTDIR/lib/target/x07/classic/x07_crt0
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote. -lx07_clib -DZ80 -DX07 -D__X07__ -M -Cz+x07 -lndos -Cc-standard-escape-chars
+
+INCLUDE alias.inc

--- a/lib/config/x1.cfg
+++ b/lib/config/x1.cfg
@@ -17,3 +17,5 @@ SUBTYPE     none
 SUBTYPE		default -startup=1 -Cz+x1
 SUBTYPE		im2 -startup=2 -Cz+x1
 
+
+INCLUDE alias.inc

--- a/lib/config/z1013.cfg
+++ b/lib/config/z1013.cfg
@@ -15,3 +15,4 @@ CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lz1013_clib -lndos
 SUBTYPE     none 
 SUBTYPE		default -Cz+z1013
 
+INCLUDE alias.inc

--- a/lib/config/z180.cfg
+++ b/lib/config/z180.cfg
@@ -20,6 +20,6 @@ CLIB     clang_iy -compiler=clang --reserve-regs-iy -D__SDCC -D__SDCC_IY -Ca-D__
 SUBTYPE  none 
 SUBTYPE  default -Cz+rom
 
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_z180   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_z180 -pragma-define:CLIB_32BIT_FLOAT=1
+INCLUDE alias.inc
+
 

--- a/lib/config/z80.cfg
+++ b/lib/config/z80.cfg
@@ -20,6 +20,5 @@ CLIB     clang_iy -compiler=clang --reserve-regs-iy -D__SDCC -D__SDCC_IY -Ca-D__
 SUBTYPE  none 
 SUBTYPE  default -Cz+rom
 
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
+INCLUDE alias.inc
 

--- a/lib/config/z80tvgame.cfg
+++ b/lib/config/z80tvgame.cfg
@@ -15,3 +15,4 @@ SUBTYPE     none
 SUBTYPE     default -Cz+rom -Cz--romsize=32768 -Cz--rombase=0
 
 
+INCLUDE alias.inc

--- a/lib/config/z88.cfg
+++ b/lib/config/z88.cfg
@@ -25,3 +25,4 @@ SUBTYPE		basic -startup=1 -bna.bas
 SUBTYPE		z88shell -startup=5 -Cz+z88shell
 SUBTYPE		app -startup=2 -Cz+z88 
 
+INCLUDE alias.inc

--- a/lib/config/z9001.cfg
+++ b/lib/config/z9001.cfg
@@ -15,3 +15,5 @@ CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lz9001_clib -lndos
 SUBTYPE     none 
 SUBTYPE		default -Cz+z9001
 SUBTYPE		kcc -Cz+kc
+
+INCLUDE alias.inc

--- a/lib/config/zx.cfg
+++ b/lib/config/zx.cfg
@@ -34,6 +34,4 @@ SUBTYPE   dotx    -Cz"+zx --dot" -startupoffset=0x200 -D__ESXDOS_DOT_COMMAND -Ca
 SUBTYPE   bin     -Cz"+zx --bin"
 SUBTYPE   plus3	  -Cz"+zx --plus3"
 
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
-
+INCLUDE alias.inc

--- a/lib/config/zx80.cfg
+++ b/lib/config/zx80.cfg
@@ -13,3 +13,5 @@ CLIB      default -Cc-standard-escape-chars -lzx80_clib -lndos
 
 SUBTYPE        none 
 SUBTYPE        default -Cz+zx81 -Cz--zx80
+
+INCLUDE alias.inc

--- a/lib/config/zx81.cfg
+++ b/lib/config/zx81.cfg
@@ -50,3 +50,5 @@ SUBTYPE		_arx -startup=14
 SUBTYPE		_arx64 -startup=16 
 SUBTYPE		gray -startup=7 
 SUBTYPE		chromag -startup=7 
+
+INCLUDE alias.inc

--- a/lib/config/zxn.cfg
+++ b/lib/config/zxn.cfg
@@ -38,6 +38,4 @@ SUBTYPE   dotx-n  -Cz"+zxn --dot" -startupoffset=0x200 -D__ESXDOS_DOT_COMMAND -C
 SUBTYPE   dotn    -Cz"+zxn --dotn" -startupoffset=0x300 -D__ESXDOS_DOT_COMMAND -Ca-D__ESXDOS_DOT_COMMAND -Cl-D__ESXDOS_DOT_COMMAND -D__NEXTOS_DOT_COMMAND -Ca-D__NEXTOS_DOT_COMMAND -Cl-D__NEXTOS_DOT_COMMAND
 SUBTYPE   dotn-n  -Cz"+zxn --dotn" -startupoffset=0x300 -D__ESXDOS_DOT_COMMAND -Ca-D__ESXDOS_DOT_COMMAND -Cl-D__ESXDOS_DOT_COMMAND -D__NEXTOS_DOT_COMMAND -Ca-D__NEXTOS_DOT_COMMAND -Cl-D__NEXTOS_DOT_COMMAND
 
-ALIAS   --math32        -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32 -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_fast   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_fast -pragma-define:CLIB_32BIT_FLOAT=1
-ALIAS   --math32_z80n   -Cc-fp-mode=ieee -Cc-D__MATH_MATH32 -D__MATH_MATH32 -lmath32_z80n -pragma-define:CLIB_32BIT_FLOAT=1
+INCLUDE alias.inc

--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -56,6 +56,7 @@ static void            add_file_to_process(char *filename);
 
 static void            SetNumber(arg_t *argument, char *arg);
 static void            SetStringConfig(arg_t *argument, char *arg);
+static void            LoadConfigFile(arg_t *argument, char *arg);
 static void            parse_cmdline_arg(char *arg);
 static void            SetBoolean(arg_t *arg, char *val);
 static void            AddPreProc(arg_t *arg, char *);
@@ -103,6 +104,7 @@ static void            BuildOptions(char **, char *);
 static void            BuildOptions_start(char **, char *);
 static void            BuildOptionsQuoted(char **, char *);
 static void            copy_output_files_to_destdir(char *suffix, int die_on_fail);
+static void            parse_configfile(const char *config_line);
 static void            parse_configfile_line(char *config_line);
 static void            KillEOL(char *line);
 static int             add_variant_args(char *wanted, int num_choices, char **choices);
@@ -393,6 +395,7 @@ static arg_t  config[] = {
     { "SUBTYPE",  0, AddArray, &c_subtype_array, &c_subtype_array_num, "Add a sub-type alias and config" },
     { "CLIB",  0, AddArray, &c_clib_array, &c_clib_array_num, "Add a clib variant config" },
     { "ALIAS",  0, AddArray, &c_aliases_array, &c_aliases_array_num, "Add an alias and options" },
+    { "INCLUDE", 0, LoadConfigFile, NULL, NULL, "Load a configuration file"},
     { "", 0, NULL, NULL }
 };
 
@@ -854,14 +857,6 @@ int main(int argc, char **argv)
     atexit(remove_temporary_files);
     add_option_to_compiler("");
 
-    // Add an alias for gencon
-    snprintf(buffer,sizeof(buffer),"ALIAS --generic-console -pragma-redirect:fputc_cons=fputc_cons_generic");
-    parse_configfile_line(buffer);
-    snprintf(buffer,sizeof(buffer),"ALIAS --hardware-keyboard -pragma-redirect:fgetc_cons=fgetc_cons_inkey");
-    parse_configfile_line(buffer);
-    snprintf(buffer,sizeof(buffer),"ALIAS --math32 -Cc-fp-mode=ieee -lmath32 -pragma-define:CLIB_32BIT_FLOATS=1");
-    parse_configfile_line(buffer);
-
     gc = 1;            /* Set for the first argument to scan for */
     if (argc == 1) {
         print_help_text(argv[0]);
@@ -881,17 +876,8 @@ int main(int argc, char **argv)
     setup_default_configuration();
 
     gc = find_zcc_config_fileFile(argv[0], argv[gc], gc, config_filename, sizeof(config_filename));
-    /* Okay, so now we read in the options file and get some info for us */
-    if ((fp = fopen(config_filename, "r")) == NULL) {
-        fprintf(stderr, "Can't open config file %s\n", config_filename);
-        exit(1);
-    }
-    while (fgets(buffer, LINEMAX, fp) != NULL) {
-        if (!isupper(buffer[0]))
-            continue;
-        parse_configfile_line(buffer);
-    }
-    fclose(fp);
+    parse_configfile(config_filename);
+
 
     /* Now, parse the default options list */
     if (c_options != NULL) {
@@ -2496,6 +2482,44 @@ void parse_cmdline_arg(char *arg)
         }
     }
     add_option_to_compiler(arg);
+}
+
+
+void LoadConfigFile(arg_t *argument, char *arg)
+{
+    char   buf[FILENAME_MAX+1];
+    char  *cfgfile;
+
+    cfgfile = getenv("ZCCCFG");
+    if (cfgfile != NULL) {
+        if (strlen(cfgfile) > FILENAME_MAX) {
+            fprintf(stderr, "Possibly corrupt env variable ZCCCFG\n");
+            exit(1);
+        }
+        /* Config file in config directory */
+        snprintf(buf, sizeof(buf), "%s/%s", cfgfile, arg);
+    } else {
+        snprintf(buf,sizeof(buf),"%s", arg);
+    }
+    parse_configfile(buf);
+}
+
+void parse_configfile(const char *filename)
+{
+    FILE *fp;
+    char  buffer[LINEMAX+1];
+
+      /* Okay, so now we read in the options file and get some info for us */
+    if ((fp = fopen(filename, "r")) == NULL) {
+        fprintf(stderr, "Can't open config file %s\n", filename);
+        exit(1);
+    }
+    while (fgets(buffer, LINEMAX, fp) != NULL) {
+        if (!isupper(buffer[0]))
+            continue;
+        parse_configfile_line(buffer);
+    }
+    fclose(fp);
 }
 
 void parse_configfile_line(char *arg)


### PR DESCRIPTION
Move aliases out from being hardcoded into an include file.

No recursion check so be careful!