### PR TITLE
[laser500] include extra keys in inKey.asm

### DIFF
--- a/lib/target/laser500/classic/laser500_crt0.asm
+++ b/lib/target/laser500/classic/laser500_crt0.asm
@@ -1,9 +1,8 @@
 ;
-;	Startup for V-Tech VZ-350/500/700?
+;	Startup for V-Tech Laser 350/500/700
 ;
 
-	module	vz700_crt0 
-
+	module	laser500_crt0
 
 ;--------
 ; Include zcc_opt.def to find out some info

--- a/lib/target/laser500/classic/laser500_crt0.asm
+++ b/lib/target/laser500/classic/laser500_crt0.asm
@@ -24,7 +24,6 @@
 	defc	CONSOLE_COLUMNS = 40
 	defc	CONSOLE_ROWS = 24
 
-
         defc    TAR__no_ansifont = 1
 	defc	CRT_KEY_DEL = 12
 	defc	__CPU_CLOCK = 3694700
@@ -36,16 +35,5 @@ ELSE
 	INCLUDE	"target/laser500/classic/ram.asm"
 ENDIF
 
-   ; The extra key rows aren't implemented by Mame, so disable
-   ; scanning of them by default
-   PUBLIC __CLIB_LASER500_SCAN_EXTRA_ROWS
-   IFDEF CLIB_LASER500_SCAN_EXTRA_ROWS
-     defc __CLIB_LASER500_SCAN_EXTRA_ROWS = CLIB_LASER500_SCAN_EXTRA_ROWS
-   ELSE
-     defc __CLIB_LASER500_SCAN_EXTRA_ROWS = 0
-   ENDIF
-
-	INCLUDE "crt/classic/crt_runtime_selection.asm" 
-	
+	INCLUDE "crt/classic/crt_runtime_selection.asm"
 	INCLUDE	"crt/classic/crt_section.asm"
-

--- a/libsrc/target/laser500/input/in_Inkey.asm
+++ b/libsrc/target/laser500/input/in_Inkey.asm
@@ -9,7 +9,6 @@ PUBLIC _in_Inkey
 EXTERN in_keytranstbl
 EXTERN l_push_di
 EXTERN l_pop_ei
-EXTERN __CLIB_LASER500_SCAN_EXTRA_ROWS
 
 INCLUDE "target/laser500/def/laser500.def"
 
@@ -53,9 +52,7 @@ row_loops:
 	rl	l
 	djnz	row_loops
 
-	ld	a,__CLIB_LASER500_SCAN_EXTRA_ROWS
-	and	a
-	jr	z,skip_extra_keys
+   ; scan the extra rows
 
 	ld	hl,$6bff
 	ld	b,4
@@ -70,7 +67,6 @@ row_loops_2:
 	dec	h
 	djnz	row_loops_2
 
-skip_extra_keys:
 	ld	a,(SYSVAR_bank1)
 	out	($41),a
 	call	l_pop_ei


### PR DESCRIPTION
in the target `laser500` there is a `CLIB_LASER500_SCAN_EXTRA_ROWS` flag disabled by default that prevents reading the extended keys (cursor keys, fkeys etc) with the keyboard input routines. 

That flag was added for some reason because early MAME versions didn't read the keyboard properly. But now MAME works correctly and we also have the much more accurate [web emulator](https://nippur72.github.io/laser500emu) so there is no reason why this flag should be enforced by default or have it in the first place.

This PR removes it.

I also fixed a reference to the old target name "vz700" which is now `laser500`.

