### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/console/enigma.c
+++ b/examples/console/enigma.c
@@ -88,7 +88,7 @@ int main()
             flag = 0;
         }
 
-        /* Step up seconond rotor if first rotor reached notch */
+        /* Step up second rotor if first rotor reached notch */
         if (pos[0] == notch[order[0] - 1]) {
             pos[1]++;
             if (pos[1] > 'Z')

--- a/examples/sam/enigma.c
+++ b/examples/sam/enigma.c
@@ -63,7 +63,7 @@ void main()
                flag=0;
           }
 
-/* Step up seconond rotor if first rotor reached notch */
+/* Step up second rotor if first rotor reached notch */
           if (pos[0]==notch[order[0]-1])
           {
                pos[1]++;

--- a/examples/ticalc/enigma.c
+++ b/examples/ticalc/enigma.c
@@ -72,7 +72,7 @@ void main()
                flag=0;
           }
 
-/* Step up seconond rotor if first rotor reached notch */
+/* Step up second rotor if first rotor reached notch */
           if (pos[0]==notch[order[0]-1])
           {
                pos[1]++;

--- a/libsrc/_DEVELOPMENT/EXAMPLES/sms/SpaceHawks/game/game_enemies.c
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/sms/SpaceHawks/game/game_enemies.c
@@ -719,7 +719,7 @@ bool enemies_groupVSBullet( )
 	
 	
 	//outside enemy group
-	//test order based on probability of occuring
+	//test order based on probability of occurring
 	if ( bulletY > FIX16((ROW0_TILEY + NB_ROW*2 -1)*8 ) )	return false;
 	if ( bulletY < FIX16((ROW0_TILEY*8) - 8) )			return false;
 	

--- a/src/appmake/cpmdisk.c
+++ b/src/appmake/cpmdisk.c
@@ -730,14 +730,14 @@ static void fat_write_file(disc_handle* h, char *filename, void* data, size_t le
 // FATFs interface
 
 DSTATUS disk_status (
-	BYTE pdrv		/* Physical drive nmuber to identify the drive */
+	BYTE pdrv		/* Physical drive number to identify the drive */
 )
 {
     return RES_OK;
 }
 
 DSTATUS disk_initialize (
-	BYTE pdrv				/* Physical drive nmuber to identify the drive */
+	BYTE pdrv				/* Physical drive number to identify the drive */
 )
 {
     return RES_OK;
@@ -745,7 +745,7 @@ DSTATUS disk_initialize (
 
 
 DRESULT disk_read (
-	BYTE pdrv,		/* Physical drive nmuber to identify the drive */
+	BYTE pdrv,		/* Physical drive number to identify the drive */
 	BYTE *buff,		/* Data buffer to store read data */
 	DWORD sector,	/* Start sector in LBA */
 	UINT count		/* Number of sectors to read */
@@ -758,7 +758,7 @@ DRESULT disk_read (
 
 
 DRESULT disk_write (
-	BYTE pdrv,			/* Physical drive nmuber to identify the drive */
+	BYTE pdrv,			/* Physical drive number to identify the drive */
 	const BYTE *buff,	/* Data to be written */
 	DWORD sector,		/* Start sector in LBA */
 	UINT count			/* Number of sectors to write */
@@ -770,7 +770,7 @@ DRESULT disk_write (
 }
 
 DRESULT disk_ioctl (
-	BYTE pdrv,		/* Physical drive nmuber (0..) */
+	BYTE pdrv,		/* Physical drive number (0..) */
 	BYTE cmd,		/* Control code */
 	void *buff		/* Buffer to send/receive control data */
 )

--- a/src/cpp/cpp4.c
+++ b/src/cpp/cpp4.c
@@ -96,7 +96,7 @@ void dodefine()
 	parlist[0] = parmp = parm;		/* Setup parm buffer	*/
 	if ((c = get()) == '(') {		/* With arguments?	*/
 	    nargs = 0;				/* Init formals counter	*/
-	    do {				/* Collect formal params	*/
+	    do {				/* Collect formal parms	*/
 		if (nargs >= LASTPARM)
 		    cfatal("Too many arguments for macro", NULLST);
 		else if ((c = skipws()) == ')')

--- a/src/cpp/cpp4.c
+++ b/src/cpp/cpp4.c
@@ -96,7 +96,7 @@ void dodefine()
 	parlist[0] = parmp = parm;		/* Setup parm buffer	*/
 	if ((c = get()) == '(') {		/* With arguments?	*/
 	    nargs = 0;				/* Init formals counter	*/
-	    do {				/* Collect formal parms	*/
+	    do {				/* Collect formal params	*/
 		if (nargs >= LASTPARM)
 		    cfatal("Too many arguments for macro", NULLST);
 		else if ((c = skipws()) == ')')

--- a/src/ucpp/arith.c
+++ b/src/ucpp/arith.c
@@ -378,7 +378,7 @@ ARITH_DECL_MONO_S_I(lval) { return x != 0; }
  *          with a non-zero result
  *       ++ if SIGNED_IS_BIGGER == 0, no overflow happens in the unsigned
  *          world; we use the fact that -NATIVE_SIGNED_MIN is then
- *          exaxctly 1 more than NATIVE_SIGNED_MAX
+ *          exactly 1 more than NATIVE_SIGNED_MAX
  *    ** if NEGATIVE_IS_BIGGER == 0, underflow check is identical to
  *       overflow check on (signed) -x and -y.
  */


### PR DESCRIPTION
There are small typos in:
- examples/console/enigma.c
- examples/sam/enigma.c
- examples/ticalc/enigma.c
- libsrc/_DEVELOPMENT/EXAMPLES/sms/SpaceHawks/game/game_enemies.c
- src/appmake/cpmdisk.c
- src/cpp/cpp4.c
- src/ucpp/arith.c

Fixes:
- Should read `number` rather than `nmuber`.
- Should read `second` rather than `seconond`.
- Should read `occurring` rather than `occuring`.
- Should read `exactly` rather than `exaxctly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md