### PR TITLE
Added zx_print(s) so you don't need to include stdio.h

### DIFF
--- a/include/spectrum.h
+++ b/include/spectrum.h
@@ -335,8 +335,7 @@ extern uint  __LIB__    zx_screenstr_callee(uchar row, uchar col) __smallc __z88
 #define zx_topleft()              fputc_cons(22); fputc_cons(0); fputc_cons(0);
 
 // Print a string on the screen
-extern int printk(char *fmt, ...);
-#define zx_print(s) printk(s)
+extern int zx_printf(char *fmt, ...);
 
 // In the following, screen address refers to a pixel address within the display file while
 // attribute address refers to the attributes area.

--- a/include/spectrum.h
+++ b/include/spectrum.h
@@ -334,6 +334,10 @@ extern uint  __LIB__    zx_screenstr_callee(uchar row, uchar col) __smallc __z88
 #define zx_setcursorpos(a,b)      fputc_cons(22); fputc_cons(a); fputc_cons(b);
 #define zx_topleft()              fputc_cons(22); fputc_cons(0); fputc_cons(0);
 
+// Print a string on the screen
+extern int printk(char *fmt, ...);
+#define zx_print(s) printk(s)
+
 // In the following, screen address refers to a pixel address within the display file while
 // attribute address refers to the attributes area.
 //

--- a/include/spectrum.h
+++ b/include/spectrum.h
@@ -335,7 +335,7 @@ extern uint  __LIB__    zx_screenstr_callee(uchar row, uchar col) __smallc __z88
 #define zx_topleft()              fputc_cons(22); fputc_cons(0); fputc_cons(0);
 
 // Print a string on the screen
-extern int zx_printf(char *fmt, ...);
+extern int __LIB__ zx_printf(char *fmt, ...);
 
 // In the following, screen address refers to a pixel address within the display file while
 // attribute address refers to the attributes area.

--- a/libsrc/target/zx/_zx_printf.asm
+++ b/libsrc/target/zx/_zx_printf.asm
@@ -1,0 +1,3 @@
+PUBLIC _zx_printf
+EXTERN _printk
+defc _zx_printf = _printk

--- a/libsrc/target/zx/spectrum.lst
+++ b/libsrc/target/zx/spectrum.lst
@@ -7,6 +7,8 @@ target/zx/obj/${TARGET}/zx_colour
 target/zx/obj/${TARGET}/zx_screenstr
 target/zx/obj/${TARGET}/zx_screenstr_callee
 target/zx/obj/${TARGET}/zx_lprintc
+target/zx/obj/${TARGET}/zx_printf
+target/zx/obj/${TARGET}/_zx_printf
 target/zx/obj/${TARGET}/zx_print_buf
 target/zx/obj/${TARGET}/zx_im2_init
 target/zx/obj/${TARGET}/add_raster_int

--- a/libsrc/target/zx/zx_printf.asm
+++ b/libsrc/target/zx/zx_printf.asm
@@ -1,0 +1,3 @@
+PUBLIC zx_printf
+EXTERN printk
+defc zx_printf = printk


### PR DESCRIPTION
Changelog:
- Added `zx_print(s)` to spectrum.h so you don't need to include stdio.h
