### PR TITLE
refactor ticks: add a framework in place for multiple backends

### DIFF
--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -8,10 +8,8 @@ endif
 
 include ../Make.common
 
-OBJS = ticks.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
-
-
-DISOBJS = disassembler_main.o  syms.o disassembler_alg.o debug.o
+OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
+DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o backend.o
 
 DEPENDS         := $(OBJS:.o=.d) $(DISOBJS:.o=.d)
 

--- a/src/ticks/backend.c
+++ b/src/ticks/backend.c
@@ -1,0 +1,8 @@
+#include "backend.h"
+
+backend_t bk = {};
+
+void set_backend(backend_t backend)
+{
+    bk = backend;
+}

--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -1,0 +1,59 @@
+#ifndef BACKEND_H
+#define BACKEND_H
+
+#include <inttypes.h>
+
+struct debugger_regs_t;
+
+typedef uint8_t (*get_get_memory_cb)(uint16_t at);
+typedef uint16_t (*get_uint16_cb)();
+typedef long long (*get_longlong_cb)();
+typedef int (*get_int_cb)();
+typedef void (*reset_paging_cb)();
+typedef void (*out_cb)(int port, int value);
+typedef void (*debugger_write_memory_cb)(int addr, uint8_t val);
+typedef void (*debugger_read_memory_cb)(int addr);
+typedef void (*get_regs_cb)(struct debugger_regs_t* regs);
+typedef void (*void_cb)();
+typedef uint8_t (*breakpoints_check_cb)();
+typedef void (*breakpoint_cb)(uint8_t type, uint16_t at, uint8_t sz);
+
+enum bk_breakpoint_type
+{
+    BK_BREAKPOINT_SOFTWARE = 0,
+    BK_BREAKPOINT_HARDWARE = 1,
+    BK_BREAKPOINT_WATCHPOINT = 2,
+    BK_BREAKPOINT_REGISTER = 2,
+};
+
+typedef struct {
+    get_longlong_cb st;
+    get_uint16_cb ff;
+    get_uint16_cb pc;
+    get_uint16_cb sp;
+    get_get_memory_cb get_memory;
+    get_regs_cb get_regs;
+    get_regs_cb set_regs;
+    get_int_cb f;
+    get_int_cb f_;
+    reset_paging_cb memory_reset_paging;
+    out_cb out;
+    debugger_write_memory_cb debugger_write_memory;
+    debugger_read_memory_cb debugger_read_memory;
+    void_cb invalidate;
+    void_cb break_;
+    void_cb resume;
+    void_cb next;
+    void_cb step;
+    breakpoint_cb add_breakpoint;
+    breakpoint_cb remove_breakpoint;
+    breakpoint_cb disable_breakpoint;
+    breakpoint_cb enable_breakpoint;
+    breakpoints_check_cb breakpoints_check;
+} backend_t;
+
+extern backend_t bk;
+
+extern void set_backend(backend_t backend);
+
+#endif

--- a/src/ticks/cpu.c
+++ b/src/ticks/cpu.c
@@ -1,0 +1,3 @@
+#include "cpu.h"
+
+int    c_cpu = CPU_Z80;

--- a/src/ticks/cpu.h
+++ b/src/ticks/cpu.h
@@ -1,0 +1,33 @@
+#ifndef CPU_H
+#define CPU_H
+
+extern int c_cpu;
+
+#define CPU_Z80      1
+#define CPU_Z180     2
+#define CPU_R2KA     4
+#define CPU_R3K      8
+#define CPU_Z80N     16
+#define CPU_R800     32
+#define CPU_GBZ80    64
+#define CPU_8080     128
+#define CPU_8085     256
+#define CPU_EZ80     512
+
+#define is8080() ( (c_cpu & CPU_8080) )
+#define is8085() ( (c_cpu & CPU_8085) )
+#define is808x() ( (c_cpu & (CPU_8080|CPU_8085)) )
+#define isgbz80() ( (c_cpu & CPU_GBZ80) == CPU_GBZ80 )
+#define isr800() ( (c_cpu & CPU_R800) == CPU_R800 )
+#define israbbit() ( c_cpu & (CPU_R2KA|CPU_R3K))
+#define israbbit3k() ( c_cpu & (CPU_R3K))
+#define isz180() ( c_cpu & (CPU_Z180))
+#define isez80() ( c_cpu & (CPU_EZ80))
+#define canaltreg() ( ( c_cpu & (CPU_8080|CPU_8085|CPU_GBZ80)) == 0 )
+#define canindex() ( ( c_cpu & (CPU_8080|CPU_8085|CPU_GBZ80)) == 0 )
+#define canixh() ( c_cpu & (CPU_Z80|CPU_Z80N|CPU_R800|CPU_EZ80))
+#define cansll() ( c_cpu & (CPU_Z80|CPU_Z80N))
+#define canz180() ( c_cpu & (CPU_Z180|CPU_EZ80))
+#define cancbundoc() ( c_cpu & (CPU_Z80|CPU_Z80N))
+
+#endif

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -2,7 +2,9 @@
 // In this case it's adb information as per sdcc
 
 
-#include "ticks.h"
+#include "debug.h"
+#include "uthash.h"
+#include "utlist.h"
 #include <ctype.h>
 #include <stdio.h>
 

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -1,0 +1,10 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+
+// debug
+extern void debug_add_info_encoded(char *encoded);
+extern int debug_find_source_location(int address, const char **filename, int *lineno);
+extern void debug_add_cline(const char *filename, int lineno, int level, int scope, const char *address);
+extern int debug_resolve_source(char *name);
+
+#endif

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -1,0 +1,43 @@
+#ifndef DEBUGGER_H
+#define DEBUGGER_H
+
+#include <stdint.h>
+
+typedef enum {
+    BREAK_PC,
+    BREAK_REGISTER,
+    BREAK_CHECK8,
+    BREAK_CHECK16,
+    BREAK_READ,
+    BREAK_WRITE,
+} breakpoint_type;
+
+typedef struct breakpoint {
+    breakpoint_type    type;
+    int                value;
+    unsigned char      lvalue;
+    uint16_t           lcheck_arg;
+    unsigned char      hvalue;
+    uint16_t           hcheck_arg;
+    char               enabled;
+    char               *text;
+    struct breakpoint  *next;
+} breakpoint;
+
+struct debugger_regs_t {
+    uint16_t pc, sp;
+    unsigned char a,b,c,d,e,h,l;
+    unsigned char a_,b_,c_,d_,e_,h_,l_;
+    unsigned char f, f_;
+    unsigned char xh, xl, yh, yl;
+};
+
+extern int debugger_active;
+extern void      debugger_init();
+extern void      debugger();
+
+extern void unwrap_reg(uint16_t data, uint8_t* h, uint8_t* l);
+extern uint16_t wrap_reg(uint8_t h, uint8_t l);
+
+
+#endif

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -1,0 +1,199 @@
+#include <stdio.h>
+
+#include "debugger.h"
+#include "ticks.h"
+#include "backend.h"
+#include "disassembler.h"
+
+long long get_st()
+{
+    return st;
+}
+
+uint16_t get_ff()
+{
+    return ff;
+}
+
+uint16_t get_pc()
+{
+    return pc;
+}
+
+uint16_t get_sp()
+{
+    return sp;
+}
+
+uint8_t get_ticks_memory(uint16_t at)
+{
+    return get_memory(at);
+}
+
+void get_regs(struct debugger_regs_t* regs)
+{
+    regs->sp = sp;
+    regs->pc = pc;
+
+    regs->a = a;
+    regs->b = b;
+    regs->c = c;
+    regs->d = d;
+    regs->e = e;
+    regs->h = h;
+    regs->l = l;
+
+    regs->a_ = a_;
+    regs->b_ = b_;
+    regs->c_ = c_;
+    regs->d_ = d_;
+    regs->e_ = e_;
+    regs->h_ = h_;
+    regs->l_ = l_;
+
+    regs->xh = xh;
+    regs->xl = xl;
+    regs->yh = yh;
+    regs->yl = yl;
+}
+
+void set_regs(struct debugger_regs_t* regs)
+{
+    sp = regs->sp;
+    pc = regs->pc;
+
+    a = regs->a;
+    b = regs->b;
+    c = regs->c;
+    d = regs->d;
+    e = regs->e;
+    h = regs->h;
+    l = regs->l;
+
+    a_ = regs->a_;
+    b_ = regs->b_;
+    c_ = regs->c_;
+    d_ = regs->d_;
+    e_ = regs->e_;
+    h_ = regs->h_;
+    l_ = regs->l_;
+
+    xh = regs->xh;
+    xl = regs->xl;
+    yh = regs->yh;
+    yl = regs->yl;
+}
+
+extern breakpoint *breakpoints;
+extern breakpoint *watchpoints;
+
+void debugger_write_memory(int addr, uint8_t val)
+{
+    breakpoint *elem;
+    int         i;
+    LL_FOREACH(watchpoints, elem) {
+        if ( elem->enabled == 0 ) {
+            continue;
+        }
+        if ( elem->type == BREAK_WRITE && elem->value == addr ) {
+            printf("Hit watchpoint %d\n",i);
+            debugger_active = 1;
+            break;
+        }
+        i++;
+    }
+}
+
+void debugger_read_memory(int addr)
+{
+    breakpoint *elem;
+    int         i;
+
+    LL_FOREACH(watchpoints, elem) {
+        if ( elem->enabled == 0 ) {
+            continue;
+        }
+        if ( elem->type == BREAK_READ && elem->value == addr ) {
+            printf("Hit watchpoint %d\n",i);
+            debugger_active = 1;
+            break;
+        }
+        i++;
+    }
+}
+
+void invalidate() {}
+void break_() {}
+void resume() {}
+void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
+void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
+void disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
+void enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
+
+void next()
+{
+    extern int next_address;
+    char  buf[100];
+    int   len;
+    const unsigned short pc = bk.pc();
+
+    uint8_t opcode = bk.get_memory(pc);
+
+    len = disassemble2(pc, buf, sizeof(buf), 0);
+
+    // Set a breakpoint after the call
+    switch ( opcode ) {
+        case 0xed: // ED prefix
+        case 0xcb: // CB prefix
+        case 0xc4:
+        case 0xcc:
+        case 0xcd:
+        case 0xd4:
+        case 0xdc:
+        case 0xe4:
+        case 0xec:
+        case 0xf4:
+            // It's a call
+            debugger_active = 0;
+            next_address = pc + len;
+        return;
+    }
+
+    debugger_active = 1;
+}
+
+void step()
+{
+    debugger_active = 1;
+}
+
+uint8_t breakpoints_check()
+{
+    return debugger_active == 0;
+}
+
+backend_t ticks_debugger_backend = {
+    .st = &get_st,
+    .ff = &get_ff,
+    .pc = &get_pc,
+    .sp = &get_sp,
+    .get_memory = &get_ticks_memory,
+    .get_regs = &get_regs,
+    .set_regs = &set_regs,
+    .f = &f,
+    .f_ = &f_,
+    .memory_reset_paging = &memory_reset_paging,
+    .out = &out,
+    .debugger_write_memory = &debugger_write_memory,
+    .debugger_read_memory = &debugger_read_memory,
+    .invalidate = &invalidate,
+    .break_ = &break_,
+    .resume = &resume,
+    .next = &next,
+    .step = &step,
+    .add_breakpoint = &add_breakpoint,
+    .remove_breakpoint = &remove_breakpoint,
+    .disable_breakpoint = &disable_breakpoint,
+    .enable_breakpoint = &enable_breakpoint,
+    .breakpoints_check = &breakpoints_check
+};

--- a/src/ticks/disassembler.h
+++ b/src/ticks/disassembler.h
@@ -1,0 +1,8 @@
+#ifndef DISASSEMBLER_H
+#define DISASSEMBLER_H
+
+#include <stddef.h>
+
+extern int disassemble2(int pc, char *buf, size_t buflen, int compact);
+
+#endif

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -1,8 +1,10 @@
 
 #include <stdio.h>
-#include "ticks.h"
-
-
+#include <inttypes.h>
+#include "cpu.h"
+#include "syms.h"
+#include "backend.h"
+#include "debugger.h"
 
 
 static char *rp2_table[] = { "bc", "de", "hl", "af"};
@@ -24,7 +26,7 @@ typedef struct {
 
 
 #define READ_BYTE(state,val) do { \
-    val = get_memory(state->pc++); \
+    val = bk.get_memory(state->pc++); \
     state->instr_bytes[state->len++] = val; \
 } while (0)
 

--- a/src/ticks/disassembler_main.c
+++ b/src/ticks/disassembler_main.c
@@ -3,9 +3,11 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <stdint.h>
+#include "disassembler.h"
+#include "syms.h"
+#include "cpu.h"
+#include "backend.h"
 #include "ticks.h"
-
-
 
 static void disassemble_loop(int start, int end);
 
@@ -36,6 +38,10 @@ static void usage(char *program)
     exit(1);
 }
 
+static backend_t disassembler_backend = {
+    .get_memory = get_memory
+};
+
 int main(int argc, char **argv)
 {
     char  *program = argv[0];
@@ -51,6 +57,8 @@ int main(int argc, char **argv)
     if ( argc == 1 ) {
         usage(program);
     }
+
+    set_backend(disassembler_backend);
 
     while ( argc > 1  ) {
         if( argv[1][0] == '-' && argv[2] ) {
@@ -141,7 +149,7 @@ static void disassemble_loop(int start, int end)
 }
 
 
-uint8_t get_memory(int pc)
+uint8_t get_memory(uint16_t pc)
 {
     return mem[pc % 65536] ^ inverted;
 }

--- a/src/ticks/memory.c
+++ b/src/ticks/memory.c
@@ -3,6 +3,8 @@
  */
 
 #include "ticks.h"
+#include "backend.h"
+#include "debugger.h"
 #include <stdio.h>
 
 
@@ -50,15 +52,15 @@ void memory_init(char *model) {
     }
 }
 
-uint8_t get_memory(int pc)
+uint8_t get_memory(uint16_t pc)
 {
-  debugger_read_memory(pc);
+  bk.debugger_read_memory(pc);
   return  *get_memory_addr(pc);
 }
 
-uint8_t put_memory(int pc, uint8_t b)
+uint8_t put_memory(uint16_t pc, uint8_t b)
 {
-  debugger_write_memory(pc, b);
+  bk.debugger_write_memory(pc, b);
   if (pc < rom_size)
     return *get_memory_addr(pc);
   else

--- a/src/ticks/srcfile.h
+++ b/src/ticks/srcfile.h
@@ -1,0 +1,6 @@
+#ifndef SRCFILE_H
+#define SRCFILE_H
+
+extern void srcfile_display(const char *filename, int start_line, int count, int highlight);
+
+#endif

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "ticks.h"
+#include "debug.h"
 
 static symbol  *symbols[65536] = {0};
 static symbol  *symbols_byname = NULL;
@@ -131,16 +132,14 @@ int symbol_resolve(char *name)
 
 
 // Find a symbol lower than where we were
-int symbol_find_lower(int addr, symboltype preferred_type, char *buf, size_t buflen)
+symbol* symbol_find_lower(int addr, symboltype preferred_type, uint16_t* offset)
 {
     symbol *sym;
     int     original_address = addr;
 
-    buf[0] = 0;
-
     while ( 1 ) {
         if ( addr < 0 ) {
-            return -1;
+            return NULL;
         }
     
         while ( (sym = symbols[addr % 65536]) == NULL && addr > 0 ) {
@@ -159,11 +158,13 @@ int symbol_find_lower(int addr, symboltype preferred_type, char *buf, size_t buf
         }
 
         if ( sym != NULL ) {
-            snprintf(buf,buflen,"%s+%d", sym->name, original_address-addr);
-            return 0;
+            *offset = original_address - addr;
+            return sym;
         } 
         addr--;
     }
+
+    return NULL;
 }
 
 const char *find_symbol(int addr, symboltype preferred_type)

--- a/src/ticks/syms.h
+++ b/src/ticks/syms.h
@@ -1,0 +1,34 @@
+
+#ifndef SYMS_H
+#define SYMS_H
+
+#include "uthash.h"
+
+typedef enum {
+    SYM_ANY = 0,
+    SYM_CONST = 1,
+    SYM_ADDRESS = 2,
+    } symboltype;
+
+typedef struct symbol_s symbol;
+
+struct symbol_s {
+    const char    *name;
+    const char    *file;
+    const char    *module;
+    int            address;
+    symboltype     symtype;
+    char           islocal;
+    const char    *section;
+    symbol        *next;
+    UT_hash_handle hh;
+};
+
+extern symbol* symbol_find_lower(int addr, symboltype preferred_type, uint16_t* offset);
+extern void      read_symbol_file(char *filename);
+extern const char     *find_symbol(int addr, symboltype preferred_symtype);
+extern symbol   *find_symbol_byname(const char *name);
+extern int symbol_resolve(char *name);
+extern char **parse_words(char *line, int *argc);
+
+#endif

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -4,6 +4,9 @@
 #include <string.h>
 
 #include "ticks.h"
+#include "cpu.h"
+#include "debugger.h"
+#include "backend.h"
 
 #if defined(_WIN32) || defined(WIN32)
 #ifndef strcasecmp
@@ -574,7 +577,6 @@ char   cmd_arguments[255];
 int    cmd_arguments_len = 0;
 
 int    ioport = -1;
-int    c_cpu = CPU_Z80;
 int    rom_size = 0;
 int    rc2014_mode = 0;
 
@@ -662,7 +664,7 @@ void setf(int a){
   fa= 255 & (fb= a & -129 | (a&4)<<5);
 }
 
-
+extern backend_t ticks_debugger_backend;
 
 int main (int argc, char **argv){
   int size= 0, start= 0, end= 0, intr= 0, tap= 0, alarmtime = 0, load_address = 0;
@@ -671,6 +673,7 @@ int main (int argc, char **argv){
   FILE * fh;
 
   hook_init();
+  set_backend(ticks_debugger_backend);
   debugger_init();
   apu_reset();
 

--- a/src/ticks/ticks.h
+++ b/src/ticks/ticks.h
@@ -5,33 +5,13 @@
 
 
 #include "cmds.h"
+#include "syms.h"
+#include "cpu.h"
 #include <sys/types.h>
 #include <inttypes.h>
 
 #include "uthash.h"
 #include "utlist.h"
-
-typedef enum {
-    SYM_ANY = 0,
-    SYM_CONST = 1,
-    SYM_ADDRESS = 2,
-} symboltype;
-
-typedef struct symbol_s symbol;
-
-struct symbol_s {
-    const char    *name;
-    const char    *file;
-    const char    *module;
-    int            address;
-    symboltype     symtype;
-    char           islocal;
-    const char    *section;
-    symbol        *next;
-    UT_hash_handle hh;
-};
-
-
 
 extern unsigned char a,b,c,d,e,h,l;
 extern unsigned char a_,b_,c_,d_,e_,h_,l_;
@@ -40,25 +20,7 @@ extern unsigned short ff, pc, sp;
 extern long long st;
 
 
-#define is8080() ( (c_cpu & CPU_8080) )
-#define is8085() ( (c_cpu & CPU_8085) )
-#define is808x() ( (c_cpu & (CPU_8080|CPU_8085)) )
-#define isgbz80() ( (c_cpu & CPU_GBZ80) == CPU_GBZ80 )
-#define isr800() ( (c_cpu & CPU_R800) == CPU_R800 )
-#define israbbit() ( c_cpu & (CPU_R2KA|CPU_R3K))
-#define israbbit3k() ( c_cpu & (CPU_R3K))
-#define isz180() ( c_cpu & (CPU_Z180))
-#define isez80() ( c_cpu & (CPU_EZ80))
-#define canaltreg() ( ( c_cpu & (CPU_8080|CPU_8085|CPU_GBZ80)) == 0 )
-#define canindex() ( ( c_cpu & (CPU_8080|CPU_8085|CPU_GBZ80)) == 0 )
-#define canixh() ( c_cpu & (CPU_Z80|CPU_Z80N|CPU_R800|CPU_EZ80))
-#define cansll() ( c_cpu & (CPU_Z80|CPU_Z80N))
-#define canz180() ( c_cpu & (CPU_Z180|CPU_EZ80))
-#define cancbundoc() ( c_cpu & (CPU_Z80|CPU_Z80N))
-
-extern int c_cpu;
 extern int trace;
-extern int debugger_active;
 extern int rom_size;		/* amount of memory in low addresses that is read-only */
 extern int ioport;
 extern int rc2014_mode;
@@ -75,17 +37,6 @@ extern int f_(void);
             a = (error);                          \
         }                                         \
     } while (0)
-
-#define CPU_Z80      1
-#define CPU_Z180     2
-#define CPU_R2KA     4
-#define CPU_R3K      8
-#define CPU_Z80N     16
-#define CPU_R800     32
-#define CPU_GBZ80    64
-#define CPU_8080     128
-#define CPU_8085     256
-#define CPU_EZ80     512
 
 #define Z88DK_O_RDONLY 0
 #define Z88DK_O_WRONLY 1
@@ -117,17 +68,6 @@ extern void      hook_misc_init(hook_command *cmds);
 extern void      hook_cpm(void);
 extern void      hook_rc2014(void);
 extern void      hook_console_init(hook_command *cmds);
-extern void      debugger_init();
-extern void      debugger();
-extern void      debugger_write_memory(int addr, uint8_t val);
-extern void      debugger_read_memory(int addr);
-extern int       disassemble2(int pc, char *buf, size_t buflen, int compact);
-extern void      read_symbol_file(char *filename);
-extern const char     *find_symbol(int addr, symboltype preferred_symtype);
-extern symbol   *find_symbol_byname(const char *name);
-extern int symbol_resolve(char *name);
-extern char **parse_words(char *line, int *argc);
-extern int symbol_find_lower(int addr, symboltype preferred_type, char *buf, size_t buflen);
 
 extern void memory_init(char *model);
 extern void memory_handle_paging(int port, int value);
@@ -139,8 +79,8 @@ extern void        out(int port, int value);
 
 extern uint8_t    *get_memory_addr(int pc);
 
-extern uint8_t     get_memory(int pc);
-extern uint8_t     put_memory(int pc, uint8_t b);
+extern uint8_t     get_memory(uint16_t pc);
+extern uint8_t     put_memory(uint16_t pc, uint8_t b);
 
 // acia
 extern int acia_out(int port, int value);
@@ -157,16 +97,6 @@ extern void apu_write_command(uint8_t cmd);
 
 extern int hook_console_out(int port, int value);
 extern int hook_console_in(int port);
-
-// srcfile
-extern void srcfile_display(const char *filename, int start_line, int count, int highlight);
-
-
-// debug
-extern void debug_add_info_encoded(char *encoded);
-extern int debug_find_source_location(int address, const char **filename, int *lineno);
-extern void debug_add_cline(const char *filename, int lineno, int level, int scope, const char *address);
-extern int debug_resolve_source(char *name);
 
 #ifndef WIN32
 extern int kbhit();


### PR DESCRIPTION
This change sets a framework for a future PR that would allow ticks' debugger to potentially debug other emulators.

Changes:
- Direct use of ticks emulator within ticks debugger has been moved to a virtual API. Aka:
```
static int cmd_continue(int argc, char **argv)
{
    bk.resume();
    debugger_active = 0;
    return 1;
}
```
- This `API` declares a bunch of functions which ticks emulator implements.
- For the perspective of the user of ticks, nothing has changed.
- Command execution is a bit smarter now, shortened commands are now possible, aka `q` for `quit` or `b` for `break`. Ambiguous results yield an error.
- Added a new command: `backtrace` (or `bt`) that would print out a backtrace (see [this repo as an example](https://github.com/desertkun/z88dk-debug-error-minimum-example)):
```
    $82a7    (_haha+13)> bt
    _haha+13 at other.c:5
    _main+19 at main.c:6
```
This command uses IX register as frame pointer, an attempt to backtrace a program that wasn't compiled with `-debug` option leads to garbage results:
```
    $8295    (_haha+5)> bt
    _haha+5 (unknown location)
    __console_y+30624 (unknown location)
    Unknown.
```