### PR TITLE
Fix z80asm - Local build - Unused function, undeclared function

### DIFF
--- a/src/z80asm/macros.c
+++ b/src/z80asm/macros.c
@@ -164,6 +164,8 @@ static bool collect_name(char **in, UT_string *out)
 }
 
 // collect formal parameters
+/* Prevent warning: defined but not used [-Wunused-function] */
+/*
 static bool collect_params(char **p, DefMacro *macro, UT_string *param)
 {
 #define P (*p)
@@ -184,6 +186,7 @@ static bool collect_params(char **p, DefMacro *macro, UT_string *param)
 
 #undef P
 }
+*/
 
 // collect macro text
 static bool collect_text(char **p, DefMacro *macro, UT_string *text)

--- a/src/z80asm/options.c
+++ b/src/z80asm/options.c
@@ -13,6 +13,7 @@
 #include "hist.h"
 #include "init.h"
 #include "model.h"
+#include "modlink.h"        /* Prevent warning: implicit declaration of function ‘library_file_append’ */
 #include "options.h"
 #include "srcfile.h"
 #include "str.h"


### PR DESCRIPTION
Solved:
- warning: ‘collect_params’ defined but not used [-Wunused-function]
- warning: implicit declaration of function ‘library_file_append’ [-Wimplicit-function-declaration]

_**Question:
would it be useful to fix the warnings in z88dk/regex since there are a lot of warnings while compiling z88dk/z88dk like**_:
````
In file included from ../../ext/regex/regcomp.c:12:0:
../../ext/regex/cclass.h:7:2: warning: missing braces around initializer [-Wmissing-braces]
  "alnum", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\
  ^
../../ext/regex/cclass.h:7:2: warning: (near initialization for ‘cclasses[0]’) [-Wmissing-braces]
In file included from ../../ext/regex/regcomp.c:13:0:
../../ext/regex/cname.h:6:2: warning: missing braces around initializer [-Wmissing-braces]
  "NUL", '\0',
  ^
````