### PR TITLE
Fix sccz80 - Travis build - Variable set but not used

### DIFF
--- a/src/sccz80/stmt.c
+++ b/src/sccz80/stmt.c
@@ -337,12 +337,11 @@ Type *doexpr()
     char *before, *start;
     double val;
     int    vconst;
-    Kind    type;
     Type   *type_ptr;
-    
+
     while (1) {
         setstage(&before, &start);
-        type = expression(&vconst, &val, &type_ptr);
+        expression(&vconst, &val, &type_ptr);
         clearstage(before, start);
         if (ch() != ',')
             return type_ptr;


### PR DESCRIPTION
This patch solves all Travis build warnings for the sccz80 module.