### PR TITLE
MSX.H: Syntax fix required to allow compiling with SDCC

### DIFF
--- a/include/msx.h
+++ b/include/msx.h
@@ -329,7 +329,13 @@ extern int __LIB__ msx_type();
 // 1 = MSX 2
 // 2 = MSX 2+
 // 3 = MSX turbo R
+#ifdef __SCCZ80
 extern unsigned char MSX2_SUBTYPE @0x002d;
+#endif
+
+#ifdef __SDCC
+extern unsigned char __at 0x002d MSX2_SUBTYPE;
+#endif
 
 // Detect the VRAM size (in KB)
 extern int __LIB__ msx_vram();


### PR DESCRIPTION
Hello,

I have had an issuing compiling with target of MSX, using the SDCC compiler.  I get a syntax error, due to what appears to me to be SCCZ80 syntax in msx.h (I dont use the SCCZ80 compiler....)

The compile error is:
```
..../z88dk/lib/config/../..//include/msx.h:333: error 1: Syntax error, declaration ignored at 'MSX2_SUBTYPE'
..../z88dk/lib/config/../..//include/msx.h:333: syntax error: token -> '0x002d' ; column 41
```

My command to compile is:
`zcc +msx -create-app -subtype=msxdos2 -compiler=sdcc -lmath32 -Cc-D__MATH_MATH32 -D__MATH_MATH32 -pragma-define:CLIB_32BIT_FLOAT=1 dots.c v9958.c msx.asm v9958.asm msxdos.asm -o dots.com`

For the time being I just commented out the offending line, and then everything worked.  But I now have others trying to compile my C code - and are naturally getting the error.

It's very possible I am not understanding something here - using z88dk wrong, or my patch is not the 'right' way to do this.

I have made my best guess as to a fix - but not sure if there is a better more correct way to do this fix.

Cheers
Dean.