### PR TITLE
preproc #line fix (incorrect numbering)

### DIFF
--- a/src/ucpp/cpp.c
+++ b/src/ucpp/cpp.c
@@ -583,7 +583,8 @@ int enter_file(struct lexer_state *ls, unsigned long flags)
 		return 1;
 	}
 	print_line_info(ls, flags);
-	ls->oline --;	/* emitted #line troubled oline */
+	ls->oline --;	/* emitted #line troubled oline as well as line */
+	ls->line --;
 	return 0;
 }
 


### PR DESCRIPTION
Consider this example: https://gist.github.com/desertkun/f3bfa644be5061406b04f0882245efd9

Preprocessor has an error that it generates incorrect `#line statements` which leads to incorrect `C_LINE` statements when zcc generates *.lis files with `--list --c-code-in-asm` flag. The example above (`z88dk-ucpp main.c`) produces such output:

```bash
#line 1 "src/zx/main.c"
#line 1 "src/zx/a.h"
int a = 1;
#line 2 "src/zx/main.c"

#line 1 "src/zx/b.h"
int b = 1;
#line 4 "src/zx/main.c"

#line 1 "src/zx/c.h"
int c = 1;
#line 6 "src/zx/main.c"

int main()
{
    int _b = 20;
}
```

It thinks `main()` is located at line 7 (`#line` plus extra line)  while in the source code is clearly at line 4. 

This fix changes behavior as such:
```bash
#line 1 "src/zx/main.c"
#line 1 "src/zx/a.h"
int a = 1;
#line 1 "src/zx/main.c"

#line 1 "src/zx/b.h"
int b = 1;
#line 2 "src/zx/main.c"

#line 1 "src/zx/c.h"
int c = 1;
#line 3 "src/zx/main.c"

int main()
{
    int _b = 20;
}
```

Now its line 3 + space = line 4, and `--list --c-code-in-asm` generates correct `*.lis` files.

(To be honest I do not know what I am doing, this code is new to me)