### PR TITLE
build on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ CC ?= gcc
 # Prefix for executables (eg z88dk-, hence z88dk-z80asm, z88dk-copt etc)
 CROSS ?= 0
 
+OCC := $(CC)
 ifneq (, $(shell which ccache))
-   OCC := $(CC)
    CC := ccache $(CC)
 endif
 

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ do_tests=0
 
 DESTDIR=/usr/local
 
-builddir=`pwd $0`
+builddir=`pwd`
 ZCCCFG=$builddir/lib/config
 PATH=$builddir/bin:$PATH
 export ZCCCFG

--- a/src/ticks/hook_io.c
+++ b/src/ticks/hook_io.c
@@ -6,10 +6,10 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #ifdef WIN32
 #include        <io.h>
-#include        <sys/stat.h>
 #else
 #include        <unistd.h>
 #endif


### PR DESCRIPTION
I tried to build z88dk on OpenBSD, we have to fix these files.

Makefile: OCC variable should be set, regardless using ccache.
build.sh: pwd cannot take arguments. (what this argument means?)
src/ticks/hook_io.c: OpenBSD needs to include <sys/stat.h> explicitly.

After modified these files, use build.sh with some parameters like this:

`CC=egcc CXX=eg++ CPPFLAGS=-I/usr/local/include ./build.sh`
or
`CC=cc CXX=c++ CPPFLAGS=-I/usr/local/include ./build.sh` (cc as clang)
