### PR TITLE
Evaluate constants in opt rules at opt time, not asm time

### DIFF
--- a/lib/z80rules.0
+++ b/lib/z80rules.0
@@ -303,7 +303,7 @@
 	ld	hl,%3
 =
 	ld	hl,%1
-	ld	a,+(%2 %% 256)	;const
+	ld	a,%eval(%2 256 %%)	;const
 	or	(hl)
 	ld	(hl),a
 	ld	hl,%3
@@ -380,7 +380,7 @@
 	ld	hl,%3
 =
 	ld	hl,%1
-	ld	a,%2 %% 256
+	ld	a,%eval(%2 256 %%)
 	add	(hl)
 	ld	(hl),a
 	ld	hl,%3

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -5587,6 +5587,7 @@
 	ld	(hl),%4
 
 %title Replace with 16 bit store
+%notcpu gbz80
 	ld	hl,_%1
 	xor	a
 	ld	(hl),a

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -1,4 +1,4 @@
-	ld	a,+(0 % 256)
+	ld	a,0
 =
 	xor	a
 
@@ -7,7 +7,7 @@
 	ld	(%1),a
 	ld	hl,%2
 =
-	ld	a,+(%0 % 256)
+	ld	a,%eval(%0 256 %%)
 	ld	(%1),a
 	ld	hl,%2
 
@@ -17,38 +17,38 @@
 .%0
 
 	ex	de,hl
-	ld	l,+(8 % 256)
+	ld	l,8
 	call	l_asr_u
 =
 	ld	l,h
 	ld	h,0
 
 	ex	de,hl
-	ld	l,+(8 % 256)
+	ld	l,8
 	call	l_asr
 =
 	ld	a,h
 	call	l_sxt
 
 	ex	de,hl
-	ld	l,+(0 % 256)
+	ld	l,0
 	call	l_asr%1
 =
 
 	ex	de,hl
-	ld	l,+(8 % 256)
+	ld	l,8
 	call	l_asl
 =
 	ld	h,l
 	ld	l,0
 
 	ex	de,hl
-	ld	l,+(0 % 256)
+	ld	l,0
 	call	l_asl
 =
 
 	ex	de,hl
-	ld	l,+(1 % 256)
+	ld	l,1
 	call	l_asl
 =
 	add	hl,hl
@@ -321,16 +321,16 @@
 	jp	z,%1	;%3
 
 ;;; Fixes up a bug in these rules
-	ld	(hl),+(%1 %% 256)
+	ld	(hl),%1
 	ld	l,(hl)
 	ld	h,0
 	inc	de
 	ld	a,h
 	ld	(de),a
 =
-	ld	(hl),+(%1 % 256)
+	ld	(hl),%1
 	inc	hl
-	ld	(hl),+(%1 / 256)
+	ld	(hl),0
 	ld	hl,%1
 
 ;;; This rule causes above bug, can't stop it from firing though
@@ -339,7 +339,7 @@
 	ld	a,l
 	ld	(de),a
 =
-	ld	(hl),+(%1 % 256)
+	ld	(hl),%eval(%1 256 %%)
 	ld	l,(hl)
 	ld	h,0
 
@@ -428,6 +428,11 @@
 =
 	ld	hl,_%1-%2
 	add	hl,bc
+
+	ld	hl,_%1+%2
+	inc	hl
+=
+	ld	hl,_%1+%eval(%2 1 +)
 
 	ld	hl,_%1
 	inc	hl
@@ -698,7 +703,7 @@
 	ld	de,%2
 	call	l_long_as%3
 =
-	ld	l,+(%1 % 256)
+	ld	l,%eval(%1 256 %%)
 	call	l_long_as%3
 
 	push	hl
@@ -720,7 +725,7 @@
 	ld	hl,%1	;const
 	call	l_as%2
 =
-	ld	l,+(%1 % 256)
+	ld	l,%eval(%1 256 %%)
 	call	l_as%2
 
 	ld	de,%1	;const
@@ -728,7 +733,7 @@
 	call	l_as%2
 =
 	ex	de,hl
-	ld	l,+(%1 % 256)
+	ld	l,%eval(%1 256 %%)
 	call	l_as%2
 
 	ex	de,hl
@@ -916,7 +921,7 @@
 	call	l_long_aslo
 
 %notcpu gbz80
-	ld	a,+(16 % 256)
+	ld	a,16
 	call	l_long_aslo
 =
 	ex	de,hl
@@ -1095,7 +1100,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	nz,%2	;%4
 	ld	hl,%3
 
@@ -1107,7 +1112,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	z,%2	;%4
 	ld	hl,%3
 
@@ -1119,7 +1124,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	nz,%2	;%4
 	ld	hl,%3
 
@@ -1451,7 +1456,7 @@
 	ld	l,h
 	ld	h,a
 =
-	ld	hl,+( (%1/256) + (%1 % 256 )*256 )
+	ld	hl,%eval(%1 256 / %1 256 %% 256 * +)
 
 	ld	hl,0	;const
 	add	hl,sp
@@ -1480,7 +1485,7 @@
 .%1
 	ld	hl,%2
 
-	ld	(hl),+(%1 % 256)
+	ld	(hl),%1
 	ld	l,(hl)
 	ld	h,0
 	pop	de
@@ -1488,20 +1493,21 @@
 	ld	(de),a
 	ld	hl,%2
 =
-	ld	a,+(%1 % 256)
+	ld	a,%1
 	ld	(hl),a
 	pop	de
 	ld	(de),a
 	ld	hl,%2
 
+%check 0 <= %1 <= 255
 	pop	hl
 	inc	hl
 	push	hl
 	dec	hl
-	ld	(hl),+(%1 % 256)
+	ld	(hl),%1
 =
 	pop	hl
-	ld	(hl),+(%1 % 256)
+	ld	(hl),%1
 	inc	hl
 	push	hl
 	dec	hl
@@ -1534,7 +1540,7 @@
 	call	l_and
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	ld	l,a
 	ld	h,0
 
@@ -1910,14 +1916,14 @@
 
 	ld	hl,0	;const
 	add	hl,sp
-	add	a,+(%1 % 256)
+	add	a,%1
 	ld	(hl),a
 	ld	l,a
 	ld	h,0
 =
 	pop	hl
 	ld	a,l
-	add	a,+(%1 % 256)
+	add	a,%1
 	ld	l,a
 	push	hl
 	ld	h,0
@@ -1950,7 +1956,7 @@
 	ld	e,(hl)
 	inc	hl
 	ld	d,(hl)
-	ld	l,+(8 % 256)
+	ld	l,8
 	call	l_asr_u
 =
 	inc	hl
@@ -1993,7 +1999,7 @@
 	rl	l
 =
 	ld	a,(hl)
-	cp	+( %1 % 256)
+	cp	%eval(%1 256 %%)
 	ld	hl,0	;const
 	jr	nz,ASMPC+3
 	inc	hl
@@ -2007,7 +2013,7 @@
 	ld	hl,%4
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	ld	hl,%2
 	jp	z,%3	;%5
 	ld	hl,%4
@@ -2060,7 +2066,7 @@
 	ld	a,l
 	sub	e
 =
-	ld	a,+(%1 % 256)
+	ld	a,%eval(%1 256 %%)
 	sub	(hl)
 
 	ld	e,(hl)
@@ -2070,7 +2076,7 @@
 	sub	l
 =
 	ld	a,(hl)
-	sub	+(%1 % 256)
+	sub	%eval(%1 256 %%)
 
 	call	l_gchar
 	ld	de,%1	;const
@@ -2079,7 +2085,7 @@
 	sub	l
 =
 	ld	a,(hl)
-	sub	+(%1 % 256)
+	sub	%eval(%1 256 %%)
 
 	xor	a
 	sub	(hl)
@@ -2103,16 +2109,17 @@
 	scf
 	jp	nc,%2	;%5
 =
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	nz,%2	;%5
 
+%check 0 <= %3 <= 255
 	ld	l,(hl)
 	ld	h,0
 	push	hl
 	ld	hl,%1	;const
 	add	hl,sp
 	ld	a,(hl)
-	%2	+%3
+	%"and|or|xor|add|sub"	%3
 	ld	l,a
 	ld	h,0
 	pop	de
@@ -2122,7 +2129,7 @@
 	ld	hl,%eval( %1 2 -)	;const
 	add	hl,sp
 	ld	a,(hl)
-	%2	+%3
+	%2	%3
 	ld	l,a
 	ld	a,e
 
@@ -2466,19 +2473,19 @@
 =
 	dec	sp
 	pop	hl
-	ld	l,+(%1 % 256)
+	ld	l,%eval(%1 256 %%)
 	push	hl
 
 	dec	sp
 	pop	hl
-	ld	l,+%1
+	ld	l,%1
 	push	hl
 	dec	sp
 	pop	hl
-	ld	l,+%2
+	ld	l,%2
 	push	hl
 =
-	ld	hl,+(( %1 * 256) + %2)
+	ld	hl,%eval(%1 256 * %2 +)
 	push	hl
 
 %check 0 <= %1 <= 127
@@ -2500,7 +2507,7 @@
 	ld	a,l
 	call	l_sxt
 =
-	ld	a,+(%1 % 256)
+	ld	a,%eval(%1 256 %%)
 	call	l_sxt
 
 	ex	de,hl
@@ -2586,14 +2593,14 @@
 
 %notcpu gbz80
 	ld	hl,_%1
-	ld	(hl),+(%2 % 256)
+	ld	(hl),%2
 	inc	hl
-	ld	(hl),+(%2 / 256)
-	ld	hl,%3
+	ld	(hl),%3
+	ld	hl,%4
 =
-	ld	hl,%2	;const
+	ld	hl,%eval(%3 256 * %2 +)	;const
 	ld	(_%1),hl
-	ld	hl,%3
+	ld	hl,%4
 
 	call	l_gintspsp	;
 	pop	hl
@@ -2788,13 +2795,13 @@
 	call	l_plong
 	ld	hl,%3
 =
-	ld	(hl),+(%1 %% 256)
+	ld	(hl),%eval(%1 256 %%)
 	inc	hl
-	ld	(hl),+(%1 / 256)
+	ld	(hl),%eval(%1 256 /)
 	inc	hl
-	ld	(hl),+(%2 %% 256)
+	ld	(hl),%eval(%2 256 %%)
 	inc	hl
-	ld	(hl),+(%2 / 256)
+	ld	(hl),%eval(%2 256 /)
 	ld	hl,%3
 
 	ld	h,%1
@@ -3178,7 +3185,7 @@
 	ld	hl,1	;const
 	add	hl,sp
 	ld	a,(hl)
-	cp	+(%1 %% 256)
+	cp	%eval(%1 256 %%)
 
 	pop	hl
 	push	hl
@@ -3189,7 +3196,7 @@
 	ld	hl,0	;const
 	add	hl,sp
 	ld	a,(hl)
-	cp	+(%1 %% 256)
+	cp	%eval(%1 256 %%)
 
 	pop	bc
 	pop	hl
@@ -3359,7 +3366,7 @@
 	ld	hl,(_%1)
 	ld	h,0
 	ld	a,l
-	and	+(128 %% 256)
+	and	128
 	jp	z,%2	;%5
 	ld	hl,%3
 =
@@ -3623,13 +3630,13 @@
 
 	ld	hl,(_%1)
 	ld	h,0
-	ld	a,+%2
+	ld	a,%2
 	and	l
 	ld	l,a
 	push	hl
 =
 	ld	a,(_%1)
-	and	+%2
+	and	%2
 	ld	l,a
 	ld	h,0
 	push	hl	
@@ -3685,12 +3692,12 @@
 =
 	pop	bc
 	ld	a,(hl)
-	and	+(%1 %% 256)
+	and	%eval(%1 256 %%)
 	ld	(bc),a
 	inc	bc
 	inc	hl
 	ld	a,(hl)
-	and	+(%1 / 256)
+	and	(%1 / 256)
 	ld	(bc),a
 	ld	hl,%2
 
@@ -3919,14 +3926,14 @@
 	inc	hl
 	ld	h,(hl)
 	ld	l,a
-	ld	(hl),+(%1 %% 256)
+	ld	(hl),%eval(%1 256 %%)
 	inc	hl
-	ld	(hl),+(%1 / 256)
+	ld	(hl),%eval(%1 256 /)
 	ld	hl,%2
 
-	ld	(hl),+(0 % 256)
+	ld	(hl),0
 	inc	hl
-	ld	(hl),+(0 / 256)
+	ld	(hl),0
 =
 	xor	a
 	ld	(hl),a
@@ -4061,13 +4068,13 @@
 	ld	de,6
 	call	l_asr_u_hl_by_e
 	ld	a,l
-	and	+(3 %% 256)
+	and	3
 	ld	l,a
 =
 	ld	a,(hl)
 	rlca
 	rlca
-	and	+(3 %% 256)
+	and	3
 	ld	l,a
 	ld	h,0
 
@@ -4228,6 +4235,15 @@
 	or	%eval( %2 256 %% %3 &)
 	ld	(hl),a
 	ld	hl,%5
+
+	ld	hl,_%1+%3
+	ld	de,%2
+	ex	de,hl
+	inc	de
+=
+	ld	hl,_%1+%eval(%3 1 +)
+	ld	de,%2
+	ex	de,hl
 
 	ld	hl,_%1
 	ld	de,%2
@@ -4444,11 +4460,6 @@
 	ld	a,h
 	or	l
 
-	ld	a,+(%1 % 256)
-	call	l_sxt
-=
-	ld	hl,%1
-
 	ld	l,(hl)
 	ld	h,0
 	ld	de,%1
@@ -4510,7 +4521,7 @@
 	jp	%1z,%2	;%5
 
 	ld	a,h
-	and	+(255 %% 256)
+	and	255
 	ld	h,a
 =
 
@@ -4528,23 +4539,23 @@
 	ld	l,(hl)
 	ld	h,0
 	ld	a,l
-	and	+%1
+	and	%1
 	jp	%2,%3	;%5
 	ld	hl,%4
 =
-	ld	a,+%1
+	ld	a,%1
 	and	(hl)
 	jp	%2,%3	;%5
 	ld	hl,%4
 
 	call	l_gint	;
 	ld	a,l
-	and	+%1
+	and	%1
 	ld	l,a
 	ld	h,0
 =
 	ld	a,(hl)
-	and	+%1
+	and	%1
 	ld	l,a
 	ld	h,0
 
@@ -5478,6 +5489,14 @@
 	ld	(hl),a
 	jp	%1	;EOS
 
+%title Cleanup tail load and decrement
+	ld	l,(hl)
+	ld	h,0
+	%"inc|dec"0	l
+	jp	%1	;EOS
+=
+	jp	%1	;EOS
+
 %title Tail int16 constant store
 %check 0 <= %1 <= 255
 	ld	(hl),%1
@@ -5554,3 +5573,66 @@
 =
 	ld	a,l
 	ld	(_%1),a
+
+%title Setting a global buffer
+%eval 1 = %5 %2 -
+	ld	hl,_%1+%2
+	ld	(hl),%3
+	ld	hl,_%1+%5
+	ld	(hl),%4
+=
+	ld	hl,_%1+%2
+	ld	(hl),%3
+	inc	hl
+	ld	(hl),%4
+
+%title Replace with 16 bit store
+	ld	hl,_%1
+	xor	a
+	ld	(hl),a
+	inc	hl
+	ld	(hl),a
+=
+	ld	hl,0	;const
+	ld	(_%1),hl
+
+%title Signed char extension after truncation
+	call	l_gchar
+	ld	a,l
+	and	%1
+	ld	l,a
+	ld	h,0
+	call	l_sxt
+=
+	ld	a,(hl)
+	and	%1
+	ld	l,a
+	ld	h,0
+
+%title Save 8 bit and load address of it
+	ld	(_%1),a
+	ld	hl,_%1
+=
+	ld	hl,_%1
+	ld	(hl),a
+
+	ld	hl,%1	;const
+	add	hl,sp
+	ld	a,(hl)
+	cp	%3
+	scf
+	jr	z,ASMPC+3
+	ccf
+	jp	c,%2
+	ld	hl,%1	;const
+	add	hl,sp
+	ld	a,(hl)
+=
+	ld	hl,%1	;const
+	add	hl,sp
+	ld	a,(hl)
+	cp	%3
+	scf
+	jr	z,ASMPC+3
+	ccf
+	jp	c,%2

--- a/lib/z80rules.2
+++ b/lib/z80rules.2
@@ -8,7 +8,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	nz,%2	;%4
 	ld	hl,%3
 
@@ -38,7 +38,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	z,%2	;%8
 	ld	hl,%3
 
@@ -52,7 +52,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	z,%2	;%8
 	ld	hl,%3
 
@@ -66,7 +66,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	nz,%2	;%8
 	ld	hl,%3
 
@@ -82,7 +82,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	jp	nz,%2	;%8
 	ld	hl,%3
 
@@ -98,7 +98,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	jp	z,%2	;%8
 	ld	hl,%3
 
@@ -114,7 +114,7 @@
 	ld	(de),a
 =
 	ld	a,(hl)
-	or	+(%1 % 256)
+	or	%eval(%1 256 %%)
 	ld	(hl),a
 	ld	l,a
 	ld	h,0
@@ -189,7 +189,7 @@
 	ld	(de),a
 =
 	ld	a,(hl)
-	or	+(%1 % 256)
+	or	%eval(%1 256 %%)
 	pop	de
 	ld	(de),a
 	ld	l,a
@@ -208,7 +208,7 @@
 .%2
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	ld	(hl),a
 .%2
 
@@ -224,7 +224,7 @@
 .%2
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	pop	de
 	ld	(de),a
 .%2
@@ -240,7 +240,7 @@
 	ld	(de),a
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	pop	de
 	ld	(de),a
 	ld	l,a
@@ -257,7 +257,7 @@
 	ld	(de),a
 =
 	ld	a,(hl)
-	xor	+(%1 % 256)
+	xor	%eval(%1 256 %%)
 	pop	de
 	ld	(de),a
 	ld	l,a
@@ -274,7 +274,7 @@
 	jp	z,%2	;%8
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	jp	z,%2	;%8
 	ld	l,a
 	ld	h,0
@@ -288,7 +288,7 @@
 	add	hl,hl
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
+	and	%eval(%1 256 %%)
 	ld	l,a
 	ld	h,0
 	add	hl,hl
@@ -306,8 +306,8 @@
 	jp	c,%3	;%8
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
-	cp	+(%2 % 256)
+	and	%eval(%1 256 %%)
+	cp	%eval(%2 256 %%)
 	ld	hl,1
 	jp	nz,%3	;%8
 	dec	hl
@@ -325,8 +325,8 @@
 	jp	nc,%3	;%8
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
-	cp	+(%2 % 256)
+	and	%eval(%1 256 %%)
+	cp	%eval(%1 256 /)
 	ld	hl,0
 	jp	z,%3	;%8
 	inc	hl
@@ -344,8 +344,8 @@
 	jp	nc,%3	;%8
 =
 	ld	a,(hl)
-	or	+(%1 % 256)
-	cp	+(%2 % 256)
+	or	%eval(%1 256 %%)
+	cp	%eval(%2 256 %%)
 	ld	hl,0
 	jp	z,%3	;%8
 	inc	hl
@@ -363,8 +363,8 @@
 	jp	nc,%3	;%8
 =
 	ld	a,(hl)
-	xor	+(%1 % 256)
-	cp	+(%2 % 256)
+	xor	%eval(%1 256 %%)
+	cp	%eval(%2 256 %%))
 	ld	hl,0
 	jp	z,%3	;%8
 	inc	hl
@@ -382,8 +382,8 @@
 	jp	nc,%3	;%8
 =
 	ld	a,(hl)
-	and	+(%1 % 256)
-	cp	+(%2 % 256)
+	and	%eval(%1 256 %%)
+	cp	%eval(%2 256 %%)
 	ld	hl,0
 	jp	nz,%3	;%8
 	inc	hl
@@ -401,8 +401,8 @@
 	jp	nc,%3	;%8
 =
 	ld	a,(hl)
-	or	+(%1 % 256)
-	cp	+(%2 % 256)
+	or	%eval(%1 256 %%)
+	cp	%eval(%2 256 %%)
 	ld	hl,0
 	jp	nz,%3	;%8
 	inc	hl
@@ -420,8 +420,8 @@
 	jp	nc,%3	;%8
 =
 	ld	a,(hl)
-	xor	+(%1 % 256)
-	cp	+(%2 % 256)
+	xor	%eval(%1 256 %%)
+	cp	%eval(%2 256 %%)
 	ld	hl,1
 	jp	nz,%3	;%8
 	dec	hl
@@ -742,9 +742,9 @@
 	call	l_pint
 	ld	hl,%2
 =
-	ld	(hl),+(%1 % 256)
+	ld	(hl),%eval(%1 256 %%)
 	inc	hl
-	ld	(hl),+(%1 / 256)
+	ld	(hl),%eval(%1 256 /)
 	ld	hl,%2
 
 	ld	hl,2	;const
@@ -773,7 +773,7 @@
 	ld	(de),a
 =
 	ld	a,(hl)
-	add	a,+(%1 % 256)
+	add	a,%eval(%1 256 %%)
 	ld	(hl),a
 	ld	l,a
 	ld	h,0
@@ -819,7 +819,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	nc,%2	;%8
 	ld	hl,%3
 
@@ -833,7 +833,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jr	z,%2_ule
 	jp	nc,%2	;%8
 .%2_ule
@@ -850,7 +850,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	z,%2	;%8
 	jp	c,%2	;%8
 	ld	hl,%3
@@ -865,7 +865,7 @@
 	ld	hl,%3
 =
 	ld	a,(hl)
-	cp	+(%1 % 256)
+	cp	%eval(%1 256 %%)
 	jp	c,%2	;%8
 	ld	hl,%3
 
@@ -993,25 +993,25 @@
 	ld	d,h
 	ld	e,l
 
-	and	+(1 % 256)
+	and	1
 	jp	z,%1	;%8
 =
 	rrca
 	jp	nc,%1	;%8
 
-	and	+(1 % 256)
+	and	1
 	jp	nz,%1	;%8
 =
 	rrca
 	jp	c,%1	;%8
 
-	and	+(128 % 256)
+	and	128
 	jp	z,%1	;%8
 =
 	rlca
 	jp	nc,%1	;%8
 
-	and	+(128 % 256)
+	and	128
 	jp	nz,%1	;%8
 =
 	rlca
@@ -1229,7 +1229,7 @@
 	ld	hl,%1	;const
 	ld	h,0
 =
-	ld	hl,%1 % 256	;const
+	ld	hl,%eval(%1 256 %%)	;const
 
 	ld	%1,%2
 	ld	%1,%3
@@ -1347,7 +1347,7 @@ REMOVE THIS LINE FOR IT TO FIRE
 	ld	(%2),a
 	ld	h%3
 =
-	ld	a,+(%1 % 256)
+	ld	a,%eval(%1 256 %%)
 	ld	(%2),a
 	ld	h%3
 
@@ -1360,7 +1360,7 @@ REMOVE THIS LINE FOR IT TO FIRE
 	ld	h%3
 =
 	pop	de
-	ld	a,+(%1 % 256)
+	ld	a,%eval(%1 256 %%)
 	ld	(de),a
 	ld	h%3
 

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -1315,8 +1315,6 @@ void testjump(LVALUE* lval, int label)
     ol("or\tl");
 
     type = lval->val_type;
-    if (lval->binop == NULL)
-        type = lval->val_type;
 
     if (type == KIND_LONG && check_lastop_was_comparison(lval)) {
         ol("or\td");
@@ -2898,22 +2896,22 @@ void zand_const(LVALUE *lval, int64_t value64)
         } else if ( (value & 0xffffff00) == 0xffffff00 ) {
            // Only the bottom 8 bits
            ol("ld\ta,l");
-           outfmt("\tand\t+(%d %% 256)\n",(value & 0xff));
+           outfmt("\tand\t%d\n",(value & 0xff));
            ol("ld\tl,a");
         } else if ( (value & 0xffff00ff) == 0xffff00ff  ) {
            // Only the bits 15-8
            ol("ld\ta,h");
-           outfmt("\tand\t+(%d %% 256)\n",(value & 0xff00)>>8);
+           outfmt("\tand\t%d\n",(value & 0xff00)>>8);
            ol("ld\th,a");
         } else if ( (value & 0xff00ffff ) == 0xff00ffff) {
            // Only the bits 23-16
            ol("ld\ta,e");
-           outfmt("\tand\t+(%d %% 256)\n",(value & 0xff0000)>>16);
+           outfmt("\tand\t%d\n",(value & 0xff0000)>>16);
            ol("ld\te,a");
         } else if ( (value & 0x00ffffff) == 0x00ffffff ) {
            // Only the bits 32-23
            ol("ld\ta,d");
-           outfmt("\tand\t+(%d %% 256)\n",(value & 0xff000000) >> 24);
+           outfmt("\tand\t%d\n",(value & 0xff000000) >> 24);
            ol("ld\td,a");
         } else if ( (value & 0xffff0000) == 0x00000000 ) {
             LVALUE tval = {0};
@@ -2936,12 +2934,12 @@ void zand_const(LVALUE *lval, int64_t value64)
         } else if ( value >= 0 && value < 256 ) {
             // 6 bytes, library call is 6 bytes, this is faster
             ol("ld\ta,l");
-            outfmt("\tand\t+(%d %% 256)\n",value % 256);
+            outfmt("\tand\t%d\n",value % 256);
             ol("ld\tl,a");
             ol("ld\th,0");
         } else if ( value % 256 == 0 ) {
             ol("ld\ta,h");
-            outfmt("\tand\t+(%d %% 256)\n",(value & 0xff00) >> 8);
+            outfmt("\tand\t%d\n",(value & 0xff00) >> 8);
             ol("ld\th,a");
             ol("ld\tl,0");            
         } else if ( value == (uint16_t)0xffff ) {

--- a/src/sccz80/expr.c
+++ b/src/sccz80/expr.c
@@ -196,8 +196,6 @@ int heir1a(LVALUE* lval)
     int falselab, endlab, skiplab;
     LVALUE lval2={0};
     int k;
-    Kind temptype;
-    Type *templtype;
 
     k = heir2a(lval);
     if (cmatch('?')) {
@@ -208,17 +206,10 @@ int heir1a(LVALUE* lval)
         if ( lval->is_const ) {
             vconst(lval->const_val);
         }
+
         /* test condition, jump to false expression evaluation if necessary */
         if (check_lastop_was_testjump(lval)) {
-            // Always evaluated as an integer, so fake it temporarily
-            force(KIND_INT, lval->val_type, 0, lval->ltype->isunsigned, 0);
-            temptype = lval->val_type;
-            templtype = lval->ltype;
-            lval->val_type = KIND_INT; /* Force to integer */
-            lval->ltype = type_int;
             testjump(lval, falselab = getlabel());
-            lval->val_type = temptype;
-            lval->ltype = templtype;
             /* evaluate 'true' expression */
             if (heir1(&lval2))
                 rvalue(&lval2);

--- a/src/sccz80/preproc.c
+++ b/src/sccz80/preproc.c
@@ -126,6 +126,9 @@ void ifline()
         if (eof)
             return;
 
+        while (ch() == ' ' || ch() == '\t')
+            gch();
+
         if (ch() == '#') {
 
             if (match("#pragma")) {

--- a/testsuite/results/02_addr_ptr.opt
+++ b/testsuite/results/02_addr_ptr.opt
@@ -10,7 +10,7 @@
 
 ._main
 	ld	hl,58056	;const
-	ld	(hl),+(100 % 256 % 256)
+	ld	(hl),100
 	ld	l,(hl)
 	ld	h,0
 	ret

--- a/testsuite/results/Issue_1126_opt_rule.opt
+++ b/testsuite/results/Issue_1126_opt_rule.opt
@@ -14,7 +14,7 @@
 	call	_zx_border
 	pop	bc
 	ld	hl,_sendbuf
-	ld	(hl),+(201 % 256 % 256)
+	ld	(hl),201
 	ld	de,_sendbuf+1
 	ld	hl,2	;const
 	add	hl,sp

--- a/testsuite/results/Issue_1133_bitfields.opt
+++ b/testsuite/results/Issue_1133_bitfields.opt
@@ -22,7 +22,7 @@
 	and	248
 	or	7
 	ld	(hl),a
-	ld	hl,_x+1+1
+	ld	hl,_x+2
 	ld	de,2	;const
 	ex	de,hl
 	ld	a,l
@@ -35,7 +35,7 @@
 	and	31
 	or	l
 	ld	(de),a
-	ld	hl,_x+1+1 + 1
+	ld	hl,_x+3
 	ld	a,(hl)
 	and	224
 	or	3
@@ -74,7 +74,7 @@
 
 
 ._func1b
-	ld	hl,_x+1+1
+	ld	hl,_x+2
 	ld	a,(hl)
 	rlca
 	rlca
@@ -87,7 +87,7 @@
 
 
 ._func1c
-	ld	hl,_x+1+1+1
+	ld	hl,_x+3
 	ld	a,(hl)
 	and	31
 	ld	l,a
@@ -98,7 +98,7 @@
 
 ._func2
 	ld	hl,_y
-	ld	(hl),+(1 % 256)
+	ld	(hl),1
 	ld	l,(hl)
 	ld	h,0
 	ret
@@ -147,7 +147,7 @@
 
 
 ._func3b
-	ld	hl,_z+1+1
+	ld	hl,_z+2
 	ld	e,(hl)
 	inc	hl
 	ld	a,(hl)

--- a/testsuite/results/Issue_1266_ranges.opt
+++ b/testsuite/results/Issue_1266_ranges.opt
@@ -13,7 +13,7 @@
 	add	hl,sp
 	call	l_glong
 	ld	a,h
-	and	+(112 % 256)
+	and	112
 	ld	h,a
 	ld	l,0
 	ld	de,0
@@ -62,7 +62,7 @@
 	push	hl
 	push	bc
 	ld	a,h
-	and	+(112 % 256)
+	and	112
 	ld	h,a
 	ld	l,0
 	ret
@@ -75,7 +75,7 @@
 	push	hl
 	push	bc
 	ld	a,l
-	and	+(112 % 256)
+	and	112
 	ld	l,a
 	ld	h,0
 	ret

--- a/testsuite/results/Issue_1283_2d_arrays.opt
+++ b/testsuite/results/Issue_1283_2d_arrays.opt
@@ -52,7 +52,7 @@
 	push	hl
 	call	_func
 	pop	bc
-	ld	hl,(_selected_data+1+1)
+	ld	hl,(_selected_data+2)
 	ld	h,0
 	push	hl
 	call	_ifunc

--- a/testsuite/results/Issue_452_struct.opt
+++ b/testsuite/results/Issue_452_struct.opt
@@ -50,14 +50,14 @@
 	ld	sp,hl
 	ld	hl,4	;const
 	add	hl,sp
-	ld	(hl),+(1 % 256)
-	inc	hl
-	ld	(hl),+(1 / 256)
+	ld	(hl),1
 	inc	hl
 	xor	a
 	ld	(hl),a
 	inc	hl
 	ld	(hl),a
+	inc	hl
+	ld	(hl),0
 	ld	hl,104	;const
 	add	hl,sp
 	ld	sp,hl

--- a/testsuite/results/Issue_452_unsigned.opt
+++ b/testsuite/results/Issue_452_unsigned.opt
@@ -9,7 +9,7 @@
 	SECTION	code_compiler
 
 ._func_char
-	ld	hl,+(( (0 % 256) * 256) + (0 % 256))
+	ld	hl,0
 	push	hl
 	ld	hl,1	;const
 	call	l_gcharspsp	;
@@ -24,7 +24,7 @@
 
 
 ._func_char2
-	ld	hl,+(( (0 % 256) * 256) + (0 % 256))
+	ld	hl,0
 	push	hl
 	ld	hl,1	;const
 	call	l_gcharspsp	;

--- a/testsuite/results/Issue_507_unnamed_structs.opt
+++ b/testsuite/results/Issue_507_unnamed_structs.opt
@@ -10,7 +10,7 @@
 
 ._func
 	ld	hl,1	;const
-	ld	(_foo+1+1),hl
+	ld	(_foo+2),hl
 	ld	hl,2	;const
 	ld	(_bar+4),hl
 	ret

--- a/testsuite/results/Issue_510_long_and.opt
+++ b/testsuite/results/Issue_510_long_and.opt
@@ -19,7 +19,7 @@
 	push	hl
 	call	l_glong
 	ld	a,l
-	and	+(18 % 256)
+	and	18
 	ld	l,a
 	pop	bc
 	call	l_plong
@@ -40,7 +40,7 @@
 	push	hl
 	call	l_glong
 	ld	a,h
-	and	+(18 % 256)
+	and	18
 	ld	h,a
 	pop	bc
 	call	l_plong
@@ -61,7 +61,7 @@
 	push	hl
 	call	l_glong
 	ld	a,e
-	and	+(18 % 256)
+	and	18
 	ld	e,a
 	pop	bc
 	call	l_plong
@@ -82,7 +82,7 @@
 	push	hl
 	call	l_glong
 	ld	a,d
-	and	+(18 % 256)
+	and	18
 	ld	d,a
 	pop	bc
 	call	l_plong
@@ -124,7 +124,7 @@
 	push	hl
 	call	l_glong
 	ld	a,l
-	and	+(18 % 256)
+	and	18
 	ld	l,a
 	pop	bc
 	call	l_plong

--- a/testsuite/results/Issue_514_flexible_member.opt
+++ b/testsuite/results/Issue_514_flexible_member.opt
@@ -17,9 +17,9 @@
 	ld	b,(hl)
 	ld	hl,8
 	add	hl,bc
-	ld	(hl),+(17 % 256)
+	ld	(hl),17
 	inc	hl
-	ld	(hl),+(17 / 256)
+	ld	(hl),0
 	ld	hl,2	;const
 	pop	bc
 	ret
@@ -35,9 +35,9 @@
 	ld	b,(hl)
 	ld	hl,8
 	add	hl,bc
-	ld	(hl),+(17 % 256)
+	ld	(hl),17
 	inc	hl
-	ld	(hl),+(17 / 256)
+	ld	(hl),0
 	ld	hl,2	;const
 	pop	bc
 	ret

--- a/testsuite/results/Issue_564_casting.opt
+++ b/testsuite/results/Issue_564_casting.opt
@@ -50,7 +50,7 @@
 
 
 ._func4
-	ld	hl,(_item+1+1)
+	ld	hl,(_item+2)
 	push	hl
 	call	_value
 	pop	bc

--- a/testsuite/results/Issue_569_jagged_array.opt
+++ b/testsuite/results/Issue_569_jagged_array.opt
@@ -27,10 +27,10 @@
 	ld	hl,(_starField+4)
 	ld	bc,20
 	add	hl,bc
-	ld	(hl),+(10 % 256 % 256)
+	ld	(hl),10
 	ld	hl,1	;const
 	add	hl,sp
-	ld	(hl),+(0 % 256 % 256)
+	ld	(hl),0
 	jp	i_5	;EOS
 .i_3
 	ld	hl,1	;const
@@ -44,7 +44,7 @@
 	jp	z,i_4	;
 	ld	hl,0	;const
 	add	hl,sp
-	ld	(hl),+(0 % 256 % 256)
+	ld	(hl),0
 	jp	i_8	;EOS
 .i_6
 	ld	hl,0	;const
@@ -72,7 +72,7 @@
 	push	hl
 	ld	h,0
 	add	hl,de
-	ld	(hl),+(12 % 256 % 256)
+	ld	(hl),12
 	jp	i_6	;EOS
 	defc	i_7 = i_3
 .i_4

--- a/testsuite/results/mathops_ieee.opt
+++ b/testsuite/results/mathops_ieee.opt
@@ -29,9 +29,9 @@
 	inc	hl
 	ld	(hl),a
 	inc	hl
-	ld	(hl),+(16416 % 256)
+	ld	(hl),32
 	inc	hl
-	ld	(hl),+(16416 / 256)
+	ld	(hl),64
 	ld	hl,0	;const
 	add	hl,sp
 	call	l_glong


### PR DESCRIPTION
+ Fix an issue with ? operator and > 16 bit parameters where the testjump wasn't evaluating all 32 bits of a ((long)x & 1L) for
example.

+ Skip whitespace when looking for pragmas.

Merge after ASMDISP change