### PR TITLE
fix CONSOLE_COLUMNS definition

### DIFF
--- a/lib/target/cpm/classic/cpm_crt0.asm
+++ b/lib/target/cpm/classic/cpm_crt0.asm
@@ -61,7 +61,7 @@
         IF !DEFINED_CONSOLE_ROWS
            defc CONSOLE_ROWS = 24
         ENDIF
-        IF !DEFINED_CONSOLE_ROWS
+        IF !DEFINED_CONSOLE_COLUMNS
            defc CONSOLE_COLUMNS = 80
         ENDIF
 


### PR DESCRIPTION
this seems a copy&paste error to me it should be `CONSOLE_COLUMNS` not `CONSOLE_ROWS`