### PR TITLE
zsdcc - bump to 12017

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 Z88DK_PATH	= $(shell pwd)
 SDCC_PATH	= $(Z88DK_PATH)/src/sdcc-build
-SDCC_VERSION    = 11940
+SDCC_VERSION    = 12017
 
 ifdef BUILD_SDCC
 ifdef BUILD_SDCC_HTTP

--- a/changelog.txt
+++ b/changelog.txt
@@ -37,7 +37,7 @@ Detailed but incomplete changelist:
 - [sccz80] Support added for Am9511 32 bit floating point numbers
 - [z80asm] Linking speed cleanup
 - [z80asm] db/dw/ds etc synonyms are now accepted
-- [zsdcc] Upgraded to SDCC 4.0.4 r11940 (bugfixes)
+- [zsdcc] Upgraded to SDCC 4.0.7 r12017 (bugfixes)
 
 z88dk v2.0 - 03.02.2020
 

--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -8,7 +8,7 @@ For Linux users follow the instructions on the [installation page](https://githu
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-11940-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r11940.
+`sdcc-12017-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12017.
 
 `sdcc-9958-z88dk.patch` is the previous z88dk v1.99c zsdcc standard patch, retained for comparison and building against sdcc r9958.
 

--- a/src/zsdcc/sdcc-12017-z88dk.patch
+++ b/src/zsdcc/sdcc-12017-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 11940)
+--- src/SDCCasm.c	(revision 12017)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 11940)
+--- src/SDCCglue.c	(revision 12017)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 11940)
+--- src/SDCCmain.c	(revision 12017)
 +++ src/SDCCmain.c	(working copy)
 @@ -505,16 +505,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 11940)
+--- src/SDCCopt.c	(revision 12017)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,7 +176,7 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 11940)
+--- src/z80/peep.c	(revision 12017)
 +++ src/z80/peep.c	(working copy)
 @@ -251,6 +251,88 @@
    return(found && found < end);

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 11940)
+--- src/SDCCasm.c	(revision 12017)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 11940)
+--- src/SDCCglue.c	(revision 12017)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 11940)
+--- src/SDCCmain.c	(revision 12017)
 +++ src/SDCCmain.c	(working copy)
 @@ -505,16 +505,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 11940)
+--- src/SDCCopt.c	(revision 12017)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,7 +176,7 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 11940)
+--- src/z80/peep.c	(revision 12017)
 +++ src/z80/peep.c	(working copy)
 @@ -251,6 +251,88 @@
    return(found && found < end);


### PR DESCRIPTION
Update zsdcc to sdcc r12017.

2020-01-21 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  support/regression/tests/bug-3169.c:
	  Fix bug #3169.

2020-01-12 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix an issue in handling of non-dead a in __sfr access, possibly bug #3168.

2020-01-01 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/pdk/gen.c,
	  support/regression/tests/bug-3167.c:
	  Fix bug #3167.

2020-01-01 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix an issue in handling surviving a when assigning single bytes from (hl) to stack.
	* support/regression/tests/bug-3166.c:
	  Test for bug #3166.

2020-12-29 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fixes in handling register operands.
	* src/z80/ralloc2.cc:
	  More flexibility for register operands in cast and ^.

2020-12-27 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix an issue in handling of surviving registers in unsigned upcast.

2020-12-01 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Improve &, |, ^ by integer constant expression, merge ^ and ~.

2020-11-29 Philipp Klaus Krause <pkk AT spth.de>
	* src/SDCCmain.c,
	  device/include/Makefile.in,
	  device/include/rab,
	  .version:
	  Migrate Rabbit headers from OpenRabbit to SDCC.

2020-11-28 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/main.c:
	  Change Rabbit default data location to 0xa000.