### PR TITLE
newlib targets - startup consistency / formatting

### DIFF
--- a/libsrc/_DEVELOPMENT/target/cpm/startup/cpm_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/cpm/startup/cpm_crt_0.asm.m4
@@ -127,8 +127,7 @@ __Continue:
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -146,56 +145,56 @@ __Restart:
    include "../crt_init_sp.inc"
 
    ; command line
-   
-   IF __crt_enable_commandline = 1
-   
-      include "../crt_cmdline_empty.inc"
-   
-   ENDIF
-   
-   IF __crt_enable_commandline >= 3
-      
-      ; copy command line words from default dma buffer to stack
-      ; must do this as the default dma buffer may be used by the cpm program
 
-      EXTERN l_command_line_parse
+IF __crt_enable_commandline = 1
 
-      ld hl,0x0080             ; default dma buffer
+   include "../crt_cmdline_empty.inc"
 
-      ld c,(hl)
-      ld b,h                   ; bc = length of command line
+ENDIF
 
-      inc l
-      ex de,hl
+IF __crt_enable_commandline >= 3
 
-      call l_command_line_parse
-      
-      ; cpm does not supply program name in command line
-      ; so place empty string in argv[0] instead
-      
-      ; bc = int argc
-      ; hl = char *argv[]
-      ; de = & empty string
-      ; bc'= num chars in redirector
-      ; hl'= char *redirector
-      
-      push de                  ; empty string added to front of argv[]
-      
-      dec hl
-      dec hl                   ; char *argv[] adjusted to include empty string at index 0
-      
-      inc c                    ; argc++
-      
-   ENDIF
+   ; copy command line words from default dma buffer to stack
+   ; must do this as the default dma buffer may be used by the cpm program
+
+   EXTERN l_command_line_parse
+
+   ld hl,0x0080                ; default dma buffer
+
+   ld c,(hl)
+   ld b,h                      ; bc = length of command line
+
+   inc l
+   ex de,hl
+
+   call l_command_line_parse
+
+   ; cpm does not supply program name in command line
+   ; so place empty string in argv[0] instead
+
+   ; bc = int argc
+   ; hl = char *argv[]
+   ; de = & empty string
+   ; bc'= num chars in redirector
+   ; hl'= char *redirector
+
+   push de                     ; empty string added to front of argv[]
+
+   dec hl
+   dec hl                      ; char *argv[] adjusted to include empty string at index 0
+
+   inc c                       ; argc++
+
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -206,7 +205,7 @@ __Restart_2:
    include "../clib_init_bss.inc"
 
    ; interrupt mode
-   
+
    include "../crt_set_interrupt_mode.inc"
 
 SECTION code_crt_init          ; user and library initialization
@@ -220,33 +219,33 @@ SECTION code_crt_main
    include "../crt_start_ei.inc"
 
    ; call user program
-   
+
    call _main                  ; hl = return status
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
-      
-      push hl                  ; save return status
+   ; not restarting
 
-   ENDIF
+   push hl                     ; save return status
+
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return
 
    ; close files
-   
+
    include "../clib_close.inc"
 
    ; terminate

--- a/libsrc/_DEVELOPMENT/target/cpm/startup/cpm_crt_4.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/cpm/startup/cpm_crt_4.asm.m4
@@ -127,7 +127,7 @@ __Continue:
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
+   include "crt_preamble.asm"  ; user provided preamble
    SECTION CODE
 
 ENDIF
@@ -146,56 +146,56 @@ __Restart:
    include "../crt_init_sp.inc"
 
    ; command line
-   
-   IF __crt_enable_commandline = 1
-   
-      include "../crt_cmdline_empty.inc"
-   
-   ENDIF
-   
-   IF __crt_enable_commandline >= 3
-      
-      ; copy command line words from default dma buffer to stack
-      ; must do this as the default dma buffer may be used by the cpm program
 
-      EXTERN l_command_line_parse
+IF __crt_enable_commandline = 1
 
-      ld hl,0x0080             ; default dma buffer
+   include "../crt_cmdline_empty.inc"
 
-      ld c,(hl)
-      ld b,h                   ; bc = length of command line
+ENDIF
 
-      inc l
-      ex de,hl
+IF __crt_enable_commandline >= 3
 
-      call l_command_line_parse
-      
-      ; cpm does not supply program name in command line
-      ; so place empty string in argv[0] instead
-      
-      ; bc = int argc
-      ; hl = char *argv[]
-      ; de = & empty string
-      ; bc'= num chars in redirector
-      ; hl'= char *redirector
-      
-      push de                  ; empty string added to front of argv[]
-      
-      dec hl
-      dec hl                   ; char *argv[] adjusted to include empty string at index 0
-      
-      inc c                    ; argc++
-      
-   ENDIF
+   ; copy command line words from default dma buffer to stack
+   ; must do this as the default dma buffer may be used by the cpm program
+
+   EXTERN l_command_line_parse
+
+   ld hl,0x0080                ; default dma buffer
+
+   ld c,(hl)
+   ld b,h                      ; bc = length of command line
+
+   inc l
+   ex de,hl
+
+   call l_command_line_parse
+
+   ; cpm does not supply program name in command line
+   ; so place empty string in argv[0] instead
+
+   ; bc = int argc
+   ; hl = char *argv[]
+   ; de = & empty string
+   ; bc'= num chars in redirector
+   ; hl'= char *redirector
+
+   push de                     ; empty string added to front of argv[]
+
+   dec hl
+   dec hl                      ; char *argv[] adjusted to include empty string at index 0
+
+   inc c                       ; argc++
+
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -206,7 +206,7 @@ __Restart_2:
    include "../clib_init_bss.inc"
 
    ; interrupt mode
-   
+
    include "../crt_set_interrupt_mode.inc"
 
 SECTION code_crt_init          ; user and library initialization
@@ -220,33 +220,33 @@ SECTION code_crt_main
    include "../crt_start_ei.inc"
 
    ; call user program
-   
+
    call _main                  ; hl = return status
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
-      
-      push hl                  ; save return status
+   ; not restarting
 
-   ENDIF
+   push hl                     ; save return status
+
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return
 
    ; close files
-   
+
    include "../clib_close.inc"
 
    ; terminate

--- a/libsrc/_DEVELOPMENT/target/hbios/startup/hbios_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/hbios/startup/hbios_crt_0.asm.m4
@@ -106,18 +106,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (__crt_org_code = 0) && !(__page_zero_present)
-
-   include "../crt_page_zero_z80.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -136,20 +125,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -179,22 +168,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/hbios/startup/hbios_crt_256.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/hbios/startup/hbios_crt_256.asm.m4
@@ -87,8 +87,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -117,20 +116,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -160,22 +159,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_0.asm.m4
@@ -95,8 +95,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -125,20 +124,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -168,22 +167,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_16.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_16.asm.m4
@@ -95,18 +95,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (ASMPC = 0) && (__crt_org_code = 0)
-
-   include "../crt_page_zero_z80.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -125,20 +114,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -168,22 +157,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return
@@ -194,38 +183,38 @@ SECTION code_crt_return
 
    ; terminate
 
-   IF (__crt_on_exit = 0x10002)
+IF (__crt_on_exit = 0x10002)
 
-      ; returning to basic
+   ; returning to basic
 
-      pop hl
+   pop hl
 
-      IF CRT_ABPASS > 0
+   IF CRT_ABPASS > 0
 
-         ld a,h
-         ld b,l
-         call CRT_ABPASS
-
-      ENDIF
-
-      ld sp,(__sp_or_ret)
-
-      IF (__crt_interrupt_mode_exit >= 0) && (__crt_interrupt_mode_exit <= 2)
-
-         im __crt_interrupt_mode_exit
-
-      ENDIF
-
-      ei
-      ret
-
-   ELSE
-
-      include "../crt_exit_eidi.inc"
-      include "../crt_restore_sp.inc"
-      include "../crt_program_exit.inc"      
+      ld a,h
+      ld b,l
+      call CRT_ABPASS
 
    ENDIF
+
+   ld sp,(__sp_or_ret)
+
+   IF (__crt_interrupt_mode_exit >= 0) && (__crt_interrupt_mode_exit <= 2)
+
+      im __crt_interrupt_mode_exit
+
+   ENDIF
+
+   ei
+   ret
+
+ELSE
+
+   include "../crt_exit_eidi.inc"
+   include "../crt_restore_sp.inc"
+   include "../crt_program_exit.inc"
+
+ENDIF
    
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; RUNTIME VARS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_256.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_256.asm.m4
@@ -87,8 +87,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -117,20 +116,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -160,22 +159,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_4.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_4.asm.m4
@@ -106,8 +106,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -136,20 +135,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -179,22 +178,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_64.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_64.asm.m4
@@ -127,18 +127,7 @@ __Continue:
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (ASMPC = 0) && (__crt_org_code = 0)
-
-   include "../crt_page_zero_z80.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -157,55 +146,55 @@ __Restart:
 
    ; command line
 
-   IF __crt_enable_commandline = 1
+IF __crt_enable_commandline = 1
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
-   IF __crt_enable_commandline >= 3
+IF __crt_enable_commandline >= 3
 
-      ; copy command line words from default dma buffer to stack
-      ; must do this as the default dma buffer may be used by the cpm program
+   ; copy command line words from default dma buffer to stack
+   ; must do this as the default dma buffer may be used by the cpm program
 
-      EXTERN l_command_line_parse
+   EXTERN l_command_line_parse
 
-      ld hl,0x0080             ; default dma buffer
+   ld hl,0x0080                ; default dma buffer
 
-      ld c,(hl)
-      ld b,h                   ; bc = length of command line
+   ld c,(hl)
+   ld b,h                      ; bc = length of command line
 
-      inc l
-      ex de,hl
+   inc l
+   ex de,hl
 
-      call l_command_line_parse
+   call l_command_line_parse
 
-      ; cpm does not supply program name in command line
-      ; so place empty string in argv[0] instead
+   ; cpm does not supply program name in command line
+   ; so place empty string in argv[0] instead
 
-      ; bc = int argc
-      ; hl = char *argv[]
-      ; de = & empty string
-      ; bc'= num chars in redirector
-      ; hl'= char *redirector
+   ; bc = int argc
+   ; hl = char *argv[]
+   ; de = & empty string
+   ; bc'= num chars in redirector
+   ; hl'= char *redirector
 
-      push de                  ; empty string added to front of argv[]
+   push de                     ; empty string added to front of argv[]
 
-      dec hl
-      dec hl                   ; char *argv[] adjusted to include empty string at index 0
+   dec hl
+   dec hl                      ; char *argv[] adjusted to include empty string at index 0
 
-      inc c                    ; argc++
+   inc c                       ; argc++
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -235,22 +224,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_8.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_8.asm.m4
@@ -106,18 +106,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (ASMPC = 0) && (__crt_org_code = 0)
-
-   include "../crt_page_zero_z80.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -136,20 +125,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -179,22 +168,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_0.asm.m4
@@ -106,8 +106,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; first pass of user provided preamble
 
 ENDIF
 
@@ -138,20 +137,26 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
+
+IF __crt_include_preamble
+
+   include "crt_preamble.asm"  ; second pass of user provided preamble
+
+ENDIF
 
    ; initialize data section
 
@@ -181,22 +186,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_256.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_256.asm.m4
@@ -87,8 +87,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -119,20 +118,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -162,22 +161,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_64.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_64.asm.m4
@@ -107,18 +107,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (__crt_org_code = 0) && !(__page_zero_present)
-
-   include "../crt_page_zero_z180.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -139,55 +128,55 @@ __Restart:
 
    ; command line
 
-   IF __crt_enable_commandline = 1
+IF __crt_enable_commandline = 1
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
-   IF __crt_enable_commandline >= 3
+IF __crt_enable_commandline >= 3
 
-      ; copy command line words from default dma buffer to stack
-      ; must do this as the default dma buffer may be used by the cpm program
+   ; copy command line words from default dma buffer to stack
+   ; must do this as the default dma buffer may be used by the cpm program
 
-      EXTERN l_command_line_parse
+   EXTERN l_command_line_parse
 
-      ld hl,0x0080             ; default dma buffer
+   ld hl,0x0080                ; default dma buffer
 
-      ld c,(hl)
-      ld b,h                   ; bc = length of command line
+   ld c,(hl)
+   ld b,h                      ; bc = length of command line
 
-      inc l
-      ex de,hl
+   inc l
+   ex de,hl
 
-      call l_command_line_parse
+   call l_command_line_parse
 
-      ; cpm does not supply program name in command line
-      ; so place empty string in argv[0] instead
+   ; cpm does not supply program name in command line
+   ; so place empty string in argv[0] instead
 
-      ; bc = int argc
-      ; hl = char *argv[]
-      ; de = & empty string
-      ; bc'= num chars in redirector
-      ; hl'= char *redirector
+   ; bc = int argc
+   ; hl = char *argv[]
+   ; de = & empty string
+   ; bc'= num chars in redirector
+   ; hl'= char *redirector
 
-      push de                  ; empty string added to front of argv[]
+   push de                     ; empty string added to front of argv[]
 
-      dec hl
-      dec hl                   ; char *argv[] adjusted to include empty string at index 0
+   dec hl
+   dec hl                      ; char *argv[] adjusted to include empty string at index 0
 
-      inc c                    ; argc++
+   inc c                       ; argc++
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -217,22 +206,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_8.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/scz180/startup/scz180_crt_8.asm.m4
@@ -106,18 +106,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (__crt_org_code = 0) && !(__page_zero_present)
-
-   include "../crt_page_zero_z180.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -138,20 +127,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -181,22 +170,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_0.asm.m4
@@ -106,7 +106,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
+   include "crt_preamble.asm"  ; first pass of user provided preamble
 
 ENDIF
 
@@ -137,26 +137,26 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
-   IF __crt_include_preamble
+IF __crt_include_preamble
 
-      include "crt_preamble.asm"
+   include "crt_preamble.asm"  ; second pass of user provided preamble
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -186,22 +186,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_16.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_16.asm.m4
@@ -107,8 +107,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -129,20 +128,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -172,22 +171,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_256.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_256.asm.m4
@@ -87,8 +87,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -119,20 +118,20 @@ __Restart:
 
    ; command line
 
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -162,22 +161,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_64.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/yaz180/startup/yaz180_crt_64.asm.m4
@@ -107,18 +107,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
-
-ENDIF
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PAGE ZERO ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-IF (__crt_org_code = 0) && !(__page_zero_present)
-
-   include "../crt_page_zero_z180.inc"
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -139,55 +128,55 @@ __Restart:
 
    ; command line
 
-   IF __crt_enable_commandline = 1
+IF __crt_enable_commandline = 1
 
-      include "../crt_cmdline_empty.inc"
+   include "../crt_cmdline_empty.inc"
 
-   ENDIF
+ENDIF
 
-   IF __crt_enable_commandline >= 3
+IF __crt_enable_commandline >= 3
 
-      ; copy command line words from default dma buffer to stack
-      ; must do this as the default dma buffer may be used by the cpm program
+   ; copy command line words from default dma buffer to stack
+   ; must do this as the default dma buffer may be used by the cpm program
 
-      EXTERN l_command_line_parse
+   EXTERN l_command_line_parse
 
-      ld hl,0x0080             ; default dma buffer
+   ld hl,0x0080                ; default dma buffer
 
-      ld c,(hl)
-      ld b,h                   ; bc = length of command line
+   ld c,(hl)
+   ld b,h                      ; bc = length of command line
 
-      inc l
-      ex de,hl
+   inc l
+   ex de,hl
 
-      call l_command_line_parse
+   call l_command_line_parse
 
-      ; cpm does not supply program name in command line
-      ; so place empty string in argv[0] instead
+   ; cpm does not supply program name in command line
+   ; so place empty string in argv[0] instead
 
-      ; bc = int argc
-      ; hl = char *argv[]
-      ; de = & empty string
-      ; bc'= num chars in redirector
-      ; hl'= char *redirector
+   ; bc = int argc
+   ; hl = char *argv[]
+   ; de = & empty string
+   ; bc'= num chars in redirector
+   ; hl'= char *redirector
 
-      push de                  ; empty string added to front of argv[]
+   push de                     ; empty string added to front of argv[]
 
-      dec hl
-      dec hl                   ; char *argv[] adjusted to include empty string at index 0
+   dec hl
+   dec hl                      ; char *argv[] adjusted to include empty string at index 0
 
-      inc c                    ; argc++
+   inc c                       ; argc++
 
-   ENDIF
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -217,22 +206,22 @@ SECTION code_crt_main
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
+IF __clib_exit_stack_size > 0
 
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
 
-   ENDIF
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
 
-      ; not restarting
+   ; not restarting
 
-      push hl                  ; save return status
+   push hl                     ; save return status
 
-   ENDIF
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return

--- a/libsrc/_DEVELOPMENT/target/z180/startup/z180_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/z180/startup/z180_crt_0.asm.m4
@@ -66,8 +66,7 @@ EXTERN _main
 
 IF __crt_include_preamble
 
-   include "crt_preamble.asm"
-   SECTION CODE
+   include "crt_preamble.asm"  ; user provided preamble
 
 ENDIF
 
@@ -85,6 +84,8 @@ ENDIF
 ;; CRT INIT ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+SECTION code_crt_start         ; system initialization
+
 __Start:
 
    include "../crt_start_di.inc"
@@ -93,23 +94,23 @@ __Start:
 __Restart:
 
    include "../crt_init_sp.inc"
-   
+
    ; command line
-   
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
-   
-      include "../crt_cmdline_empty.inc"
-   
-   ENDIF
+
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+
+   include "../crt_cmdline_empty.inc"
+
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -120,55 +121,61 @@ __Restart_2:
    include "../clib_init_bss.inc"
 
    ; interrupt mode
-   
+
    include "../crt_set_interrupt_mode.inc"
 
 SECTION code_crt_init          ; user and library initialization
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; MAIN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 SECTION code_crt_main
 
    include "../crt_start_ei.inc"
 
    ; call user program
-   
+
    call _main                  ; hl = return status
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
-   
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
-   
-   ENDIF
+IF __clib_exit_stack_size > 0
+
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
+
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
-   
-      ; not restarting
-      
-      push hl                  ; save return status
-   
-   ENDIF
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+
+   ; not restarting
+
+   push hl                     ; save return status
+
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return
 
    ; close files
-   
+
    include "../clib_close.inc"
 
    ; terminate
-   
+
    include "../crt_exit_eidi.inc"
    include "../crt_restore_sp.inc"
-   include "../crt_program_exit.inc"      
+   include "../crt_program_exit.inc"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; RUNTIME VARS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 include "../crt_jump_vectors_z180.inc"
+include "crt_interrupt_vectors_z180.inc"
 
 IF (__crt_on_exit & 0x10000) && ((__crt_on_exit & 0x6) || ((__crt_on_exit & 0x8) && (__register_sp = -1)))
 

--- a/libsrc/_DEVELOPMENT/target/z80/startup/z80_crt_0.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/z80/startup/z80_crt_0.asm.m4
@@ -93,23 +93,23 @@ __Start:
 __Restart:
 
    include "../crt_init_sp.inc"
-   
+
    ; command line
-   
-   IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
-   
-      include "../crt_cmdline_empty.inc"
-   
-   ENDIF
+
+IF (__crt_enable_commandline = 1) || (__crt_enable_commandline >= 3)
+
+   include "../crt_cmdline_empty.inc"
+
+ENDIF
 
 __Restart_2:
 
-   IF __crt_enable_commandline >= 1
+IF __crt_enable_commandline >= 1
 
-      push hl                  ; argv
-      push bc                  ; argc
+   push hl                     ; argv
+   push bc                     ; argc
 
-   ENDIF
+ENDIF
 
    ; initialize data section
 
@@ -120,49 +120,54 @@ __Restart_2:
    include "../clib_init_bss.inc"
 
    ; interrupt mode
-   
+
    include "../crt_set_interrupt_mode.inc"
 
 SECTION code_crt_init          ; user and library initialization
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; MAIN ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 SECTION code_crt_main
 
    include "../crt_start_ei.inc"
 
    ; call user program
-   
+
    call _main                  ; hl = return status
 
    ; run exit stack
 
-   IF __clib_exit_stack_size > 0
-   
-      EXTERN asm_exit
-      jp asm_exit              ; exit function jumps to __Exit
-   
-   ENDIF
+IF __clib_exit_stack_size > 0
+
+   EXTERN asm_exit
+   jp asm_exit                 ; exit function jumps to __Exit
+
+ENDIF
 
 __Exit:
 
-   IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
-   
-      ; not restarting
-      
-      push hl                  ; save return status
-   
-   ENDIF
+IF !((__crt_on_exit & 0x10000) && (__crt_on_exit & 0x8))
+
+   ; not restarting
+
+   push hl                     ; save return status
+
+ENDIF
 
 SECTION code_crt_exit          ; user and library cleanup
 SECTION code_crt_return
 
    ; close files
-   
+
    include "../clib_close.inc"
 
    ; terminate
-   
+
    include "../crt_exit_eidi.inc"
    include "../crt_restore_sp.inc"
-   include "../crt_program_exit.inc"      
+   include "../crt_program_exit.inc"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; RUNTIME VARS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
- Rework some of the newlib targets for consistency.
- Remove Page 0 config from subtype startups where a bios is already present.

Checking and testing before merging.