### PR TITLE
Remove tabs after opcodes and directives with no arguments.

### DIFF
--- a/src/z80asm/Makefile
+++ b/src/z80asm/Makefile
@@ -125,6 +125,7 @@ install: $(TARGET) z80asm_lib
 	$(INSTALL) $(TARGET)     $(PREFIX)/bin/$(TARGET)
 	$(INSTALL) $(TARGET)     $(PREFIX)/bin/z88dk-$(TARGET)
 	$(INSTALL) asmpp.pl      $(PREFIX)/bin/asmpp.pl
+	$(INSTALL) asmstyle.pl   $(PREFIX)/bin/asmstyle.pl
 	$(MAKE) -C dev/z80asm_lib install PREFIX=$(PREFIX_SHARE)
 
 #------------------------------------------------------------------------------

--- a/src/z80asm/asmstyle.pl
+++ b/src/z80asm/asmstyle.pl
@@ -120,7 +120,10 @@ sub format_line {
             $LEVEL-- if $line->{opcode} =~ /^el|^end/i;
             $out .= "  " x $LEVEL;
             $out .= $line->{opcode};
-            $out = tab($out);
+            # If there are no args, don't add a tab
+            if ("$line->{args}" ne "") {
+                $out = tab($out);
+            }
             $out .= $line->{args};
             $LEVEL++ if $line->{opcode} =~ /^el/i;
             $LEVEL++ if $line->{opcode} =~ /^if/i;
@@ -132,7 +135,10 @@ sub format_line {
             if ($line->{opcode}) {
                 $out = tab_to_newline($out, $OPCODE, $fh);
                 $out .= $line->{opcode};
-                $out = tab_to($out, $ARGS);
+                # If there are no args, don't add a tab
+                if ("$line->{args}" ne "") {
+                    $out = tab_to($out, $ARGS);
+                }
                 $out .= $line->{args};
             }
             if ($line->{macro_label}) {


### PR DESCRIPTION
asmstyle.pl would insert tabs after opcodes and directives even if they had no arguments. This update prevents the insertion of these tabs.
Updated Makefile to install asmstyle.pl in $PREFIX/bin