### PR TITLE
fix sizeof(“concat" “strings”)

### DIFF
--- a/src/sccz80/const.c
+++ b/src/sccz80/const.c
@@ -584,10 +584,19 @@ void size_of(LVALUE* lval)
         }
     } else if (cmatch('"')) { /* Check size of string */
         length = 1; /* Always at least one */
-        while (!cmatch('"')) {
-            length++;
-            litchar();
-        };
+        do
+        {
+            while (!cmatch('"')) {
+                length++;
+                litchar();
+            };
+            /* Keep going for "concatenated" "strings" */
+            if (!cmatch('"')) {
+                break;
+            }
+            /* But correct the opening quotes */
+            length--;
+        } while (1);
         lval->const_val = length;
         if ( deref ) 
             lval->const_val = 1;

--- a/testsuite/results/sizeof_w_str_concat.opt
+++ b/testsuite/results/sizeof_w_str_concat.opt
@@ -1,0 +1,36 @@
+
+
+
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._main
+	ld	hl,14	;const
+	push	hl
+	ld	hl,8	;const
+	push	hl
+	ld	hl,7	;const
+	push	hl
+	ld	hl,0	;const
+	pop	bc
+	pop	bc
+	pop	bc
+	ret
+
+
+
+
+	SECTION	bss_compiler
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_main
+
+
+
+

--- a/testsuite/sizeof_w_str_concat.c
+++ b/testsuite/sizeof_w_str_concat.c
@@ -1,0 +1,7 @@
+int main()
+{
+    int a = sizeof("partone" "parttwo");
+    int b = sizeof("partone" "a");
+    int c = sizeof("partone" "");
+    return 0;
+}


### PR DESCRIPTION
Existing sizeof cannot handle C-style `"concatenated" "strings"`, fails like so:
```
src/main:4:26: error: Missing token, expecting ) got "
src/main:4:26: error: Missing token, expecting ; got "
src/main:4:29: fatal error: Expected ';'
Compilation aborted
```

Caught this trying to compile [mbedtls](https://github.com/ARMmbed/mbedtls/blob/e8582ba0f3858d59ad7321ae56c95e2f4e05e657/include/mbedtls/asn1.h#L121).

I also added a regression.