### PR TITLE
ucpp: fix line numbering with \r\n

### DIFF
--- a/src/ucpp/cpp.c
+++ b/src/ucpp/cpp.c
@@ -335,7 +335,6 @@ static void reinit_lexer_state(struct lexer_state *ls, int wb)
 	ls->input = 0;
 	ls->ebuf = ls->pbuf = 0;
 	ls->nlka = 0;
-	ls->macfile = 0;
 	ls->discard = 1;
 	ls->last = 0;		/* we suppose '\n' is not 0 */
 	ls->line = 1;

--- a/src/ucpp/cpp.h
+++ b/src/ucpp/cpp.h
@@ -158,7 +158,6 @@ struct lexer_state {
 	size_t pbuf;
 	int lka[2];
 	int nlka;
-	int macfile;
 	int last;
 	int discard;
 	unsigned long utf8;

--- a/src/ucpp/lexer.c
+++ b/src/ucpp/lexer.c
@@ -524,21 +524,15 @@ static inline int read_char(struct lexer_state *ls)
 				ls->copy_line[ls->cli ++] = c;
 			}
 		}
-		if (ls->macfile && c == '\n') {
-			ls->macfile = 0;
-			continue;
-		}
-		ls->macfile = 0;
 		if (c == '\r') {
 			/*
-			 * We found a '\r'; we handle it as a newline
-			 * and ignore the next newline. This should work
-			 * with all combinations of Msdos, MacIntosh and
-			 * Unix files on these three platforms. On other
-			 * platforms, native file formats are always
-			 * supported.
+			 * We found a '\r'; we handle it as a newline.
+			 * For '\r\n' cases (Windows) prefer to ignore this one and use '\n' later.
 			 */
-			ls->macfile = 1;
+            if (ls->pbuf != ls->ebuf && ls->input_buf[ls->pbuf] == '\n')
+            {
+                continue;
+            }
 			c = '\n';
 		}
 		break;


### PR DESCRIPTION
I've finally figured out behavior for #1653 the ucpp preprocessor is incorrectly handling `\r\n` endlines on Windows. I know this compiler does not support windows, but it works with WSL and I would like to be able to compile windows-edited files under WSL.

The fix is simple, when we hit `\r\n` (figured out by looking ahead of buffer one char), ignore the current one (`\r`) and process just the next one `\n`.

Tested both with windows-edited files (`\r\n`) and linux ones (`\n`), the following file (`a.h` is an empty file)

```
#include "a.h"
/*
 * comment
 */
int b = 20;
```

is treated like so all the times

```
#line 1 "main.c"
#line 1 "a.h"

#line 2 "main.c"
 


int b = 20;
```