### PR TITLE
Fix-zcc - Solved warnings

### DIFF
--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -2487,7 +2487,7 @@ void LoadConfigFile(arg_t *argument, char *arg)
 
     cfgfile = getenv("ZCCCFG");
     if (cfgfile != NULL) {
-        if (strlen(cfgfile) > FILENAME_MAX) {
+        if (strlen(cfgfile) > ( FILENAME_MAX - strlen(arg) - strlen("/") )) {
             fprintf(stderr, "Possibly corrupt env variable ZCCCFG\n");
             exit(1);
         }
@@ -3027,7 +3027,7 @@ int find_zcc_config_fileFile(const char *program, char *arg, int gc, char *buf, 
         }
         cfgfile = getenv("ZCCCFG");
         if (cfgfile != NULL) {
-            if (strlen(cfgfile) > FILENAME_MAX) {
+            if (strlen(cfgfile) > ( FILENAME_MAX - strlen(arg+1) - strlen("/.cfg") )) {
                 fprintf(stderr, "Possibly corrupt env variable ZCCCFG\n");
                 exit(1);
             }

--- a/src/zcc/zcc.h
+++ b/src/zcc/zcc.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Some standard defines which are the same for all machines - hopefully!
  *
  * rcs messing up..hohum! (twiddle, keep adding here till I sort it!)


### PR DESCRIPTION
Dear development team,

this is a pull request for the support **_module zcc_**.

The following **_warnings_** were solved:

- zcc.h: erased trailing **_whitespace_**
- zcc.c: erased trailing **_whitespace_**
- zcc.c: **_cpu_map_** initialisation missed brackets
- zcc.c: **_copy empty string_** with strcpy
- zcc.c: snprintf **_buffer overrun_**

I hope these changes can have your approval. As far as I'm concerned, **_this pull request can be merged with the master branch_**.

Kind regards,
PB