### PR TITLE
zcc_opt.def is no longer a public file

### DIFF
--- a/src/sccz80/main.c
+++ b/src/sccz80/main.c
@@ -34,6 +34,7 @@ int c_line_labels = 0;
 int c_cline_directive = 0;
 int c_cpu = CPU_Z80;
 int c_old_diagnostic_fmt = 0;
+char *c_zcc_opt = "zcc_opt.def";
 
 /* Settings for genmath + math48 */
 int c_fp_mantissa_bytes = 5;
@@ -136,6 +137,7 @@ static option  sccz80_opts[] = {
     { 0, "frameix", OPT_ASSIGN|OPT_INT, "Use ix as the frame pointer", &c_framepointer_is_ix, 1},
     { 0, "frameiy", OPT_ASSIGN|OPT_INT, "Use iy as the frame pointer", &c_framepointer_is_ix, 0},
 #endif
+    { 0, "zcc-opt", OPT_STRING, "Location for zcc_opt.def", &c_zcc_opt, "zcc_opt.def"},
 
     { 0, "", OPT_HEADER, "Error/warning handling:", NULL, 0 },
     { 0, "stop-on-error", OPT_BOOL, "Stop on any error", &c_errstop, 0 },
@@ -286,7 +288,6 @@ int main(int argc, char** argv)
         WriteDefined("CPU_GBZ80", 1);
     }
 
-
     litlab = getlabel(); /* Get labels for function lits*/
     openout(); /* get the output file */
     openin(); /* and initial input file */
@@ -420,6 +421,8 @@ void info()
     fprintf(stderr, "Usage: %s [flags] [file]\n", gargv[0]);
 }
 
+
+
 /*
  ***********************************************************************
  *
@@ -463,7 +466,7 @@ static void dumpfns()
         }
     }
 
-    if ((fp = fopen("zcc_opt.def", "a")) == NULL) {
+    if ((fp = fopen(c_zcc_opt, "a")) == NULL) {
         errorfmt("Can't open zcc_opt.def file", 1);
     }
 
@@ -532,7 +535,7 @@ void WriteDefined(char* sname, int value)
 {
     FILE* fp;
 
-    if ((fp = fopen("zcc_opt.def", "a")) == NULL) {
+    if ((fp = fopen(c_zcc_opt, "a")) == NULL) {
         errorfmt("Can't open zcc_opt.def file", 1);
     }
     fprintf(fp, "\nIF !DEFINED_%s\n", sname);

--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -951,8 +951,12 @@ int main(int argc, char **argv)
         snprintf(tempdir, sizeof(tempdir),"/tmp/tmpzccXXXXXXXX");
         mkdtemp(tempdir);
 #else
-        tempname(tempdir);
-        mkdir(tempdir);
+        int ret = -1;
+
+        while ( ret != 0 ) {
+            tempname(tempdir);
+            ret = mkdir(tempdir);
+        }
 #endif
         zcc_opt_dir = strdup(tempdir);
         strcat(tempdir,"/zcc_opt.def");

--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -1086,6 +1086,14 @@ int main(int argc, char **argv)
         free(p);
     }
 
+    // m4 must include zcc_opt_dir
+    {
+        char  optdir[FILENAME_MAX+1];
+
+        snprintf(optdir,sizeof(optdir),"-I \"%s\"",zcc_opt_dir);
+        BuildOptions(&m4arg, optdir);
+    }
+
     /* m4 include path finds z88dk macro definition file "z88dk.m4" */
     BuildOptions(&m4arg, c_m4opts);
 

--- a/src/zpragma/zpragma.c
+++ b/src/zpragma/zpragma.c
@@ -10,6 +10,7 @@
 static char buf[65536];
 
 static char filename[FILENAME_MAX+1];
+static char *c_zcc_opt = "zcc_opt.def";
 static int  lineno = 0;
 static int  sccz80_mode = 0;
 
@@ -55,7 +56,7 @@ void write_pragma_string(char *ptr)
     if ( text != NULL ) {
         *text = 0;
         text++;
-        if ( (fp=fopen("zcc_opt.def","a")) == NULL ) {
+        if ( (fp=fopen(c_zcc_opt,"a")) == NULL ) {
             fprintf(stderr,"%s:%d Cannot open zcc_opt.def file\n", filename, lineno);
             exit(1);
         }
@@ -85,7 +86,7 @@ void write_bytes(char *line, int flag)
     *ptr = 0;
 
     if ( strlen(sname) ) {
-        if ( (fp=fopen("zcc_opt.def","a")) == NULL ) {
+        if ( (fp=fopen(c_zcc_opt,"a")) == NULL ) {
             fprintf(stderr,"%s:%d Cannot open zcc_opt.def file\n", filename, lineno);
             exit(1);
         }
@@ -137,7 +138,7 @@ void write_defined(char *sname, int32_t value, int export)
 {
     FILE *fp;
 
-    if ( (fp=fopen("zcc_opt.def","a")) == NULL ) {
+    if ( (fp=fopen(c_zcc_opt,"a")) == NULL ) {
         fprintf(stderr,"%s:%d Cannot open zcc_opt.def file\n", filename, lineno);
         exit(1);
     }
@@ -156,7 +157,7 @@ void write_need(char *sname, int value)
 {
     FILE *fp;
 
-    if ( (fp=fopen("zcc_opt.def","a")) == NULL ) {
+    if ( (fp=fopen(c_zcc_opt,"a")) == NULL ) {
         fprintf(stderr,"%s:%d Cannot open zcc_opt.def file\n", filename, lineno);
         exit(1);
     }
@@ -173,7 +174,7 @@ void write_redirect(char *sname, char *value)
     strip_nl(sname);
     value = skip_ws(value);
     first_word_only(value);
-    if ( (fp=fopen("zcc_opt.def","a")) == NULL ) {
+    if ( (fp=fopen(c_zcc_opt,"a")) == NULL ) {
         fprintf(stderr,"%s:%d Cannot open zcc_opt.def file\n", filename, lineno);
         exit(1);
     }
@@ -321,10 +322,15 @@ static uint64_t parse_format_string(char *arg, CONVSPEC *specifiers)
 
 int main(int argc, char **argv)
 {
+    int     i;
     char   *ptr;
 
-    if ( argc == 2 && strcmp(argv[1],"-sccz80") == 0 ) {
-         sccz80_mode = 1;
+    for ( i = 1 ; i < argc; i++ ) {
+        if (strcmp(argv[i],"-sccz80") == 0 ) {
+            sccz80_mode = 1;
+        } else if ( strncmp(argv[i],"-zcc-opt=", 9) == 0 ) {
+            c_zcc_opt = argv[i] + 9;
+        }
     }
 
     strcpy(filename,"<stdin>");


### PR DESCRIPTION
It's kept in /tmp and then removed at the end of a zcc incantation.

This will work for single command line compilations and forces the use of -pragma-include or the other pragma directives at linking time.

