### PR TITLE
Fix-cpp - Solved warnings

### DIFF
--- a/src/cpp/cpp2.c
+++ b/src/cpp/cpp2.c
@@ -485,7 +485,10 @@ int             searchlocal;            /* TRUE if #include "file"      */
                 if (filename[0] == '/')
                     strcpy(tmpname, filename);
                 else {
-                    sprintf(tmpname, "%s/%s", *incptr, filename);
+                    if (strlen(*incptr) + strlen(filename) >= sizeof(tmpname))
+                        sprintf(tmpname, "%s/%s", *incptr, filename);
+                    else
+                        cfatal("Filename work buffer overflow", NULLST);
                 }
 #else
                 if (!hasdirectory(filename, tmpname))
@@ -504,7 +507,10 @@ int             searchlocal;            /* TRUE if #include "file"      */
                     if (filename[0] == '/')
                         strcpy(tmpname, filename);
                     else {
-                        sprintf(tmpname, "%s/%s", *incptr, filename);
+                        if (strlen(*incptr) + strlen(filename) >= sizeof(tmpname))
+                            sprintf(tmpname, "%s/%s", *incptr, filename);
+                        else
+                            cfatal("Filename work buffer overflow", NULLST);
                     }
     #else
                     if (!hasdirectory(filename, tmpname))
@@ -523,7 +529,10 @@ int             searchlocal;            /* TRUE if #include "file"      */
                     if (filename[0] == '/')
                         strcpy(tmpname, filename);
                     else {
-                        sprintf(tmpname, "%s/%s", *incptr, filename);
+                        if (strlen(*incptr) + strlen(filename) >= sizeof(tmpname))
+                            sprintf(tmpname, "%s/%s", *incptr, filename);
+                        else
+                            cfatal("Filename work buffer overflow", NULLST);
                     }
         #else
                     if (!hasdirectory(filename, tmpname))

--- a/src/cpp/cpp5.c
+++ b/src/cpp/cpp5.c
@@ -777,7 +777,8 @@ int		skip;		/* TRUE if short-circuit evaluation	*/
  * evaleval() returns the new pointer to the top of the value stack.
  */
 {
-	register int	v1, v2;
+	register int	v1;
+	register int    v2 = 0;
 
 	if (isbinary(op))
 	    v2 = *--valp;


### PR DESCRIPTION
Dear development team,

this is a pull request for the support **_module cpp_**.

The following warnings were solved:

- cpp2.c: s(n)printf **_buffer overrun_**
- cpp5.c: potential **_uninitialized variable_**

I hope these changes can have your approval. As far as I'm concerned, **_this pull request can be merged with the master branch_**.

Kind regards,
PB