### PR TITLE
fix rs232 if1 implementation for zx

### DIFF
--- a/libsrc/target/zx/rs232/if1/rs232_get.c
+++ b/libsrc/target/zx/rs232/if1/rs232_get.c
@@ -20,6 +20,9 @@
 uint8_t rs232_get(uint8_t *char) __naked __z88dk_fastcall
 {
 #asm
+        EXTERN BAUD
+        EXTERN SERFL
+
         push	hl
 ;	rst	8
 ;	defb	$1d  		; Calls the Hook Code here
@@ -41,7 +44,7 @@ uint8_t rs232_get(uint8_t *char) __naked __z88dk_fastcall
 ; (Hook Code: $1D)
 
 ;; BCHAN-IN
-L0B88:  LD      HL,$5CC7        ; sv SER_FL
+L0B88:  LD      HL, SERFL        ; sv SER_FL
         LD      A,(HL)          ; Is the second-character received flag set?
         AND     A               ;
         JR      Z,L0B95         ; forward to REC-BYTE (if Z set)
@@ -57,15 +60,9 @@ L0B88:  LD      HL,$5CC7        ; sv SER_FL
 
 ; ---
 
-;; REC-BYTE
-;; L0B95:  CALL    L163E          ; routine TEST-BRK  - Thanks Jetset Willy really dont need this!
-
 L0B95:	DI                      ; Disable Interrupts
 
-        LD      A,($5CC6)       ; sv IOBORD
-;        OUT     ($FE),A		; Change the border colour.  -  No Thanks Jetset Willy change the borders in program if wanted
-
-        LD      DE,($5CC3)      ; sv BAUD
+        LD      DE,(BAUD)       ; sv BAUD
         LD      HL,$0320        ; 800d.
         LD      B,D             ;
         LD      C,E             ;
@@ -214,7 +211,7 @@ L0C1D:  DEC     HL              ;
 
 ;  The start bit has been pushed out and B contains the second received byte.
 
-        LD      HL,$5CC7        ; Address the SER_FL System Variable.
+        LD      HL,(SERFL)        ; Address the SER_FL System Variable.
 
         LD      (HL),$01        ; Signal there is a byte in the next location.
         INC     HL              ; Address that location.

--- a/libsrc/target/zx/rs232/if1/rs232_init.c
+++ b/libsrc/target/zx/rs232/if1/rs232_init.c
@@ -17,12 +17,16 @@
 u8_t rs232_init()
 {
 #asm
-        rst     8
-        defb    $31             ; Create the IF1 system variables area
-        ;xor     a
-        ;ld      ($5cc7),a       ; Reset SER-FL to clean the input buffer
-        ;ld      a,(23624)
-        ;ld      (23750),a       ; Set IOBORD to the current border colour (hide flashing)
+    PUBLIC BAUD
+    PUBLIC SERFL
+
+    BAUD:
+        ; Default speed: 2400 baud
+        defw $36
+    SERFL:
+        ; flag + data byte about an eventual 2nd character already transmitted
+        defw 0
+
         ld      hl,RS_ERR_OK
 #endasm
 }

--- a/libsrc/target/zx/rs232/if1/rs232_params.c
+++ b/libsrc/target/zx/rs232/if1/rs232_params.c
@@ -21,10 +21,7 @@
 u8_t rs232_params(unsigned char param, unsigned char parity)
 {
 #asm
-        rst     8
-        defb    $31             ; Create the IF1 system variables area
-        ;xor     a
-        ;ld      ($5cc7),a       ; Reset SER-FL to clean the input buffer
+        EXTERN BAUD
 
         pop     bc
         pop     de
@@ -62,7 +59,7 @@ avail:
         inc     hl
         ld      h,(hl)
         ld      l,a
-        ld      (23747),hl
+        ld      (BAUD),hl
         ld      hl,0            ; RS_ERR_OK
         ret
 

--- a/libsrc/target/zx/rs232/if1/rs232_put.c
+++ b/libsrc/target/zx/rs232/if1/rs232_put.c
@@ -17,6 +17,8 @@
 uint8_t __FASTCALL__ rs232_put(uint8_t char)
 {       
 #asm
+        EXTERN BAUD
+
         ld      a,l     		;get byte
 ;        rst     8
 ;        defb    $1E			;  Calls the Hook Code
@@ -36,16 +38,13 @@ L0D07:  LD      B,$0B           ; Set bit count to eleven - 1 + 8 + 2.
         CPL                     ; Invert the bits of the character.
         LD      C,A             ; Copy the character to C.
 
-        LD      A,($5CC6)       ; Load A from System Variable IOBORD
-;        OUT     ($FE),A         ; Change the border colour.  -  No Thanks Jetset Willy change the borders in program if wanted
-
         LD      A,$EF           ; Set to %11101111
         OUT     ($EF),A         ; Make CTS (Clear to Send) low.
 
         CPL                     ; reset bit 0 (other bits of no importance)
         OUT     ($F7),A         ; Make RXdata low. %00010000
 
-        LD      HL,($5CC3)      ; Fetch value from BAUD System Variable.
+        LD      HL,(BAUD)      ; Fetch value from BAUD System Variable.
         LD      D,H             ; Copy BAUD value to DE for count.
         LD      E,L             ;
 


### PR DESCRIPTION
Current implementation of `rs232if1.lib` does not work at all, calling `rs232_init` or `rs232_params` leads to crash. Tested this on 48k and 128k spectrum on FUSE emulator (do not have real hardware at this time).

This is my very first assembly code, I basically moved things over from `rs232plus.lib`, what I gathered is current implementation of `rs232if1` is a leftover of disassembly with little thought into it. I also put little thought in actual timing, since FUSE's implantation simply responds to read events. But because I haven't touched the timing part of the old assembly, it should work fine. Hope there is anyone around with real speccy that can try this.

Here are "proofs" this fix works with my custom FUSE peripheral that handles port `0xF7`
![image](https://user-images.githubusercontent.com/1666014/92276246-4b8caf80-eef9-11ea-9e49-13089edce259.png)

Code to test this:
```C
#include <stdio.h>
#include <z88.h>
#include <rs232.h>

int main()
{

    printf("\x0C"); // clear screen
    printf("Hello, world!\n");
    if (rs232_init() != RS_ERR_OK) {
        printf("Error\n");
        return(2);
    }
    printf("RS232 init OK\n");
    if (rs232_params(RS_BAUD_9600, RS_PAR_NONE) != RS_ERR_OK) {
        printf("Error\n");
        return(2);
    }

    printf("RS232 params OK\n");
    uint8_t test = 0x00;
    if (rs232_get(&test) == RS_ERR_OK)
    {
        printf("GET 1 OK: 0x%1x\n", test);
    }
    if (rs232_get(&test) == RS_ERR_OK)
    {
        printf("GET 2 OK: 0x%1x\n", test);
    }

    rs232_put(0xAA);
    rs232_put(0xAA);
    rs232_put(0xAA);
    rs232_put(0xAA);
    rs232_put(0xAA);

    printf("SEND OK\n");

    return 0;
}
```

Here's my custom FUST port handler capturing this:
![image](https://user-images.githubusercontent.com/1666014/92276396-8ee71e00-eef9-11ea-885f-da97c3e5b160.png)
