### PR TITLE
Issue #1431: Fix long promotion for value on stack

### DIFF
--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -2982,7 +2982,7 @@ void asr_const(LVALUE *lval, int32_t value)
     } else {
         if ( value == 1 && IS_8085() && !ulvalue(lval) ) {
             ol("sra\thl");
-        } else if ( value == 1  && !IS_8080() ) { /* 4 bytes, 16T */
+        } else if ( value == 1  && !IS_808x() ) { /* 4 bytes, 16T */
             if ( ulvalue(lval) ) {
                 ol("srl\th");
             } else {

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -4843,6 +4843,34 @@ void zconvert_to_double(Kind type, unsigned char isunsigned)
    else callrts("sint2f");
 }
 
+void zwiden_stack_to_long(LVALUE *lval)
+{
+    if ( IS_808x() || IS_GBZ80() ) {
+        int label = getlabel();
+        // We have a value in dehl that we must preserve
+        ol("ld\tc,l");
+        ol("ld\tb,h");
+        ol("ld\thl,0");
+        ol("ex\t(sp),hl"); // Emulated on GBZ80 unfortunately
+        ol("ld\ta,h");
+        ol("rlca");
+        opjumpr("nc,",label);
+        ol("ex\t(sp),hl"); // Emulated on GBZ80 unfortunately
+        ol("dec\thl");
+        ol("ex\t(sp),hl"); // Emulated on GBZ80 unfortunately
+        postlabel(label);
+        zpush();
+        ol("ld\tl,c");
+        ol("ld\th,b");
+    } else {
+        doexx(); /* Preserve other operator */
+        mainpop();
+        force(KIND_LONG, lval->val_type, lval->ltype->isunsigned, lval->ltype->isunsigned, 0);
+        lpush(); /* Put the new expansion on stk*/
+        doexx(); /* Get it back again */
+    }
+}
+
 /*
  * Local Variables:
  *  indent-tabs-mode:nil

--- a/src/sccz80/codegen.h
+++ b/src/sccz80/codegen.h
@@ -139,3 +139,4 @@ extern void zconvert_from_double(Kind type, unsigned char isunsigned);
 extern int push_function_argument(Kind expr, Type *type, int push_sdccchar);
 extern int push_function_argument_fnptr(Kind expr, Type *type, int push_sdccchar, int is_last_argument);
 extern void reset_namespace();
+extern void zwiden_stack_to_long(LVALUE *lval);

--- a/src/sccz80/plunge.c
+++ b/src/sccz80/plunge.c
@@ -404,11 +404,13 @@ void plnge2a(int (*heir)(LVALUE* lval), LVALUE* lval, LVALUE* lval2, void (*oper
             }
             lval->stage_add = NULL;
 
+#if 0
            if ( lhs_val_type != KIND_CHAR && rhs_val_type == KIND_CHAR ) {
                 rhs_val_type = lhs_val_type;
             } else if ( lhs_val_type == KIND_CHAR && rhs_val_type != KIND_CHAR ) {
                 lhs_val_type = rhs_val_type;
             }
+#endif
 
             if ( lval2->is_const && (lval->val_type == KIND_INT || lval->val_type == KIND_CHAR || lval->val_type == KIND_LONG) ) {
                 doconstoper = 1;

--- a/src/sccz80/primary.c
+++ b/src/sccz80/primary.c
@@ -361,11 +361,7 @@ void widenlong(LVALUE* lval, LVALUE* lval2)
     if (lval2->val_type == KIND_LONG) {
         /* Second operator is long */
         if (lval->val_type != KIND_LONG) {
-            doexx(); /* Preserve other operator */
-            mainpop();
-            force(KIND_LONG, lval->val_type, lval->ltype->isunsigned, lval->ltype->isunsigned, 0);
-            lpush(); /* Put the new expansion on stk*/
-            doexx(); /* Get it back again */
+            zwiden_stack_to_long(lval);
             if ( lval->ltype->isunsigned ) {
                 lval->ltype = type_ulong;
             } else {

--- a/testsuite/8080/Issue_1431_8080_long_promotion.c
+++ b/testsuite/8080/Issue_1431_8080_long_promotion.c
@@ -1,0 +1,13 @@
+
+#define EXTRA_POINTS 100UL
+#define EXTRA_POINTS_LEVEL_INCREASE 5UL
+
+static unsigned int points;
+static unsigned char level;
+
+
+int func() 
+{
+	points+=EXTRA_POINTS+level*EXTRA_POINTS_LEVEL_INCREASE;
+
+}

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -1,11 +1,17 @@
 
 
 
-SOURCES = $(wildcard *.c) $(wildcard z80n/*.c) $(wildcard rabbit/*.c) $(wildcard z180/*.c)
+SOURCES = $(wildcard *.c) $(wildcard z80n/*.c) $(wildcard rabbit/*.c) $(wildcard z180/*.c) $(wildcard 8080/*.c)
 OUTPUT = $(SOURCES:.c=.opt)
 
 
 all: $(OUTPUT)
+
+8080/%.opt: 8080/%.c
+	zcc +test -m8080 -vn -a $^ -o tmp1.opt
+	@cat tmp1.opt | grep -v '^;' | grep -v MODULE > tmp2.opt
+	diff -w tmp2.opt results/$@
+	@mv -f tmp1.opt $@
 
 z180/%.opt: z180/%.c
 	zcc +test -mz180 -vn -a $^ -o tmp1.opt

--- a/testsuite/results/8080/Issue_1431_8080_long_promotion.opt
+++ b/testsuite/results/8080/Issue_1431_8080_long_promotion.opt
@@ -1,0 +1,60 @@
+
+
+
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	EXTERN	saved_hl
+	EXTERN	saved_de
+	SECTION	code_compiler
+
+._func
+	ld	hl,(_points)
+	push	hl
+	ld	hl,(_level)
+	ld	h,0
+	ld	de,0
+	push	de
+	push	hl
+	ld	hl,5	;const
+	ld	de,0
+	call	l_long_mult
+	ld	bc,100
+	add	hl,bc
+	jp	nc,ASMPC+4
+	inc	de
+	ld	c,l
+	ld	b,h
+	ld	hl,0
+	ex	(sp),hl
+	ld	a,h
+	rlca
+	jr	nc,i_3
+	ex	(sp),hl
+	dec	hl
+	ex	(sp),hl
+.i_3
+	push	hl
+	ld	l,c
+	ld	h,b
+	call	l_long_add
+	ld	(_points),hl
+	ret
+
+
+
+
+	SECTION	bss_compiler
+._points	defs	2
+._level	defs	1
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_func
+
+
+
+


### PR DESCRIPTION
The 8080 port was using attempting to use exx so replace it with a few ex (sp),hl to make it work.

The gbz80 follows the same code as the 8080 code, but of course ex (sp),hl has to be emulated on that platform.