### PR TITLE
(classic) Add a destructor section. Move closeall() call into this

### DIFF
--- a/lib/crt/classic/crt_section.asm
+++ b/lib/crt/classic/crt_section.asm
@@ -80,7 +80,12 @@ IF ( __crt_model & 2 )
 	call    asm_dzx7_standard
 ENDIF
 	
+		SECTION code_crt_init_exit
+			ret
 		SECTION code_crt_exit
+crt0_exit:
+			; Teardown code can go here
+		SECTION code_crt_exit_exit
 			ret
 
 		SECTION bss_crt

--- a/lib/crt/classic/crt_section_standard.asm
+++ b/lib/crt/classic/crt_section_standard.asm
@@ -19,7 +19,9 @@
 		SECTION CODE
 
 		SECTION code_crt_init
+		SECTION code_crt_init_exit
 		SECTION code_crt_exit
+		SECTION code_crt_exit_exit
 		SECTION code_driver
 		SECTION rodata_driver		;Keep it in low memoey
 		SECTION code_compiler
@@ -73,6 +75,9 @@ ENDIF
 		SECTION rodata_fp_mbf64
 		SECTION rodata_compiler
 		SECTION rodata_clib
+IF !__crt_org_graphics
+		SECTION rodata_graphics
+ENDIF
 		SECTION rodata_user
 		SECTION rodata_font
 		SECTION rodata_font_fzx
@@ -85,6 +90,9 @@ IF !__crt_model
 		SECTION smc_user
 		SECTION data_clib
 		SECTION data_stdlib
+IF !__crt_org_graphics
+		SECTION data_graphics
+ENDIF
 		SECTION data_crt
 		SECTION data_compiler
 		SECTION data_user
@@ -129,6 +137,9 @@ IF __crt_model > 0
 		SECTION data_clib
 		SECTION data_crt
 		SECTION data_stdlib
+IF !__crt_org_graphics
+		SECTION data_graphics
+ENDIF
 		SECTION data_compiler
 		SECTION data_user
 		SECTION data_alloc_balloc
@@ -141,6 +152,8 @@ IF __crt_org_graphics
 		org	__crt_org_graphics
 		SECTION code_graphics
 		SECTION code_himem
+		SECTION rodata_graphics
+		SECTION rodata_himem
 		SECTION data_himem
 		SECTION data_graphics
 		SECTION bss_graphics

--- a/lib/target/ace/classic/ace_crt0.asm
+++ b/lib/target/ace/classic/ace_crt0.asm
@@ -152,10 +152,7 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
 	pop	bc
 start1:
         ld      sp,0

--- a/lib/target/alphatro/classic/alphatro_crt0.asm
+++ b/lib/target/alphatro/classic/alphatro_crt0.asm
@@ -66,12 +66,7 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl				; return code
-
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
-
+        call    crt0_exit
 
 cleanup_exit:
 

--- a/lib/target/aquarius/classic/ram.asm
+++ b/lib/target/aquarius/classic/ram.asm
@@ -38,11 +38,8 @@ cleanup:
 ;
 ;       Deallocate memory which has been allocated here!
 ;
+    call    crt0_exit
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
 
 start1:	ld	sp,0		;Restore stack to entry value
         ret

--- a/lib/target/aquarius/classic/rom.asm
+++ b/lib/target/aquarius/classic/rom.asm
@@ -39,10 +39,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN 	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 endloop:
 	jr	endloop

--- a/lib/target/bee/classic/bee_crt0.asm
+++ b/lib/target/bee/classic/bee_crt0.asm
@@ -80,10 +80,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 ;        push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+    call    crt0_exit
+
 ;        pop     bc
 start1:
         ld      sp,0

--- a/lib/target/c128/classic/c128_crt0.asm
+++ b/lib/target/c128/classic/c128_crt0.asm
@@ -137,10 +137,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	;ld	bc,$d030
 	;xor	a

--- a/lib/target/c7420/classic/c7420_crt0.asm
+++ b/lib/target/c7420/classic/c7420_crt0.asm
@@ -62,10 +62,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	hl
 start1:
 	ld 	sp,0

--- a/lib/target/cpc/classic/cpc_crt0.asm
+++ b/lib/target/cpc/classic/cpc_crt0.asm
@@ -81,13 +81,10 @@ cleanup:
 ;
 ;       Deallocate memory which has been allocated here!
 ;
+    call    crt0_exit
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
 
-        di
+    di
 	call    cpc_enable_fw_exx_set
 start1: ld      sp,0
         ei

--- a/lib/target/cpm/classic/cpm_crt0.asm
+++ b/lib/target/cpm/classic/cpm_crt0.asm
@@ -176,10 +176,8 @@ ENDIF
 
 cleanup:
 	push	hl		;Save return value
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall	;Close any opened files
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	bc		;Get exit() value into bc
 start1:	ld      sp,0		;Pick up entry sp
         jp	0

--- a/lib/target/embedded/classic/embedded_crt0.asm
+++ b/lib/target/embedded/classic/embedded_crt0.asm
@@ -61,10 +61,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 endloop:
 	jr	endloop

--- a/lib/target/enterprise/classic/enterprise_crt0.asm
+++ b/lib/target/enterprise/classic/enterprise_crt0.asm
@@ -174,10 +174,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 IF (!DEFINED_startup | (startup=1))
 warmreset:

--- a/lib/target/excali64/classic/excali64_crt0.asm
+++ b/lib/target/excali64/classic/excali64_crt0.asm
@@ -78,10 +78,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
         pop     hl
 start1:
         ld      sp,0

--- a/lib/target/fp1100/classic/fp1100_crt0.asm
+++ b/lib/target/fp1100/classic/fp1100_crt0.asm
@@ -73,10 +73,8 @@ cleanup:
 ;
         push    hl				; return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
 cleanup_exit:
 

--- a/lib/target/g800/classic/g800_crt0.asm
+++ b/lib/target/g800/classic/g800_crt0.asm
@@ -62,10 +62,8 @@ cleanup:
 ;
 ;       Deallocate memory which has been allocated here!
 ;
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
 cleanup_exit:
 start1: ld      sp,0            ;Restore stack to entry value

--- a/lib/target/gal/classic/gal_crt0.asm
+++ b/lib/target/gal/classic/gal_crt0.asm
@@ -56,10 +56,8 @@ cleanup:
 ;
 ;       Deallocate memory which has been allocated here!
 ;
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+    call    crt0_exit
+
 
 cleanup_exit:
 	halt

--- a/lib/target/kc/classic/kc_crt0.asm
+++ b/lib/target/kc/classic/kc_crt0.asm
@@ -103,10 +103,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/laser500/classic/ram.asm
+++ b/lib/target/laser500/classic/ram.asm
@@ -44,10 +44,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
         pop     bc
 start1:
         ld      sp,0

--- a/lib/target/lynx/classic/lynx_crt0.asm
+++ b/lib/target/lynx/classic/lynx_crt0.asm
@@ -71,10 +71,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	bc
 start1:
         ld      sp,0

--- a/lib/target/m5/classic/ram.asm
+++ b/lib/target/m5/classic/ram.asm
@@ -43,10 +43,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 	exx

--- a/lib/target/m5/classic/rom.asm
+++ b/lib/target/m5/classic/rom.asm
@@ -59,10 +59,8 @@ cleanup:
 ;
         push    hl				; return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
 
 cleanup_exit:

--- a/lib/target/mc1000/classic/mc1000_crt0.asm
+++ b/lib/target/mc1000/classic/mc1000_crt0.asm
@@ -301,10 +301,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
         pop     bc
 start1:
         ld      sp,0

--- a/lib/target/msx/classic/msxdos.asm
+++ b/lib/target/msx/classic/msxdos.asm
@@ -75,10 +75,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 start1:
 	ld	sp,0

--- a/lib/target/msx/classic/ram.asm
+++ b/lib/target/msx/classic/ram.asm
@@ -38,10 +38,8 @@ start:
 	ld	ix,$d2	; TOTEXT - force text mode on exit
 	call	msxbios
 cleanup:
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 start1:
         ld      sp,0

--- a/lib/target/mtx/classic/mtx_crt0.asm
+++ b/lib/target/mtx/classic/mtx_crt0.asm
@@ -84,10 +84,8 @@ cleanup:
 ;
         push    hl				; return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
 
 cleanup_exit:

--- a/lib/target/multi8/classic/16k.asm
+++ b/lib/target/multi8/classic/16k.asm
@@ -41,10 +41,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/multi8/classic/64k.asm
+++ b/lib/target/multi8/classic/64k.asm
@@ -106,10 +106,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN 	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 endloop:
 	jr	endloop

--- a/lib/target/mz/classic/mz_crt0.asm
+++ b/lib/target/mz/classic/mz_crt0.asm
@@ -62,10 +62,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 start1:
         ld      sp,0

--- a/lib/target/mz2500/classic/mz2500_crt0.asm
+++ b/lib/target/mz2500/classic/mz2500_crt0.asm
@@ -142,10 +142,8 @@ ENDIF
 
 cleanup:
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+    call    crt0_exit
+
 
 	;push    hl				; return code
 	

--- a/lib/target/nascom/classic/nascom_crt0.asm
+++ b/lib/target/nascom/classic/nascom_crt0.asm
@@ -76,10 +76,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/nc/classic/nc100_crt0.asm
+++ b/lib/target/nc/classic/nc100_crt0.asm
@@ -109,10 +109,8 @@ start:
 
 cleanup:
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall	;Close all opened files
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	bc
 start1:
 	ld	sp,0

--- a/lib/target/newbrain/classic/newbrain_crt0.asm
+++ b/lib/target/newbrain/classic/newbrain_crt0.asm
@@ -68,10 +68,7 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
 
 IF (startup=2)
 	ld	hl,(oldintaddr)

--- a/lib/target/osca/classic/osca_crt0.asm
+++ b/lib/target/osca/classic/osca_crt0.asm
@@ -207,10 +207,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push	hl		;save exit value
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+        call    crt0_exit
+
 	; kjt_flos_display restores the text mode but makes the screen flicker
 	; if it is in text mode already
 	;

--- a/lib/target/oz/classic/oz_crt0.asm
+++ b/lib/target/oz/classic/oz_crt0.asm
@@ -218,10 +218,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-		EXTERN	closeall
-		call	closeall
-ENDIF
+        call    crt0_exit
+
 
 start1:	ld	sp,0		;Restore stack to entry value
 		;ret

--- a/lib/target/p2000/classic/p2000_crt0.asm
+++ b/lib/target/p2000/classic/p2000_crt0.asm
@@ -88,10 +88,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 start1:
         ld      sp,0

--- a/lib/target/pc6001/classic/pc6001_crt0.asm
+++ b/lib/target/pc6001/classic/pc6001_crt0.asm
@@ -131,10 +131,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 ;        push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN      closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 ;        pop     bc
 start1:
         ld      sp,0

--- a/lib/target/pc88/classic/pc88_crt0.asm
+++ b/lib/target/pc88/classic/pc88_crt0.asm
@@ -126,10 +126,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+        call    crt0_exit
+
 
 start1:
         ld      sp,0

--- a/lib/target/pps/classic/pps_crt0.asm
+++ b/lib/target/pps/classic/pps_crt0.asm
@@ -95,10 +95,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl	;save return code
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value
 	ld	bc,$41		;exit with - error code

--- a/lib/target/pv2000/classic/pv2000_crt0.asm
+++ b/lib/target/pv2000/classic/pv2000_crt0.asm
@@ -91,10 +91,8 @@ cleanup:
 ;
         push    hl				; return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
 
 cleanup_exit:

--- a/lib/target/rcmx000/classic/rcmx000_crt0.asm
+++ b/lib/target/rcmx000/classic/rcmx000_crt0.asm
@@ -66,10 +66,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to some sane value

--- a/lib/target/rx78/classic/rx78_crt0.asm
+++ b/lib/target/rx78/classic/rx78_crt0.asm
@@ -69,10 +69,8 @@ cleanup:
 ;
         push    hl				; return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+      call    crt0_exit
+
 
 
 cleanup_exit:

--- a/lib/target/sam/classic/sam_crt0.asm
+++ b/lib/target/sam/classic/sam_crt0.asm
@@ -96,10 +96,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
         pop     bc
 

--- a/lib/target/sc3000/classic/ram.asm
+++ b/lib/target/sc3000/classic/ram.asm
@@ -46,10 +46,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN 	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 start1:
         ld      sp,0

--- a/lib/target/sc3000/classic/rom.asm
+++ b/lib/target/sc3000/classic/rom.asm
@@ -137,10 +137,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN 	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 endloop:
 	jr	endloop

--- a/lib/target/sms/classic/sms_crt0.asm
+++ b/lib/target/sms/classic/sms_crt0.asm
@@ -160,10 +160,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN 	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 endloop:
 	jr	endloop

--- a/lib/target/sos/classic/sos_crt0.asm
+++ b/lib/target/sos/classic/sos_crt0.asm
@@ -112,10 +112,8 @@ find_end:
 
 cleanup:
 	push	hl		;Save return value
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall	;Close any opened files
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	bc		;Get exit() value into bc
 start1:	ld      sp,0		;Pick up entry sp
         jp	$1FFA	; HOT boot

--- a/lib/target/spc1000/classic/spc1000_crt0.asm
+++ b/lib/target/spc1000/classic/spc1000_crt0.asm
@@ -65,10 +65,8 @@ cleanup:
 ;
         push    hl				; return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 
 IF CRT_ENABLE_VDP
 ELSE

--- a/lib/target/srr/classic/sorcerer_crt0.asm
+++ b/lib/target/srr/classic/sorcerer_crt0.asm
@@ -69,10 +69,8 @@ ENDIF
 
 cleanup:
 	push	hl		;Save return value
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall	;Close any opened files
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 	pop	bc		;Get exit() value into bc
 start1:	ld      sp,0		;Pick up entry sp
         jp	$e003		; Monitor warm start

--- a/lib/target/svi/classic/svi_crt0.asm
+++ b/lib/target/svi/classic/svi_crt0.asm
@@ -75,11 +75,8 @@ cleanup:
 ;
 ;       Deallocate memory which has been allocated here!
 ;
+    call    crt0_exit
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
 
 start1:
 IF startup = 2

--- a/lib/target/test/classic/test_crt0.asm
+++ b/lib/target/test/classic/test_crt0.asm
@@ -145,6 +145,9 @@ ENDIF
 	pop	bc
 	pop	bc
 cleanup:
+	push	hl
+	call	crt0_exit
+	pop	hl
 	ld	a,CMD_EXIT	;exit
 	; Fall into SYSCALL
 

--- a/lib/target/trs80/classic/trs80_crt0.asm
+++ b/lib/target/trs80/classic/trs80_crt0.asm
@@ -194,10 +194,8 @@ cleanup:
 ;
 ;       Deallocate memory which has been allocated here!
 ;
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+    call    crt0_exit
+
 
 cleanup_exit:
 start1: ld      sp,0            ;Restore stack to entry value

--- a/lib/target/tvc/classic/tvc_crt0.asm
+++ b/lib/target/tvc/classic/tvc_crt0.asm
@@ -77,10 +77,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-    EXTERN  closeall
-    call    closeall
-ENDIF
+    call    crt0_exit
+
 
 
 start1:

--- a/lib/target/vg5k/classic/vg5k_crt0.asm
+++ b/lib/target/vg5k/classic/vg5k_crt0.asm
@@ -74,10 +74,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 start1:
         ld      sp,0
 	pop     hl		; ..let's restore them !

--- a/lib/target/vz/classic/vz_crt0.asm
+++ b/lib/target/vz/classic/vz_crt0.asm
@@ -119,10 +119,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
         pop     bc
 start1:
         ld      sp,0

--- a/lib/target/x07/classic/x07_crt0.asm
+++ b/lib/target/x07/classic/x07_crt0.asm
@@ -64,10 +64,8 @@ ENDIF
 
 cleanup:
 ;	push	hl		;Save return value
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall	;Close any opened files
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 ;	pop	bc		;Get exit() value into bc
 
 start1:	ld  sp,0    ;Pick up entry sp

--- a/lib/target/x1/classic/allram.asm
+++ b/lib/target/x1/classic/allram.asm
@@ -96,10 +96,8 @@ ENDIF
     call    _main
 
 cleanup:
-IF CRT_ENABLE_STDIO = 1
-    EXTERN     closeall
-    call    closeall
-ENDIF
+    call    crt0_exit
+
 end:
     jr	end
     rst	0

--- a/lib/target/x1/classic/ipl.asm
+++ b/lib/target/x1/classic/ipl.asm
@@ -59,10 +59,8 @@ isr_table_fill:
 
 cleanup:
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+    call    crt0_exit
+
 
 	push    hl				; return code
 end:

--- a/lib/target/z1013/classic/z1013_crt0.asm
+++ b/lib/target/z1013/classic/z1013_crt0.asm
@@ -67,10 +67,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/z80tvgame/classic/z80tvgame_crt0.asm
+++ b/lib/target/z80tvgame/classic/z80tvgame_crt0.asm
@@ -118,11 +118,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl				; return code
+        call    crt0_exit
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
 
 
 cleanup_exit:

--- a/lib/target/z88/classic/z88a_crt0.asm
+++ b/lib/target/z88/classic/z88a_crt0.asm
@@ -168,8 +168,7 @@ ENDIF
 cleanup:			;Jump back to here from exit()
 IF CRT_ENABLE_STDIO = 1
 	push	af		;Save exit value
-	EXTERN	closeall
-	call	closeall	;Close all files
+    call    crt0_exit
  IF DEFINED_farheapsz
 	EXTERN	freeall_far
  	call	freeall_far	;Deallocate far memory

--- a/lib/target/z88/classic/z88b_crt0.asm
+++ b/lib/target/z88/classic/z88b_crt0.asm
@@ -75,10 +75,8 @@ ENDIF
 
         call    _main		;Run the program
 cleanup:			;Jump back here from exit() if needed
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall	;Close any open files (fopen)
-ENDIF
+        call    crt0_exit
+
         call_oz(gn_nln)		;Print a new line
         call    resterrhan	;Restore the original error handler
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/z88/classic/z88s_crt0.asm
+++ b/lib/target/z88/classic/z88s_crt0.asm
@@ -131,10 +131,8 @@ ENDIF
 	pop	bc		; kill argc
 	
 cleanup:			;Jump back here from exit() if needed
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall	;Close any open files (fopen)
-ENDIF
+    call    crt0_exit
+
         call    resterrhan	;Restore the original error handler
 	
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/z9001/classic/z9001_crt0.asm
+++ b/lib/target/z9001/classic/z9001_crt0.asm
@@ -65,10 +65,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
 	push	hl
-IF CRT_ENABLE_STDIO = 1
-	EXTERN	closeall
-	call	closeall
-ENDIF
+    call    crt0_exit
+
 
 	pop	bc
 start1:	ld	sp,0		;Restore stack to entry value

--- a/lib/target/zx/classic/spec_crt0.asm
+++ b/lib/target/zx/classic/spec_crt0.asm
@@ -169,10 +169,8 @@ cleanup:
 ;       Deallocate memory which has been allocated here!
 ;
         push    hl
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+      call    crt0_exit
+
 
 
 IF (startup=2)      ; ROM ?

--- a/lib/target/zx80/classic/zx80_crt0.asm
+++ b/lib/target/zx80/classic/zx80_crt0.asm
@@ -100,10 +100,8 @@ cleanup:
 ;
         push    hl		; keep return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
     ;    ld      iy,16384	; no ix/iy swap here
 	;LD      (IY+$12),2    ; set DF-SZ to 24 lines.
 	;call	1863

--- a/lib/target/zx81/classic/zx81_crt0.asm
+++ b/lib/target/zx81/classic/zx81_crt0.asm
@@ -206,10 +206,8 @@ cleanup:
 ;
         push    hl		; keep return code
 
-IF CRT_ENABLE_STDIO = 1
-        EXTERN     closeall
-        call    closeall
-ENDIF
+        call    crt0_exit
+
 		; The BASIC USR call would restore IY on return, but it could not be enough
         call    restore81
 

--- a/libsrc/stdio/_freopen1.c
+++ b/libsrc/stdio/_freopen1.c
@@ -65,3 +65,12 @@ FILE *_freopen1(const char* name, int fd, const char* mode, FILE* fp)
         return fp2;
     }
 }
+
+/* If fopen/freopen() is used, we need to close all files, so do it */
+static void freopen1_cleanup_exit() __naked {
+#asm
+	SECTION	code_crt_exit
+	EXTERN	closeall
+	call	closeall
+#endasm
+}

--- a/libsrc/stdio/trs80/generic_console.asm
+++ b/libsrc/stdio/trs80/generic_console.asm
@@ -186,3 +186,9 @@ __eg2000_custom_font:	defb	0
 	ld	bc,768
 	ldir
 no_set_font:
+
+	SECTION	code_crt_exit
+	EXTERN	__console_x
+	ld	bc,(__console_x)
+	call	xypos
+	ld	($4020),hl	


### PR DESCRIPTION
This comes out of the request to align trs80 cursor with ROM on the forums