### PR TITLE
zsdcc - r12419 - bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 Z88DK_PATH	= $(shell pwd)
 SDCC_PATH	= $(Z88DK_PATH)/src/sdcc-build
-SDCC_VERSION    = 12407
+SDCC_VERSION    = 12419
 
 ifdef BUILD_SDCC
 ifdef BUILD_SDCC_HTTP

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 Z88DK_PATH	= $(shell pwd)
 SDCC_PATH	= $(Z88DK_PATH)/src/sdcc-build
-SDCC_VERSION    = 12288
+SDCC_VERSION    = 12407
 
 ifdef BUILD_SDCC
 ifdef BUILD_SDCC_HTTP

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,7 +29,7 @@ Detailed but incomplete changelist:
 - [newlib] +zxn: dot files are now created correctly
 - [sccz80] Temporary files now removed on windows
 - [sccz80] Bug fixes + optimisations
-- [zsdcc] Upgraded to SDCC 4.1.6 r12288 (bugfixes)
+- [zsdcc] Upgraded to SDCC 4.1.6 r12407 (bugfixes)
 
 
 z88dk v2.1 - 07.02.2021

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,7 +29,7 @@ Detailed but incomplete changelist:
 - [newlib] +zxn: dot files are now created correctly
 - [sccz80] Temporary files now removed on windows
 - [sccz80] Bug fixes + optimisations
-- [zsdcc] Upgraded to SDCC 4.1.6 r12407 (bugfixes)
+- [zsdcc] Upgraded to SDCC 4.1.6 r12419 (bugfixes)
 
 
 z88dk v2.1 - 07.02.2021

--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -8,7 +8,7 @@ For Linux users follow the instructions on the [installation page](https://githu
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-12407-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12407.
+`sdcc-12419-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12419.
 
 `sdcc-9958-z88dk.patch` is the previous z88dk v1.99c zsdcc standard patch, retained for comparison and building against sdcc r9958.
 

--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -8,7 +8,7 @@ For Linux users follow the instructions on the [installation page](https://githu
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-12288-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12288.
+`sdcc-12407-z88dk.patch` is the current zsdcc patch, retained for comparison and building against sdcc r12407.
 
 `sdcc-9958-z88dk.patch` is the previous z88dk v1.99c zsdcc standard patch, retained for comparison and building against sdcc r9958.
 

--- a/src/zsdcc/sdcc-12407-z88dk.patch
+++ b/src/zsdcc/sdcc-12407-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12288)
+--- src/SDCCasm.c	(revision 12407)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12288)
+--- src/SDCCglue.c	(revision 12407)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12288)
+--- src/SDCCmain.c	(revision 12407)
 +++ src/SDCCmain.c	(working copy)
 @@ -514,16 +514,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12288)
+--- src/SDCCopt.c	(revision 12407)
 +++ src/SDCCopt.c	(working copy)
 @@ -1016,7 +1016,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -132,7 +132,7 @@ Index: src/SDCCopt.c
        goto convert;
      }
    
-@@ -2139,10 +2139,11 @@
+@@ -2148,10 +2148,11 @@
    int i;
    int change = 0;
    iCode *ic, *newic;
@@ -145,7 +145,7 @@ Index: src/SDCCopt.c
  
    // Wide loop counter
    for (i = 0; i < count; i++)
-@@ -2332,8 +2333,8 @@
+@@ -2341,8 +2342,8 @@
              IS_ITEMP (right) && bitVectnBitsOn (OP_DEFS (right)) != 1)
              continue;
  
@@ -156,7 +156,7 @@ Index: src/SDCCopt.c
  
            if (lic)
              {
-@@ -2340,7 +2341,7 @@
+@@ -2349,7 +2350,7 @@
                if (lic->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (lic)) && !IS_OP_LITERAL (IC_RIGHT (lic)))
                  continue;
  
@@ -165,7 +165,7 @@ Index: src/SDCCopt.c
  
                if (litval > 0x7f)
                  continue;
-@@ -2353,7 +2354,7 @@
+@@ -2362,7 +2363,7 @@
                if (ric->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (ric)) && !IS_OP_LITERAL (IC_RIGHT (ric)))
                  continue;
  
@@ -176,9 +176,9 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12288)
+--- src/z80/peep.c	(revision 12407)
 +++ src/z80/peep.c	(working copy)
-@@ -225,6 +225,88 @@
+@@ -165,6 +165,88 @@
    return(found && found < end);
  }
  
@@ -267,7 +267,7 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -382,6 +464,8 @@
+@@ -324,6 +406,8 @@
  static bool
  z80MightRead(const lineNode *pl, const char *what)
  {
@@ -276,7 +276,7 @@ Index: src/z80/peep.c
    if(strcmp(what, "iyl") == 0 || strcmp(what, "iyh") == 0)
      what = "iy";
    if(strcmp(what, "ixl") == 0 || strcmp(what, "ixh") == 0)
-@@ -390,6 +474,16 @@
+@@ -332,6 +416,16 @@
    if(ISINST(pl->line, "call") && strcmp(what, "sp") == 0)
      return TRUE;
  
@@ -293,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -838,6 +932,7 @@
+@@ -763,6 +857,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -301,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -844,6 +939,16 @@
+@@ -769,6 +864,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  

--- a/src/zsdcc/sdcc-12419-z88dk.patch
+++ b/src/zsdcc/sdcc-12419-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12407)
+--- src/SDCCasm.c	(revision 12419)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12407)
+--- src/SDCCglue.c	(revision 12419)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12407)
+--- src/SDCCmain.c	(revision 12419)
 +++ src/SDCCmain.c	(working copy)
 @@ -514,16 +514,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12407)
+--- src/SDCCopt.c	(revision 12419)
 +++ src/SDCCopt.c	(working copy)
 @@ -1016,7 +1016,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,7 +176,7 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12407)
+--- src/z80/peep.c	(revision 12419)
 +++ src/z80/peep.c	(working copy)
 @@ -165,6 +165,88 @@
    return(found && found < end);

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12407)
+--- src/SDCCasm.c	(revision 12419)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12407)
+--- src/SDCCglue.c	(revision 12419)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12407)
+--- src/SDCCmain.c	(revision 12419)
 +++ src/SDCCmain.c	(working copy)
 @@ -514,16 +514,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12407)
+--- src/SDCCopt.c	(revision 12419)
 +++ src/SDCCopt.c	(working copy)
 @@ -1016,7 +1016,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -176,7 +176,7 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12407)
+--- src/z80/peep.c	(revision 12419)
 +++ src/z80/peep.c	(working copy)
 @@ -165,6 +165,88 @@
    return(found && found < end);

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -1,6 +1,6 @@
 Index: src/SDCCasm.c
 ===================================================================
---- src/SDCCasm.c	(revision 12288)
+--- src/SDCCasm.c	(revision 12407)
 +++ src/SDCCasm.c	(working copy)
 @@ -403,8 +403,8 @@
  static const ASM_MAPPING _asxxxx_mapping[] = {
@@ -23,7 +23,7 @@ Index: src/SDCCasm.c
     "; ---------------------------------\n"
 Index: src/SDCCglue.c
 ===================================================================
---- src/SDCCglue.c	(revision 12288)
+--- src/SDCCglue.c	(revision 12407)
 +++ src/SDCCglue.c	(working copy)
 @@ -195,7 +195,7 @@
             (sym->_isparm && !IS_REGPARM (sym->etype) && !IS_STATIC (sym->localof->etype))) &&
@@ -84,7 +84,7 @@ Index: src/SDCCglue.c
  
 Index: src/SDCCmain.c
 ===================================================================
---- src/SDCCmain.c	(revision 12288)
+--- src/SDCCmain.c	(revision 12407)
 +++ src/SDCCmain.c	(working copy)
 @@ -514,16 +514,15 @@
  {
@@ -112,7 +112,7 @@ Index: src/SDCCmain.c
  static void
 Index: src/SDCCopt.c
 ===================================================================
---- src/SDCCopt.c	(revision 12288)
+--- src/SDCCopt.c	(revision 12407)
 +++ src/SDCCopt.c	(working copy)
 @@ -1016,7 +1016,7 @@
        /* TODO: Eliminate it, convert any SEND of volatile into DUMMY_READ_VOLATILE. */
@@ -132,7 +132,7 @@ Index: src/SDCCopt.c
        goto convert;
      }
    
-@@ -2139,10 +2139,11 @@
+@@ -2148,10 +2148,11 @@
    int i;
    int change = 0;
    iCode *ic, *newic;
@@ -145,7 +145,7 @@ Index: src/SDCCopt.c
  
    // Wide loop counter
    for (i = 0; i < count; i++)
-@@ -2332,8 +2333,8 @@
+@@ -2341,8 +2342,8 @@
              IS_ITEMP (right) && bitVectnBitsOn (OP_DEFS (right)) != 1)
              continue;
  
@@ -156,7 +156,7 @@ Index: src/SDCCopt.c
  
            if (lic)
              {
-@@ -2340,7 +2341,7 @@
+@@ -2349,7 +2350,7 @@
                if (lic->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (lic)) && !IS_OP_LITERAL (IC_RIGHT (lic)))
                  continue;
  
@@ -165,7 +165,7 @@ Index: src/SDCCopt.c
  
                if (litval > 0x7f)
                  continue;
-@@ -2353,7 +2354,7 @@
+@@ -2362,7 +2363,7 @@
                if (ric->op != BITWISEAND || !IS_OP_LITERAL (IC_LEFT (ric)) && !IS_OP_LITERAL (IC_RIGHT (ric)))
                  continue;
  
@@ -176,9 +176,9 @@ Index: src/SDCCopt.c
                  continue;
 Index: src/z80/peep.c
 ===================================================================
---- src/z80/peep.c	(revision 12288)
+--- src/z80/peep.c	(revision 12407)
 +++ src/z80/peep.c	(working copy)
-@@ -225,6 +225,88 @@
+@@ -165,6 +165,88 @@
    return(found && found < end);
  }
  
@@ -267,7 +267,7 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -382,6 +464,8 @@
+@@ -324,6 +406,8 @@
  static bool
  z80MightRead(const lineNode *pl, const char *what)
  {
@@ -276,7 +276,7 @@ Index: src/z80/peep.c
    if(strcmp(what, "iyl") == 0 || strcmp(what, "iyh") == 0)
      what = "iy";
    if(strcmp(what, "ixl") == 0 || strcmp(what, "ixh") == 0)
-@@ -390,6 +474,16 @@
+@@ -332,6 +416,16 @@
    if(ISINST(pl->line, "call") && strcmp(what, "sp") == 0)
      return TRUE;
  
@@ -293,7 +293,7 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -838,6 +932,7 @@
+@@ -763,6 +857,7 @@
      return(true);
    if(ISINST(pl->line, "call") && strchr(pl->line, ',') == 0)
      {
@@ -301,7 +301,7 @@ Index: src/z80/peep.c
        const symbol *f = findSym (SymbolTab, 0, pl->line + 6);
        const bool *preserved_regs;
  
-@@ -844,6 +939,16 @@
+@@ -769,6 +864,16 @@
        if(!strcmp(what, "ix"))
          return(false);
  


### PR DESCRIPTION
Updating sdcc addressing bugs.

Closes #1792
Closes #1794

Partial changelog from r12288 (previous zsdcc version).
```
2021-06-03 Philipp Klaus Krause <pkk AT spth.de>
	* src/SDCCast.c,
	  src/SDCCerr.c,
	  src/SDCCerr.h,
	  support/valdiag/tests/bug-2798.c:
	  Fix bug #2798.

2021-05-27 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  support/regression/tests/bug-3244.c:
	  Fix bug #3244.

2021-05-20 Philipp Klaus Krause <pkk AT spth.de>
	* support/regression/Makefile.in,
	  support/regression/ports/ucz180-resiy:
	  Test z180 port with --reserve-regs-iy.
	* sdcc/support/regression/ports/ucz80/spec.mk,
	  sdcc/support/regression/ports/ucr3ka/spec.mk:
	  Drop --profile option, so we get better coverage of tail call optimization.

2021-05-19 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Partial fix for bug #3054.

2021-05-18 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  support/regression/tests/bug-3242.c:
	  Fix bug #3242.

2021-05-17 Philipp Klaus Krause <pkk AT spth.de>
	* src/SDCCpeeph.c,
	  src/pdk/peep.c,
	  src/stm8/peep.c,
	  src/z80/gen.c,
	  src/z80/peep.c,
	  support/regression/tests/bug-3239.c:
	  Fix bugs #3235, 3239.

2021-05-17 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix a code generation bug in hl handling.

2021-05-17 Philipp Klaus Krause <pkk AT spth.de>
	* src/stm8/gen.c,
	  src/z80/gen.c:
	  Refactor __z88dk_callee support to allow other calling conventions to use callee stack cleanup.

2021-05-17 Philipp Klaus Krause <pkk AT spth.de>
	* src/SDCCicode.h,
	  src/SDCCicode.c,
	  src/SDCCsalloc.hpp,
	  src/stm8/gen.c,
	  src/z80/gen.c,
	  support/regression/tests/bug-3240.c:
	  Tail call optimization fixes for register parameters.

2021-05-14 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/stm8/gen.c:
	  Fix code generation bugs triggered by register arguments.

2021-05-14 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Improve tail call optimization.

2021-05-14 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix a bug in handling of register parameters to function calls via pointer.

2021-05-13 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/stm8/gen.c:
	  Fix handling of multiple register parameters.

2021-05-13 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/z80/ralloc.c:
	  Increase some regalloc_dry_run_cost penalties to avoid invalid allocation even when all alternatives result in expensive spilling.

2021-05-12 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/peep.c,
	  src/z80/gen.c:
	  Fixes for register parameter in a, l or hl.

2021-05-12 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/peep.c:
	  Fix bug #3234.

2021-05-12 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/z80/gen.h,
	  src/z80/main.c,
	  src/z80/peep.c:
	  Infrastructure for non-__z88dk_fastcall register arguments.

2021-05-09 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  src/stm8/gen.c:
	  Improve stack adjustment.

2021-05-09 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  support/regression/tests/bug-3231.c:
	  Fix bug #3231.

2021-05-08 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c,
	  support/regression/tests/bug-3230.c:
	  Fix bug #3230.

2021-05-07 Philipp Klaus Krause <pkk AT spth.de>
	* src/stm8/gen.c,
	  src/z80/gen.c,
	  support/regression/tests/bug-3229.c:
	  Fix bug #3229.

2021-05-07 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix some bugs triggered by return values in other than the conventional registers.

2021-05-07 Philipp Klaus Krause <pkk AT spth.de>
	* src/z80/gen.c:
	  Fix a bug in handling of return values in bc.

2021-05-07 Philipp Klaus Krause <pkk AT spth.de>
	* src/stm8/gen.h,
	  src/stm8/gen.c,
	  src/stm8/peep.c,
	  src/z80/gen.h,
	  src/z80/gen.c,
	  src/z80/peep.c:
	  Deduplicate return value handling in peephole optimizer vs code generation.

```