### PR TITLE
Automation of Dhrystone measurements

### DIFF
--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/dhrystone21/z88dk-classic/Makefile
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/dhrystone21/z88dk-classic/Makefile
@@ -1,0 +1,27 @@
+SRC:=$(wildcard *.[ch])
+BIN:=dhry.bin
+
+Q=@
+ifeq ($V,1)
+Q=
+endif
+
+all:	benchmark
+
+${BIN}:	${SRC}
+	@echo "[-] Compiling Dhrystone code..."
+	${Q}zcc +test -vn -compiler=sdcc -SO3 --max-allocs-per-node200000 -DTIMER -D__Z88DK dhry_1.c dhry_2.c -o dhry.bin -m -lndos
+
+
+benchmark:	${BIN}
+	@echo "[-] Measuring T-states (cycles):"
+	${Q}TIMER_START=$$(grep TIMER_START dhry.map | awk '{print $$3}' | sed 's,^.,,' | tr '[A-Z]' '[a-z]') ; \
+	TIMER_STOP=$$(grep TIMER_STOP dhry.map | awk '{print $$3}' | sed 's,^.,,' | tr '[A-Z]' '[a-z]') ; \
+	echo "[-] From $${TIMER_START} to $${TIMER_STOP}" ; \
+	z88dk-ticks $< -start $${TIMER_START} -end $${TIMER_STOP} -counter 4999999999 > dhrystone_ticks
+	@echo "[-] Computing Dhrystones..."
+	@echo -n "[-] DMIPS = "
+	@bash -c '{ echo -en "scale=5\n(20000.0 / (" ; cat dhrystone_ticks | tr -d "\012" ; echo  ".0 / 4000000)) / 1757." ; }' | bc -l
+
+clean:
+	rm -f ${BIN} dhrystone_ticks dhry.map dhry.bin zcc_opt.def *.bin *.tap dhry

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/dhrystone21/z88dk-new/Makefile
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/dhrystone21/z88dk-new/Makefile
@@ -1,0 +1,27 @@
+SRC:=$(wildcard *.[ch])
+BIN:=dhry.bin
+
+Q=@
+ifeq ($V,1)
+Q=
+endif
+
+all:	benchmark
+
+${BIN}:	${SRC}
+	@echo "[-] Compiling Dhrystone code..."
+	${Q}zcc +z80 -vn -startup=0 -clib=sdcc_iy -SO3 --max-allocs-per-node200000 -DTIMER dhry_1.c dhry_2.c -o dhry -m -pragma-include:zpragma.inc -create-app
+
+
+benchmark:	${BIN}
+	@echo "[-] Measuring T-states (cycles):"
+	${Q}TIMER_START=$$(grep TIMER_START dhry.map | awk '{print $$3}' | sed 's,^.,,' | tr '[A-Z]' '[a-z]') ; \
+	TIMER_STOP=$$(grep TIMER_STOP dhry.map | awk '{print $$3}' | sed 's,^.,,' | tr '[A-Z]' '[a-z]') ; \
+	echo "[-] From $${TIMER_START} to $${TIMER_STOP}" ; \
+	z88dk-ticks $< -start $${TIMER_START} -end $${TIMER_STOP} -counter 4999999999 > dhrystone_ticks
+	@echo "[-] Computing Dhrystones..."
+	@echo -n "[-] DMIPS = "
+	@bash -c '{ echo -en "scale=5\n(20000.0 / (" ; cat dhrystone_ticks | tr -d "\012" ; echo  ".0 / 4000000)) / 1757." ; }' | bc -l
+
+clean:
+	rm -f ${BIN} dhrystone_ticks dhry.map dhry.bin zcc_opt.def *.bin


### PR DESCRIPTION
These two Makefiles allow for very easy computation of the Dhrystone
results:

    $ cd z88dk/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/
    $ cd dhrystone21/z88dk-classic
    $ make

    [-] Compiling Dhrystone code...
    [-] Measuring T-states (cycles):
    [-] From 014b to 02b4
    [-] Computing Dhrystones...
    [-] DMIPS = .18446

    $ make clean
    $ cd ../z88dk-new
    $ make

    [-] Compiling Dhrystone code...
    [-] Measuring T-states (cycles):
    [-] From 01c0 to 0345
    [-] Computing Dhrystones...
    [-] DMIPS = .17738

    $ make clean
    $ git status
    $
    $ # All clean

In addition to z88dk itself, the only dependencies used by the Makefiles
are "cat", "bash", "tr", "awk" and "bc" - traditional UNIX tools that exist
out of the box in all modern distributions.