### PR TITLE
Fix testsuite - Issue 1409 switch - Warning Implicit definition of function 'dofunc'

### DIFF
--- a/testsuite/Issue_1409_switch.c
+++ b/testsuite/Issue_1409_switch.c
@@ -1,4 +1,6 @@
 
+void dofunc(int);
+
 void func(int i) {
    switch ( i ) {
    case 1:

--- a/testsuite/Issue_1409_switch.c
+++ b/testsuite/Issue_1409_switch.c
@@ -1,5 +1,4 @@
 
-
 void func(int i) {
    switch ( i ) {
    case 1:

--- a/testsuite/results/Issue_1409_switch.opt
+++ b/testsuite/results/Issue_1409_switch.opt
@@ -43,8 +43,8 @@
 
 
 
-	GLOBAL	_func
 	GLOBAL	_dofunc
+	GLOBAL	_func
 
 
 


### PR DESCRIPTION
Hi,

_**I'd like to continue the cleanup of the build process with the testsuite**_. Therefore, I have done a first test (Issue_1409_switch) for which I need to change the .c and the .opt file to get rid of the warning: `Implicit definition of function 'dofunc'`

In the .c file, an explicit function definition has to be added: `void dofunc(int);`

In the .opt file, the two lines `GLOBAL _dofunc` and `GLOBAL _func` have to be switched. No real functional changes have to be applied to the .opt file.

_**Can you tell me if this change is acceptable**_? If so, I'll continue with cleaning up the other warnings for the testsuite.

Thanks in advance for a reply.

Grtz,
PB