### PR TITLE
zsdcc - r11690 for #1512 fix & z80n support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ setup:
 
 
 bin/zsdcc$(EXESUFFIX):
-	svn checkout -r 11556 https://svn.code.sf.net/p/sdcc/code/trunk/sdcc -q $(SDCC_PATH)
+	svn checkout -r 11690 https://svn.code.sf.net/p/sdcc/code/trunk/sdcc -q $(SDCC_PATH)
 	cd $(SDCC_PATH) && patch -p0 < $(Z88DK_PATH)/src/zsdcc/sdcc-z88dk.patch
 	cd $(SDCC_PATH) && CC=$(OCC) ./configure \
 		--disable-ds390-port --disable-ds400-port \

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@ Detailed but incomplete changelist:
 - [sccz80] Bitfields now work and on the 8080
 - [sccz80] Code generator fixes for gbz80
 - [z80asm] db/dw/ds etc synonyms are now accepted
-- [zsdcc] Upgraded to SDCC 4.0.0 r11556 (bugfixes)
+- [zsdcc] Upgraded to SDCC 4.0.2 r11690 (bugfixes)
 
 z88dk v2.0 - 03.02.2020
 

--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -2,7 +2,7 @@
 
 Windows and MacOSX users can get zsdcc and zsdcpp binaries from the [nightly build](http://nightly.z88dk.org/).
 
-To build from source apply the patch in this directory to sdcc r11556 v4.0.0.
+To build from source apply the patch in this directory to sdcc r11690 v4.0.2.
 Compile instructions can be found [here](https://www.z88dk.org/wiki/doku.php?id=temp:front#sdcc1).
 
 For an error-free compile you may want to limit the target cpus in the build to just the z80 family (z80/z180/rabbits).  [z88dk.Dockerfile](https://github.com/z88dk/z88dk/blob/master/z88dk.Dockerfile)
@@ -18,10 +18,10 @@ to install z88dk.
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-11556-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r11556.
+`sdcc-11690-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r11690.
 
-`sdcc-9958-z88dk.patch` is the previous zsdcc standard patch, retained for comparison and building against sdcc r9958.
+`sdcc-9958-z88dk.patch` is the previous z88dk v1.99c zsdcc standard patch, retained for comparison and building against sdcc r9958.
 
-`sdcc-10892-z88dk-peep.patch` has been submitted as sdcc [feature request # 289](https://sourceforge.net/p/sdcc/patches/289/) for review, test, and integrate from that end. This file is retained for the record. z88dk does not normally use the sdcc peephole optimiser, so these patches remain optional.
+`sdcc-10892-z88dk-peep.patch` has been submitted as sdcc [feature request # 289](https://sourceforge.net/p/sdcc/patches/289/) for review, test, and integrate from that end. This file is retained for the record.
 
 Essentially, the patch items remaining are just those things which are zsdcc specific, which don't make sense to push into sdcc.

--- a/src/zsdcc/sdcc-11690-z88dk.patch
+++ b/src/zsdcc/sdcc-11690-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 11556)
+--- src/SDCCasm.c	(revision 11690)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 11556)
+--- src/SDCCglue.c	(revision 11690)
 +++ src/SDCCglue.c	(working copy)
 @@ -189,7 +189,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,9 +84,9 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 11556)
+--- src/SDCCmain.c	(revision 11690)
 +++ src/SDCCmain.c	(working copy)
-@@ -499,16 +499,15 @@
+@@ -502,16 +502,15 @@
  {
    int i;
  
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 11556)
+--- src/SDCCopt.c	(revision 11690)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -132,7 +132,7 @@ Index: src/SDCCopt.c
        goto convert;
      }
    
-@@ -2103,10 +2103,11 @@
+@@ -2133,10 +2133,11 @@
    int i;
    int change = 0;
    iCode *ic, *newic;
@@ -145,7 +145,7 @@ Index: src/SDCCopt.c
  
    // Wide loop counter
    for (i = 0; i < count; i++)
-@@ -2286,8 +2287,8 @@
+@@ -2326,8 +2327,8 @@
              IS_ITEMP (right) && bitVectnBitsOn (OP_DEFS (right)) != 1)
              continue;
  
@@ -156,7 +156,7 @@ Index: src/SDCCopt.c
  
            if (lic)
              {
-@@ -2294,7 +2295,7 @@
+@@ -2334,7 +2335,7 @@
                if (lic->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (lic)) && !IS_OP_LITERAL (IC_RIGHT (lic)))
                  continue;
  
@@ -165,7 +165,7 @@ Index: src/SDCCopt.c
  
                if (litval > 0x7f)
                  continue;
-@@ -2307,7 +2308,7 @@
+@@ -2347,7 +2348,7 @@
                if (ric->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (ric)) && !IS_OP_LITERAL (IC_RIGHT (ric)))
                  continue;
  
@@ -176,9 +176,9 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 11556)
+--- src/z80/peep.c	(revision 11690)
 +++ src/z80/peep.c	(working copy)
-@@ -228,6 +228,88 @@
+@@ -248,6 +248,88 @@
    return(found && found < end);
  }
  
@@ -267,7 +267,7 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -252,11 +334,23 @@
+@@ -374,6 +456,8 @@
  static bool
  z80MightRead(const lineNode *pl, const char *what)
  {
@@ -276,7 +276,9 @@ Index: src/z80/peep.c
    if(strcmp(what, "iyl") == 0 || strcmp(what, "iyh") == 0)
      what = "iy";
    if(strcmp(what, "ixl") == 0 || strcmp(what, "ixh") == 0)
-     what = "ix";
+@@ -382,6 +466,16 @@
+   if(ISINST(pl->line, "call") && strcmp(what, "sp") == 0)
+     return TRUE;
  
 +  /* look for z88dk special functions */
 +  if (strstr(pl->line, "call\t____sdcc") != 0)
@@ -291,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0)
      return TRUE;
  
-@@ -523,6 +617,7 @@
+@@ -793,6 +887,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -299,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -529,6 +624,16 @@
+@@ -799,6 +894,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 11556)
+--- src/SDCCasm.c	(revision 11690)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 11556)
+--- src/SDCCglue.c	(revision 11690)
 +++ src/SDCCglue.c	(working copy)
 @@ -189,7 +189,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,9 +84,9 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 11556)
+--- src/SDCCmain.c	(revision 11690)
 +++ src/SDCCmain.c	(working copy)
-@@ -499,16 +499,15 @@
+@@ -502,16 +502,15 @@
  {
    int i;
  
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 11556)
+--- src/SDCCopt.c	(revision 11690)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -132,7 +132,7 @@ Index: src/SDCCopt.c
        goto convert;
      }
    
-@@ -2103,10 +2103,11 @@
+@@ -2133,10 +2133,11 @@
    int i;
    int change = 0;
    iCode *ic, *newic;
@@ -145,7 +145,7 @@ Index: src/SDCCopt.c
  
    // Wide loop counter
    for (i = 0; i < count; i++)
-@@ -2286,8 +2287,8 @@
+@@ -2326,8 +2327,8 @@
              IS_ITEMP (right) && bitVectnBitsOn (OP_DEFS (right)) != 1)
              continue;
  
@@ -156,7 +156,7 @@ Index: src/SDCCopt.c
  
            if (lic)
              {
-@@ -2294,7 +2295,7 @@
+@@ -2334,7 +2335,7 @@
                if (lic->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (lic)) && !IS_OP_LITERAL (IC_RIGHT (lic)))
                  continue;
  
@@ -165,7 +165,7 @@ Index: src/SDCCopt.c
  
                if (litval > 0x7f)
                  continue;
-@@ -2307,7 +2308,7 @@
+@@ -2347,7 +2348,7 @@
                if (ric->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (ric)) && !IS_OP_LITERAL (IC_RIGHT (ric)))
                  continue;
  
@@ -176,9 +176,9 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 11556)
+--- src/z80/peep.c	(revision 11690)
 +++ src/z80/peep.c	(working copy)
-@@ -228,6 +228,88 @@
+@@ -248,6 +248,88 @@
    return(found && found < end);
  }
  
@@ -267,7 +267,7 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -252,11 +334,23 @@
+@@ -374,6 +456,8 @@
  static bool
  z80MightRead(const lineNode *pl, const char *what)
  {
@@ -276,7 +276,9 @@ Index: src/z80/peep.c
    if(strcmp(what, "iyl") == 0 || strcmp(what, "iyh") == 0)
      what = "iy";
    if(strcmp(what, "ixl") == 0 || strcmp(what, "ixh") == 0)
-     what = "ix";
+@@ -382,6 +466,16 @@
+   if(ISINST(pl->line, "call") && strcmp(what, "sp") == 0)
+     return TRUE;
  
 +  /* look for z88dk special functions */
 +  if (strstr(pl->line, "call\t____sdcc") != 0)
@@ -291,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0)
      return TRUE;
  
-@@ -523,6 +617,7 @@
+@@ -793,6 +887,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -299,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -529,6 +624,16 @@
+@@ -799,6 +894,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  

--- a/z88dk.Dockerfile
+++ b/z88dk.Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache build-base libxml2 m4 \
 RUN cd ${Z88DK_PATH} \
     && chmod 777 build.sh \
     && ./build.sh \
-    && svn checkout -r 11556 https://svn.code.sf.net/p/sdcc/code/trunk/sdcc ${SDCC_PATH} \
+    && svn checkout -r 11690 https://svn.code.sf.net/p/sdcc/code/trunk/sdcc ${SDCC_PATH} \
     && cd ${SDCC_PATH} \
     && patch -p0 < ${Z88DK_PATH}/src/zsdcc/sdcc-z88dk.patch \
     && ./configure \


### PR DESCRIPTION
This patch for zsdcc contains a fix for #1512, and brings support for z80n op codes along with it.

NOTE that the `z80/peep.c` patches are __not included__ in this, so the status of patch file in #1511  is not changed.
There has been substantial rework of the `z80/peep.c` file upstream, so the patches will need to be adjusted (again).