### PR TITLE
Changed banked_call to _banked_call.

### DIFF
--- a/libsrc/_DEVELOPMENT/sdcc_opt.1
+++ b/libsrc/_DEVELOPMENT/sdcc_opt.1
@@ -558,23 +558,23 @@ __xinit_%0
 =
 	ld	hl,sp + %2
 
-	call	banked_call
+	call	_banked_call
 	DEFW	%1
 	DEFW 0
 =
-	call	banked_call
+	call	_banked_call
 	defq	%1
 
 	call	___sdcc_bcall
 	DEFW	%1
 	DEFW	%2
 =
-	call	banked_call
+	call	_banked_call
 	defq	%1
 
 	ld	e,%1
 	ld	hl,%2
 	call	___sdcc_bcall_ehl
 =
-	call	banked_call
+	call	_banked_call
 	defq	%2

--- a/libsrc/_DEVELOPMENT/sdcc_opt.1
+++ b/libsrc/_DEVELOPMENT/sdcc_opt.1
@@ -68,7 +68,7 @@
 	EXTERN ___sdcc_call_hl
 	EXTERN ___sdcc_call_iy
 	EXTERN ___sdcc_enter_ix
-	EXTERN _banked_call
+	EXTERN banked_call
 	EXTERN _banked_ret
 	EXTERN ___fs2schar
 	EXTERN ___fs2schar_callee
@@ -558,23 +558,23 @@ __xinit_%0
 =
 	ld	hl,sp + %2
 
-	call	_banked_call
+	call	banked_call
 	DEFW	%1
 	DEFW 0
 =
-	call	_banked_call
+	call	banked_call
 	defq	%1
 
 	call	___sdcc_bcall
 	DEFW	%1
 	DEFW	%2
 =
-	call	_banked_call
+	call	banked_call
 	defq	%1
 
 	ld	e,%1
 	ld	hl,%2
 	call	___sdcc_bcall_ehl
 =
-	call	_banked_call
+	call	banked_call
 	defq	%2

--- a/libsrc/_DEVELOPMENT/target/zx/driver/banking/zx_banked_call.asm
+++ b/libsrc/_DEVELOPMENT/target/zx/driver/banking/zx_banked_call.asm
@@ -1,0 +1,58 @@
+	SECTION code_driver
+	PUBLIC banked_call
+	EXTERN l_jphl
+	defc CLIB_BANKING_STACK_SIZE = 100
+	defc ZX_BANK_IOPORT = 0x7ffd
+	INCLUDE "target/zx/def/sysvar.def"
+
+banked_call:
+    di
+    pop     hl     ;Return address
+    ld      (mainsp),sp
+    ld      sp,(tempsp)
+    ld      a,(SV_BANKM)
+    push    af
+    ld      e,(hl)          ; Fetch the call address
+    inc     hl
+    ld      d,(hl)
+    inc     hl
+    ld      a,(hl)          ; ...and page
+    inc     hl	
+    inc     hl              ; Yes this should be here
+    push    hl              ; Push the real return address
+    ld      (tempsp),sp
+    ld      sp,(mainsp)
+    ld      bc,ZX_BANK_IOPORT
+    or      0x10
+    ld      (SV_BANKM),a
+    out     (c),a
+    ei
+    ld      l,e
+    ld      h,d
+    call    l_jphl
+    di
+    ld      (mainsp),sp
+    ld      sp,(tempsp)
+    pop     bc              ; Get the return address
+    pop     af              ; Pop the old bank
+    ld      (tempsp),sp
+    ld      sp,(mainsp)
+    push    bc
+    ld      bc,ZX_BANK_IOPORT
+    ld      (SV_BANKM),a
+    out     (c),a
+    ei
+    ret
+
+
+	SECTION code_crt_init
+_initbankedsp:
+    ld      (tempsp),sp
+    ld      hl,-CLIB_BANKING_STACK_SIZE
+    add     hl,sp
+    ld      sp,hl 
+
+	SECTION bss_driver
+
+mainsp:	defw	0
+tempsp:	defw	0

--- a/libsrc/_DEVELOPMENT/target/zx/driver/driver.lst
+++ b/libsrc/_DEVELOPMENT/target/zx/driver/driver.lst
@@ -11,3 +11,4 @@ target/zx/driver/terminal/_font_8x8_rom
 @target/zx/driver/terminal/zx_tty.lst
 @target/zx/driver/math/math32.lst
 target/zx/driver/sound/asm_wyz_hardware_out
+target/zx/driver/banking/zx_banked_call


### PR DESCRIPTION
It seems the banked call code for SDCC tries to call the wrong function which causes a compilation error when using __banked from C to call another banked C function. Adding the _ (underscore) to the banked_call function resolves this issue.
