### PR TITLE
zsdcc - bump to 12036 (bugfix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 Z88DK_PATH	= $(shell pwd)
 SDCC_PATH	= $(Z88DK_PATH)/src/sdcc-build
-SDCC_VERSION    = 12017
+SDCC_VERSION    = 12036
 
 ifdef BUILD_SDCC
 ifdef BUILD_SDCC_HTTP

--- a/changelog.txt
+++ b/changelog.txt
@@ -37,7 +37,7 @@ Detailed but incomplete changelist:
 - [sccz80] Support added for Am9511 32 bit floating point numbers
 - [z80asm] Linking speed cleanup
 - [z80asm] db/dw/ds etc synonyms are now accepted
-- [zsdcc] Upgraded to SDCC 4.0.7 r12017 (bugfixes)
+- [zsdcc] Upgraded to SDCC 4.0.7 r12036 (bugfixes)
 
 z88dk v2.0 - 03.02.2020
 

--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -8,7 +8,7 @@ For Linux users follow the instructions on the [installation page](https://githu
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-12017-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12017.
+`sdcc-12036-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12036.
 
 `sdcc-9958-z88dk.patch` is the previous z88dk v1.99c zsdcc standard patch, retained for comparison and building against sdcc r9958.
 

--- a/src/zsdcc/sdcc-12036-z88dk.patch
+++ b/src/zsdcc/sdcc-12036-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12017)
+--- src/SDCCasm.c	(revision 12036)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12017)
+--- src/SDCCglue.c	(revision 12036)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12017)
+--- src/SDCCmain.c	(revision 12036)
 +++ src/SDCCmain.c	(working copy)
 @@ -505,16 +505,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12017)
+--- src/SDCCopt.c	(revision 12036)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,7 +176,7 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12017)
+--- src/z80/peep.c	(revision 12036)
 +++ src/z80/peep.c	(working copy)
 @@ -251,6 +251,88 @@
    return(found && found < end);
@@ -293,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -862,6 +956,7 @@
+@@ -864,6 +958,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -301,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -868,6 +963,16 @@
+@@ -870,6 +965,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12017)
+--- src/SDCCasm.c	(revision 12036)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12017)
+--- src/SDCCglue.c	(revision 12036)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12017)
+--- src/SDCCmain.c	(revision 12036)
 +++ src/SDCCmain.c	(working copy)
 @@ -505,16 +505,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12017)
+--- src/SDCCopt.c	(revision 12036)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,7 +176,7 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12017)
+--- src/z80/peep.c	(revision 12036)
 +++ src/z80/peep.c	(working copy)
 @@ -251,6 +251,88 @@
    return(found && found < end);
@@ -293,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -862,6 +956,7 @@
+@@ -864,6 +958,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -301,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -868,6 +963,16 @@
+@@ -870,6 +965,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  


### PR DESCRIPTION
Thinking that a new z88dk release is due soon, this small bump to sdcc adds fixes for a stack frame optimisation bug, and to improve a rule.

2020-01-29 Philipp Klaus Krause
	* src/z80/peep.c:
	  Fix bug #3173 (this is probably causing bug #3171 and #3166 too... ?)
	* src/z80/peeph.def:
	  Split rule for add from adc, sbc rule due to differences in flag handling.
