### PR TITLE
Added bright, flash and inverse control to spectrum.h

### DIFF
--- a/include/spectrum.h
+++ b/include/spectrum.h
@@ -317,6 +317,18 @@ extern void __LIB__   in_MouseKempSetPos_callee(uint xcoord, uint ycoord) __smal
 // DISPLAY FILE FUNCTIONS
 //////////////////////////
 
+// Clear the screen
+#define zx_cls()                  fputc_cons(12)
+
+// Set or unset the flash attribute for now on
+#define zx_setattrflash(b)        fputc_cons(18); fputc_cons((b)? 49: 48)
+
+// Set or unset the bright attribute for now on
+#define zx_setattrbright(b)       fputc_cons(19); fputc_cons((b)? 49: 48)
+
+// Set or unset the inverse attribute for now on
+#define zx_setattrinverse(b)      fputc_cons(20); fputc_cons((b)? 49: 48)
+
 // Set the border color
 extern void  __LIB__  zx_border(uchar colour) __z88dk_fastcall;
 // Quickly set the whole screen color attributes


### PR DESCRIPTION
**Changelog**:

- Added the following to `spectrum.h`:
    - zx_cls()                         *Clear the screen.*
    - zx_setattrinverse(b)      *Set or unset the inverse attribute from now on.*
    - zx_setattrflash(b)          *Set or unset the flash attribute from now on.*
    - zx_setattrbright(b)        *Set or unset the bright attribute from now on.*

    These functions have been implemented as macros in the form: `fputc_cons(FNi); fputc_cons((b)? 49:48)`
