### PR TITLE
zsdcc - update to 4.1.0 Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 Z88DK_PATH	= $(shell pwd)
 SDCC_PATH	= $(Z88DK_PATH)/src/sdcc-build
-SDCC_VERSION    = 12036
+SDCC_VERSION    = 12070
 
 ifdef BUILD_SDCC
 ifdef BUILD_SDCC_HTTP

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Detailed but incomplete changelist:
 
 - [appmake] Compressed ROM data sections can now use zx0
 - [newlib] +rc2014: Support for shadow RAM copying
+- [zsdcc] Upgraded to SDCC 4.1.0 r12070 (bugfixes)
 
 
 z88dk v2.1 - 07.02.2021

--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -8,7 +8,7 @@ For Linux users follow the instructions on the [installation page](https://githu
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-12036-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12036.
+`sdcc-12070-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12070.
 
 `sdcc-9958-z88dk.patch` is the previous z88dk v1.99c zsdcc standard patch, retained for comparison and building against sdcc r9958.
 

--- a/src/zsdcc/sdcc-12070-z88dk.patch
+++ b/src/zsdcc/sdcc-12070-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12036)
+--- src/SDCCasm.c	(revision 12070)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12036)
+--- src/SDCCglue.c	(revision 12070)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,9 +84,9 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12036)
+--- src/SDCCmain.c	(revision 12070)
 +++ src/SDCCmain.c	(working copy)
-@@ -505,16 +505,15 @@
+@@ -514,16 +514,15 @@
  {
    int i;
  
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12036)
+--- src/SDCCopt.c	(revision 12070)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,9 +176,9 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12036)
+--- src/z80/peep.c	(revision 12070)
 +++ src/z80/peep.c	(working copy)
-@@ -251,6 +251,88 @@
+@@ -225,6 +225,88 @@
    return(found && found < end);
  }
  
@@ -267,7 +267,7 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -408,6 +490,8 @@
+@@ -382,6 +464,8 @@
  static bool
  z80MightRead(const lineNode *pl, const char *what)
  {
@@ -276,7 +276,7 @@ Index: src/z80/peep.c
    if(strcmp(what, "iyl") == 0 || strcmp(what, "iyh") == 0)
      what = "iy";
    if(strcmp(what, "ixl") == 0 || strcmp(what, "ixh") == 0)
-@@ -416,6 +500,16 @@
+@@ -390,6 +474,16 @@
    if(ISINST(pl->line, "call") && strcmp(what, "sp") == 0)
      return TRUE;
  
@@ -293,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -864,6 +958,7 @@
+@@ -838,6 +932,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -301,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -870,6 +965,16 @@
+@@ -844,6 +939,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12036)
+--- src/SDCCasm.c	(revision 12070)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12036)
+--- src/SDCCglue.c	(revision 12070)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,9 +84,9 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12036)
+--- src/SDCCmain.c	(revision 12070)
 +++ src/SDCCmain.c	(working copy)
-@@ -505,16 +505,15 @@
+@@ -514,16 +514,15 @@
  {
    int i;
  
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12036)
+--- src/SDCCopt.c	(revision 12070)
 +++ src/SDCCopt.c	(working copy)
 @@ -1010,7 +1010,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,9 +176,9 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12036)
+--- src/z80/peep.c	(revision 12070)
 +++ src/z80/peep.c	(working copy)
-@@ -251,6 +251,88 @@
+@@ -225,6 +225,88 @@
    return(found && found < end);
  }
  
@@ -267,7 +267,7 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -408,6 +490,8 @@
+@@ -382,6 +464,8 @@
  static bool
  z80MightRead(const lineNode *pl, const char *what)
  {
@@ -276,7 +276,7 @@ Index: src/z80/peep.c
    if(strcmp(what, "iyl") == 0 || strcmp(what, "iyh") == 0)
      what = "iy";
    if(strcmp(what, "ixl") == 0 || strcmp(what, "ixh") == 0)
-@@ -416,6 +500,16 @@
+@@ -390,6 +474,16 @@
    if(ISINST(pl->line, "call") && strcmp(what, "sp") == 0)
      return TRUE;
  
@@ -293,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -864,6 +958,7 @@
+@@ -838,6 +932,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -301,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -870,6 +965,16 @@
+@@ -844,6 +939,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  


### PR DESCRIPTION
This is sdcc 4.1.0 Release.

2021-02-19 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  support/regression/tests/lonesha256.c:
	  Fix gbz80 xor code generation bug #3181.

2021-02-09 Philipp Klaus Krause <pkk AT spth.de>
	* src/SDCCpeeph.c
	  src/port.h
	  src/z80/gen.c
	  src/z80/peep.c
	  src/z80/peep.h,
	  support/regression/tests/bug-3178.c:
	  Fix bug #3178.

2021-02-04 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Make end-of-call stack adjustment tolerate return value in a.

2021-02-03 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Separate __z88dk_fastcall registers from return value registers.

2021-02-03 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix a bug in code generation for wide unary minus with upper operand word in hl.

2021-02-03 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/z80/peep.c:
	  Refactor handling of return value registers.

2021-02-03 Philipp Klaus Krause <pkk AT spth.de>
	* src/SDCCsymt.c:
	  Fix printing of function with variable arguments (e.g. for debug dumps).
	* src/z80/gen.c,
	  src/stm8/gen.c:
	  Refactor register asmop intialization.

2021-02-01 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/z80/ralloc2.cc:
	  Fix bug #3174.

2021-01-29 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/peep.c:
	  Fix bug #3173.
	* src/z80/peeph.def:
	  Split rule for add from adc, sbc rule due to differences in flag handling.