### PR TITLE
zsdcc - newlib - fix peephole 12

### DIFF
--- a/libsrc/_DEVELOPMENT/sdcc_peeph.2
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.2
@@ -969,7 +969,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1)
-	ld	(hl),a
 	ld	hl,#%1
 	; peephole z88dk-bugfix-12a
 }
@@ -981,7 +980,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1+%2)
-	ld	(hl),a
 	ld	hl,#%1 + %2
 	; peephole z88dk-bugfix-12b
 }

--- a/libsrc/_DEVELOPMENT/sdcc_peeph.2
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.2
@@ -962,27 +962,7 @@ replace restart {
 	; peephole z88dk-bugfix-11b
 }
 
-replace restart
-{
-	ld	hl,#%1
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1)
-	ld	hl,#%1
-	; peephole z88dk-bugfix-12a
-}
-
-replace restart
-{
-	ld	hl,#%1 + %2
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1+%2)
-	ld	hl,#%1 + %2
-	; peephole z88dk-bugfix-12b
-}
+// z88dk-bugfix-12a and z88dk-bugfix-12b removed in #1811
 
 replace restart
 {

--- a/libsrc/_DEVELOPMENT/sdcc_peeph.3
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.3
@@ -969,7 +969,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1)
-	ld	(hl),a
 	ld	hl,#%1
 	; peephole z88dk-bugfix-12a
 }
@@ -981,7 +980,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1+%2)
-	ld	(hl),a
 	ld	hl,#%1 + %2
 	; peephole z88dk-bugfix-12b
 }

--- a/libsrc/_DEVELOPMENT/sdcc_peeph.3
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph.3
@@ -962,27 +962,7 @@ replace restart {
 	; peephole z88dk-bugfix-11b
 }
 
-replace restart
-{
-	ld	hl,#%1
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1)
-	ld	hl,#%1
-	; peephole z88dk-bugfix-12a
-}
-
-replace restart
-{
-	ld	hl,#%1 + %2
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1+%2)
-	ld	hl,#%1 + %2
-	; peephole z88dk-bugfix-12b
-}
+// z88dk-bugfix-12a and z88dk-bugfix-12b removed in #1811
 
 replace restart
 {

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.2
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.2
@@ -4178,7 +4178,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1)
-	ld	(hl),a
 	ld	hl,#%1
 	; peephole z88dk-bugfix-12a
 }
@@ -4190,7 +4189,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1+%2)
-	ld	(hl),a
 	ld	hl,#%1 + %2
 	; peephole z88dk-bugfix-12b
 }

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.2
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.2
@@ -4171,27 +4171,7 @@ replace restart {
 	; peephole z88dk-bugfix-11b
 }
 
-replace restart
-{
-	ld	hl,#%1
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1)
-	ld	hl,#%1
-	; peephole z88dk-bugfix-12a
-}
-
-replace restart
-{
-	ld	hl,#%1 + %2
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1+%2)
-	ld	hl,#%1 + %2
-	; peephole z88dk-bugfix-12b
-}
+// z88dk-bugfix-12a and z88dk-bugfix-12b removed in #1811
 
 replace restart
 {

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.3
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.3
@@ -4608,27 +4608,7 @@ replace restart {
 	; peephole z88dk-bugfix-11b
 }
 
-replace restart
-{
-	ld	hl,#%1
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1)
-	ld	hl,#%1
-	; peephole z88dk-bugfix-12a
-}
-
-replace restart
-{
-	ld	hl,#%1 + %2
-	ld	a,(hl)
-	ld	(hl),a
-} by {
-	ld	a,(#%1+%2)
-	ld	hl,#%1 + %2
-	; peephole z88dk-bugfix-12b
-}
+// z88dk-bugfix-12a and z88dk-bugfix-12b removed in #1811
 
 replace restart
 {

--- a/libsrc/_DEVELOPMENT/sdcc_peeph_cs.3
+++ b/libsrc/_DEVELOPMENT/sdcc_peeph_cs.3
@@ -4615,7 +4615,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1)
-	ld	(hl),a
 	ld	hl,#%1
 	; peephole z88dk-bugfix-12a
 }
@@ -4627,7 +4626,6 @@ replace restart
 	ld	(hl),a
 } by {
 	ld	a,(#%1+%2)
-	ld	(hl),a
 	ld	hl,#%1 + %2
 	; peephole z88dk-bugfix-12b
 }


### PR DESCRIPTION
sdcc peephole 12a and 12b were setting the location pointed to by `hl`, without first setting `hl`.
This lead to writing into a wild location.

I think deleting the offending `ld (hl),a` instruction is the right way to fix this.

__Background__

Recently SDCC has been improved to be able to use `hl` to restore the stack `sp` when returning from functions with a large number of parameters, and/or large parameters.

These means that it has become quite possible or even common for `hl` to contain the same value as `sp` following a function return, and also potentially for that value to be pointing at the function return address on the stack.

```asm
860   007C  CD 00 00    	call	_fprintf
861   007F              ;	adjustStack by 8
862   007F  21 08 00    	ld	hl,8
863   0082  39          	add	hl, sp
864   0083  F9          	ld	sp, hl    ; <<< hl and sp are the same here
865   0084              ;	genPlus
866   0084              ;setupPair	HL
867   0084              ;fetchLitPair	hl
868   0084              ;setupPair	HL
869   0084              ;fetchLitPair	hl
870   0084  3A 04 00    	ld	a,(_ya_md_origin_65536_419)
871   0087  77          	ld	(hl),a    ; <<< this has overwritten the function return address
872   0088              ; peephole z88dk-bugfix-12a
```
Closes #1809