### PR TITLE
z80asm: Add -Dvar=nn do define a numeric variable in the command line

### DIFF
--- a/src/z80asm/error_func.c
+++ b/src/z80asm/error_func.c
@@ -312,6 +312,15 @@ void error_invalid_org_option(const char *org_hex)
 	
 	STR_DELETE(msg);
 }
+void error_invalid_define_option(const char *define)
+{
+	STR_DEFINE(msg, STR_SIZE);
+
+	Str_append_sprintf( msg, "invalid -DVAR=VAL option '%s'", define );
+	do_error( ErrError, Str_data(msg) );
+	
+	STR_DELETE(msg);
+}
 void error_invalid_org(int origin)
 {
 	STR_DEFINE(msg, STR_SIZE);

--- a/src/z80asm/error_func.h
+++ b/src/z80asm/error_func.h
@@ -36,6 +36,7 @@ extern void error_org_redefined(void);
 extern void error_align_redefined(void);
 extern void error_org_not_aligned(int org, int align);
 extern void error_invalid_org_option(const char *org_hex);
+extern void error_invalid_define_option(const char *define);
 extern void error_invalid_org(int origin);
 extern void error_invalid_filler_option(const char *filler_hex);
 extern void warn_org_ignored(const char *filename, const char *section_name);

--- a/src/z80asm/tt/error_func.yaml
+++ b/src/z80asm/tt/error_func.yaml
@@ -187,6 +187,11 @@ errors:
     message	: "\"invalid --origin option '%s'\", org_hex"
 	
   - type	: ErrError
+    func	: error_invalid_define_option
+    args	: const char *define
+    message	: "\"invalid -DVAR=VAL option '%s'\", define"
+	
+  - type	: ErrError
     func	: error_invalid_org
     args	: int origin
     message	: "\"invalid origin: %d\", origin"


### PR DESCRIPTION
Option -Dvariable=value defines the variable with the given numeric value. The value can be passed in decimal (e.g. -Dvar=255) or hexadecimal
(e.g. -Dvar=0xff or -Dvar=0ffh or -Dvar=$ff). Note that the $ may have to be escaped from the shell.

If the value is not given, i.e. -Dvariable, the previous behaviour is kept, i.e. the variable is defined with the value 1.