### PR TITLE
newlib - align before section (rather than after)

### DIFF
--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.bak
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.bak
@@ -36,29 +36,29 @@ section code_lib
 section code_compiler
 section code_user
 
-section rodata_align_256
 align 256
+section rodata_align_256
 
-section rodata_align_128
 align 128
+section rodata_align_128
 
-section rodata_align_64
 align 64
+section rodata_align_64
 
-section rodata_align_32
 align 32
+section rodata_align_32
 
-section rodata_align_16
 align 16
+section rodata_align_16
 
-section rodata_align_8
 align 8
+section rodata_align_8
 
-section rodata_align_4
 align 4
+section rodata_align_4
 
-section rodata_align_2
 align 2
+section rodata_align_2
 
 section rodata_driver
 section rodata_font
@@ -96,29 +96,29 @@ ELSE
 
 ENDIF
 
-section data_align_256
 align 256
+section data_align_256
 
-section data_align_128
 align 128
+section data_align_128
 
-section data_align_64
 align 64
+section data_align_64
 
-section data_align_32
 align 32
+section data_align_32
 
-section data_align_16
 align 16
+section data_align_16
 
-section data_align_8
 align 8
+section data_align_8
 
-section data_align_4
 align 4
+section data_align_4
 
-section data_align_2
 align 2
+section data_align_2
 
 section smc_jump_vectors
 section smc_driver
@@ -161,29 +161,29 @@ ELSE
 
 ENDIF
 
-section bss_align_256
 align 256
+section bss_align_256
 
-section bss_align_128
 align 128
+section bss_align_128
 
-section bss_align_64
 align 64
+section bss_align_64
 
-section bss_align_32
 align 32
+section bss_align_32
 
-section bss_align_16
 align 16
+section bss_align_16
 
-section bss_align_8
 align 8
+section bss_align_8
 
-section bss_align_4
 align 4
+section bss_align_4
 
-section bss_align_2
 align 2
+section bss_align_2
 
 section bss_driver
 section bss_font

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.inc
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.inc
@@ -36,29 +36,29 @@ section code_lib
 section code_compiler
 section code_user
 
-section rodata_align_256
 align 256
+section rodata_align_256
 
-section rodata_align_128
 align 128
+section rodata_align_128
 
-section rodata_align_64
 align 64
+section rodata_align_64
 
-section rodata_align_32
 align 32
+section rodata_align_32
 
-section rodata_align_16
 align 16
+section rodata_align_16
 
-section rodata_align_8
 align 8
+section rodata_align_8
 
-section rodata_align_4
 align 4
+section rodata_align_4
 
-section rodata_align_2
 align 2
+section rodata_align_2
 
 section rodata_driver
 section rodata_font
@@ -96,29 +96,29 @@ ELSE
 
 ENDIF
 
-section data_align_256
 align 256
+section data_align_256
 
-section data_align_128
 align 128
+section data_align_128
 
-section data_align_64
 align 64
+section data_align_64
 
-section data_align_32
 align 32
+section data_align_32
 
-section data_align_16
 align 16
+section data_align_16
 
-section data_align_8
 align 8
+section data_align_8
 
-section data_align_4
 align 4
+section data_align_4
 
-section data_align_2
 align 2
+section data_align_2
 
 section smc_jump_vectors
 section smc_driver
@@ -161,29 +161,29 @@ ELSE
 
 ENDIF
 
-section bss_align_256
 align 256
+section bss_align_256
 
-section bss_align_128
 align 128
+section bss_align_128
 
-section bss_align_64
 align 64
+section bss_align_64
 
-section bss_align_32
 align 32
+section bss_align_32
 
-section bss_align_16
 align 16
+section bss_align_16
 
-section bss_align_8
 align 8
+section bss_align_8
 
-section bss_align_4
 align 4
+section bss_align_4
 
-section bss_align_2
 align 2
+section bss_align_2
 
 section bss_driver
 section bss_font

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.bak
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.bak
@@ -36,29 +36,29 @@ section code_lib
 section code_compiler
 section code_user
 
-section rodata_align_256
 align 256
+section rodata_align_256
 
-section rodata_align_128
 align 128
+section rodata_align_128
 
-section rodata_align_64
 align 64
+section rodata_align_64
 
-section rodata_align_32
 align 32
+section rodata_align_32
 
-section rodata_align_16
 align 16
+section rodata_align_16
 
-section rodata_align_8
 align 8
+section rodata_align_8
 
-section rodata_align_4
 align 4
+section rodata_align_4
 
-section rodata_align_2
 align 2
+section rodata_align_2
 
 section rodata_driver
 section rodata_font
@@ -91,29 +91,29 @@ ELSE
 
 ENDIF
 
-section data_align_256
 align 256
+section data_align_256
 
-section data_align_128
 align 128
+section data_align_128
 
-section data_align_64
 align 64
+section data_align_64
 
-section data_align_32
 align 32
+section data_align_32
 
-section data_align_16
 align 16
+section data_align_16
 
-section data_align_8
 align 8
+section data_align_8
 
-section data_align_4
 align 4
+section data_align_4
 
-section data_align_2
 align 2
+section data_align_2
 
 section smc_jump_vectors
 section smc_driver
@@ -156,29 +156,29 @@ ELSE
 
 ENDIF
 
-section bss_align_256
 align 256
+section bss_align_256
 
-section bss_align_128
 align 128
+section bss_align_128
 
-section bss_align_64
 align 64
+section bss_align_64
 
-section bss_align_32
 align 32
+section bss_align_32
 
-section bss_align_16
 align 16
+section bss_align_16
 
-section bss_align_8
 align 8
+section bss_align_8
 
-section bss_align_4
 align 4
+section bss_align_4
 
-section bss_align_2
 align 2
+section bss_align_2
 
 section bss_driver
 section bss_font

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.inc
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.inc
@@ -36,29 +36,29 @@ section code_lib
 section code_compiler
 section code_user
 
-section rodata_align_256
 align 256
+section rodata_align_256
 
-section rodata_align_128
 align 128
+section rodata_align_128
 
-section rodata_align_64
 align 64
+section rodata_align_64
 
-section rodata_align_32
 align 32
+section rodata_align_32
 
-section rodata_align_16
 align 16
+section rodata_align_16
 
-section rodata_align_8
 align 8
+section rodata_align_8
 
-section rodata_align_4
 align 4
+section rodata_align_4
 
-section rodata_align_2
 align 2
+section rodata_align_2
 
 section rodata_driver
 section rodata_font
@@ -91,29 +91,29 @@ ELSE
 
 ENDIF
 
-section data_align_256
 align 256
+section data_align_256
 
-section data_align_128
 align 128
+section data_align_128
 
-section data_align_64
 align 64
+section data_align_64
 
-section data_align_32
 align 32
+section data_align_32
 
-section data_align_16
 align 16
+section data_align_16
 
-section data_align_8
 align 8
+section data_align_8
 
-section data_align_4
 align 4
+section data_align_4
 
-section data_align_2
 align 2
+section data_align_2
 
 section smc_jump_vectors
 section smc_driver
@@ -156,29 +156,29 @@ ELSE
 
 ENDIF
 
-section bss_align_256
 align 256
+section bss_align_256
 
-section bss_align_128
 align 128
+section bss_align_128
 
-section bss_align_64
 align 64
+section bss_align_64
 
-section bss_align_32
 align 32
+section bss_align_32
 
-section bss_align_16
 align 16
+section bss_align_16
 
-section bss_align_8
 align 8
+section bss_align_8
 
-section bss_align_4
 align 4
+section bss_align_4
 
-section bss_align_2
 align 2
+section bss_align_2
 
 section bss_driver
 section bss_font


### PR DESCRIPTION
Currently `align` is done after the `section` rather than before.

This PR moves the `align xxx` before the `section_align_xxx` statement.

IIRC there was some discussion about which was the right order, but IMHO it makes more sense to have each section starting with the right alignment, and to ensure that each following smaller section is also starting with the right alignment offset.

If this is not correct assumption, please just close this PR with a note for future reference.