### PR TITLE
newlib - demote uint16_t inputs in mulu_32_32x32

### DIFF
--- a/libsrc/_DEVELOPMENT/math/integer/small/l_small_mul_32_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/integer/small/l_small_mul_32_32x32.asm
@@ -1,77 +1,105 @@
 
 ; 2000 djm
 ; 2007 aralbrec - use bcbc' rather than bytes indexed by ix per djm suggestion
-
-INCLUDE "config_private.inc"
+; 2020 feilipu - demote uint16_t
 
 SECTION code_clib
 SECTION code_math
 
+EXTERN l_small_mul_32_16x16
+
 PUBLIC l_small_mul_32_32x32, l0_small_mul_32_32x32
+
+l0_small_mul_32_16x16:
+
+    ; multiplication of two 16-bit numbers into a 32-bit product
+    ;
+    ; enter : hl'= 16-bit multiplier   = y
+    ;         hl = 16-bit multiplicand = x
+    ;
+    ; exit  : dehl = 32-bit product
+    ;         carry reset
+    ;
+    ; uses  : af, hl, bc', de', hl'
+
+    push hl
+    exx
+    pop de
+    jp l_small_mul_32_16x16
 
 l_small_mul_32_32x32:
 
    ; multiplication of two 32-bit numbers into a 32-bit product
    ;
-   ; enter : dehl = 32-bit multiplicand
-   ;         dehl'= 32-bit multiplicand (more leading zeroes = better performance)
+   ; enter : dehl = 32-bit multiplicand (more leading zeroes = better performance)
+   ;         dehl'= 32-bit multiplicand
    ;
    ; exit  : dehl = 32-bit product
    ;         carry reset
    ;
    ; uses  : af, bc, de, hl, bc', de', hl'
 
-   xor a
-   push hl
-   exx
-   ld c,l
-   ld b,h
-   pop hl
-   push de
-   ex de,hl
-   ld l,a
-   ld h,a
-   exx
-   pop bc
-   ld l,a
-   ld h,a
+
+    xor a
+    or e
+    or d
+
+    exx
+    or e
+    or d
+    jr Z,l0_small_mul_32_16x16  ; demote if both are uint16_t
+
+    xor a
+    push hl
+    exx
+    ld c,l
+    ld b,h
+    pop hl
+    push de
+    ex de,hl
+    ld l,a
+    ld h,a
+    exx
+    pop bc
+    ld l,a
+    ld h,a
 
 l0_small_mul_32_32x32:
 
-   ; dede' = 32-bit multiplicand
-   ; bcbc' = 32-bit multiplicand
-   ; hlhl' = 0
+    ; dede' = 32-bit multiplicand
+    ; bcbc' = 32-bit multiplicand
+    ; hlhl' = 0
 
-   ld a,b
-   ld b,32
+    ld a,b
+    ld b,32
 
 loop_0:
 
-   rra
-   rr c
-   exx
-   rr b
-   rr c
-   jr nc, loop_1
-   
-   add hl,de
-   exx
-   adc hl,de
-   exx
+    rra
+    rr c
+    exx
+    rr b
+    rr c
+    jr nc, loop_1
+
+    add hl,de
+    exx
+    adc hl,de
+    exx
 
 loop_1:
 
-   sla e
-   rl d
-   exx
-   rl e
-   rl d
-   
-   djnz loop_0
+    sla e
+    rl d
+    exx
+    rl e
+    rl d
 
-   push hl
-   exx
-   pop de
-   
-   or a
-   ret
+    djnz loop_0
+
+    push hl
+    exx
+    pop de
+
+    or a
+    ret

--- a/libsrc/_DEVELOPMENT/math/integer/small/l_small_mul_32_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/integer/small/l_small_mul_32_32x32.asm
@@ -1,4 +1,3 @@
-
 ; 2000 djm
 ; 2007 aralbrec - use bcbc' rather than bytes indexed by ix per djm suggestion
 ; 2020 feilipu - demote uint16_t
@@ -20,7 +19,7 @@ l0_small_mul_32_16x16:
     ; exit  : dehl = 32-bit product
     ;         carry reset
     ;
-    ; uses  : af, hl, bc', de', hl'
+    ; uses  : af, bc, de, hl, bc', de', hl'
 
     push hl
     exx
@@ -29,15 +28,15 @@ l0_small_mul_32_16x16:
 
 l_small_mul_32_32x32:
 
-   ; multiplication of two 32-bit numbers into a 32-bit product
-   ;
-   ; enter : dehl = 32-bit multiplicand (more leading zeroes = better performance)
-   ;         dehl'= 32-bit multiplicand
-   ;
-   ; exit  : dehl = 32-bit product
-   ;         carry reset
-   ;
-   ; uses  : af, bc, de, hl, bc', de', hl'
+    ; multiplication of two 32-bit numbers into a 32-bit product
+    ;
+    ; enter : dehl = 32-bit multiplicand (more leading zeroes = better performance)
+    ;         dehl'= 32-bit multiplicand
+    ;
+    ; exit  : dehl = 32-bit product
+    ;         carry reset
+    ;
+    ; uses  : af, bc, de, hl, bc', de', hl'
 
 
     xor a

--- a/libsrc/_DEVELOPMENT/math/integer/z180/l_z180_mulu_32_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/integer/z180/l_z180_mulu_32_32x32.asm
@@ -43,7 +43,7 @@ l_z180_mulu_32_32x32:
     exx
     or e
     or d
-    jr Z,l0_z180_mulu_32_16x16   ;   demote if both are uint16_t
+    jr Z,l0_z180_mulu_32_16x16  ; demote if both are uint16_t
 
     push hl
     exx

--- a/libsrc/_DEVELOPMENT/math/integer/z180/l_z180_mulu_32_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/integer/z180/l_z180_mulu_32_32x32.asm
@@ -17,7 +17,7 @@ l0_z180_mulu_32_16x16:
     ; exit  : dehl = 32-bit product
     ;         carry reset
     ;
-    ; uses  : af, hl, bc', de', hl'
+    ; uses  : af, bc, de, hl, bc', de', hl'
 
     push hl
     exx
@@ -175,4 +175,3 @@ l0_z180_mulu_32_32x32:
     pop de
     xor a                       ; carry reset
     ret                         ; exit  : DEHL = 32-bit product
-

--- a/libsrc/_DEVELOPMENT/math/integer/z80n/l_z80n_mulu_32_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/integer/z80n/l_z80n_mulu_32_32x32.asm
@@ -43,7 +43,7 @@ l_z80n_mulu_32_32x32:
     exx
     or e
     or d
-    jr Z,l0_z80n_mulu_32_16x16   ;   demote if both are uint16_t
+    jr Z,l0_z80n_mulu_32_16x16  ; demote if both are uint16_t
 
     push hl
     exx

--- a/libsrc/_DEVELOPMENT/math/integer/z80n/l_z80n_mulu_32_32x32.asm
+++ b/libsrc/_DEVELOPMENT/math/integer/z80n/l_z80n_mulu_32_32x32.asm
@@ -17,7 +17,7 @@ l0_z80n_mulu_32_16x16:
     ; exit  : dehl = 32-bit product
     ;         carry reset
     ;
-    ; uses  : af, hl, bc', de', hl'
+    ; uses  : af, bc, de, hl, bc', de', hl'
 
     push hl
     exx
@@ -188,4 +188,3 @@ l0_z80n_mulu_32_32x32:
     pop de
     xor a                       ; carry reset
     ret                         ; exit  : DEHL = 32-bit product
-


### PR DESCRIPTION
For both compilers (for z80) multiplying two `uint16_t` variables will either;

- `__mulint_callee` - truncate the result to `uint16_t` (if no casting), or
- `__mulong_callee` - if a `uint32_t` result is required and one of the inputs is cast to indicate this, then issue a `l_mul_32_32x32`.

This does PR checks whether the inputs to `__mulong_callee` are `uint16_t`, and if so issues  a `l_small_mul_32_16x16`, which is substantially faster.

This would match the z180 and z80n solutions.

@suborb classic z80 `~/z88dk/libsrc/z80_crt0s/z80/sccz80/l_long_mult.asm` doesn't `defc` to `l_small_mul_32_32x32`. I've left that untouched, but it might be worth moving over to newlib too?

__EDIT__ the reason I've put this up for review is that the `l_small_` functions are small, and this modification pulls the `32_16x16` code into every build using `32_32x32`, which may not be acceptably small.