### PR TITLE
[m100] basic support for generating option ROMs

### DIFF
--- a/lib/config/m100.cfg
+++ b/lib/config/m100.cfg
@@ -9,10 +9,10 @@ CRT0		 DESTDIR/lib/target/m100/classic/m100_crt0
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote.  -DZ80 -M -subtype=default -clib=default -Ca-IDESTDIR/lib/target/m100/def -m8085 -startuplib=8080_crt0 -l8085_opt -D__8080__ -D__8085__ -D__M100__  -custom-copt-rules=DESTDIR/lib/arch/8085/8085_rules.1
 
-CLIB      default -Cc-standard-escape-chars -lm100_clib -lndos
+CLIB      default -Cc-standard-escape-chars -lndos
 
-SUBTYPE   default -Cz+trs80 -Cz--co
-
+SUBTYPE   default -lm100_clib -startup=1 -Cz+trs80 -Cz--co
+SUBTYPE   optrom  -lm100_optrom_clib -startup=0 -Cz+rom -Cz--romsize=32768
 
 
 INCLUDE alias.inc

--- a/lib/config/m100.cfg
+++ b/lib/config/m100.cfg
@@ -7,12 +7,12 @@ CRT0		 DESTDIR/lib/target/m100/classic/m100_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2 -iquote.  -DZ80 -M -subtype=default -clib=default -Ca-IDESTDIR/lib/target/m100/def -m8085 -startuplib=8080_crt0 -l8085_opt -D__8080__ -D__8085__ -D__M100__  -custom-copt-rules=DESTDIR/lib/arch/8085/8085_rules.1
+OPTIONS		 -O2 -SO2 -iquote.  -DZ80 -M -subtype=default -clib=default -lm100_clib -Ca-IDESTDIR/lib/target/m100/def -m8085 -startuplib=8080_crt0 -l8085_opt -D__8080__ -D__8085__ -D__M100__  -custom-copt-rules=DESTDIR/lib/arch/8085/8085_rules.1
 
 CLIB      default -Cc-standard-escape-chars -lndos
 
-SUBTYPE   default -lm100_clib -startup=1 -Cz+trs80 -Cz--co
-SUBTYPE   optrom  -lm100_optrom_clib -startup=0 -Cz+rom -Cz--romsize=32768
+SUBTYPE   default -startup=1 -Cz+trs80 -Cz--co
+SUBTYPE   optrom  -startup=0 -Cz+rom -Cz--romsize=32768
 
 
 INCLUDE alias.inc

--- a/lib/target/m100/classic/m100_crt0.asm
+++ b/lib/target/m100/classic/m100_crt0.asm
@@ -18,6 +18,8 @@
         PUBLIC    cleanup         ;jp'd to by exit()
         PUBLIC    l_dcal          ;jp(hl)
 
+	PUBLIC	ROMCALL_OP	; Opcode to use for ROM calls
+
         IF !CLIB_FGETC_CONS_DELAY
                 defc CLIB_FGETC_CONS_DELAY = 150
         ENDIF
@@ -34,8 +36,10 @@
         INCLUDE "crt/classic/crt_rules.inc"
         
 	IF startup = 1 
+		defc	ROMCALL_OP = $CD	; CALL
 		INCLUDE	"target/m100/classic/ram.asm"
         ELSE
+		defc	ROMCALL_OP = $F7	; RST6
 		INCLUDE	"target/m100/classic/optrom.asm"
 	ENDIF
  

--- a/lib/target/m100/classic/m100_crt0.asm
+++ b/lib/target/m100/classic/m100_crt0.asm
@@ -27,11 +27,13 @@
         defc    TAR__clib_exit_stack_size = 4
 ;	defc    TAR__fputc_cons_generic = 1
         defc    TAR__register_sp = -1 
-	defc	CRT_KEY_DEL = 12
+	defc	CRT_KEY_DEL = 8
 	defc	__CPU_CLOCK = 2400000
 
 	defc	CONSOLE_COLUMNS = 40
 	defc	CONSOLE_ROWS = 8
+	defc	CLIB_DISABLE_FGETS_CURSOR = 1
+
 
         INCLUDE "crt/classic/crt_rules.inc"
         

--- a/lib/target/m100/classic/m100_crt0.asm
+++ b/lib/target/m100/classic/m100_crt0.asm
@@ -1,15 +1,5 @@
-;
-;	Startup for m100
-;	Stefano, February 2020
-;
-;	"appmake +trs80 --co" will prepare a valid binary file, to be invoked from within BASIC:
-;	CLEAR 0,49999: RUNM "A.CO"
-;
-
-
 
 	module m100_crt0
-
 
 ;--------
 ; Include zcc_opt.def to find out some info
@@ -33,58 +23,23 @@
         ENDIF
 
         defc    TAR__clib_exit_stack_size = 4
-	defc    TAR__fputc_cons_generic = 1
+;	defc    TAR__fputc_cons_generic = 1
         defc    TAR__register_sp = -1 
 	defc	CRT_KEY_DEL = 12
 	defc	__CPU_CLOCK = 2400000
 
-	defc	CONSOLE_COLUMNS = 80
+	defc	CONSOLE_COLUMNS = 40
 	defc	CONSOLE_ROWS = 8
 
         INCLUDE "crt/classic/crt_rules.inc"
-
-        IF      !DEFINED_CRT_ORG_CODE
-                    defc  CRT_ORG_CODE  = 50000
-        ENDIF
-
-	org	  CRT_ORG_CODE
-
-
-
-program:
-
-        INCLUDE "crt/classic/crt_init_sp.asm"
-        INCLUDE "crt/classic/crt_init_atexit.asm"
-	call    crt0_init_bss
-	ld	hl,0
-	add	hl,sp
-	ld	(exitsp),hl
-
-; Optional definition for auto MALLOC init
-; it assumes we have free space between the end of
-; the compiled program and the stack pointer
-IF DEFINED_USING_amalloc
-	defc	CRT_MAX_HEAP_ADDRESS = $F500
-    INCLUDE "crt/classic/crt_init_amalloc.asm"
-ENDIF
-
-	push	bc	;argv
-	push	bc	;argc
-	call	_main
-	pop	bc
-	pop	bc
-cleanup:
-	push	hl
-	call	crt0_exit
-	pop	hl
-
-	ret
-
-
-
+        
+	IF startup = 1 
+		INCLUDE	"target/m100/classic/ram.asm"
+        ELSE
+		INCLUDE	"target/m100/classic/optrom.asm"
+	ENDIF
+ 
 l_dcal: jp      (hl)            ;Used for function pointer calls
-
-
 
 	INCLUDE "crt/classic/crt_runtime_selection.asm" 
 	

--- a/lib/target/m100/classic/optrom.asm
+++ b/lib/target/m100/classic/optrom.asm
@@ -90,15 +90,14 @@ stdcall:
 	
 	push	hl
 	push	de
-	
-	defb	$38	; ldsi $06, 8085 undocumented opcode
-	defb	$06
 
-	defb	$ed ; lhlx undocumented 8085 opcode
+	ldsi	$06	
+
+	lhlx
 	dec	hl
 	dec	hl
 	ex	de, hl
-	defb	$ed ; lhlx undocumented 8085 opcode
+	lhlx
 	
 	pop	de
 	ex	(sp), hl
@@ -108,9 +107,8 @@ intcall:
 	push	hl
 	push	de
 	
-	defb	$38	; ldsi $04, 8085 undocumented opcode
-	defb	$04
-	defb	$ed ; lhlx undocumented 8085 opcode
+	ldsi	$04
+	lhlx
 
 	dec	hl
 	dec	hl
@@ -119,7 +117,8 @@ intcall:
 
 	push	hl	
 	ld	hl, OPON
-	defb	$d9	; shlx, 8085 undocumented opcode
+
+	shlx
 	pop	hl
 	pop	de
 	ex	(sp), hl	

--- a/lib/target/m100/classic/optrom.asm
+++ b/lib/target/m100/classic/optrom.asm
@@ -1,0 +1,161 @@
+;
+;	Startup for m100 optrom mostly based on Stephen Adolph optrom demo:
+;	http://bitchin100.com/wiki/index.php?title=OPTROM_Switching&oldid=2419
+;	Alexei Gordeev, Nov 2020
+;
+
+	; guaranteed safe place to put some variables
+	defc ALTLCD_RAM = $FCC0
+	defc ALTLCD_LEN = 320        
+        
+        defc OPON = $FAA4
+        defc CRT_ORG_DATA = ALTLCD_RAM
+        defc CRT_ORG_CODE = $0000
+
+IFNDEF CRT_ORG_BSS
+        defc CRT_ORG_BSS = ALTLCD_RAM ; Ram variables will be kept in safe RAM area by default
+ENDIF
+        defc    __crt_org_bss = CRT_ORG_BSS
+
+	org	  CRT_ORG_CODE
+rst0:
+	jp	program		; RST0 standard entry
+
+	defs	$08-ASMPC
+rst1:
+	ret			; RST1 not used
+	defs	$10-ASMPC
+rst2:
+	ret			; RST2 not used
+
+	defs	$18-ASMPC
+rst3:
+	ret			; RST3 not used
+
+	defs	$20-ASMPC
+rst4:
+	ret			; RST4 not used
+
+	defs	$24-ASMPC
+trap:
+	di			; TRAP
+	call	intcall
+
+	defs	$28-ASMPC
+rst5:
+	ret			; RST5 not used
+
+	defs	$2c-ASMPC
+rst55:
+	di
+	call	intcall
+
+	defs	$30-ASMPC
+rst6:
+	jp	stdcall		;RST 6 used as short call to a Standard ROM routine.
+
+	defs	$34-ASMPC
+rst65:
+	di	;Replaces the 6.5 interrupt and sets up a call to 6.5 in Standard ROM
+	call	intcall
+
+	defs	$38-ASMPC
+rst7:
+	ret			; RST7 not used
+
+	defs	$3c-ASMPC
+rst75:	
+	di	;Replaces the 7.5 interrupt and sets up a call to 7.5 in Standard ROM
+	call	intcall
+
+	defs	$40-ASMPC
+	
+OPON_img:
+	push	af
+	ld	a, $01
+	out	$e8
+	pop	af
+	ret
+	
+	defs	$48-ASMPC
+stdcall:
+	ex	(sp), hl
+	inc	hl
+	inc	hl
+	ex	(sp), hl
+
+	push	hl
+	ld	hl, OPON
+	ex	(sp), hl
+	
+	push	hl
+	push	de
+	
+	defb	$38	; ldsi $06, 8085 undocumented opcode
+	defb	$06
+
+	defb	$ed ; lhlx undocumented 8085 opcode
+	dec	hl
+	dec	hl
+	ex	de, hl
+	defb	$ed ; lhlx undocumented 8085 opcode
+	
+	pop	de
+	ex	(sp), hl
+	jp	stdon
+
+intcall:
+	push	hl
+	push	de
+	
+	defb	$38	; ldsi $04, 8085 undocumented opcode
+	defb	$04
+	defb	$ed ; lhlx undocumented 8085 opcode
+
+	dec	hl
+	dec	hl
+	dec	hl
+	dec	hl
+
+	push	hl	
+	ld	hl, OPON
+	defb	$d9	; shlx, 8085 undocumented opcode
+	pop	hl
+	pop	de
+	ex	(sp), hl	
+	jp	stdon
+
+	defs	$85-ASMPC
+stdon:
+	push	af
+	push	hl ; 26C8, F1 C9  POP PSW, RET
+	ld	hl, $26c8 ; it returns to this location --> pop psw; ret
+	ex	(sp), hl
+opexit:
+	xor	a
+	out	$e8
+	ret	; RET can be found at 008EH in stdrom
+		; in both M100 and T200
+
+	defs	$94-ASMPC
+exit:
+	pop	hl
+	ld	hl, 0
+	ex	(sp), hl	; restart
+	jp	opexit
+	
+program:
+        INCLUDE "crt/classic/crt_init_sp.asm"
+        INCLUDE "crt/classic/crt_init_atexit.asm"
+	call    crt0_init_bss
+	ei
+	push	bc	;argv
+	push	bc	;argc
+	call	_main
+	pop	bc
+	pop	bc
+cleanup:
+	push	hl
+	call	crt0_exit
+	pop	hl
+	jp exit

--- a/lib/target/m100/classic/ram.asm
+++ b/lib/target/m100/classic/ram.asm
@@ -1,0 +1,43 @@
+;
+;	Startup for m100
+;	Stefano, February 2020
+;
+;	"appmake +trs80 --co" will prepare a valid binary file, to be invoked from within BASIC:
+;	CLEAR 0,49999: RUNM "A.CO"
+;
+
+        IF      !DEFINED_CRT_ORG_CODE
+                    defc  CRT_ORG_CODE  = 50000
+        ENDIF
+
+	org	  CRT_ORG_CODE
+
+program:
+
+        INCLUDE "crt/classic/crt_init_sp.asm"
+        INCLUDE "crt/classic/crt_init_atexit.asm"
+	call    crt0_init_bss
+	ld	hl,0
+	add	hl,sp
+	ld	(exitsp),hl
+
+; Optional definition for auto MALLOC init
+; it assumes we have free space between the end of
+; the compiled program and the stack pointer
+IF DEFINED_USING_amalloc
+	defc	CRT_MAX_HEAP_ADDRESS = $F500
+    INCLUDE "crt/classic/crt_init_amalloc.asm"
+ENDIF
+
+	push	bc	;argv
+	push	bc	;argc
+	call	_main
+	pop	bc
+	pop	bc
+cleanup:
+	push	hl
+	call	crt0_exit
+	pop	hl
+
+	ret
+

--- a/lib/target/m100/def/romcalls.def
+++ b/lib/target/m100/def/romcalls.def
@@ -25,3 +25,6 @@ defc	CURPOS	= $427C	; position cursor; H=column (1-40), L=row(1-8)
 defc	CURSON	= $4249	; turn cursor on
 defc	CURSOFF	= $424E	; ...and off
 defc	BEEP	= $4229	; sound the beeper
+
+defc	LCDSET	= $744C ; LCD set pixel (D, E)
+defc	LCDRES	= $744D ; LCD reset pixel (D, E)

--- a/lib/target/m100/def/romcalls.def
+++ b/lib/target/m100/def/romcalls.def
@@ -1,0 +1,32 @@
+; M100 firmware macros and defs
+; Applicable to American M100/M102 ONLY (probably, I've never seen any European M100)
+; Nov 2020
+;
+; M100 system ROM aka firmware can be called in atleast a couple of ways
+; If we're calling it from OPTROM made with Stephen Adolph's template, we do
+; RST 6; DEFW ROM_ADDR
+; And if we're calling from normal RAM, then we simply do CALL ROM_ADDR
+
+; With ROMCALL macro, all ROM calls (except RSTs) can be abstracted into
+; ROMCALL; DEFW ROM_ADDR
+; ...and be conditionally compiled depending on the subtype we use.
+
+#define ROMCALL defb ROMCALL_OP
+
+IF __OPTROM__
+ROMCALL_OP EQU $F7 ; rst 6 if calling from OPTROM
+ELSE
+ROMCALL_OP EQU $CD ; normall CALL if calling from RAM
+ENDIF
+
+; ROM calls:
+
+defc	KYREAD	= $12CB	; wait for key from the keyboard
+defc	KYPEND	= $13DB	; check keyboard queue for pending characters
+
+defc	CLS	= $4231	; clear screen
+defc	CHROUT	= $4B44	; print character in reg. A to LCD/printer
+defc	CURPOS	= $42C7	; position cursor; H=column (1-40), L=row(1-8)
+defc	CURSON	= $4249	; turn cursor on
+defc	CURSOFF	= $424E	; ...and off
+defc	BEEP	= $4229	; sound the beeper

--- a/lib/target/m100/def/romcalls.def
+++ b/lib/target/m100/def/romcalls.def
@@ -21,7 +21,7 @@ defc	KYPEND	= $13DB	; check keyboard queue for pending characters
 
 defc	CLS	= $4231	; clear screen
 defc	CHROUT	= $4B44	; print character in reg. A to LCD/printer
-defc	CURPOS	= $42C7	; position cursor; H=column (1-40), L=row(1-8)
+defc	CURPOS	= $427C	; position cursor; H=column (1-40), L=row(1-8)
 defc	CURSON	= $4249	; turn cursor on
 defc	CURSOFF	= $424E	; ...and off
 defc	BEEP	= $4229	; sound the beeper

--- a/lib/target/m100/def/romcalls.def
+++ b/lib/target/m100/def/romcalls.def
@@ -11,14 +11,9 @@
 ; ROMCALL; DEFW ROM_ADDR
 ; ...and be conditionally compiled depending on the subtype we use.
 
+	EXTERN	ROMCALL_OP ; it's defined in m100_crt0.asm
 #define ROMCALL defb ROMCALL_OP
-
-IF __OPTROM__
-ROMCALL_OP EQU $F7 ; rst 6 if calling from OPTROM
-ELSE
-ROMCALL_OP EQU $CD ; normall CALL if calling from RAM
-ENDIF
-
+	
 ; ROM calls:
 
 defc	KYREAD	= $12CB	; wait for key from the keyboard

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -59,7 +59,7 @@ TOCREATE += $(call check_target,laser500,laser500_clib.lib)
 TOCREATE += $(call check_target,lm80c,lm80c_clib.lib)
 TOCREATE += $(call check_target,lviv,lviv_clib.lib)
 TOCREATE += $(call check_target,lynx,lynx_clib.lib)
-TOCREATE += $(call check_target,m100,m100_clib.lib)
+TOCREATE += $(call check_target,m100,m100_clib.lib m100_optrom_clib.lib)
 TOCREATE += $(call check_target,m5,m5_clib.lib)
 TOCREATE += $(call check_target,mc1000,mc1000_clib.lib)
 TOCREATE += $(call check_target,mikro80,mikro80_clib.lib)
@@ -1598,9 +1598,18 @@ m100_clib.lib:
 	@echo ''
 	@echo '--- Building m100 Library ---'
 	@echo ''
+	$(RM) target/m100/stdio/*.o
 	$(call buildgeneric,m100,"portable narrow")
 	$(MAKE) -C games TARGET=m100
 	TARGET=m100 TYPE=8080 $(LIBLINKER) -m8080 -DFORm100 -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/m100_clib @$(LISTFILE_DIRECTORY)/m100.lst
+
+m100_optrom_clib.lib:
+	@echo ''
+	@echo '--- Building m100 Library (OPTROM stdio-only version) ---'
+	@echo ''
+	$(RM) target/m100/stdio/*.o
+	$(call buildgeneric,m100,"portable narrow")
+	TARGET=m100 TYPE=8080 $(LIBLINKER) -m8080 -DFORm100 -D__OPTROM__ -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/m100_optrom_clib @$(LISTFILE_DIRECTORY)/m100_optrom.lst
 
 vector06c_clib.lib:
 	@echo ''

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -59,7 +59,7 @@ TOCREATE += $(call check_target,laser500,laser500_clib.lib)
 TOCREATE += $(call check_target,lm80c,lm80c_clib.lib)
 TOCREATE += $(call check_target,lviv,lviv_clib.lib)
 TOCREATE += $(call check_target,lynx,lynx_clib.lib)
-TOCREATE += $(call check_target,m100,m100_clib.lib m100_optrom_clib.lib)
+TOCREATE += $(call check_target,m100,m100_clib.lib)
 TOCREATE += $(call check_target,m5,m5_clib.lib)
 TOCREATE += $(call check_target,mc1000,mc1000_clib.lib)
 TOCREATE += $(call check_target,mikro80,mikro80_clib.lib)
@@ -1592,24 +1592,13 @@ special_clib.lib:
 	$(call buildgeneric,special,"wide portable")
 	TARGET=special TYPE=8080 $(LIBLINKER) -m8080 -DFORspecial -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/special_clib.lib @$(LISTFILE_DIRECTORY)/special.lst
 
-
-
 m100_clib.lib:
 	@echo ''
 	@echo '--- Building m100 Library ---'
 	@echo ''
-	$(RM) target/m100/stdio/*.o
 	$(call buildgeneric,m100,"portable narrow")
 	$(MAKE) -C games TARGET=m100
-	TARGET=m100 TYPE=8080 $(LIBLINKER) -m8080 -DFORm100 -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/m100_clib @$(LISTFILE_DIRECTORY)/m100.lst
-
-m100_optrom_clib.lib:
-	@echo ''
-	@echo '--- Building m100 Library (OPTROM stdio-only version) ---'
-	@echo ''
-	$(RM) target/m100/stdio/*.o
-	$(call buildgeneric,m100,"portable narrow")
-	TARGET=m100 TYPE=8080 $(LIBLINKER) -m8080 -DFORm100 -D__OPTROM__ -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/m100_optrom_clib @$(LISTFILE_DIRECTORY)/m100_optrom.lst
+	TARGET=m100 TYPE=8080 $(LIBLINKER) -m8085 -DFORm100 -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/m100_clib @$(LISTFILE_DIRECTORY)/m100.lst
 
 vector06c_clib.lib:
 	@echo ''

--- a/libsrc/m100_optrom.lst
+++ b/libsrc/m100_optrom.lst
@@ -1,0 +1,8 @@
+target/m100/stdio/fgetc_cons
+target/m100/stdio/fputc_cons
+target/m100/stdio/getk
+target/m100/stdio/generic_console
+@stdio/stdio_8080.lst
+@time/time.lst
+
+

--- a/libsrc/m100_optrom.lst
+++ b/libsrc/m100_optrom.lst
@@ -1,8 +1,0 @@
-target/m100/stdio/fgetc_cons
-target/m100/stdio/fputc_cons
-target/m100/stdio/getk
-target/m100/stdio/generic_console
-@stdio/stdio_8080.lst
-@time/time.lst
-
-

--- a/libsrc/target/m100/graphics/clg.asm
+++ b/libsrc/target/m100/graphics/clg.asm
@@ -11,10 +11,11 @@
                 PUBLIC    _clg
 				
 			EXTERN w_pixeladdress
-
+	INCLUDE "target/m100/def/romcalls.def"
 ;		INCLUDE  "target/kc/def/caos.def"
 
 .clg
 ._clg
-	ld	a,12
-	jp	$20
+	ROMCALL
+	defw	CLS
+	ret

--- a/libsrc/target/m100/graphics/plotpixl.asm
+++ b/libsrc/target/m100/graphics/plotpixl.asm
@@ -19,9 +19,12 @@
 
 			EXTERN	__gfx_coords
 			EXTERN	base_graphics
-
+	INCLUDE "target/m100/def/romcalls.def"
 .plotpixel
 			ld	d,h
 			ld	e,l
 			ld	(__gfx_coords),hl
-			jp	$744C
+			ROMCALL
+			defw	LCDSET
+			ret
+

--- a/libsrc/target/m100/graphics/respixl.asm
+++ b/libsrc/target/m100/graphics/respixl.asm
@@ -17,10 +17,12 @@
 
 			EXTERN	__gfx_coords
 			EXTERN	base_graphics
-
+	INCLUDE "target/m100/def/romcalls.def"
 .respixel
 			ld	d,h
 			ld	e,l
 			ld	(__gfx_coords),hl
-			jp	$744D
+			ROMCALL
+			defw	LCDRES
+			ret
 

--- a/libsrc/target/m100/stdio/fgetc_cons.asm
+++ b/libsrc/target/m100/stdio/fgetc_cons.asm
@@ -4,6 +4,7 @@
 ;	getkey() Wait for keypress
 ;
 ;	Stefano Bodrato - Feb 2020
+;	Alexei Gordeev - Nov 2020
 ;
 ;
 ;	$Id: fgetc_cons.asm $
@@ -12,10 +13,14 @@
         SECTION code_clib
 	PUBLIC	fgetc_cons
 	PUBLIC	_fgetc_cons
-
+	INCLUDE "target/m100/def/romcalls.def"
+	
 .fgetc_cons
 ._fgetc_cons
-        call    $12CB
+
+	ROMCALL
+	defw	KYREAD
+
 	;and	a
 	;jr	z,fgetc_cons
 

--- a/libsrc/target/m100/stdio/fputc_cons.asm
+++ b/libsrc/target/m100/stdio/fputc_cons.asm
@@ -4,31 +4,40 @@
 ;	Print character to the screen
 ;
 ;	Stefano Bodrato - Feb 2020
-;
+;	Alexei Gordeev - Nov 2020
 ;
 ;	$Id: fputc_cons.asm$
 ;
 ;	Prints at cooards from 4020-4021
 
-	  SECTION code_clib
-          PUBLIC  fputc_cons_native
-
-
-.fputc_cons_native
+	SECTION code_clib
+	PUBLIC  fputc_cons_native
+	PUBLIC  _fputc_cons_native
+	
+	INCLUDE "target/m100/def/romcalls.def"
+	
+fputc_cons_native:
+_fputc_cons_native:
 	ld	hl,2
 	add	hl,sp
 	ld	a,(hl)
 ;	cp	12
 ;	jr	z,cls
 IF STANDARDESCAPECHARS
-	cp  13
-	ret z
-	cp  10
-	jr  nz,notCR
-	ld	a,13
-.notCR
+	; if slash-n encountered, print slash-r slash-n through ROM call
+	cp	10  ; LF (n)?
+	jr	z, isLF
 ENDIF
-
-	rst $20
+	; if building for OPTROM, rst 6 is shortcut for "call system ROM by address"
+	ROMCALL
+	defw CHROUT
 	ret
-
+IF STANDARDESCAPECHARS
+isLF:
+	ROMCALL
+	defw CHROUT
+	ld	a,13
+	ROMCALL
+	defw CHROUT
+	ret
+ENDIF

--- a/libsrc/target/m100/stdio/generic_console.asm
+++ b/libsrc/target/m100/stdio/generic_console.asm
@@ -1,24 +1,25 @@
 
 
-                SECTION         code_clib
+        SECTION         code_clib
 
-                PUBLIC          generic_console_cls
-                PUBLIC          generic_console_printc
-                PUBLIC          generic_console_scrollup
-                PUBLIC          generic_console_set_ink
-                PUBLIC          generic_console_set_paper
-                PUBLIC          generic_console_set_attribute
-		PUBLIC		generic_console_xypos
+        PUBLIC          generic_console_cls
+        PUBLIC          generic_console_printc
+        PUBLIC          generic_console_scrollup
+        PUBLIC          generic_console_set_ink
+        PUBLIC          generic_console_set_paper
+        PUBLIC          generic_console_set_attribute
+	PUBLIC		generic_console_xypos
 
 
-                EXTERN          CONSOLE_COLUMNS
-                EXTERN          CONSOLE_ROWS
+        EXTERN          CONSOLE_COLUMNS
+        EXTERN          CONSOLE_ROWS
 
-                ;EXTERN          generic_console_font32
-                ;EXTERN          generic_console_udg32
-		;EXTERN		generic_console_flags
-		;EXTERN		conio_map_colour
+        ;EXTERN          generic_console_font32
+        ;EXTERN          generic_console_udg32
+	;EXTERN		generic_console_flags
+	;EXTERN		conio_map_colour
 
+	INCLUDE "target/m100/def/romcalls.def"
 
 generic_console_set_paper:
 generic_console_set_attribute:
@@ -29,23 +30,24 @@ generic_console_set_ink:
 	ret
 
 generic_console_scrollup:
-	push bc
-	push de
+	push	bc
+	push	de
 	ld	bc,$0808
 	call generic_console_xypos
 	ld	a,13
-	rst $20
+	ROMCALL
+	defw	CHROUT
 	ld	a,10
-	rst $20
-	pop de
-	pop bc
+	ROMCALL
+	defw	CHROUT
+	pop	de
+	pop	bc
 	ret
   
 generic_console_cls:
-	ld	a,12
-	rst $20
+	ROMCALL
+	defw	CLS
 	ret
-
 
 ; c = x
 ; b = y
@@ -54,7 +56,8 @@ generic_console_cls:
 generic_console_printc:
 	call generic_console_xypos
 	ld	a,d
-	rst $20
+	ROMCALL
+	defw	CHROUT
 	ret
 
 

--- a/libsrc/target/m100/stdio/getk.asm
+++ b/libsrc/target/m100/stdio/getk.asm
@@ -4,23 +4,26 @@
 ;	getk() Read key status
 ;
 ;	Stefano Bodrato - Feb 2020
+;	Alexei Gordeev - Nov 2020
 ;
 ;
 ;	$Id: getk.asm $
 ;
 
-
         SECTION code_clib
 	PUBLIC	getk
 	PUBLIC	_getk
-
+	INCLUDE "target/m100/def/romcalls.def"
 .getk
 ._getk
-        call    $13DB
-		ld	a,0
-		JP Z,INKEY_S_0
-		
-        call    $12CB
+
+	ROMCALL
+	defw	KYPEND
+	ld	a,0
+	JP	Z,INKEY_S_0
+
+	ROMCALL
+	defw	KYREAD
 
 IF STANDARDESCAPECHARS
 	cp	13


### PR DESCRIPTION
Hello.
This version is now able to produce basic option ROM software for TRS-80 Model 100/102 computers.
Option ROMs can be used to add extra software to those machines without much RAM penalty.
They can be called from machine's BASIC typically with `call 63012` command. Some software packages released on option ROMs also drop a small file in RAM as a simple launcher.

At the moment only console I/O is supported for option ROMs. I haven't looked into more advanced features (i.e. graphics) but if they use firmware calls, they now should be easily adaptable.

The main hurdle of making option ROM in either machine language or in C is the awkward bank-switching of M100. System ROM aka 'firmware' occupies same address space 0x0000...0x7FFF as the optional ROM and machine switches between ROMs back and forth when needed. Thus, using firmware calls in option ROM is tricky.
[Luckily this trickiness has already been solved at least once for machine code by Stephen Adolph.](http://bitchin100.com/wiki/index.php?title=OPTROM_Switching&oldid=2419)
I merely translated Stephen's template into Zilog mnemonics and made a CRT out of it.
There's now also ROMCALL macro used during clib compilation, which allows to build 2 versions of m100 clib from the same source set - one calls firmware from RAM, and another one uses template-provided firmware-calling RST 6.

CRT_ORG_DATA and CRT_ORG_BSS are pointed to ALTLCD area of RAM, which leaves C program with only around 320 bytes of RAM, including temporary math variables etc. ALTLCD normally keeps the previous text display page, and storing stuff there shouldn't interfere with anything else on the machine.

I suppose for more memory, it's either possible to access it directly, or use firmware functions to avoid interfering with OS and other files in RAM.

Both A.CO and option ROM targets now use 'native' stdio routines since 'generic' ones didn't seem to handle newlines at all on this machine.

Apart from anything already mentioned A.CO target shouldn't have changed.

**Usage:**
`zcc +m100 -subtype=default ...` compiles `A.CO` target for RAM
`zcc +m100 -subtype=optrom ...` compiles for option ROM

![Снимок экрана_2020-11-28_21-39-35](https://user-images.githubusercontent.com/13421195/100519135-9bada200-31c8-11eb-8866-5cf3fe229db6.png)

![m100](https://user-images.githubusercontent.com/13421195/100519562-5048c300-31cb-11eb-9a9d-394d0a946737.jpg)
