### PR TITLE
Update SpecNext build instructions in examples

### DIFF
--- a/libsrc/_DEVELOPMENT/EXAMPLES/zxn/copper/layer_priority/readme.md
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/zxn/copper/layer_priority/readme.md
@@ -1,7 +1,7 @@
 ## Compile
 
 ```
-zcc +zxn -vn -startup=31 -SO3 -clib=sdcc_iy --max-allocs-per-node200000 @zproject.lst -o terms -pragma-include:zpragma.inc -subtype=sna -create-app
+zcc +zxn -vn -startup=31 -SO3 -clib=sdcc_iy --max-allocs-per-node200000 @zproject.lst -o terms -pragma-include:zpragma.inc -subtype=nex -Cz"--clean" -create-app
 ```
 
 ## Run

--- a/libsrc/_DEVELOPMENT/EXAMPLES/zxn/copper/layer_priority/terms.c
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/zxn/copper/layer_priority/terms.c
@@ -1,4 +1,4 @@
-// zcc +zxn -vn -startup=31 -SO3 -clib=sdcc_iy --max-allocs-per-node200000 @zproject.lst -o terms -pragma-include:zpragma.inc -subtype=sna -create-app
+// zcc +zxn -vn -startup=31 -SO3 -clib=sdcc_iy --max-allocs-per-node200000 @zproject.lst -o terms -pragma-include:zpragma.inc -subtype=nex -Cz"--clean" -create-app
 
 #include <stdio.h>
 #include <stropts.h>

--- a/libsrc/_DEVELOPMENT/EXAMPLES/zxn/esxdos/dir/dir.c
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/zxn/esxdos/dir/dir.c
@@ -1,5 +1,5 @@
-// zcc +zxn -v -clib=sdcc_iy -SO3 --max-allocs-per-node200000 dir.c -o dir -subtype=sna -Cz"--clean" -create-app
-// zcc +zxn -v -clib=new dir.c -o dir -subtype=sna -Cz"--clean" -create-app
+// zcc +zxn -v -clib=sdcc_iy -SO3 --max-allocs-per-node200000 dir.c -o dir -subtype=nex -Cz"--clean" -create-app
+// zcc +zxn -v -clib=new dir.c -o dir -subtype=nex -Cz"--clean" -create-app
 
 #include <stdio.h>
 #include <arch/zxn/esxdos.h>

--- a/libsrc/_DEVELOPMENT/EXAMPLES/zxn/esxdos/readme.md
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/zxn/esxdos/readme.md
@@ -23,10 +23,10 @@ functions should be used instead of `esx_*` to indicate this.
 
 zsdcc compile:
 ```
-zcc +zxn -v -clib=sdcc_iy -SO3 --max-allocs-per-node200000 dir.c -o dir -subtype=sna -Cz"--clean" -create-app
+zcc +zxn -v -clib=sdcc_iy -SO3 --max-allocs-per-node200000 dir.c -o dir -subtype=nex -Cz"--clean" -create-app
 ```
 
 sccz80 compile:
 ```
-zcc +zxn -v -clib=new dir.c -o dir -subtype=sna -Cz"--clean" -create-app
+zcc +zxn -v -clib=new dir.c -o dir -subtype=nex -Cz"--clean" -create-app
 ```

--- a/libsrc/_DEVELOPMENT/EXAMPLES/zxn/sprites/mixed-sw-hw/main.c
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/zxn/sprites/mixed-sw-hw/main.c
@@ -1,4 +1,4 @@
-// zcc +zxn -v -startup=1 -clib=sdcc_iy -SO3 --max-allocs-per-node200000 main.c graphics.asm.m4 interrupt.asm -o main -pragma-include:zpragma.inc -subtype=sna -create-app
+// zcc +zxn -v -startup=1 -clib=sdcc_iy -SO3 --max-allocs-per-node200000 main.c graphics.asm.m4 interrupt.asm -o main -pragma-include:zpragma.inc -subtype=nex -Cz"--clean" -create-app
 
 #include <arch/zxn.h>
 #include <arch/zxn/color.h>

--- a/libsrc/_DEVELOPMENT/EXAMPLES/zxn/sprites/mixed-sw-hw/readme.md
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/zxn/sprites/mixed-sw-hw/readme.md
@@ -1,7 +1,7 @@
 ## Compile
 
 ```
-zcc +zxn -v -startup=1 -clib=sdcc_iy -SO3 --max-allocs-per-node200000 main.c graphics.asm.m4 interrupt.asm -o main -pragma-include:zpragma.inc -subtype=sna -Cz"--clean" -create-app
+zcc +zxn -v -startup=1 -clib=sdcc_iy -SO3 --max-allocs-per-node200000 main.c graphics.asm.m4 interrupt.asm -o main -pragma-include:zpragma.inc -subtype=nex -Cz"--clean" -create-app
 ```
 
 ## Run


### PR DESCRIPTION
The use of the .sna format now turns off much of the advanced hardware
found in the Spectrum Next by default (for legacy compatibility reasons)
therefore apps wishing to use these features should now use the extension
.SNX or, preferably, the Next specific .NEX format.

I've taken the liberty of updating all the examples in _DEVELOPMENT except
those that specifically reference the "bigsna" format.

This pull request is a product of discussion https://github.com/z88dk/z88dk/issues/1424#issuecomment-602651540

-Dx