### PR TITLE
proposal: add __z88dk_shortcall_hl declspec

### DIFF
--- a/src/sccz80/callfunc.c
+++ b/src/sccz80/callfunc.c
@@ -331,6 +331,8 @@ void callfunction(SYMBOL *ptr, Type *fnptr_type)
             nargs = 0;
         } else if ( functype->flags & SHORTCALL ) {
             gen_shortcall(functype, functype->funcattrs.shortcall_rst, functype->funcattrs.shortcall_value);
+        } else if ( functype->flags & HL_CALL ) {
+            gen_hl_call(functype, functype->funcattrs.hlcall_module, functype->funcattrs.hlcall_addr);
         } else if ( functype->flags & BANKED ) {
             gen_bankedcall(ptr);
         } else {

--- a/src/sccz80/ccdefs.h
+++ b/src/sccz80/ccdefs.h
@@ -78,6 +78,7 @@ extern void gen_critical_enter(void);
 extern void gen_critical_leave(void);
 extern void gen_shortcall(Type *functype, int rst, int value);
 extern void gen_bankedcall(SYMBOL *sym);
+extern void gen_hl_call(Type *functype, int module, int address);
 extern void gen_emit_line(int);
 
 extern void gen_load_indirect(LVALUE *lval);

--- a/src/sccz80/define.h
+++ b/src/sccz80/define.h
@@ -130,6 +130,8 @@ struct type_s {
         int   params_offset;
         uint8_t  shortcall_rst;
         uint16_t shortcall_value;
+        uint16_t hlcall_module;
+        uint16_t hlcall_addr;
     } funcattrs;
 
     UT_hash_handle hh;
@@ -172,7 +174,9 @@ enum symbol_flags {
         CRITICAL = 0x1000,    /* Disable interrupts around the function */
         SDCCDECL = 0x2000,   /* Function uses sdcc convention for chars */
         SHORTCALL = 0x4000,   /* Function uses short call (via rst) */
-        BANKED = 0x8000      /* Call via the banked_call function */
+        SHORTCALL_HL = 0x8000,   /* Use ld HL,$addr style of shortcall */
+        BANKED = 0x10000,      /* Call via the banked_call function */
+        HL_CALL = 0x20000 /* Call via ld hl, (module) call (addr) */
 };
 
 

--- a/testsuite/results/shortcall.opt
+++ b/testsuite/results/shortcall.opt
@@ -60,6 +60,58 @@
 
 
 
+._hlfunc1
+	ld	hl,1	;const
+	ld	de,0
+	push	de
+	push	hl
+	ld	hl,2	;const
+	push	hl
+	ld	hl,5000	;const
+	rst	8
+	pop	bc
+	pop	bc
+	pop	bc
+	ret
+
+
+
+._hlfunc2
+	ld	hl,1	;const
+	ld	de,0
+	push	de
+	push	hl
+	ld	hl,2	;const
+	push	hl
+	ld	hl,2000	;const
+	call	5000
+	pop	bc
+	pop	bc
+	pop	bc
+	ret
+
+
+
+._hlfunc3
+	ld	hl,1	;const
+	ld	de,0
+	ld bc,	hl
+	ld	hl,5000	;const
+	rst	8
+	ret
+
+
+
+._hlfunc4
+	ld	hl,1	;const
+	ld	de,0
+	ld bc,	hl
+	ld	hl,2000	;const
+	call	5000
+	ret
+
+
+
 
 	SECTION	bss_compiler
 	SECTION	code_compiler
@@ -68,9 +120,17 @@
 
 	GLOBAL	_scall
 	GLOBAL	_scall2
+	GLOBAL	_hlcall1
+	GLOBAL	_hlcall2
+	GLOBAL	_hlcall3
+	GLOBAL	_hlcall4
 	GLOBAL	_func
 	GLOBAL	_func2
 	GLOBAL	_func3
+	GLOBAL	_hlfunc1
+	GLOBAL	_hlfunc2
+	GLOBAL	_hlfunc3
+	GLOBAL	_hlfunc4
 
 
 

--- a/testsuite/shortcall.c
+++ b/testsuite/shortcall.c
@@ -2,6 +2,10 @@
 
 extern int scall(long x, int y) __z88dk_shortcall(8, 200);
 extern int scall2(long x, int y) __z88dk_shortcall(8, 2000);
+extern int hlcall1(long x, int y) __z88dk_shortcall_hl(8, 5000);
+extern int hlcall2(long x, int y) __z88dk_hl_call(2000, 5000);
+extern int hlcall3(long x) __z88dk_shortcall_hl(8, 5000) __z88dk_fastcall;
+extern int hlcall4(long x) __z88dk_hl_call(2000, 5000) __z88dk_fastcall;
 
 int func() 
 {
@@ -20,4 +24,22 @@ int func3()
 	return funcptr(2L, 3);
 }
 
-	
+int hlfunc1()
+{
+    return hlcall1(1L, 2);
+}
+
+int hlfunc2()
+{
+    return hlcall2(1L, 2);
+}
+
+int hlfunc3()
+{
+    return hlcall3(1L);
+}
+
+int hlfunc4()
+{
+    return hlcall4(1L);
+}


### PR DESCRIPTION
I am trying to implement couple of modules for [spectranet](http://spectrum.alioth.net/doc/index.php/Spectranet:_Tutorial_7#Installing_ROM_modules_into_the_Spectranet.27s_flash) which have the following calling convention:
```asm
LD HL, 0xFE01
RST 0x28
```
which I almost like `__z88dk_shortcall` but the latter does this instead
```asm
RST 0x28
DEFW 0xFE01
```
which has it uses cases, but not good for me. This change adds `__z88dk_shortcall_hl` declspec, which has exact parameters (rst, addr), but instead of defining a word it loads the addr into `HL` register.

With this declspec I could declare such a function
```
static void a_function(char a) __z88dk_shortcall_hl(0x28, 0xAB01);
```
And have the corresponding assembly ready inside of the internals of spectranet internals, and C will do the the rst required.

I also made sure that `__z88dk_shortcall_hl` and `__z88dk_fastcall` are impossible to have togethere since they both use HL register.

I have added a regression for this,  and if merged, will update the [wiki](https://github.com/z88dk/z88dk/wiki/CallingConventions#far-convention-modifiers). I understand that this use case is fairly unique, and that's fine I could keep my copy around, but maybe someone else could ever need this.