### PR TITLE
Urgent fix - build.sh - Impossible to use parameters -b nor -l

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,97 +4,157 @@
 # Build z88dk on unix systems
 #
 
+function show_help_and_exit {
+
+  if [[ -n $1 ]]; then rc=$1; else rc=0; fi
+
+  echo ""
+  echo "Usage: $0 [-b][-c][-C][-e][-h][-k][-l][-p][-t]"
+  echo ""
+  echo "  -b    Don't build binaries"
+  echo "  -c    Clean build environment"
+  echo "  -C    Clean build environment and binaries (including bin/*)"
+  echo "        Chosing this option makes a manual rebuild of zsdcc and"
+  echo "        szdcpp necessary in the win32 environment"
+  echo "  -e    Build examples"
+  echo "  -h    This help information"
+  echo "  -k    Keep building ignoring errors"
+  echo "  -l    Don't build libraries"
+  echo "  -p    TARGET Build specified targets"
+  echo "  -t    Run tests"
+  echo ""
+  echo "Default is to build binaries and libraries"
+  echo ""
+
+  exit $rc
+}
+
+
 set -e      # -e: exit on error; -u: exit on undefined variable
             # -e can be overidden by -k option
 
+
+do_build=1                              # Set initial (default)  values (build binaries and libraries)
 do_clean=0
-do_tests=0
-do_build=1
+do_clean_bin=0
 do_examples=0
 do_libbuild=1
+do_tests=0
 
-while getopts "hkctep:" arg; do
+
+while getopts "bcCehklpt" arg; do       # Handle all given arguments
   case "$arg" in
-    k) set +e                  ;;  # keep building ignoring errors
-    c) do_clean=1              ;;  # clean before building
-    t) do_tests=1              ;;  # Run tests as well
-    e) do_examples=1           ;;  # Build examples as well 
-    p) export TARGETS=$OPTARG  ;;
-    b) do_build=0              ;;  # Don't build
-    l) do_libbuild=0           ;;  # Don't build libraries
-    h | *) 
-    echo "Usage: $0 [-e][-k][-c][-t][-nb][-nl]"
-    echo
-    echo "-k\tKeep building ignoring errors"
-    echo "-c\tClean before building"
-    echo "-t\tRun tests"
-    echo "-e\tBuild examples"
-    echo "-p\tTARGET Build specified targets"
-    echo "-b\tDon't build binaries"
-    echo "-l\tDon't build libraries"
-    echo ""
-    echo "Default is to build binaries and libraries"
-    exit 1 
-    ;;
+    b)     do_build=0              ;;   # Don't build
+    c)     do_clean=1              ;;   # clean except bin/*
+    C)     do_clean_bin=1          ;;   # Clean including bin/*
+    e)     do_examples=1           ;;   # Build examples as well
+    k)     set +e                  ;;   # keep building ignoring errors
+    l)     do_libbuild=0           ;;   # Don't build libraries
+    p)     export TARGETS=$OPTARG  ;;
+    t)     do_tests=1              ;;   # Run tests as well
+    h | *) show_help_and_exit 0    ;;   # Show help on demand
   esac
 done
 
-if [ $do_clean = 1 ]; then
-  make clean
-  # dont remove bin, as zsdcc and szdcpp must be built by hand in win32
-  #rm -rf bin/*
+                                        # If there will be no action at all with the given parameters, then show help and exit with error
+if [[ $do_clean     = 0 ]]         \
+&& [[ $do_clean_bin = 0 ]]         \
+&& [[ $do_build     = 0 ]]         \
+&& [[ $do_libbuild  = 0 ]]         \
+&& [[ $do_tests     = 0 ]]         \
+&& [[ $do_examples  = 0 ]]; then
+  show_help_and_exit 1
+fi
+                                        # Only execute the most complete clean of the two options
+if [[ $do_clean     = 1 ]]         \
+&& [[ $do_clean_bin = 1 ]]; then
+  do_clean=0
 fi
 
-mkdir -p bin
-PATH=`pwd`/bin:$PATH
-export PATH
+if [ $do_clean = 1 ]; then              # Dont remove bin, as zsdcc and szdcpp must be built by hand in win32
+  make clean
+fi
 
-ZCCCFG=`pwd`/lib/config/
+
+if [ $do_clean_bin = 1 ]; then          # Remove bin => zsdcc and zdcpp must be built again by hand in win32
+  make clean
+  echo "rm -rf bin"
+  rm -rf bin
+fi
+
+                                        # If there was only cleaning to do then don't change paths, global variables, ...
+if [[ $do_build    != 1 ]]         \
+&& [[ $do_libbuild != 1 ]]         \
+&& [[ $do_tests    != 1 ]]         \
+&& [[ $do_examples != 1 ]]; then
+  exit 0
+fi
+
+
+if [ -z "$CC" ]; then                   # Insert default value for CC if CC is empty
+  CC="gcc"
+  export CC
+fi
+
+
+if [ -z "$CFLAGS" ]; then               # Insert default value for CFLAGS if CFLAGS is empty
+  CFLAGS="-g -O2"
+  export CFLAGS
+fi
+
+
+case `uname -s` in                      # Insert default values for MAKE and INSTALL following used OS
+  SunOS)
+    MAKE="gmake"
+    INSTALL="ginstall"
+    export INSTALL
+    ;;
+  OpenBSD|NetBSD|FreeBSD)
+    MAKE="gmake"
+    INSTALL="install"
+    export INSTALL
+    ;;
+  *)
+    MAKE="make"
+    INSTALL="install"
+    export INSTALL
+    ;;
+esac
+
+
+path=`pwd`/bin                          # Add bin directory to path if it's not already there
+mkdir -p $path                          # Guarantee that the directory exists
+if [[ $PATH != *$path* ]]; then
+  PATH=$path:$PATH
+  export PATH
+fi
+
+
+ZCCCFG=`pwd`/lib/config/                # Set ZCCCFG to the lib config directory
+mkdir -p $ZCCCFG                        # Guarantee that the directory exists
 export ZCCCFG
 
 
-if [ -z "$CFLAGS" ]; then
-   CFLAGS="-g -O2"
-fi
-
-export CC
-export CFLAGS
-
-case `uname -s` in
-    SunOS)
-        MAKE="gmake"
-        INSTALL="ginstall"
-        ;;
-    OpenBSD|NetBSD|FreeBSD)
-        MAKE="gmake"
-        INSTALL="install"
-        ;;
-    *)
-        MAKE="make"
-        INSTALL="install"
-        ;;
-esac
-
-export INSTALL
-
-
-if [ $do_build = 1 ]; then
-    $MAKE 
+if [ $do_build = 1 ]; then              # Build binaries or not...
+  $MAKE
 fi
 
 
-if [ $do_libbuild = 1 ]; then
-    $MAKE -C libsrc clean
-    $MAKE -C libsrc 
-    $MAKE -C libsrc install 
-    $MAKE -C libsrc/_DEVELOPMENT 
-    $MAKE -C include/_DEVELOPMENT 
-fi
-if [ $do_tests = 1 ]; then
-    $MAKE -C testsuite 
-    $MAKE -C test 
-fi
-if [ $do_examples = 1 ]; then
-    $MAKE -C examples
+if [ $do_libbuild = 1 ]; then           # Build libraries or not...
+  $MAKE -C libsrc clean
+  $MAKE -C libsrc
+  $MAKE -C libsrc install
+  $MAKE -C libsrc/_DEVELOPMENT
+  $MAKE -C include/_DEVELOPMENT
 fi
 
+
+if [ $do_tests = 1 ]; then              # Build tests or not...
+  $MAKE -C testsuite
+  $MAKE -C test
+fi
+
+
+if [ $do_examples = 1 ]; then           # Build examples or not...
+  $MAKE -C examples
+fi

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,8 @@
 # Build z88dk on unix systems
 #
 
-function show_help_and_exit {
+show_help_and_exit()
+{
 
   if [[ -n $1 ]]; then rc=$1; else rc=0; fi
 


### PR DESCRIPTION
Hi,

launching `./build.sh -c -b -l` gives as a result that -b is an invalid option. Likewise _**'`./build.sh -c -b -l`' gives as result that -l (small L) is an invalid option**_.

Besides above problems, _**I still see that -nb and -nl are usable parameters**_: `Usage: ./build.sh [-e][-k][-c][-t][-nb][-nl]`.

```
./build.sh: illegal option -- b
Usage: ./build.sh [-e][-k][-c][-t][-nb][-nl]

-k\tKeep building ignoring errors
-c\tClean before building
-t\tRun tests
-e\tBuild examples
-p\tTARGET Build specified targets
-b\tDon't build binaries
-l\tDon't build libraries

Default is to build binaries and libraries
```
I have _**fixed and changed build.sh**_ so to be _**backward compatible with the idea behind the one in z88dk/s88dk/master**_. But _**besides the urgent fix**_, I have also:
- added some logic to _**prevent strange cases**_ to happen: `./build.sh -b -l`
- added some logic (_**extra option: '-C'**_) that also _**cleans the bin directory**_
- added some logic to _**prevent adding the bin directory multiple times to $PATH**_
- _**changed the '\t' in the help text**_ so to have a nicer layout on the console (see below)

_**build.sh has been thoroughly tested**_ with a large number of parameter combinations (even '-c -C') and seems to behave correctly. The Travis build _**gives the same results as the one for the actual master branch**_.

The proposed help screen is:
```
Usage: ./build.sh [-b][-c][-C][-e][-h][-k][-l][-p][-t]

  -b    Don't build binaries
  -c    Clean build environment
  -C    Clean build environment and binaries (including bin/*)
        Chosing this option makes a manual rebuild of zsdcc and
        szdcpp necessary in the win32 environment
  -e    Build examples
  -h    This help information
  -k    Keep building ignoring errors
  -l    Don't build libraries
  -p    TARGET Build specified targets
  -t    Run tests

Default is to build binaries and libraries
```