### PR TITLE
classic - cp/m sequential read/write

### DIFF
--- a/include/cpm.h
+++ b/include/cpm.h
@@ -28,7 +28,7 @@
 /* Size of CPM Sector */
 #define SECSIZE  128
 
-/* Falgs for fcp->use */
+/* Flags for fcp->use */
 #define U_READ  1               /* file open for reading */
 #define U_WRITE 2               /* file open for writing */
 #define U_RDWR  3               /* open for read and write */
@@ -51,8 +51,9 @@ struct fcb {
     char    discmap[16];    /* CP/M disc map */
     char    next_record;    /* next record to read or write */
     u8_t    ranrec[3];      /* random record number (24 bit no. ) */
+
     /* Below here is used by the library */
-    unsigned long    rwptr;          /* read/write pointer in bytes */
+    unsigned long rwptr;    /* read/write pointer in bytes */
     u8_t    use;            /* use flag */
     u8_t    uid;            /* user id belonging to this file */
     u8_t    mode;           /* TEXT/BINARY discrimination */

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -89,7 +89,7 @@ struct filestr {
                 int         fd;
                 uint8_t    *ptr;
         } desc;
-        uint8_t  flags;
+        uint8_t   flags;
         uint8_t   ungetc;
         intptr_t  extra;
         uint8_t   flags2;
@@ -103,32 +103,32 @@ struct filestr {
  */
 
 /* Exit: hl = byte read, c = error, nc = success */
-#define __STDIO_MSG_GETC		1
+#define __STDIO_MSG_GETC        1
 /* Entry: bc = byte to write, Exit: hl = byte written (or EOF) */
-#define __STDIO_MSG_PUTC		2
+#define __STDIO_MSG_PUTC        2
 /* Entry: de = buf, bc = len, Exit: hl = bytes read */
-#define __STDIO_MSG_READ		3
+#define __STDIO_MSG_READ        3
 /* Entry: de = buf, bc = len, Exit: hl = bytes written */
-#define __STDIO_MSG_WRITE		4
+#define __STDIO_MSG_WRITE       4
 /* Entry: debc = offset, a' = whence */
-#define __STDIO_MSG_SEEK		5
-#define __STDIO_MSG_FLUSH		6
-#define __STDIO_MSG_CLOSE		7
-#define __STDIO_MSG_IOCTL		8
+#define __STDIO_MSG_SEEK        5
+#define __STDIO_MSG_FLUSH       6
+#define __STDIO_MSG_CLOSE       7
+#define __STDIO_MSG_IOCTL       8
 
 
 /* For asm routines kinda handy to have a nice DEFVARS of the structure*/
 #ifdef STDIO_ASM
 #asm
 DEFVARS 0 {
-	fp_desc		ds.w	1
-	fp_flags	ds.b	1
-	fp_ungetc	ds.b	1
-	fp_extra        ds.w	1
-        fp_flags2       ds.b    1
-        reserved        ds.b    1
-        reserved2       ds.b    1
-        reserved3       ds.b    1
+    fp_desc         ds.w    1
+    fp_flags        ds.b    1
+    fp_ungetc       ds.b    1
+    fp_extra        ds.w    1
+    fp_flags2       ds.b    1
+    reserved        ds.b    1
+    reserved2       ds.b    1
+    reserved3       ds.b    1
 }
 #endasm
 #endif
@@ -177,11 +177,11 @@ extern FILE __LIB__ *fdopen(const int fildes, const char *mode) __smallc;
 extern FILE __LIB__ *_freopen1(const char *name, int fd, const char *mode, FILE *fp) __smallc;
 extern FILE __LIB__ *fmemopen(void *buf, size_t size, const char *mode) __smallc;
 extern FILE __LIB__ *funopen(const void     *cookie, int (*readfn)(void *, char *, int),
-			int (*writefn)(void *, const char *, int),
-			fpos_t (*seekfn)(void *, fpos_t, int), int (*closefn)(void *)) __smallc;
+                    int (*writefn)(void *, const char *, int),
+                    fpos_t (*seekfn)(void *, fpos_t, int), int (*closefn)(void *)) __smallc;
 
-extern int __LIB__ fclose(FILE *fp);
-extern int __LIB__ fflush(FILE *);
+extern int __LIB__  fclose(FILE *fp);
+extern int __LIB__  fflush(FILE *);
 
 extern void __LIB__ closeall();
 

--- a/libsrc/target/cpm/fcntl/README
+++ b/libsrc/target/cpm/fcntl/README
@@ -5,3 +5,6 @@ These routines are a port of the Hitech C routines.
 They've been modified to work within the z88dk stdio framework and
 seem to quite well within the tests that I've made. There is no distinction
 between binary and text files.
+
+May 2020 - feilipu. Added sequential read and write to try to improve performance for large buffer moves. Issue uncovered through performance comparision with CP/M PIP tool.
+

--- a/libsrc/target/cpm/fcntl/open.c
+++ b/libsrc/target/cpm/fcntl/open.c
@@ -60,7 +60,7 @@ int open(char *name, int flags, mode_t mode)
     }
 	
 	/* we keep an extra byte in the FCB struct to support random access,
-	   but at the moment we use only a "TEXT/BINARY" discrimintation flag */
+	   but at the moment we use only a "TEXT/BINARY" discrimination flag */
 	fc->mode = mode & _IOTEXT;
 
     fd =  (fc - &_fcb[0]);

--- a/libsrc/target/cpm/fcntl/read.c
+++ b/libsrc/target/cpm/fcntl/read.c
@@ -57,7 +57,6 @@ ssize_t read(int fd, void *buf, size_t len)
         while ( len ) {
             setuid(fc->uid);
             offset = fc->rwptr%SECSIZE;
-
             if ( ( size = SECSIZE - offset ) > len )
                 size = len;
             _putoffset(fc->ranrec,fc->rwptr/SECSIZE);

--- a/libsrc/target/cpm/fcntl/read.c
+++ b/libsrc/target/cpm/fcntl/read.c
@@ -3,6 +3,7 @@
  * 
  *  27/1/2002 - djm
  *
+ *  May, 2020 - feilipu - added sequential read
  *
  *  $Id: read.c,v 1.3 2013-06-06 08:58:32 stefano Exp $
  */
@@ -53,24 +54,31 @@ ssize_t read(int fd, void *buf, size_t len)
     case U_RDWR:
         uid = getuid();
         cnt = len;
+        offset = fc->rwptr%SECSIZE;
         while ( len ) {
             setuid(fc->uid);
-            offset = fc->rwptr%SECSIZE;
-
-            if ( ( size = SECSIZE - offset ) > len )
-                size = len;
-            _putoffset(fc->ranrec,fc->rwptr/SECSIZE);
-            if ( size == SECSIZE ) {
+            if ( offset == 0 && len >= SECSIZE ) {
+                size = SECSIZE;
                 bdos(CPM_SDMA,buf);
-                if ( bdos(CPM_RRAN,fc) ) {
+                if ( bdos(CPM_READ,fc) ) {
                     return cnt-len;
-		}
-            } else {
-                bdos(CPM_SDMA,buffer);
-                if ( bdos(CPM_RRAN,fc) ) {
-                    return cnt-len;          
                 }
-                memcpy(buf,buffer+offset,size);
+            } else {
+                if ( ( size = SECSIZE - offset ) > len )
+                    size = len;
+                _putoffset(fc->ranrec,fc->rwptr/SECSIZE);
+                if ( size == SECSIZE ) {
+                    bdos(CPM_SDMA,buf);
+                    if ( bdos(CPM_RRAN,fc) ) {
+                        return cnt-len;
+		            }
+                } else {
+                    bdos(CPM_SDMA,buffer);
+                    if ( bdos(CPM_RRAN,fc) ) {
+                        return cnt-len;          
+                    }
+                    memcpy(buf,buffer+offset,size);
+                }
             }
             buf += size;
             fc->rwptr += size;
@@ -85,9 +93,4 @@ ssize_t read(int fd, void *buf, size_t len)
         break;
     }
 }
-            
-
-        
-
-
 

--- a/libsrc/target/cpm/fcntl/write.c
+++ b/libsrc/target/cpm/fcntl/write.c
@@ -50,9 +50,8 @@ ssize_t write(int fd, void *buf, size_t len)
     case U_RDWR:
         uid = getuid();
         while ( len ) {
-			setuid(fc->uid);
+            setuid(fc->uid);
             offset = fc->rwptr%SECSIZE;
-
             if ( (size = SECSIZE-offset) > len )
                 size = len;
             _putoffset(fc->ranrec,fc->rwptr/SECSIZE);

--- a/libsrc/target/cpm/fcntl/write.c
+++ b/libsrc/target/cpm/fcntl/write.c
@@ -1,6 +1,6 @@
 /*
  *  Write to a file
- * 
+ *
  *  27/1/2002 - djm
  *
  *  May, 2020 - feilipu - added sequential write
@@ -16,14 +16,14 @@
 
 
 ssize_t write(int fd, void *buf, size_t len)
-{   
+{
     char    buffer[SECSIZE+2];
     unsigned char uid;
     struct fcb *fc;
     int    cnt,size,offset;
 
     if ( fd >= MAXFILE )
-	return -1;
+    return -1;
 
     fc = &_fcb[fd];
     cnt = len;
@@ -32,62 +32,62 @@ ssize_t write(int fd, void *buf, size_t len)
     switch ( fc->use ) {
 #ifdef DEVICES
     case U_PUN:
-		while ( len-- ) {
-			bdos(CPM_WPUN,*buf++);
-		}
-		return cnt;
-		break;
-	case U_LST:
-		offset = CPM_WLST;
-	case U_CON:
-		while ( len-- ) {
-			bdos(offset,*buf++);
-		}
-		return cnt;
-		break;
+        while ( len-- ) {
+            bdos(CPM_WPUN,*buf++);
+        }
+        return cnt;
+        break;
+    case U_LST:
+        offset = CPM_WLST;
+    case U_CON:
+        while ( len-- ) {
+            bdos(offset,*buf++);
+        }
+        return cnt;
+        break;
 #endif
     case U_WRITE:
     case U_RDWR:
-		uid = getuid();
-		offset = fc->rwptr%SECSIZE;
-		while ( len ) {
-			setuid(fc->uid);
-			if ( offset == 0 && len >= SECSIZE ) {
+        uid = getuid();
+        offset = fc->rwptr%SECSIZE;
+        while ( len ) {
+            setuid(fc->uid);
+            if ( offset == 0 && len >= SECSIZE ) {
                 size = SECSIZE;
                 bdos(CPM_SDMA,buf);
                 if ( bdos(CPM_WRIT,fc) ) {
                     return cnt-len;
                 }
-			} else {
-			    if ( ( size = SECSIZE - offset ) > len )
-			        size = len;
-				_putoffset(fc->ranrec,fc->rwptr/SECSIZE);
-			    if ( size == SECSIZE ) {
-			        bdos(CPM_SDMA,buf);
-			    } else {  /* Not the required size, read in the extent */
-			        bdos(CPM_SDMA,buffer);
-			        /* Blank out the buffer to indicate EOF */
-			        buffer[0] = 26;         /* ^Z */
-			        memcpy(buffer+1,buffer,SECSIZE-1);
-			        bdos(CPM_RRAN,fc);
-			        memcpy(buffer+offset,buf,size);
-			    }
-			    if ( bdos(CPM_WRAN,fc) ) {
-			        setuid(uid);
-			        return -1;   /* Not sure about this.. */
-			    }
-			}
-			buf += size;
-			fc->rwptr += size;
-			len -= size;
-			setuid(uid);
-		}
-		setuid(uid);
-		return cnt-len;	
-		break;
+            } else {
+                if ( ( size = SECSIZE - offset ) > len )
+                    size = len;
+                _putoffset(fc->ranrec,fc->rwptr/SECSIZE);
+                if ( size == SECSIZE ) {
+                    bdos(CPM_SDMA,buf);
+                } else {  /* Not the required size, read in the extent */
+                    bdos(CPM_SDMA,buffer);
+                    /* Blank out the buffer to indicate EOF */
+                    buffer[0] = 26;         /* ^Z */
+                    memcpy(buffer+1,buffer,SECSIZE-1);
+                    bdos(CPM_RRAN,fc);
+                    memcpy(buffer+offset,buf,size);
+                }
+                if ( bdos(CPM_WRAN,fc) ) {
+                    setuid(uid);
+                    return -1;   /* Not sure about this.. */
+                }
+            }
+            buf += size;
+            fc->rwptr += size;
+            len -= size;
+            setuid(uid);
+        }
+        setuid(uid);
+        return cnt-len;
+        break;
     default:
-		return -1;
-		break;
+        return -1;
+        break;
     }
 }
 


### PR DESCRIPTION
Working on adding sequential read and write to the CP/M BDOS `read()` and `write()` functions.

- PIP is the benchmark.
- I've an asm program that can beat PIP (by copying what it does).
- classic lib using the Hitech-C derived functions is slower.

These modifications are to speed up large consecutive reads and writes with no offset.

- The offset calculation is moved outside the while loop because the offset can't change within a call.
- If there is no offset, and the read/write is longer than a sector, then sequential mode is used.
- The function already prepares for random read/write by doing `_putoffset()`, I think.

__EDIT__ a more conservative set of changes produces the same outcome.