### PR TITLE
Fix copt - Travis build - Unused functions, uninitialized variables

### DIFF
--- a/src/copt/regex/engine.c
+++ b/src/copt/regex/engine.c
@@ -248,7 +248,6 @@ sopno stopst;
 	register char *ssp;	/* start of string matched by subsubRE */
 	register char *sep;	/* end of string matched by subsubRE */
 	register char *oldssp;	/* previous ssp */
-	register char *dp;
 
 	AT("diss", start, stop, startst, stopst);
 	sp = start;
@@ -307,8 +306,7 @@ sopno stopst;
 			esub = es - 1;
 			/* did innards match? */
 			if (slow(m, sp, rest, ssub, esub) != NULL) {
-				dp = dissect(m, sp, rest, ssub, esub);
-				assert(dp == rest);
+				assert( rest == dissect(m, sp, rest, ssub, esub) );
 			} else		/* no */
 				assert(sp == rest);
 			sp = rest;
@@ -345,8 +343,7 @@ sopno stopst;
 			}
 			assert(sep == rest);	/* must exhaust substring */
 			assert(slow(m, ssp, sep, ssub, esub) == rest);
-			dp = dissect(m, ssp, sep, ssub, esub);
-			assert(dp == sep);
+			assert( sep == dissect(m, ssp, sep, ssub, esub) );
 			sp = rest;
 			break;
 		case OCH_:
@@ -380,8 +377,8 @@ sopno stopst;
 				else
 					assert(OP(m->g->strip[esub]) == O_CH);
 			}
-			dp = dissect(m, sp, rest, ssub, esub);
-			assert(dp == rest);
+
+			assert( rest == dissect(m, sp, rest, ssub, esub) );
 			sp = rest;
 			break;
 		case O_PLUS:

--- a/src/copt/regex/regcomp.c
+++ b/src/copt/regex/regcomp.c
@@ -1194,6 +1194,7 @@ register char *cp;
  - mcsub - subtract a collating element from a cset
  == static void mcsub(register cset *cs, register char *cp);
  */
+/*
 static void
 mcsub(cs, cp)
 register cset *cs;
@@ -1216,11 +1217,13 @@ register char *cp;
 	cs->multis = realloc(cs->multis, cs->smultis);
 	assert(cs->multis != NULL);
 }
+*/
 
 /*
  - mcin - is a collating element in a cset?
  == static int mcin(register cset *cs, register char *cp);
  */
+/*
 static int
 mcin(cs, cp)
 register cset *cs;
@@ -1228,11 +1231,14 @@ register char *cp;
 {
 	return(mcfind(cs, cp) != NULL);
 }
+*/
 
 /*
  - mcfind - find a collating element in a cset
  == static char *mcfind(register cset *cs, register char *cp);
  */
+
+/*
 static char *
 mcfind(cs, cp)
 register cset *cs;
@@ -1247,6 +1253,7 @@ register char *cp;
 			return(p);
 	return(NULL);
 }
+*/
 
 /*
  - mcinvert - invert the list of collating elements in a cset
@@ -1515,9 +1522,9 @@ findmust(p, g)
 struct parse *p;
 register struct re_guts *g;
 {
-	register sop *scan;
-	sop *start;
-	register sop *newstart;
+	register sop *scan = NULL;
+	sop *start = NULL;
+	register sop *newstart = NULL;
 	register sopno newlen;
 	register sop s;
 	register char *cp;

--- a/src/copt/regex/regcomp.h
+++ b/src/copt/regex/regcomp.h
@@ -28,9 +28,9 @@ static int freezeset(register struct parse *p, register cset *cs);
 static int firstch(register struct parse *p, register cset *cs);
 static int nch(register struct parse *p, register cset *cs);
 static void mcadd(register struct parse *p, register cset *cs, register char *cp);
-static void mcsub(register cset *cs, register char *cp);
-static int mcin(register cset *cs, register char *cp);
-static char *mcfind(register cset *cs, register char *cp);
+/* static void mcsub(register cset *cs, register char *cp);   */
+/* static int mcin(register cset *cs, register char *cp);     */
+/* static char *mcfind(register cset *cs, register char *cp); */
 static void mcinvert(register struct parse *p, register cset *cs);
 static void mccase(register struct parse *p, register cset *cs);
 static int isinsets(register struct re_guts *g, int c);


### PR DESCRIPTION
This patch solves all Travis build warnings for the copt module.