### PR TITLE
definition consistency using types.h

### DIFF
--- a/include/_DEVELOPMENT/clang/arch/rc2014/diskio.h
+++ b/include/_DEVELOPMENT/clang/arch/rc2014/diskio.h
@@ -73,8 +73,13 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
 
 //
 // IDE DISK COMMANDS

--- a/include/_DEVELOPMENT/clang/arch/yaz180/diskio.h
+++ b/include/_DEVELOPMENT/clang/arch/yaz180/diskio.h
@@ -73,8 +73,14 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
+
 //
 // IDE DISK COMMANDS
 //

--- a/include/_DEVELOPMENT/clang/fcntl.h
+++ b/include/_DEVELOPMENT/clang/fcntl.h
@@ -7,8 +7,8 @@
 
 typedef unsigned int  mode_t;
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef unsigned long off_t;
 #endif
 

--- a/include/_DEVELOPMENT/clang/math.h
+++ b/include/_DEVELOPMENT/clang/math.h
@@ -7,8 +7,8 @@
 
 // THE SELECTED FLOATING POINT PACKAGE MAY NOT SUPPORT ALL LISTED FUNCTIONS
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    typedef float float_t;
@@ -24,8 +24,8 @@
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    typedef float double_t;
@@ -41,8 +41,8 @@
    
 #endif
 
-#ifndef _FLOAT16_T_DEFINED
-#define _FLOAT16_T_DEFINED
+#ifndef _FLOAT16_T
+#define _FLOAT16_T
 
    #ifndef __SCCZ80
    typedef short _Float16;      /* IEEE-754 half float type */  

--- a/include/_DEVELOPMENT/clang/stddef.h
+++ b/include/_DEVELOPMENT/clang/stddef.h
@@ -11,15 +11,15 @@
 
 typedef int           ptrdiff_t;
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
 typedef unsigned char max_align_t;
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 

--- a/include/_DEVELOPMENT/clang/stdint.h
+++ b/include/_DEVELOPMENT/clang/stdint.h
@@ -55,8 +55,8 @@ typedef unsigned long long     uint_fast64_t;
 
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/clang/stdio.h
+++ b/include/_DEVELOPMENT/clang/stdio.h
@@ -9,12 +9,16 @@
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int    size_t;
 #endif
 
+#ifndef _FPOS_T
+#define _FPOS_T
 typedef unsigned long   fpos_t;
+#endif
+
 typedef struct { unsigned char file[13];} FILE;
 
 #ifndef NULL

--- a/include/_DEVELOPMENT/clang/stdlib.h
+++ b/include/_DEVELOPMENT/clang/stdlib.h
@@ -10,18 +10,18 @@
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    
@@ -43,8 +43,8 @@ typedef unsigned char wchar_t;
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    

--- a/include/_DEVELOPMENT/clang/string.h
+++ b/include/_DEVELOPMENT/clang/string.h
@@ -7,8 +7,8 @@
 
 #include <stddef.h>
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 

--- a/include/_DEVELOPMENT/clang/sys/types.h
+++ b/include/_DEVELOPMENT/clang/sys/types.h
@@ -15,20 +15,48 @@
 
 #ifndef _FLOAT_T
 #define _FLOAT_T
-#ifdef __SDCC
-typedef float float_t;
-#else
-typedef double float_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float float_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float float_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double float_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _DOUBLE_T
 #define _DOUBLE_T
-#ifdef __SDCC
-typedef float double_t;
-#else
-typedef double double_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float double_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float double_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double double_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _SIZE_T

--- a/include/_DEVELOPMENT/clang/unistd.h
+++ b/include/_DEVELOPMENT/clang/unistd.h
@@ -25,23 +25,23 @@
 #define STDOUT_FILENO          1
 #define STDERR_FILENO          2
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int           size_t;
 #endif
 
-#ifndef _SSIZE_T_DEFINED
-#define _SSIZE_T_DEFINED
+#ifndef _SSIZE_T
+#define _SSIZE_T
 typedef unsigned int           ssize_t;
 #endif
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef long                   off_t;
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/proto/arch/rc2014/diskio.h
+++ b/include/_DEVELOPMENT/proto/arch/rc2014/diskio.h
@@ -71,8 +71,13 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
 
 //
 // IDE DISK COMMANDS

--- a/include/_DEVELOPMENT/proto/arch/yaz180/diskio.h
+++ b/include/_DEVELOPMENT/proto/arch/yaz180/diskio.h
@@ -71,8 +71,14 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
+
 //
 // IDE DISK COMMANDS
 //

--- a/include/_DEVELOPMENT/proto/fcntl.h
+++ b/include/_DEVELOPMENT/proto/fcntl.h
@@ -5,8 +5,8 @@ include(__link__.m4)
 
 typedef unsigned int  mode_t;
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef unsigned long off_t;
 #endif
 

--- a/include/_DEVELOPMENT/proto/math.h
+++ b/include/_DEVELOPMENT/proto/math.h
@@ -5,8 +5,8 @@ include(__link__.m4)
 
 // THE SELECTED FLOATING POINT PACKAGE MAY NOT SUPPORT ALL LISTED FUNCTIONS
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    typedef float float_t;
@@ -22,8 +22,8 @@ include(__link__.m4)
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    typedef float double_t;
@@ -39,8 +39,8 @@ include(__link__.m4)
    
 #endif
 
-#ifndef _FLOAT16_T_DEFINED
-#define _FLOAT16_T_DEFINED
+#ifndef _FLOAT16_T
+#define _FLOAT16_T
 
    #ifndef __SCCZ80
    typedef short _Float16;      /* IEEE-754 half float type */  

--- a/include/_DEVELOPMENT/proto/stddef.h
+++ b/include/_DEVELOPMENT/proto/stddef.h
@@ -9,15 +9,15 @@ include(__link__.m4)
 
 typedef int           ptrdiff_t;
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
 typedef unsigned char max_align_t;
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 

--- a/include/_DEVELOPMENT/proto/stdint.h
+++ b/include/_DEVELOPMENT/proto/stdint.h
@@ -53,8 +53,8 @@ typedef unsigned long long     uint_fast64_t;
 
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/proto/stdio.h
+++ b/include/_DEVELOPMENT/proto/stdio.h
@@ -7,12 +7,16 @@ include(__link__.m4)
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int    size_t;
 #endif
 
+#ifndef _FPOS_T
+#define _FPOS_T
 typedef unsigned long   fpos_t;
+#endif
+
 typedef struct { unsigned char file[13];} FILE;
 
 #ifndef NULL

--- a/include/_DEVELOPMENT/proto/stdlib.h
+++ b/include/_DEVELOPMENT/proto/stdlib.h
@@ -8,18 +8,18 @@ include(__link__.m4)
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    
@@ -41,8 +41,8 @@ typedef unsigned char wchar_t;
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    

--- a/include/_DEVELOPMENT/proto/string.h
+++ b/include/_DEVELOPMENT/proto/string.h
@@ -5,8 +5,8 @@ include(__link__.m4)
 
 #include <stddef.h>
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 

--- a/include/_DEVELOPMENT/proto/sys/types.h
+++ b/include/_DEVELOPMENT/proto/sys/types.h
@@ -13,20 +13,48 @@ include(__link__.m4)
 
 #ifndef _FLOAT_T
 #define _FLOAT_T
-#ifdef __SDCC
-typedef float float_t;
-#else
-typedef double float_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float float_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float float_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double float_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _DOUBLE_T
 #define _DOUBLE_T
-#ifdef __SDCC
-typedef float double_t;
-#else
-typedef double double_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float double_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float double_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double double_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _SIZE_T

--- a/include/_DEVELOPMENT/proto/unistd.h
+++ b/include/_DEVELOPMENT/proto/unistd.h
@@ -23,23 +23,23 @@ include(__link__.m4)
 #define STDOUT_FILENO          1
 #define STDERR_FILENO          2
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int           size_t;
 #endif
 
-#ifndef _SSIZE_T_DEFINED
-#define _SSIZE_T_DEFINED
+#ifndef _SSIZE_T
+#define _SSIZE_T
 typedef unsigned int           ssize_t;
 #endif
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef long                   off_t;
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/sccz80/arch/rc2014/diskio.h
+++ b/include/_DEVELOPMENT/sccz80/arch/rc2014/diskio.h
@@ -73,8 +73,13 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
 
 //
 // IDE DISK COMMANDS

--- a/include/_DEVELOPMENT/sccz80/arch/yaz180/diskio.h
+++ b/include/_DEVELOPMENT/sccz80/arch/yaz180/diskio.h
@@ -73,8 +73,14 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
+
 //
 // IDE DISK COMMANDS
 //

--- a/include/_DEVELOPMENT/sccz80/fcntl.h
+++ b/include/_DEVELOPMENT/sccz80/fcntl.h
@@ -7,8 +7,8 @@
 
 typedef unsigned int  mode_t;
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef unsigned long off_t;
 #endif
 

--- a/include/_DEVELOPMENT/sccz80/math.h
+++ b/include/_DEVELOPMENT/sccz80/math.h
@@ -7,8 +7,8 @@
 
 // THE SELECTED FLOATING POINT PACKAGE MAY NOT SUPPORT ALL LISTED FUNCTIONS
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    typedef float float_t;
@@ -24,8 +24,8 @@
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    typedef float double_t;
@@ -41,8 +41,8 @@
    
 #endif
 
-#ifndef _FLOAT16_T_DEFINED
-#define _FLOAT16_T_DEFINED
+#ifndef _FLOAT16_T
+#define _FLOAT16_T
 
    #ifndef __SCCZ80
    typedef short _Float16;      /* IEEE-754 half float type */  

--- a/include/_DEVELOPMENT/sccz80/stddef.h
+++ b/include/_DEVELOPMENT/sccz80/stddef.h
@@ -11,15 +11,15 @@
 
 typedef int           ptrdiff_t;
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
 typedef unsigned char max_align_t;
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 

--- a/include/_DEVELOPMENT/sccz80/stdint.h
+++ b/include/_DEVELOPMENT/sccz80/stdint.h
@@ -55,8 +55,8 @@ typedef unsigned long long     uint_fast64_t;
 
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/sccz80/stdio.h
+++ b/include/_DEVELOPMENT/sccz80/stdio.h
@@ -9,12 +9,16 @@
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int    size_t;
 #endif
 
+#ifndef _FPOS_T
+#define _FPOS_T
 typedef unsigned long   fpos_t;
+#endif
+
 typedef struct { unsigned char file[13];} FILE;
 
 #ifndef NULL

--- a/include/_DEVELOPMENT/sccz80/stdlib.h
+++ b/include/_DEVELOPMENT/sccz80/stdlib.h
@@ -10,18 +10,18 @@
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    
@@ -43,8 +43,8 @@ typedef unsigned char wchar_t;
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    

--- a/include/_DEVELOPMENT/sccz80/string.h
+++ b/include/_DEVELOPMENT/sccz80/string.h
@@ -7,8 +7,8 @@
 
 #include <stddef.h>
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 

--- a/include/_DEVELOPMENT/sccz80/sys/types.h
+++ b/include/_DEVELOPMENT/sccz80/sys/types.h
@@ -15,20 +15,48 @@
 
 #ifndef _FLOAT_T
 #define _FLOAT_T
-#ifdef __SDCC
-typedef float float_t;
-#else
-typedef double float_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float float_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float float_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double float_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _DOUBLE_T
 #define _DOUBLE_T
-#ifdef __SDCC
-typedef float double_t;
-#else
-typedef double double_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float double_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float double_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double double_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _SIZE_T

--- a/include/_DEVELOPMENT/sccz80/unistd.h
+++ b/include/_DEVELOPMENT/sccz80/unistd.h
@@ -25,23 +25,23 @@
 #define STDOUT_FILENO          1
 #define STDERR_FILENO          2
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int           size_t;
 #endif
 
-#ifndef _SSIZE_T_DEFINED
-#define _SSIZE_T_DEFINED
+#ifndef _SSIZE_T
+#define _SSIZE_T
 typedef unsigned int           ssize_t;
 #endif
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef long                   off_t;
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/sdcc/arch/rc2014/diskio.h
+++ b/include/_DEVELOPMENT/sdcc/arch/rc2014/diskio.h
@@ -73,8 +73,13 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
 
 //
 // IDE DISK COMMANDS

--- a/include/_DEVELOPMENT/sdcc/arch/yaz180/diskio.h
+++ b/include/_DEVELOPMENT/sdcc/arch/yaz180/diskio.h
@@ -73,8 +73,14 @@ typedef enum {
     RES_PARERR = 4  /* 4: Invalid Parameter */
 } DRESULT;
 
+#ifndef FF_DEFINED
+#ifndef _LBA_T
+#define _LBA_T
 /* FatFS for non exFAT file systems */
 typedef DWORD LBA_t;
+#endif
+#endif
+
 //
 // IDE DISK COMMANDS
 //

--- a/include/_DEVELOPMENT/sdcc/fcntl.h
+++ b/include/_DEVELOPMENT/sdcc/fcntl.h
@@ -7,8 +7,8 @@
 
 typedef unsigned int  mode_t;
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef unsigned long off_t;
 #endif
 

--- a/include/_DEVELOPMENT/sdcc/math.h
+++ b/include/_DEVELOPMENT/sdcc/math.h
@@ -7,8 +7,8 @@
 
 // THE SELECTED FLOATING POINT PACKAGE MAY NOT SUPPORT ALL LISTED FUNCTIONS
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    typedef float float_t;
@@ -24,8 +24,8 @@
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    typedef float double_t;
@@ -41,8 +41,8 @@
    
 #endif
 
-#ifndef _FLOAT16_T_DEFINED
-#define _FLOAT16_T_DEFINED
+#ifndef _FLOAT16_T
+#define _FLOAT16_T
 
    #ifndef __SCCZ80
    typedef short _Float16;      /* IEEE-754 half float type */  

--- a/include/_DEVELOPMENT/sdcc/stddef.h
+++ b/include/_DEVELOPMENT/sdcc/stddef.h
@@ -11,15 +11,15 @@
 
 typedef int           ptrdiff_t;
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
 typedef unsigned char max_align_t;
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 

--- a/include/_DEVELOPMENT/sdcc/stdint.h
+++ b/include/_DEVELOPMENT/sdcc/stdint.h
@@ -55,8 +55,8 @@ typedef unsigned long long     uint_fast64_t;
 
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 

--- a/include/_DEVELOPMENT/sdcc/stdio.h
+++ b/include/_DEVELOPMENT/sdcc/stdio.h
@@ -9,12 +9,16 @@
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int    size_t;
 #endif
 
+#ifndef _FPOS_T
+#define _FPOS_T
 typedef unsigned long   fpos_t;
+#endif
+
 typedef struct { unsigned char file[13];} FILE;
 
 #ifndef NULL

--- a/include/_DEVELOPMENT/sdcc/stdlib.h
+++ b/include/_DEVELOPMENT/sdcc/stdlib.h
@@ -10,18 +10,18 @@
 
 // DATA STRUCTURES
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 
-#ifndef _WCHAR_T_DEFINED
-#define _WCHAR_T_DEFINED
+#ifndef _WCHAR_T
+#define _WCHAR_T
 typedef unsigned char wchar_t;
 #endif
 
-#ifndef _FLOAT_T_DEFINED
-#define _FLOAT_T_DEFINED
+#ifndef _FLOAT_T
+#define _FLOAT_T
 
    #ifdef __CLANG
    
@@ -43,8 +43,8 @@ typedef unsigned char wchar_t;
    
 #endif
 
-#ifndef _DOUBLE_T_DEFINED
-#define _DOUBLE_T_DEFINED
+#ifndef _DOUBLE_T
+#define _DOUBLE_T
 
    #ifdef __CLANG
    

--- a/include/_DEVELOPMENT/sdcc/string.h
+++ b/include/_DEVELOPMENT/sdcc/string.h
@@ -7,8 +7,8 @@
 
 #include <stddef.h>
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int  size_t;
 #endif
 

--- a/include/_DEVELOPMENT/sdcc/sys/types.h
+++ b/include/_DEVELOPMENT/sdcc/sys/types.h
@@ -15,20 +15,48 @@
 
 #ifndef _FLOAT_T
 #define _FLOAT_T
-#ifdef __SDCC
-typedef float float_t;
-#else
-typedef double float_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float float_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float float_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double float_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _DOUBLE_T
 #define _DOUBLE_T
-#ifdef __SDCC
-typedef float double_t;
-#else
-typedef double double_t;
-#endif
+
+   #ifdef __CLANG
+   
+   typedef float double_t;
+   
+   #endif
+
+   #ifdef __SDCC
+   
+   typedef float double_t;
+   
+   #endif
+   
+   #ifdef __SCCZ80
+   
+   typedef double double_t;
+   
+   #endif
+   
 #endif
 
 #ifndef _SIZE_T

--- a/include/_DEVELOPMENT/sdcc/unistd.h
+++ b/include/_DEVELOPMENT/sdcc/unistd.h
@@ -25,23 +25,23 @@
 #define STDOUT_FILENO          1
 #define STDERR_FILENO          2
 
-#ifndef _SIZE_T_DEFINED
-#define _SIZE_T_DEFINED
+#ifndef _SIZE_T
+#define _SIZE_T
 typedef unsigned int           size_t;
 #endif
 
-#ifndef _SSIZE_T_DEFINED
-#define _SSIZE_T_DEFINED
+#ifndef _SSIZE_T
+#define _SSIZE_T
 typedef unsigned int           ssize_t;
 #endif
 
-#ifndef _OFF_T_DEFINED
-#define _OFF_T_DEFINED
+#ifndef _OFF_T
+#define _OFF_T
 typedef long                   off_t;
 #endif
 
-#ifndef _INTPTR_T_DEFINED
-#define _INTPTR_T_DEFINED
+#ifndef _INTPTR_T
+#define _INTPTR_T
 typedef int                    intptr_t;
 #endif
 


### PR DESCRIPTION
Resolve inconsistencies of `_xxx_T_DEFINED` and `_xxx_T` appearing in different files, leading to double definitions of some types.

The intent is to remove all references to the `_xxx_T_DEFINED` cases in the repository.

Another way of resolving [this 2003 issue](https://github.com/z88dk/z88dk/commit/103d6d3c96ae94a92058c5476fcaa588e764fbb0).