### PR TITLE
Resolved "Unescaped left brace..."

### DIFF
--- a/src/z80asm/asmstyle.pl
+++ b/src/z80asm/asmstyle.pl
@@ -94,7 +94,7 @@ sub parse_line {
             }
         }
         elsif (s/^\s*(;.*)//)                       { $ret{comment} = $1; }
-        elsif (s/^\s*({|})//)                       { $ret{opcode} = $1; $ret{args} = ''; }
+	elsif (s/^\s*(\{|\})//)                       { $ret{opcode} = $1; $ret{args} = ''; }
         /\S/ and die "cannot parse: $_";
     }
     return \%ret;


### PR DESCRIPTION
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/^\s*({ <-- HERE |})/ at ./asmstyle.pl line 97."