### PR TITLE
zsdcc - peephole rule consistency

### DIFF
--- a/libsrc/_DEVELOPMENT/sdcc_peeph.1
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.1
@@ -1606,7 +1606,7 @@ replace restart {
 	; peephole 66 removed redundant load of 0 into a.
 }
 
-replace {
+replace restart {
 	ld	e,#0x%1
 	ld	d,#0x%2
 } by {
@@ -1614,7 +1614,7 @@ replace {
 	; peephole 67 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	d,#0x%1
 	ld	e,#0x%2
 } by {
@@ -1622,7 +1622,7 @@ replace {
 	; peephole 67a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	l,#0x%1
 	ld	h,#0x%2
 } by {
@@ -1630,7 +1630,7 @@ replace {
 	; peephole 68 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	h,#0x%1
 	ld	l,#0x%2
 } by {
@@ -1638,7 +1638,7 @@ replace {
 	; peephole 68a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	c,#0x%1
 	ld	b,#0x%2
 } by {
@@ -1646,7 +1646,7 @@ replace {
 	; peephole 69 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	b,#0x%1
 	ld	c,#0x%2
 } by {
@@ -1725,7 +1725,7 @@ replace restart {
 	; peephole 77 removed redundant or after xor.
 }
 
-replace {
+replace restart {
 	ld	%1,%2
 	ld	a,%2
 } by {
@@ -2565,7 +2565,7 @@ replace restart {
 	; peephole 142 used value still in a instead of reloading from %1.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ret
 } by {
@@ -2573,7 +2573,7 @@ replace {
 	; peephole 143 removed unused ret.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ld	sp,ix
 	pop	ix

--- a/libsrc/_DEVELOPMENT/sdcc_peeph.2
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.2
@@ -2044,7 +2044,7 @@ replace restart {
 	; peephole 66 removed redundant load of 0 into a.
 }
 
-replace {
+replace restart {
 	ld	e,#0x%1
 	ld	d,#0x%2
 } by {
@@ -2052,7 +2052,7 @@ replace {
 	; peephole 67 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	d,#0x%1
 	ld	e,#0x%2
 } by {
@@ -2060,7 +2060,7 @@ replace {
 	; peephole 67a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	l,#0x%1
 	ld	h,#0x%2
 } by {
@@ -2068,7 +2068,7 @@ replace {
 	; peephole 68 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	h,#0x%1
 	ld	l,#0x%2
 } by {
@@ -2076,7 +2076,7 @@ replace {
 	; peephole 68a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	c,#0x%1
 	ld	b,#0x%2
 } by {
@@ -2084,7 +2084,7 @@ replace {
 	; peephole 69 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	b,#0x%1
 	ld	c,#0x%2
 } by {
@@ -2163,7 +2163,7 @@ replace restart {
 	; peephole 77 removed redundant or after xor.
 }
 
-replace {
+replace restart {
 	ld	%1,%2
 	ld	a,%2
 } by {
@@ -3003,7 +3003,7 @@ replace restart {
 	; peephole 142 used value still in a instead of reloading from %1.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ret
 } by {
@@ -3011,7 +3011,7 @@ replace {
 	; peephole 143 removed unused ret.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ld	sp,ix
 	pop	ix

--- a/libsrc/_DEVELOPMENT/sdcc_peeph.3
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.3
@@ -17527,7 +17527,6 @@ replace restart {
 	; peephole z88dk-414k2
 } if operandsNotRelated(%9 %7), operandsNotRelated(%9 %8), operandsNotRelated(%10 %7), operandsNotRelated(%10 %8)
 
-
 replace restart {
 	ld	%1 (%2),a
 	ld	a,%4 (%5)

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.1
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.1
@@ -3789,7 +3789,6 @@ replace restart {
 	; peephole z88dk-intrinsic-retret
 }
 
-
 barrier
 
 
@@ -4816,7 +4815,7 @@ replace restart {
 	; peephole 66 removed redundant load of 0 into a.
 }
 
-replace {
+replace restart {
 	ld	e,#0x%1
 	ld	d,#0x%2
 } by {
@@ -4824,7 +4823,7 @@ replace {
 	; peephole 67 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	d,#0x%1
 	ld	e,#0x%2
 } by {
@@ -4832,7 +4831,7 @@ replace {
 	; peephole 67a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	l,#0x%1
 	ld	h,#0x%2
 } by {
@@ -4840,7 +4839,7 @@ replace {
 	; peephole 68 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	h,#0x%1
 	ld	l,#0x%2
 } by {
@@ -4848,7 +4847,7 @@ replace {
 	; peephole 68a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	c,#0x%1
 	ld	b,#0x%2
 } by {
@@ -4856,7 +4855,7 @@ replace {
 	; peephole 69 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	b,#0x%1
 	ld	c,#0x%2
 } by {
@@ -4935,7 +4934,7 @@ replace restart {
 	; peephole 77 removed redundant or after xor.
 }
 
-replace {
+replace restart {
 	ld	%1,%2
 	ld	a,%2
 } by {
@@ -5775,7 +5774,7 @@ replace restart {
 	; peephole 142 used value still in a instead of reloading from %1.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ret
 } by {
@@ -5783,7 +5782,7 @@ replace {
 	; peephole 143 removed unused ret.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ld	sp,ix
 	pop	ix

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.2
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.2
@@ -5253,7 +5253,7 @@ replace restart {
 	; peephole 66 removed redundant load of 0 into a.
 }
 
-replace {
+replace restart {
 	ld	e,#0x%1
 	ld	d,#0x%2
 } by {
@@ -5261,7 +5261,7 @@ replace {
 	; peephole 67 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	d,#0x%1
 	ld	e,#0x%2
 } by {
@@ -5269,7 +5269,7 @@ replace {
 	; peephole 67a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	l,#0x%1
 	ld	h,#0x%2
 } by {
@@ -5277,7 +5277,7 @@ replace {
 	; peephole 68 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	h,#0x%1
 	ld	l,#0x%2
 } by {
@@ -5285,7 +5285,7 @@ replace {
 	; peephole 68a combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	c,#0x%1
 	ld	b,#0x%2
 } by {
@@ -5293,7 +5293,7 @@ replace {
 	; peephole 69 combined constant loads into register pair.
 }
 
-replace {
+replace restart {
 	ld	b,#0x%1
 	ld	c,#0x%2
 } by {
@@ -5372,7 +5372,7 @@ replace restart {
 	; peephole 77 removed redundant or after xor.
 }
 
-replace {
+replace restart {
 	ld	%1,%2
 	ld	a,%2
 } by {
@@ -6212,7 +6212,7 @@ replace restart {
 	; peephole 142 used value still in a instead of reloading from %1.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ret
 } by {
@@ -6220,7 +6220,7 @@ replace {
 	; peephole 143 removed unused ret.
 }
 
-replace {
+replace restart {
 	jp	%5
 	ld	sp,ix
 	pop	ix

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.3
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.3
@@ -21398,7 +21398,6 @@ replace restart {
 
 
 
-
 replace restart {
 	ld	c,l
 	ld	b,h
@@ -27425,7 +27424,7 @@ replace restart {
 	ld	b,#%4
 	add	hl,bc
 	ld	(#%1),hl
-	; peephole peephole z88dk-485e17d1
+	; peephole z88dk-485e17d1
 } if notUsed('a'), notUsed('bc'), notUsed('hl')
 
 replace restart {
@@ -27443,7 +27442,7 @@ replace restart {
 	ld	d,#%4
 	add	hl,de
 	ld	(#%1),hl
-	; peephole peephole z88dk-485e17d2
+	; peephole z88dk-485e17d2
 } if notUsed('a'), notUsed('de'), notUsed('hl')
 
 replace restart {
@@ -27610,7 +27609,7 @@ replace restart {
 	ld	c,l
 	ld	b,h
 	ld	hl,#%1 + 1
-	; peephole peephole z88dk-485e18
+	; peephole z88dk-485e18
 }
 
 replace restart {
@@ -27621,7 +27620,7 @@ replace restart {
 } by {
 	ld	bc,%1
 	add	hl,bc
-	; peephole peephole z88dk-485e19
+	; peephole z88dk-485e19
 } if notUsed('bc')
 
 replace restart {
@@ -28729,7 +28728,6 @@ replace restart {
 	ld	h,a
 	; peephole z88dk-494a4
 }
-
 
 
 


### PR DESCRIPTION
Looking through the zsdcc peephole rule sets, there are some inconsistencies.

This PR is to make the application of rules present in one set, the same as the rules in another set.
I think that's the right thing to do, but done as a PR in case it is not.