### PR TITLE
z88dk-gdb

### DIFF
--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -9,30 +9,37 @@ endif
 include ../Make.common
 
 OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
+GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o debugger.o debugger_gdb.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
 DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o backend.o
 
-DEPENDS         := $(OBJS:.o=.d) $(DISOBJS:.o=.d)
+DEPENDS         := $(OBJS:.o=.d) $(DISOBJS:.o=.d) $(GDBOBJS:.o=.d)
 
 INSTALL ?= install
 
+GDBLDFLAGS = -lpthread
 CFLAGS += -I../../ext/uthash/src/ -g -MMD $(UNIXem_CFLAGS)
 LDFLAGS = -lm
 
-all: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX)
+all: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX) z88dk-gdb$(EXESUFFIX)
 
 z88dk-ticks$(EXESUFFIX):	$(OBJS)
 	$(CC) -o $@ $(CFLAGS) $(OBJS) $(LDFLAGS)
 
+z88dk-gdb$(EXESUFFIX):	$(GDBOBJS)
+	$(CC) -o $@ $(CFLAGS) $(GDBOBJS) $(LDFLAGS) $(GDBLDFLAGS)
+
 z88dk-dis$(EXESUFFIX):	$(DISOBJS)
 	$(CC) -o $@ $(CFLAGS) $(DISOBJS)
 
-install: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX)
+install: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX) z88dk-gdb$(EXESUFFIX)
 	$(INSTALL) z88dk-ticks$(EXESUFFIX) $(PREFIX)/bin/z88dk-ticks$(EXESUFFIX)
 	$(INSTALL) z88dk-dis$(EXESUFFIX) $(PREFIX)/bin/z88dk-dis$(EXESUFFIX)
+	$(INSTALL) z88dk-gdb$(EXESUFFIX) $(PREFIX)/bin/z88dk-gdb$(EXESUFFIX)
 
 clean:
 	$(RM) z88dk-ticks$(EXESUFFIX) $(OBJS) core
 	$(RM) z88dk-dis$(EXESUFFIX) $(DISOBJS) core
+	$(RM) z88dk-gdb$(EXESUFFIX) $(GDBOBJS) core
 	$(RM) $(DEPENDS)
 	$(RM) -rf Debug Release
 

--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -45,6 +45,7 @@ typedef struct {
     void_cb resume;
     void_cb next;
     void_cb step;
+    void_cb detach;
     breakpoint_cb add_breakpoint;
     breakpoint_cb remove_breakpoint;
     breakpoint_cb disable_breakpoint;

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -35,6 +35,7 @@ struct debugger_regs_t {
 extern int debugger_active;
 extern void      debugger_init();
 extern void      debugger();
+extern void      debugger_process_signals();
 
 extern void unwrap_reg(uint16_t data, uint8_t* h, uint8_t* l);
 extern uint16_t wrap_reg(uint8_t h, uint8_t l);

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -1,0 +1,933 @@
+#include "debugger.h"
+#include "backend.h"
+#include "disassembler.h"
+#include "syms.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <sys/fcntl.h>
+#include <semaphore.h>
+#include "debugger_gdb_packets.h"
+#include "sxmlc.h"
+#include "sxmlsearch.h"
+
+typedef void (*trapped_action_t)(const void* data, void* response);
+typedef void (*network_op_cb)(void* arg);
+
+struct network_op
+{
+    network_op_cb callback;
+    void* arg;
+    struct network_op* prev;
+};
+
+uint8_t verbose = 0;
+static uint8_t registers_invalidated = 1;
+static sem_t* req_response_mutex = NULL;
+static sem_t* response_mutex = NULL;
+static sem_t* trap_mutex = NULL;
+static pthread_mutex_t network_op_mutex;
+static pthread_mutex_t trap_process_mutex;
+static trapped_action_t scheduled_action = NULL;
+static const void* scheduled_action_data = NULL;
+static void* scheduled_action_response = NULL;
+static char request_response[1024];
+static uint8_t write_request = 0;
+static uint8_t waiting_for_response = 0;
+static const char hexchars[] = "0123456789abcdef";
+static struct debugger_regs_t registers;
+#define MEM_FETCH_SIZE (32)
+static uint8_t mem_fetch[MEM_FETCH_SIZE] = {};
+static uint16_t mem_requested_at = 0;
+static uint16_t mem_requested_amount = 0;
+static int connection_socket = 0;
+static struct network_op* last_network_op = NULL;
+
+enum register_mapping_t {
+    REGISTER_MAPPING_AF = 0,
+    REGISTER_MAPPING_BC,
+    REGISTER_MAPPING_DE,
+    REGISTER_MAPPING_HL,
+    REGISTER_MAPPING_AF_,
+    REGISTER_MAPPING_BC_,
+    REGISTER_MAPPING_DE_,
+    REGISTER_MAPPING_HL_,
+    REGISTER_MAPPING_IX,
+    REGISTER_MAPPING_IY,
+    REGISTER_MAPPING_SP,
+    REGISTER_MAPPING_PC,
+
+    REGISTER_MAPPING_MAX
+};
+
+static const char* register_mapping_names[] = {
+    "af",
+    "bc",
+    "de",
+    "hl",
+    "af'",
+    "bc'",
+    "de'",
+    "hl'",
+    "ix",
+    "iy",
+    "sp",
+    "pc",
+};
+
+static enum register_mapping_t register_mappings[32] = {};
+static int register_mappings_count = 0;
+
+void post_network_op(network_op_cb calllack, void* arg)
+{
+    pthread_mutex_lock(&network_op_mutex);
+    struct network_op* new_op = malloc(sizeof(struct network_op));
+    new_op->callback = calllack;
+    new_op->arg = arg;
+    new_op->prev = last_network_op;
+    last_network_op = new_op;
+    pthread_mutex_unlock(&network_op_mutex);
+}
+
+void _write_packet_cb(void* arg)
+{
+    char* cp = (char*)arg;
+    write_packet(cp);
+    free(cp);
+}
+
+void schedule_write_packet(const char* data)
+{
+    char* cp = strdup(data);
+    post_network_op(_write_packet_cb, (void*)cp);
+}
+
+struct scheduled_write_t
+{
+    uint8_t* data;
+    ssize_t length;
+};
+
+void _write_raw_packet_cb(void* arg)
+{
+    struct scheduled_write_t* w = (struct scheduled_write_t*)arg;
+    write_data_raw(w->data, w->length);
+    free(w->data);
+    free(w);
+}
+
+void schedule_write_raw(const uint8_t* data, ssize_t length)
+{
+    struct scheduled_write_t* w = malloc(sizeof(struct scheduled_write_t));
+    w->data = malloc(length);
+    memcpy(w->data, data, length);
+    w->length = length;
+    post_network_op(_write_raw_packet_cb, (void*)w);
+}
+
+static void send_request_no_response(const char* request)
+{
+    waiting_for_response = 0;
+
+    schedule_write_packet(request);
+}
+
+static const char* send_request(const char* request)
+{
+    waiting_for_response = 1;
+
+    schedule_write_packet(request);
+    sem_wait(req_response_mutex);
+
+    return request_response;
+}
+
+int hex(char ch)
+{
+    if ((ch >= 'a') && (ch <= 'f'))
+        return (ch - 'a' + 10);
+    if ((ch >= '0') && (ch <= '9'))
+        return (ch - '0');
+    if ((ch >= 'A') && (ch <= 'F'))
+        return (ch - 'A' + 10);
+    return (-1);
+}
+
+char *mem2hex(char *mem, char *buf, uint32_t count)
+{
+    unsigned char ch;
+    for (int i = 0; i < count; i++)
+    {
+        ch = *(mem++);
+        *buf++ = hexchars[ch >> 4];
+        *buf++ = hexchars[ch % 16];
+    }
+    *buf = 0;
+    return (buf);
+}
+
+char *hex2mem(const char *buf, char *mem, uint32_t count)
+{
+    unsigned char ch;
+    for (int i = 0; i < count; i++)
+    {
+        ch = hex(*buf++) << 4;
+        ch = ch + hex(*buf++);
+        *(mem++) = (char)ch;
+    }
+    return (mem);
+}
+
+static struct debugger_regs_t* fetch_registers()
+{
+    if (registers_invalidated)
+    {
+        const char* regs = send_request("g");
+        if (strlen(regs) != register_mappings_count * 4)
+        {
+            printf("Warning: received incorrect amount of register data: %lu.\n", strlen(regs));
+            return &registers;
+        }
+
+        uint16_t rr[32];
+        hex2mem(regs, (void*)rr, register_mappings_count * 4);
+
+        for (int i = 0; i < register_mappings_count; i++) {
+            enum register_mapping_t reg = register_mappings[i];
+            uint16_t value = rr[i];
+            switch (reg)
+            {
+                case REGISTER_MAPPING_AF: {
+                    unwrap_reg(value, &registers.a, &registers.f);
+                    break;
+                }
+                case REGISTER_MAPPING_BC: {
+                    unwrap_reg(value, &registers.b, &registers.c);
+                    break;
+                }
+                case REGISTER_MAPPING_DE: {
+                    unwrap_reg(value, &registers.d, &registers.e);
+                    break;
+                }
+                case REGISTER_MAPPING_HL: {
+                    unwrap_reg(value, &registers.h, &registers.l);
+                    break;
+                }
+                case REGISTER_MAPPING_SP: {
+#ifdef __BIG_ENDIAN__
+                    registers.sp = (value>>8)|((value&0xff)<<8);
+#else
+                    registers.sp = value;
+#endif
+                    break;
+                }
+                case REGISTER_MAPPING_PC: {
+#ifdef __BIG_ENDIAN__
+                    registers.pc = (value>>8)|((value&0xff)<<8);
+#else
+                    registers.pc = value;
+#endif
+                    break;
+                }
+                case REGISTER_MAPPING_IX: {
+                    unwrap_reg(value, &registers.xh, &registers.xl);
+                    break;
+                }
+                case REGISTER_MAPPING_IY: {
+                    unwrap_reg(value, &registers.yh, &registers.yl);
+                    break;
+                }
+                case REGISTER_MAPPING_AF_: {
+                    unwrap_reg(value, &registers.a_, &registers.f_);
+                    break;
+                }
+                case REGISTER_MAPPING_BC_: {
+                    unwrap_reg(value, &registers.b_, &registers.c_);
+                    break;
+                }
+                case REGISTER_MAPPING_DE_: {
+                    unwrap_reg(value, &registers.d_, &registers.e_);
+                    break;
+                }
+                case REGISTER_MAPPING_HL_: {
+                    unwrap_reg(value, &registers.h_, &registers.l_);
+                    break;
+                }
+                default:
+                {
+                    printf("Warning: unknown mapping %d\n", reg);
+                    break;
+                }
+            }
+        }
+
+        registers_invalidated = 0;
+    }
+
+    return &registers;
+}
+
+void invalidate()
+{
+    registers_invalidated = 1;
+    mem_requested_amount = 0;
+}
+
+long long get_st()
+{
+    return 0;
+}
+
+uint16_t get_ff()
+{
+    return 0;
+}
+
+uint16_t get_pc()
+{
+    return fetch_registers()->pc;
+}
+
+uint16_t get_sp()
+{
+    return fetch_registers()->sp;
+}
+
+uint8_t get_memory(uint16_t at)
+{
+    if (at >= mem_requested_at && (int)at < (int)(mem_requested_at + mem_requested_amount))
+    {
+        return mem_fetch[at - mem_requested_at];
+    }
+
+    mem_requested_at = at;
+    if (mem_requested_at > 4)
+    {
+        // request a bir early in case prior memory is needed
+        mem_requested_at -= 4;
+    }
+    else
+    {
+        mem_requested_at = 0;
+    }
+    mem_requested_amount = MEM_FETCH_SIZE;
+    if ((int)(mem_requested_at + mem_requested_amount) > 0xFFFF)
+    {
+        mem_requested_amount = (uint16_t)(0x10000 - (int)mem_requested_at);
+    }
+
+    if (verbose)
+    {
+        printf("Fetching a chunk of %d bytes starting from address %d.\n", mem_requested_amount, mem_requested_at);
+    }
+
+    char req[64];
+    sprintf(req, "m%zx,%zx", (size_t)mem_requested_at, (size_t)mem_requested_amount);
+
+    const char* mem = send_request(req);
+    uint32_t bytes_recv = strlen(mem) / 2;
+    if (bytes_recv != mem_requested_amount)
+    {
+        printf("Warning: received incorrect amount of data.");
+        return 0;
+    }
+
+    hex2mem(mem, (void*)mem_fetch, bytes_recv);
+
+    return mem_fetch[at - mem_requested_at];
+}
+
+void get_regs(struct debugger_regs_t* regs)
+{
+    memcpy(regs, fetch_registers(), sizeof(struct debugger_regs_t));
+}
+
+void set_regs(struct debugger_regs_t* regs)
+{
+    memcpy(&registers, regs, sizeof(struct debugger_regs_t));
+
+
+    uint16_t rr[32] = {};
+
+    for (int i = 0; i < register_mappings_count; i++) {
+        enum register_mapping_t reg = register_mappings[i];
+        uint16_t value;
+        switch (reg)
+        {
+            case REGISTER_MAPPING_AF: {
+                value = wrap_reg(regs->a, regs->f);
+                break;
+            }
+            case REGISTER_MAPPING_BC: {
+                value = wrap_reg(regs->b, regs->c);
+                break;
+            }
+            case REGISTER_MAPPING_DE: {
+                value = wrap_reg(regs->d, regs->e);
+                break;
+            }
+            case REGISTER_MAPPING_HL: {
+                value = wrap_reg(regs->h, regs->l);
+                break;
+            }
+            case REGISTER_MAPPING_SP: {
+#ifdef __BIG_ENDIAN__
+                value = (registers.sp>>8)|((registers.sp&0xff)<<8);
+#else
+                value = registers.sp;
+#endif
+                break;
+            }
+            case REGISTER_MAPPING_PC: {
+#ifdef __BIG_ENDIAN__
+                value = (registers.pc>>8)|((registers.pc&0xff)<<8);
+#else
+                value = registers.pc;
+#endif
+                break;
+            }
+            case REGISTER_MAPPING_IX: {
+                value = wrap_reg(regs->xh, regs->xl);
+                break;
+            }
+            case REGISTER_MAPPING_IY: {
+                value = wrap_reg(regs->yh, regs->yl);
+                break;
+            }
+            case REGISTER_MAPPING_AF_: {
+                value = wrap_reg(regs->a_, regs->f_);
+                break;
+            }
+            case REGISTER_MAPPING_BC_: {
+                value = wrap_reg(regs->b_, regs->c_);
+                break;
+            }
+            case REGISTER_MAPPING_DE_: {
+                value = wrap_reg(regs->d_, regs->e_);
+                break;
+            }
+            case REGISTER_MAPPING_HL_: {
+                value = wrap_reg(regs->h_, regs->l_);
+                break;
+            }
+            default:
+            {
+                continue;
+            }
+        }
+        rr[i] = value;
+    }
+
+    char req[128] = {};
+    req[0] = 'G';
+    mem2hex((void*)rr, &req[1], register_mappings_count * 4);
+
+    const char* resp = send_request(req);
+
+    if (strcmp(resp, "OK") != 0)
+    {
+        printf("Warning: could not set the registers: %s\n", resp);
+    }
+}
+
+int f()
+{
+    return fetch_registers()->f;
+}
+
+int f_()
+{
+    return fetch_registers()->f_;
+}
+
+void memory_reset_paging() {}
+void port_out(int port, int value) {}
+void debugger_write_memory(int addr, uint8_t val) {}
+void debugger_read_memory(int addr) {}
+
+void debugger_break()
+{
+    static uint8_t req[] = { 0x03 };
+    schedule_write_raw(req, 1);
+}
+
+void debugger_detach()
+{
+    send_request("D");
+}
+
+void debugger_resume()
+{
+    debugger_active = 0;
+    send_request_no_response("c");
+}
+
+void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+{
+    switch (type)
+    {
+        case BK_BREAKPOINT_REGISTER:
+        case BK_BREAKPOINT_HARDWARE:
+        {
+            printf("Warning: not supported.\n");
+            return;
+        }
+    }
+
+    char req[64];
+    sprintf(req, "Z%zx,%zx,%zx", (size_t)type, (size_t)at, (size_t)sz);
+    const char* resp = send_request(req);
+    if (strcmp(resp, "E01") == 0)
+    {
+        printf("Could not set breakpoint.\n");
+    }
+    else if (strcmp(resp, "OK") != 0)
+    {
+        printf("Could not set breakpoint: %s\n", resp);
+    }
+}
+
+void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+{
+    char req[64];
+    sprintf(req, "z%zx,%zx,%zx", (size_t)type, (size_t)at, (size_t)sz);
+    const char* resp = send_request(req);
+    if (strcmp(resp, "E01") == 0)
+    {
+        printf("Could not set breakpoint.\n");
+    }
+    else if (strcmp(resp, "OK") != 0)
+    {
+        printf("Could not set breakpoint: %s\n", resp);
+    }
+}
+
+void disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+{
+    printf("Warning: not supported.\n");
+}
+
+void enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+{
+    printf("Warning: not supported.\n");
+}
+
+uint8_t breakpoints_check()
+{
+    return 1;
+}
+
+void debugger_next()
+{
+    char  buf[100];
+    int len = disassemble2(bk.pc(), buf, sizeof(buf), 0);
+
+    char req[64];
+    sprintf(req, "i%d", len);
+    schedule_write_packet(req);
+    debugger_active = 0;
+}
+
+void debugger_step()
+{
+    schedule_write_packet("s");
+    debugger_active = 0;
+}
+
+static backend_t gdb_backend = {
+    .st = &get_st,
+    .ff = &get_ff,
+    .pc = &get_pc,
+    .sp = &get_sp,
+    .get_memory = &get_memory,
+    .get_regs = &get_regs,
+    .set_regs = &set_regs,
+    .f = &f,
+    .f_ = &f_,
+    .memory_reset_paging = &memory_reset_paging,
+    .out = &port_out,
+    .debugger_write_memory = &debugger_write_memory,
+    .debugger_read_memory = &debugger_read_memory,
+    .invalidate = &invalidate,
+    .break_ = &debugger_break,
+    .resume = &debugger_resume,
+    .next = &debugger_next,
+    .step = &debugger_step,
+    .detach = &debugger_detach,
+    .add_breakpoint = &add_breakpoint,
+    .remove_breakpoint = &remove_breakpoint,
+    .disable_breakpoint = &disable_breakpoint,
+    .enable_breakpoint = &enable_breakpoint,
+    .breakpoints_check = &breakpoints_check
+};
+
+static void execute_on_main_thread(trapped_action_t call, const void* data, void* response)
+{
+    // prepare the action arguments
+    pthread_mutex_lock(&trap_process_mutex);
+    scheduled_action = call;
+    scheduled_action_data = data;
+    scheduled_action_response = response;
+    pthread_mutex_unlock(&trap_process_mutex);
+
+    // notify the main thread
+    sem_post(trap_mutex);
+
+    // wait for the response
+    sem_wait(response_mutex);
+}
+
+static void execute_on_main_thread_no_response(trapped_action_t call, const void* data)
+{
+    // prepare the action arguments
+    pthread_mutex_lock(&trap_process_mutex);
+    scheduled_action = call;
+    scheduled_action_data = data;
+    scheduled_action_response = NULL;
+    pthread_mutex_unlock(&trap_process_mutex);
+
+    // notify the main thread
+    sem_post(trap_mutex);
+}
+
+void remote_execution_stopped(const void* data, void* response)
+{
+    if (debugger_active == 1)
+    {
+        return;
+    }
+
+    if (verbose)
+    {
+        printf("Execution stopped.\n");
+    }
+
+    debugger_active = 1;
+}
+
+static uint8_t process_packet()
+{
+    uint8_t *inbuf = inbuf_get();
+    int inbuf_size = inbuf_end();
+
+    if (inbuf_size == 0) {
+        return 0;
+    }
+
+    if (inbuf_size > 0 && *inbuf == '+') {
+        if (verbose) {
+            printf("ack.\n");
+        }
+        inbuf_erase_head(1);
+        return 1;
+    }
+
+    if (verbose) {
+        printf("r: %.*s\n", inbuf_size, inbuf);
+    }
+
+    uint8_t *packetend_ptr = (uint8_t *)memchr(inbuf, '#', inbuf_size);
+    if (packetend_ptr == NULL) {
+        return 0;
+    }
+
+    int packetend = packetend_ptr - inbuf;
+    inbuf[packetend] = '\0';
+
+    uint8_t checksum = 0;
+    int i;
+    for (i = 1; i < packetend; i++)
+        checksum += inbuf[i];
+
+    if (checksum != (hex(inbuf[packetend + 1]) << 4 | hex(inbuf[packetend + 2])))
+    {
+        inbuf_erase_head(packetend + 3);
+        return 1;
+    }
+
+    char recv_data[1024];
+    strcpy(recv_data, (char*)&inbuf[1]);
+    inbuf_erase_head(packetend + 3);
+
+    if (waiting_for_response)
+    {
+        waiting_for_response = 0;
+        strcpy(request_response, recv_data);
+        sem_post(req_response_mutex);
+    }
+    else
+    {
+        char request = recv_data[0];
+        char *payload = (char *)&recv_data[1];
+
+        switch (request)
+        {
+            case 'T':
+            {
+                execute_on_main_thread_no_response(&remote_execution_stopped, NULL);
+
+                break;
+            }
+        }
+    }
+
+    return 1;
+}
+
+static void* network_read_thread(void* arg)
+{
+    int socket = *(int*)arg;
+
+    while (1)
+    {
+        int ret;
+        if ((ret = read_packet(socket)))
+        {
+            printf("A network error occured: %d\n", ret);
+            break;
+        }
+
+        while (process_packet()) {};
+    }
+
+    shutdown(socket, 0);
+    printf("Disconnected.\n");
+    exit(1);
+
+    return NULL;
+}
+
+static void* network_write_thread(void* arg)
+{
+    int socket = *(int*)arg;
+
+    while (1)
+    {
+        // execute network operations from main thread
+        pthread_mutex_lock(&network_op_mutex);
+        while (last_network_op) {
+            struct network_op* prev = last_network_op->prev;
+            last_network_op->callback(last_network_op->arg);
+            free(last_network_op);
+            last_network_op = prev;
+        }
+        pthread_mutex_unlock(&network_op_mutex);
+        write_flush(socket);
+#ifdef __MACH__
+        pthread_yield_np();
+#else
+        pthread_yield();
+#endif
+    }
+
+    return NULL;
+}
+
+
+int main(int argc, char **argv) {
+    char* connect_host = NULL;
+    int connect_port = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-p") == 0) {
+            connect_port = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "-h") == 0) {
+            connect_host = argv[++i];
+        } else if (strcmp(argv[i], "-x") == 0) {
+            char* debug_symbols = argv[++i];
+            printf("Reading debug symbols...");
+            read_symbol_file(debug_symbols);
+            printf("OK\n");
+        } else if (strcmp(argv[i], "-v") == 0) {
+            verbose = 1;
+        }
+    }
+
+    if (connect_port == 0 || connect_host == NULL) {
+        printf("z88dk-gdb, a gdb client.\n");
+        printf("Usage: z88dk-gdb -h <connect host> -p <connect port> -x <debug symbols> [-x <debug symbols>] [-v]\n");
+        return 1;
+    }
+
+    debugger_init();
+    set_backend(gdb_backend);
+
+    connection_socket = socket(AF_INET, SOCK_STREAM, 0);
+
+    struct sockaddr_in servaddr;
+    bzero(&servaddr, sizeof(servaddr));
+
+    // assign IP, PORT
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_addr.s_addr = inet_addr(connect_host);
+    servaddr.sin_port = htons(connect_port);
+
+    // connect the client socket to server socket
+    int ret = connect(connection_socket, (struct sockaddr*)&servaddr, sizeof(servaddr));
+    if (ret) {
+        printf("Could not connect to the server: %d\n", ret);
+        return 1;
+    } else {
+        printf("Connected to the server.\n");
+    }
+
+    sem_unlink("req_response_mutex");
+    req_response_mutex = sem_open("req_response_mutex", O_CREAT|O_EXCL, 0600, 0);
+    sem_unlink("response_mutex");
+    response_mutex = sem_open("response_mutex", O_CREAT|O_EXCL, 0600, 0);
+    sem_unlink("trap_mutex");
+    trap_mutex = sem_open("trap_mutex", O_CREAT|O_EXCL, 0600, 0);
+
+    pthread_mutex_init(&network_op_mutex, NULL);
+    pthread_mutex_init(&trap_process_mutex, NULL);
+
+    {
+        pthread_t id;
+        pthread_create(&id, NULL, network_read_thread, &connection_socket);
+        pthread_detach(id);
+    }
+
+    {
+        pthread_t id;
+        pthread_create(&id, NULL, network_write_thread, &connection_socket);
+        pthread_detach(id);
+    }
+
+    {
+        const char* supported = send_request("qSupported");
+        if (supported == NULL || strstr(supported, "qXfer:features:read+") == NULL)
+        {
+            printf("Remote target does not support qXfer:features:read+\n");
+            goto shutdown;
+        }
+    }
+
+    {
+        const char* target = send_request("qXfer:features:read:target.xml:0,3fff");
+        if (target == NULL || *target++ != 'l') {
+            printf("Could not obtain target.xml\n");
+            goto shutdown;
+        }
+
+        XMLDoc xml;
+        XMLDoc_init(&xml);
+
+        if (XMLDoc_parse_buffer_DOM(target, "features", &xml) == 0) {
+            printf("Cannot parse target.xml.\n");
+            XMLDoc_free(&xml);
+            goto shutdown;
+        }
+
+        {
+            XMLSearch search;
+            XMLSearch_init_from_XPath("target/architecture", &search);
+            XMLNode* arch = xml.nodes[xml.i_root];
+            if ((arch = XMLSearch_next(arch, &search)) == NULL) {
+                printf("Unknown architecture.\n");
+                goto shutdown;
+            }
+
+            if (strcmp(arch->text, "z80") != 0) {
+                printf("Unsupported architecture: %s\n", arch->text);
+                goto shutdown;
+            }
+            XMLSearch_free(&search, 1);
+        }
+
+        {
+            XMLSearch search;
+            XMLSearch_init_from_XPath("target/feature[@name='*z80*']/reg", &search);
+            XMLNode* reg = xml.nodes[xml.i_root];
+            while ((reg = XMLSearch_next(reg, &search)))
+            {
+                const char* reg_name;
+                if (XMLNode_get_attribute(reg, "name", &reg_name) == 0) {
+                    continue;
+                }
+
+                for (int i = 0; i < REGISTER_MAPPING_MAX; i++) {
+                    if (strcmp(reg_name, register_mapping_names[i]) == 0) {
+                        register_mappings[register_mappings_count++] = i;
+                        break;
+                    }
+                }
+            }
+
+            XMLSearch_free(&search, 1);
+        }
+
+        XMLDoc_free(&xml);
+
+        uint8_t got_ix = 0;
+        uint8_t got_sp = 0;
+        uint8_t got_pc = 0;
+        if (verbose) {
+            printf("Registers: ");
+        }
+        for (int i = 0; i < register_mappings_count; i++) {
+            if (verbose) {
+                printf(" %s", register_mapping_names[register_mappings[i]]);
+            }
+            if (register_mappings[i] == REGISTER_MAPPING_IX) {
+                got_ix = 1;
+                continue;
+            }
+            if (register_mappings[i] == REGISTER_MAPPING_SP) {
+                got_sp = 1;
+                continue;
+            }
+            if (register_mappings[i] == REGISTER_MAPPING_PC) {
+                got_pc = 1;
+                continue;
+            }
+        }
+        if (verbose) {
+            printf("\n");
+        }
+        if (got_ix == 0 || got_pc == 0 || got_sp == 0) {
+            printf("Insufficient register information.\n");
+        }
+    }
+
+    // this should break us
+    send_request_no_response("?");
+
+    while (1)
+    {
+        registers_invalidated = 1;
+
+        debugger_process_signals();
+
+        if (debugger_active)
+        {
+            debugger();
+        }
+        else
+        {
+            sem_wait(trap_mutex);
+
+            pthread_mutex_lock(&trap_process_mutex);
+            if (scheduled_action != NULL)
+            {
+                scheduled_action(scheduled_action_data, scheduled_action_response);
+                scheduled_action = NULL;
+
+                if (scheduled_action_response != NULL)
+                {
+                    // notify the waiter that we're done
+                    sem_post(response_mutex);
+                }
+            }
+            pthread_mutex_unlock(&trap_process_mutex);
+        }
+    }
+
+shutdown:
+    shutdown(connection_socket, 0);
+
+    return 0;
+}

--- a/src/ticks/debugger_gdb_packets.c
+++ b/src/ticks/debugger_gdb_packets.c
@@ -1,0 +1,210 @@
+// Many codes in this file was borrowed from GdbConnection.cc in rr
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <assert.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <sys/poll.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include "debugger_gdb_packets.h"
+
+struct packet_buf
+{
+    uint8_t buf[PACKET_BUF_SIZE];
+    int end;
+} in = {}, out = {};
+
+uint8_t *inbuf_get()
+{
+    return in.buf;
+}
+
+int inbuf_end()
+{
+    return in.end;
+}
+
+static void pktbuf_clear(struct packet_buf *pkt)
+{
+    pkt->end = 0;
+    pkt->buf[pkt->end] = 0;
+}
+
+void inbuf_reset()
+{
+    pktbuf_clear(&in);
+}
+
+void pktbuf_insert(struct packet_buf *pkt, const uint8_t *buf, ssize_t len)
+{
+    if (pkt->end + len >= sizeof(pkt->buf))
+    {
+        puts("Packet buffer overflow");
+        exit(-2);
+    }
+    memcpy(pkt->buf + pkt->end, buf, len);
+    pkt->end += len;
+    pkt->buf[pkt->end] = 0;
+}
+
+void pktbuf_erase_head(struct packet_buf *pkt, ssize_t end)
+{
+    memmove(pkt->buf, pkt->buf + end, pkt->end - end);
+    pkt->end -= end;
+    pkt->buf[pkt->end] = 0;
+}
+
+void inbuf_erase_head(ssize_t end)
+{
+    pktbuf_erase_head(&in, end);
+}
+
+int read_data_once(int sockfd)
+{
+    ssize_t nread;
+    uint8_t buf[4096];
+
+    nread = read(sockfd, buf, sizeof(buf));
+    if (nread <= 0)
+    {
+        return -1;
+    }
+
+    pktbuf_insert(&in, buf, nread);
+    return 0;
+}
+
+void write_flush(int sockfd)
+{
+    size_t write_index = 0;
+    while (write_index < out.end)
+    {
+        ssize_t nwritten;
+        nwritten = write(sockfd, out.buf + write_index, out.end - write_index);
+        if (nwritten < 0)
+        {
+            printf("Write error\n");
+            exit(-2);
+        }
+        write_index += nwritten;
+    }
+    pktbuf_clear(&out);
+}
+
+void write_data_raw(const uint8_t *data, ssize_t len)
+{
+    pktbuf_insert(&out, data, len);
+}
+
+void write_hex(unsigned long hex)
+{
+    char buf[32];
+    size_t len;
+
+    len = snprintf(buf, sizeof(buf) - 1, "%02lx", hex);
+    write_data_raw((uint8_t *)buf, len);
+}
+
+void write_packet_bytes(const uint8_t *data, size_t num_bytes)
+{
+    uint8_t checksum;
+    size_t i;
+
+    write_data_raw((uint8_t *)"$", 1);
+
+    for (i = 0, checksum = 0; i < num_bytes; ++i)
+        checksum += data[i];
+
+    write_data_raw((uint8_t *)data, num_bytes);
+    write_data_raw((uint8_t *)"#", 1);
+    write_hex(checksum);
+}
+
+extern uint8_t verbose;
+
+void write_packet(const char *data)
+{
+    write_packet_bytes((const uint8_t *)data, strlen(data));
+    if (verbose)
+    {
+        printf("w: %s\n", data);
+    }
+}
+
+void write_binary_packet(const char *pfx, const uint8_t *data, ssize_t num_bytes)
+{
+    uint8_t *buf;
+    ssize_t pfx_num_chars = strlen(pfx);
+    ssize_t buf_num_bytes = 0;
+    int i;
+
+    buf = malloc(2 * num_bytes + pfx_num_chars);
+    memcpy(buf, pfx, pfx_num_chars);
+    buf_num_bytes += pfx_num_chars;
+
+    for (i = 0; i < num_bytes; ++i)
+    {
+        uint8_t b = data[i];
+        switch (b)
+        {
+            case '#':
+            case '$':
+            case '}':
+            case '*':
+                buf[buf_num_bytes++] = '}';
+                buf[buf_num_bytes++] = b ^ 0x20;
+            break;
+            default:
+                buf[buf_num_bytes++] = b;
+            break;
+        }
+    }
+    write_packet_bytes(buf, buf_num_bytes);
+    free(buf);
+}
+
+bool skip_to_packet_start()
+{
+    if (in.end && in.buf[0] == '+')
+    {
+        return true;
+    }
+
+    ssize_t end = -1;
+    for (size_t i = 0; i < in.end; ++i)
+        if (in.buf[i] == '$' || in.buf[i] == INTERRUPT_CHAR)
+        {
+            end = i;
+            break;
+        }
+
+    if (end < 0)
+    {
+        pktbuf_clear(&in);
+        return false;
+    }
+
+    pktbuf_erase_head(&in, end);
+    assert(1 <= in.end);
+    assert('$' == in.buf[0] || INTERRUPT_CHAR == in.buf[0]);
+    return true;
+}
+
+int read_packet(int sockfd)
+{
+    while (!skip_to_packet_start())
+    {
+        int ret = read_data_once(sockfd);
+        if (ret)
+        {
+            return ret;
+        }
+    }
+    return 0;
+}

--- a/src/ticks/debugger_gdb_packets.h
+++ b/src/ticks/debugger_gdb_packets.h
@@ -1,0 +1,21 @@
+#ifndef PACKETS_H
+#define PACKETS_H
+
+#include <stdint.h>
+
+#define PACKET_BUF_SIZE 0x4000
+
+static const char INTERRUPT_CHAR = '\x03';
+
+uint8_t *inbuf_get();
+int inbuf_end();
+void inbuf_reset();
+void inbuf_erase_head(ssize_t end);
+void write_flush(int sockfd);
+void write_packet(const char *data);
+void write_packet_bytes(const uint8_t *data, size_t num_bytes);
+void write_data_raw(const uint8_t *data, ssize_t len);
+void write_binary_packet(const char *pfx, const uint8_t *data, ssize_t num_bytes);
+int read_packet(int sockfd);
+
+#endif /* PACKETS_H */

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -125,6 +125,7 @@ void debugger_read_memory(int addr)
 void invalidate() {}
 void break_() {}
 void resume() {}
+void detach() {}
 void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
 void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
 void disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
@@ -191,6 +192,7 @@ backend_t ticks_debugger_backend = {
     .resume = &resume,
     .next = &next,
     .step = &step,
+    .detach = &detach,
     .add_breakpoint = &add_breakpoint,
     .remove_breakpoint = &remove_breakpoint,
     .disable_breakpoint = &disable_breakpoint,

--- a/src/ticks/linenoise.c
+++ b/src/ticks/linenoise.c
@@ -2290,8 +2290,15 @@ static int linenoiseEdit(struct current *current) {
             }
             return sb_len(current->buf);
         case ctrl('C'):     /* ctrl-c */
-            errno = EAGAIN;
-            return -1;
+#ifdef SIGINT
+            /* send ourselves SIGINT */
+            disableRawMode(current);
+            raise(SIGINT);
+            /* and resume */
+            enableRawMode(current);
+            refreshLine(current);
+#endif
+            continue;
         case ctrl('Z'):     /* ctrl-z */
 #ifdef SIGTSTP
             /* send ourselves SIGSUSP */

--- a/src/ticks/sxmlc.c
+++ b/src/ticks/sxmlc.c
@@ -1,0 +1,2507 @@
+/*
+	Copyright (c) 2010, Matthieu Labas
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice,
+	   this list of conditions and the following disclaimer in the documentation
+	   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+	PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGE.
+
+	The views and conclusions contained in the software and documentation are those of the
+	authors and should not be interpreted as representing official policies, either expressed
+	or implied, of the FreeBSD Project.
+*/
+#if defined(WIN32) || defined(WIN64)
+#pragma warning(disable : 4996)
+#else
+#ifndef strdup
+#define _GNU_SOURCE
+#endif
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "sxmlc.h"
+
+#define CHECK_NODE(node,ret) if (!XMLNode_is_valid(node)) return (ret)
+
+/* UTF8 handling for Windows */
+#ifndef SXMLC_UNICODE
+#if defined(WIN32) || defined(WIN64)
+#include <windows.h>
+#endif
+#endif
+
+/* Determine if character is not ASCII. */
+#define sx_isunicode(c) ((int)c < 0 || (int)c > 127)
+
+#if defined(WIN32) || defined(WIN64)
+FILE* sx_fopen(const SXML_CHAR* filename, const SXML_CHAR* mode)
+{
+	FILE* ret = NULL;
+	int is_unicode = false;
+	const char* p;
+	
+	for (p = filename; p && *p; p++) {
+		if (sx_isunicode(*p)) {
+			is_unicode = true;
+			break;
+		}
+	}
+
+	if (is_unicode) {
+		wchar_t* wmode = mode[0] == 'w'
+			? mode[1] == 'b' ? L"wb" : L"wt"
+			: mode[1] == 'b' ? L"rb" : L"rt";
+		wchar_t*  wide = NULL;
+		const int length = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+
+		if (length > 1) {
+			wide = (wchar_t*)malloc(length * sizeof(wchar_t));
+			if (wide) {
+				MultiByteToWideChar(CP_UTF8, 0, filename, -1, wide, length);
+				ret = _wfopen(wide, wmode);
+				free(wide);
+			}
+		}
+	} else
+		ret = fopen(filename, mode);
+
+	return ret;
+}
+#endif
+
+/**
+ * \brief Definition of "special" tags such as "&lt;? ?&gt;" or "&lt;![CDATA[ ]]/&gt;".
+ *
+ * These tags are considered having a start and an end with some data in between that will
+ * be stored in the 'tag' member of an XMLNode.
+ * The `tag_type` member is a constant that is associated to such tag.
+ * All `len_*` members are basically the "sx_strlen()" of 'start' and 'end' members.
+ */
+typedef struct _Tag {
+	TagType tag_type;	/**< The tag type. */
+	SXML_CHAR* start;	/**< The string representing the tag "opening". *Must start with &lt;*. */
+	int len_start;		/**< The `strlen(start)`. */
+	SXML_CHAR* end;		/**< The string representing the tag "closing". *Must end with &gt;*. */
+	int len_end;		/**< The `strlen(end)`. */
+} _TAG;
+
+/*
+ List of "special" tags handled by sxmlc.
+ NB the "<!DOCTYPE" tag has a special handling because its 'end' changes according
+ to its content ('>' or ']>').
+ */
+static _TAG _spec[] = {
+		{ TAG_INSTR, C2SX("<?"), 2, C2SX("?>"), 2 },
+		{ TAG_COMMENT, C2SX("<!--"), 4, C2SX("-->"), 3 },
+		{ TAG_CDATA, C2SX("<![CDATA["), 9, C2SX("]]>"), 3 }
+};
+static int NB_SPECIAL_TAGS = (int)(sizeof(_spec) / sizeof(_TAG)); /* Auto computation of number of special tags */
+
+/*
+ User-registered tags.
+ */
+static struct _SpecialTag {
+	_TAG *tags;
+	int n_tags;
+} _user_tags = { NULL, 0 };
+
+int XML_register_user_tag(TagType tag_type, SXML_CHAR* start, SXML_CHAR* end)
+{
+	_TAG* p;
+	int i, n, le;
+
+	if (tag_type < TAG_USER)
+		return -1;
+
+	if (start == NULL || end == NULL || *start != C2SX('<'))
+		return -1;
+
+	le = sx_strlen(end);
+	if (end[le-1] != C2SX('>'))
+		return -1;
+
+	i = _user_tags.n_tags;
+	n = i + 1;
+	p = __realloc(_user_tags.tags, n * sizeof(_TAG));
+	if (p == NULL)
+		return -1;
+
+	p[i].tag_type = tag_type;
+	p[i].start = start;
+	p[i].end = end;
+	p[i].len_start = sx_strlen(start);
+	p[i].len_end = le;
+	_user_tags.tags = p;
+	_user_tags.n_tags = n;
+
+	return i;
+}
+
+int XML_unregister_user_tag(int i_tag)
+{
+	_TAG* pt;
+
+	if (i_tag < 0 || i_tag >= _user_tags.n_tags)
+ 		return -1;
+
+	if (_user_tags.n_tags == 1)
+		pt = NULL;
+	else {
+		pt = __malloc((_user_tags.n_tags - 1) * sizeof(_TAG));
+		if (pt == NULL)
+			return -1;
+	}
+ 
+	if (pt != NULL) {
+		memcpy(pt, _user_tags.tags, i_tag * sizeof(_TAG));
+		memcpy(&pt[i_tag], &_user_tags.tags[i_tag + 1], (_user_tags.n_tags - i_tag - 1) * sizeof(_TAG));
+	}
+	if (_user_tags.tags != NULL)
+		__free(_user_tags.tags);
+	_user_tags.tags = pt;
+	_user_tags.n_tags--;
+
+	return _user_tags.n_tags;
+}
+
+int XML_get_nb_registered_user_tags(void)
+{
+	return _user_tags.n_tags;
+}
+
+int XML_get_registered_user_tag(TagType tag_type)
+{
+	int i;
+
+	for (i = 0; i < _user_tags.n_tags; i++)
+		if (_user_tags.tags[i].tag_type == tag_type)
+			return i;
+
+	return -1;
+}
+
+/* --- XMLNode methods --- */
+
+/*
+ Add 'node' to given '*children_array' of '*len_array' elements.
+ '*len_array' is overwritten with the number of elements in '*children_array' after its reallocation.
+ Return the index of the newly added 'node' in '*children_array', or '-1' for memory error.
+ */
+static int _add_node(XMLNode*** children_array, int* len_array, XMLNode* node)
+{
+	XMLNode** pt = __realloc(*children_array, (*len_array+1) * sizeof(XMLNode*));
+	
+	if (pt == NULL)
+		return -1;
+	
+	pt[*len_array] = node;
+	*children_array = pt;
+	
+	return (*len_array)++;
+}
+
+int XMLNode_init(XMLNode* node)
+{
+	if (node == NULL)
+		return false;
+	
+	if (node->init_value == XML_INIT_DONE)
+		return true; /*(void)XMLNode_free(node);*/
+
+	node->tag = NULL;
+	node->text = NULL;
+	
+	node->attributes = NULL;
+	node->n_attributes = 0;
+	
+	node->father = NULL;
+	node->children = NULL;
+	node->n_children = 0;
+	
+	node->tag_type = TAG_NONE;
+	node->active = true;
+
+	node->init_value = XML_INIT_DONE;
+
+	return true;
+}
+
+XMLNode* XMLNode_allocN(int n)
+{
+	int i;
+	XMLNode* p;
+	
+	if (n <= 0)
+		return NULL;
+	
+	p = __calloc(n, sizeof(XMLNode));
+	if (p == NULL)
+		return NULL;
+
+	for (i = 0; i < n; i++)
+		(void)XMLNode_init(&p[i]);
+	
+	return p;
+}
+
+XMLNode* XMLNode_new(const TagType tag_type, const SXML_CHAR* tag, const SXML_CHAR* text)
+{
+	XMLNode* node = XMLNode_alloc();
+	if (node == NULL)
+		return NULL;
+	
+	if (!XMLNode_set_tag(node, tag) || (text != NULL && !XMLNode_set_text(node, text))) {
+		__free(node);
+		return NULL;
+	}
+	
+	node->tag_type = tag_type;
+	
+	return node;
+}
+
+XMLNode* XMLNode_dup(const XMLNode* node, int copy_children)
+{
+	XMLNode* n;
+
+	if (node == NULL)
+		return NULL;
+
+	n = __calloc(1, sizeof(XMLNode));
+	if (n == NULL)
+		return NULL;
+
+	XMLNode_init(n);
+	if (!XMLNode_copy(n, node, copy_children)) {
+		XMLNode_free(n);
+
+		return NULL;
+	}
+
+	return n;
+}
+
+int XMLNode_free(XMLNode* node)
+{
+	CHECK_NODE(node, false);
+	
+	if (node->tag != NULL) {
+		__free(node->tag);
+		node->tag = NULL;
+	}
+
+	XMLNode_remove_text(node);
+	XMLNode_remove_all_attributes(node);
+	XMLNode_remove_children(node);
+	
+	node->tag_type = TAG_NONE;
+
+	return true;
+}
+
+int XMLNode_copy(XMLNode* dst, const XMLNode* src, int copy_children)
+{
+	int i;
+	
+	if (dst == NULL || (src != NULL && src->init_value != XML_INIT_DONE))
+		return false;
+	
+	(void)XMLNode_free(dst); /* 'dst' is freed first */
+	
+	/* NULL 'src' resets 'dst' */
+	if (src == NULL)
+		return true;
+	
+	/* Tag */
+	if (src->tag != NULL) {
+		dst->tag = sx_strdup(src->tag);
+		if (dst->tag == NULL) goto copy_err;
+	}
+
+	/* Text */
+	if (dst->text != NULL) {
+		dst->text = sx_strdup(src->text);
+		if (dst->text == NULL) goto copy_err;
+	}
+
+	/* Attributes */
+	if (src->n_attributes > 0) {
+		dst->attributes = __calloc(src->n_attributes, sizeof(XMLAttribute));
+		if (dst->attributes== NULL) goto copy_err;
+		dst->n_attributes = src->n_attributes;
+		for (i = 0; i < src->n_attributes; i++) {
+			dst->attributes[i].name = sx_strdup(src->attributes[i].name);
+			dst->attributes[i].value = sx_strdup(src->attributes[i].value);
+			if (dst->attributes[i].name == NULL || dst->attributes[i].value == NULL) goto copy_err;
+			dst->attributes[i].active = src->attributes[i].active;
+		}
+	}
+
+	dst->tag_type = src->tag_type;
+	dst->father = src->father;
+	dst->user = src->user;
+	dst->active = src->active;
+	
+	/* Copy children if required (and there are any) */
+	if (copy_children && src->n_children > 0) {
+		dst->children = __calloc(src->n_children, sizeof(XMLNode*));
+		if (dst->children == NULL) goto copy_err;
+		dst->n_children = src->n_children;
+		for (i = 0; i < src->n_children; i++) {
+			if (!XMLNode_copy(dst->children[i], src->children[i], true)) goto copy_err;
+		}
+	}
+	
+	return true;
+	
+copy_err:
+	(void)XMLNode_free(dst);
+	
+	return false;
+}
+
+int XMLNode_set_active(XMLNode* node, int active)
+{
+	CHECK_NODE(node, false);
+
+	node->active = active;
+
+	return true;
+}
+
+int XMLNode_set_tag(XMLNode* node, const SXML_CHAR* tag)
+{
+	SXML_CHAR* newtag;
+	if (node == NULL || tag == NULL || node->init_value != XML_INIT_DONE)
+		return false;
+	
+	newtag = sx_strdup(tag);
+	if (newtag == NULL)
+		return false;
+	if (node->tag != NULL) __free(node->tag);
+	node->tag = newtag;
+
+	return true;
+}
+
+int XMLNode_set_type(XMLNode* node, const TagType tag_type)
+{
+	CHECK_NODE(node, false);
+
+	switch (tag_type) {
+		case TAG_ERROR:
+		case TAG_END:
+		case TAG_PARTIAL:
+		case TAG_NONE:
+			return false;
+
+		default:
+			node->tag_type = tag_type;
+			return true;
+	}
+}
+
+int XMLNode_set_attribute(XMLNode* node, const SXML_CHAR* attr_name, const SXML_CHAR* attr_value)
+{
+	XMLAttribute* pt;
+	int i;
+	
+	if (node == NULL || attr_name == NULL || attr_name[0] == NULC || node->init_value != XML_INIT_DONE)
+		return -1;
+	
+	i = XMLNode_search_attribute(node, attr_name, 0);
+	if (i >= 0) { /* Attribute found: update it */
+		SXML_CHAR* value = NULL;
+		if (attr_value != NULL && (value = sx_strdup(attr_value)) == NULL)
+			return -1;
+		pt = node->attributes;
+		if (pt[i].value != NULL)
+			__free(pt[i].value);
+		pt[i].value = value;
+	} else { /* Attribute not found: add it */
+		SXML_CHAR* name = sx_strdup(attr_name);
+		SXML_CHAR* value = (attr_value == NULL ? NULL : sx_strdup(attr_value));
+		if (name == NULL || (value == NULL && attr_value != NULL)) {
+			if (value != NULL)
+				__free(value);
+			if (name != NULL)
+				__free(name);
+ 			return -1;
+		}
+		i = node->n_attributes;
+		pt = __realloc(node->attributes, (i+1) * sizeof(XMLAttribute));
+		if (pt == NULL) {
+			if (value != NULL)
+				__free(value);
+			__free(name);
+			return -1;
+		}
+
+		pt[i].name = name;
+		pt[i].value = value;
+		pt[i].active = true;
+		node->attributes = pt;
+		node->n_attributes = i + 1;
+	}
+
+	return node->n_attributes;
+}
+
+int XMLNode_get_attribute_with_default(XMLNode* node, const SXML_CHAR* attr_name, const SXML_CHAR** attr_value, const SXML_CHAR* default_attr_value)
+{
+	XMLAttribute* pt;
+	int i;
+	
+	if (node == NULL || attr_name == NULL || attr_name[0] == NULC || attr_value == NULL || node->init_value != XML_INIT_DONE)
+		return false;
+	
+	i = XMLNode_search_attribute(node, attr_name, 0);
+	if (i >= 0) {
+		pt = node->attributes;
+		if (pt[i].value != NULL) {
+			*attr_value = sx_strdup(pt[i].value);
+			if (*attr_value == NULL)
+				return false;
+		} else
+			*attr_value = NULL; /* NULL but returns 'true' as 'NULL' is the actual attribute value */
+	} else if (default_attr_value != NULL) {
+		*attr_value = sx_strdup(default_attr_value);
+		if (*attr_value == NULL)
+			return false;
+	} else
+		*attr_value = NULL;
+
+	return true;
+}
+
+int XMLNode_get_attribute_count(const XMLNode* node)
+{
+	int i, n;
+
+	CHECK_NODE(node, -1);
+
+	for (i = n = 0; i < node->n_attributes; i++)
+		if (node->attributes[i].active) n++;
+
+	return n;
+}
+
+int XMLNode_search_attribute(const XMLNode* node, const SXML_CHAR* attr_name, int i_search)
+{
+	int i;
+	
+	if (node == NULL || attr_name == NULL || attr_name[0] == NULC || i_search < 0 || i_search >= node->n_attributes)
+		return -1;
+	
+	for (i = i_search; i < node->n_attributes; i++)
+		if (node->attributes[i].active && !sx_strcmp(node->attributes[i].name, attr_name))
+			return i;
+	
+	return -1;
+}
+
+int XMLNode_remove_attribute(XMLNode* node, int i_attr)
+{
+	XMLAttribute* pt;
+	if (node == NULL || node->init_value != XML_INIT_DONE || i_attr < 0 || i_attr >= node->n_attributes)
+		return -1;
+	
+	/* Before modifying first see if we run out of memory */
+	if (node->n_attributes == 1)
+		pt = NULL;
+	else {
+		pt = __malloc((node->n_attributes - 1) * sizeof(XMLAttribute));
+		if (pt == NULL)
+			return -1;
+	}
+
+	/* Can't fail anymore, free item */
+	if (node->attributes[i_attr].name != NULL) __free(node->attributes[i_attr].name);
+	if (node->attributes[i_attr].value != NULL) __free(node->attributes[i_attr].value);
+	
+	if (pt != NULL) {
+		memcpy(pt, node->attributes, i_attr * sizeof(XMLAttribute));
+		memcpy(&pt[i_attr], &node->attributes[i_attr + 1], (node->n_attributes - i_attr - 1) * sizeof(XMLAttribute));
+	}
+	if (node->attributes != NULL)
+		__free(node->attributes);
+	node->attributes = pt;
+	node->n_attributes--;
+	
+	return node->n_attributes;
+}
+
+int XMLNode_remove_all_attributes(XMLNode* node)
+{
+	int i;
+
+	CHECK_NODE(node, false);
+
+	if (node->attributes != NULL) {
+		for (i = 0; i < node->n_attributes; i++) {
+			if (node->attributes[i].name != NULL)
+				__free(node->attributes[i].name);
+			if (node->attributes[i].value != NULL)
+				__free(node->attributes[i].value);
+		}
+		__free(node->attributes);
+		node->attributes = NULL;
+	}
+	node->n_attributes = 0;
+
+	return true;
+}
+
+int XMLNode_set_text(XMLNode* node, const SXML_CHAR* text)
+{
+	SXML_CHAR* p;
+	CHECK_NODE(node, false);
+
+	if (text == NULL) { /* We want to remove it => free node text */
+		if (node->text != NULL) {
+			__free(node->text);
+			node->text = NULL;
+		}
+
+		return true;
+	}
+
+	p = sx_strdup(text);
+	if (p == NULL)
+		return false;
+	if (node->text != NULL)
+		__free(node->text);
+	node->text = p;
+
+	return true;
+}
+
+int XMLNode_add_child(XMLNode* node, XMLNode* child)
+{
+	if (node == NULL || child == NULL || node->init_value != XML_INIT_DONE || child->init_value != XML_INIT_DONE)
+		return false;
+	
+	if (_add_node(&node->children, &node->n_children, child) >= 0) {
+		node->tag_type = TAG_FATHER;
+		child->father = node;
+		return true;
+	} else
+		return false;
+}
+
+int XMLNode_insert_child(XMLNode* node, XMLNode* child, int index)
+{
+	int i, j;
+
+	CHECK_NODE(node, -1);
+
+	/* We could process cases "first" and "last" in an optimized way, but we prefer readability to (micro-)optimization */
+	if (index < 0) /* Before first => first */
+		index = 0;
+	if (index >= node->n_children) /* After last => last */
+		index = node->n_children - 1;
+
+	for (i = 0; i < node->n_children; i++) {
+		if (!node->children[i]->active || index-- > 0)
+			continue;
+		/* Insert it here, at 'i' */
+		if (_add_node(&node->children, &node->n_children, child) >= 0) {
+			node->tag_type = TAG_FATHER;
+			child->father = node;
+			/* Erase 'child', which is the last node ('n_children' has been incremented by '_add_node()') */
+			for (j = node->n_children - 1; j >= i; j--)
+				node->children[j] = node->children[j-1];
+			node->children[i] = child; /* Set it */
+			return true;
+		} else
+			return false;
+	}
+
+	return false; /* Oops! */
+}
+
+int XMLNode_move_child(XMLNode* node, int from, int to)
+{
+	XMLNode* nfrom;
+
+	CHECK_NODE(node, false);
+	if (from < 0 || from >= node->n_children)
+		return false;
+	if (to < 0) /* Before first => first */
+		to = 0;
+	if (to >= node->n_children) /* After last => last */
+		to = node->n_children - 1;
+
+	nfrom = node->children[from];
+	if (to > from) { /* Move forward: bring following nodes (up to 'to') backward one position */
+		int i;
+		for (i = from; i < to; i++)
+			node->children[i] = node->children[i+1];
+	} else { /* Move backward: bring previous nodes (up to 'from') forward one position */
+		int i;
+		for (i = from - 1; i >= to; i--)
+			node->children[i+1] = node->children[i];
+	}
+	node->children[to] = nfrom;
+
+	return true;
+}
+
+
+int XMLNode_get_children_count(const XMLNode* node)
+{
+	int i, n;
+
+	CHECK_NODE(node, -1);
+
+	for (i = n = 0; i < node->n_children; i++)
+		if (node->children[i]->active)
+			n++;
+	
+	return n;
+}
+
+int XMLNode_get_index(const XMLNode* node)
+{
+	int i, i_child;
+
+	CHECK_NODE(node, -1);
+
+	if (node->father == NULL)
+		return 0;
+
+	for (i = i_child = 0; i < node->father->n_children; i++) {
+		if (!node->father->children[i]->active)
+			continue;
+		if (node->father->children[i] == node)
+			return i_child;
+		i_child++;
+	}
+
+	return -2; /* Oops! */
+}
+
+XMLNode* XMLNode_get_child(const XMLNode* node, int i_child)
+{
+	int i;
+	
+	if (node == NULL || node->init_value != XML_INIT_DONE || i_child < 0 || i_child >= node->n_children)
+		return NULL;
+	
+	for (i = 0; i < node->n_children; i++) {
+		if (!node->children[i]->active)
+			i_child++;
+		else if (i == i_child)
+			return node->children[i];
+	}
+	
+	return NULL;
+}
+
+int XMLNode_remove_child(XMLNode* node, int i_child, int free_child)
+{
+	int i;
+	XMLNode** pt;
+
+	if (node == NULL || node->init_value != XML_INIT_DONE || i_child < 0 || i_child >= node->n_children)
+		return -1;
+	
+	/* Lookup 'i_child'th active child */
+	for (i = 0; i < node->n_children; i++) {
+		if (!node->children[i]->active)
+			i_child++;
+		else if (i == i_child)
+			break;
+	}
+	if (i >= node->n_children)
+		return -1; /* Children is not found */
+
+	/* Before modifying first see if we run out of memory */
+	if (node->n_children == 1) {
+		pt = NULL;
+	} else {
+		pt = __malloc((node->n_children - 1) * sizeof(XMLNode*));
+		if (pt == NULL)
+			return -1;
+	}
+
+	/* Can't fail anymore, free item */
+	(void)XMLNode_free(node->children[i_child]);
+	if (free_child)
+		__free(node->children[i_child]);
+	
+	if (pt != NULL) {
+		memcpy(pt, node->children, i_child * sizeof(XMLNode*));
+		memcpy(&pt[i_child], &node->children[i_child + 1], (node->n_children - i_child - 1) * sizeof(XMLNode*));
+	}
+	if (node->children != NULL)
+		__free(node->children);
+	node->children = pt;
+	node->n_children--;
+	if (node->n_children == 0)
+		node->tag_type = TAG_SELF;
+	
+	return node->n_children;
+}
+
+int XMLNode_remove_children(XMLNode* node)
+{
+	int i;
+
+	CHECK_NODE(node, false);
+
+	if (node->children != NULL) {
+		for (i = 0; i < node->n_children; i++)
+			if (node->children[i] != NULL) {
+				(void)XMLNode_free(node->children[i]);
+				__free(node->children[i]);
+			}
+		__free(node->children);
+		node->children = NULL;
+	}
+	node->n_children = 0;
+	
+	return true;
+}
+
+int XMLNode_equal(const XMLNode* node1, const XMLNode* node2)
+{
+	int i, j;
+
+	if (node1 == node2)
+		return true;
+
+	if (node1 == NULL || node2 == NULL || node1->init_value != XML_INIT_DONE || node2->init_value != XML_INIT_DONE)
+		return false;
+
+	if (sx_strcmp(node1->tag, node2->tag))
+		return false;
+
+	/* Test all attributes from 'node1' */
+	for (i = 0; i < node1->n_attributes; i++) {
+		if (!node1->attributes[i].active)
+			continue;
+		j = XMLNode_search_attribute(node2, node1->attributes[i].name, 0);
+		if (j < 0)
+			return false;
+		if (sx_strcmp(node1->attributes[i].value, node2->attributes[j].value))
+			return false;
+	}
+
+	/* Test other attributes from 'node2' that might not be in 'node1' */
+	for (i = 0; i < node2->n_attributes; i++) {
+		if (!node2->attributes[i].active)
+			continue;
+		j = XMLNode_search_attribute(node1, node2->attributes[i].name, 0);
+		if (j < 0)
+			return false;
+		if (sx_strcmp(node2->attributes[i].name, node1->attributes[j].name))
+			return false;
+	}
+
+	return true;
+}
+
+XMLNode* XMLNode_next_sibling(const XMLNode* node)
+{
+	int i;
+	XMLNode* father;
+
+	if (node == NULL || node->init_value != XML_INIT_DONE || node->father == NULL)
+		return NULL;
+
+	father = node->father;
+	for (i = 0; i < father->n_children && father->children[i] != node; i++) ;
+	i++; /* father->children[i] is now 'node' next sibling */
+
+	return i < father->n_children ? father->children[i] : NULL;
+}
+
+static XMLNode* _XMLNode_next(const XMLNode* node, int in_children)
+{
+	XMLNode* node2;
+
+	CHECK_NODE(node, NULL);
+
+	/* Check first child */
+	if (in_children && node->n_children > 0)
+		return node->children[0];
+
+	/* Check next sibling */
+	if ((node2 = XMLNode_next_sibling(node)) != NULL)
+		return node2;
+
+	/* Check next uncle */
+	return _XMLNode_next(node->father, false);
+}
+
+XMLNode* XMLNode_next(const XMLNode* node)
+{
+	return _XMLNode_next(node, true);
+}
+
+/* --- XMLDoc methods --- */
+
+int XMLDoc_init(XMLDoc* doc)
+{
+	if (doc == NULL)
+		return false;
+
+	doc->filename[0] = NULC;
+	memset(&doc->bom, 0, sizeof(doc->bom));
+	doc->sz_bom = 0;
+	doc->nodes = NULL;
+	doc->n_nodes = 0;
+	doc->i_root = -1;
+	doc->init_value = XML_INIT_DONE;
+
+	return true;
+}
+
+int XMLDoc_free(XMLDoc* doc)
+{
+	int i;
+	
+	if (doc == NULL || doc->init_value != XML_INIT_DONE)
+		return false;
+
+	for (i = 0; i < doc->n_nodes; i++) {
+		(void)XMLNode_free(doc->nodes[i]);
+		__free(doc->nodes[i]);
+	}
+	__free(doc->nodes);
+	doc->nodes = NULL;
+	doc->n_nodes = 0;
+	doc->i_root = -1;
+
+	return true;
+}
+
+int XMLDoc_set_root(XMLDoc* doc, int i_root)
+{
+	if (doc == NULL || doc->init_value != XML_INIT_DONE || i_root < 0 || i_root >= doc->n_nodes)
+		return false;
+	
+	doc->i_root = i_root;
+	
+	return true;
+}
+
+int XMLDoc_add_node(XMLDoc* doc, XMLNode* node)
+{
+	if (doc == NULL || node == NULL || doc->init_value != XML_INIT_DONE)
+		return -1;
+	
+	if (_add_node(&doc->nodes, &doc->n_nodes, node) < 0)
+		return -1;
+
+	if (node->tag_type == TAG_FATHER)
+		doc->i_root = doc->n_nodes - 1; /* Main root node is the last father node */
+
+	return doc->n_nodes;
+}
+
+int XMLDoc_remove_node(XMLDoc* doc, int i_node, int free_node)
+{
+	XMLNode** pt;
+	if (doc == NULL || doc->init_value != XML_INIT_DONE || i_node < 0 || i_node > doc->n_nodes)
+		return false;
+
+	/* Before modifying first see if we run out of memory */
+	if (doc->n_nodes == 1)
+		pt = NULL;
+	else {
+		pt = __malloc((doc->n_nodes - 1) * sizeof(XMLNode*));
+		if (pt == NULL)
+			return false;
+	}
+
+	/* Can't fail anymore, free item */
+	(void)XMLNode_free(doc->nodes[i_node]);
+	if (free_node) __free(doc->nodes[i_node]);
+	
+	if (pt != NULL) {
+		memcpy(pt, &doc->nodes[i_node], i_node * sizeof(XMLNode*));
+		memcpy(&pt[i_node], &doc->nodes[i_node + 1], (doc->n_nodes - i_node - 1) * sizeof(XMLNode*));
+	}
+
+	if (doc->nodes != NULL)
+		__free(doc->nodes);
+	doc->nodes = pt;
+	doc->n_nodes--;
+
+	return true;
+}
+
+/*
+ Helper functions to print formatting before a new tag.
+ Returns the new number of characters in the line.
+ */
+static int _count_new_char_line(const SXML_CHAR* str, int nb_char_tab, int cur_sz_line)
+{
+	for (; *str; str++) {
+		if (*str == C2SX('\n'))
+			cur_sz_line = 0;
+		else if (*str == C2SX('\t'))
+			cur_sz_line += nb_char_tab;
+		else
+			cur_sz_line++;
+	}
+	
+	return cur_sz_line;
+}
+static int _print_formatting(const XMLNode* node, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, int nb_char_tab, int cur_sz_line)
+{
+	if (tag_sep != NULL) {
+		sx_fputs(tag_sep, f);
+		cur_sz_line = _count_new_char_line(tag_sep, nb_char_tab, cur_sz_line);
+	}
+	if (child_sep != NULL) {
+		for (node = node->father; node != NULL; node = node->father) {
+			sx_fputs(child_sep, f);
+			cur_sz_line = _count_new_char_line(child_sep, nb_char_tab, cur_sz_line);
+		}
+	}
+	
+	return cur_sz_line;
+}
+
+static int _XMLNode_print_header(const XMLNode* node, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, const SXML_CHAR* attr_sep, int sz_line, int cur_sz_line, int nb_char_tab)
+{
+	int i;
+	SXML_CHAR* p;
+
+	if (node == NULL || f == NULL || !node->active || node->tag == NULL || node->tag[0] == NULC)
+		return -1;
+	
+	/* Special handling of DOCTYPE */
+	if (node->tag_type == TAG_DOCTYPE) {
+		/* Search for an unescaped '[' in the DOCTYPE definition, in which case the end delimiter should be ']>' instead of '>' */
+		for (p = sx_strchr(node->tag, C2SX('[')); p != NULL && *(p-1) == C2SX('\\'); p = sx_strchr(p+1, C2SX('['))) ;
+		cur_sz_line += sx_fprintf(f, C2SX("<!DOCTYPE%s%s>"), node->tag, p != NULL ? C2SX("]") : C2SX(""));
+		return cur_sz_line;
+	}
+
+	/* Check for special tags first */
+	for (i = 0; i < NB_SPECIAL_TAGS; i++) {
+		if (node->tag_type == _spec[i].tag_type) {
+			sx_fprintf(f, C2SX("%s%s%s"), _spec[i].start, node->tag, _spec[i].end);
+			cur_sz_line += sx_strlen(_spec[i].start) + sx_strlen(node->tag) + sx_strlen(_spec[i].end);
+			return cur_sz_line;
+		}
+	}
+
+	/* Check for user tags */
+	for (i = 0; i < _user_tags.n_tags; i++) {
+		if (node->tag_type == _user_tags.tags[i].tag_type) {
+			sx_fprintf(f, C2SX("%s%s%s"), _user_tags.tags[i].start, node->tag, _user_tags.tags[i].end);
+			cur_sz_line += sx_strlen(_user_tags.tags[i].start) + sx_strlen(node->tag) + sx_strlen(_user_tags.tags[i].end);
+			return cur_sz_line;
+		}
+	}
+	
+	/* Print tag name */
+	cur_sz_line += sx_fprintf(f, C2SX("<%s"), node->tag);
+
+	/* Print attributes */
+	if (attr_sep == NULL)
+		attr_sep = C2SX(" ");
+	for (i = 0; i < node->n_attributes; i++) {
+		if (!node->attributes[i].active)
+			continue;
+		cur_sz_line += sx_strlen(node->attributes[i].name) + sx_strlen(node->attributes[i].value) + 3;
+		if (sz_line > 0 && cur_sz_line > sz_line) {
+			cur_sz_line = _print_formatting(node, f, tag_sep, child_sep, nb_char_tab, cur_sz_line);
+			/* Add extra separator, as if new line was a child of the previous one */
+			if (child_sep != NULL) {
+				sx_fputs(child_sep, f);
+				cur_sz_line = _count_new_char_line(child_sep, nb_char_tab, cur_sz_line);
+			}
+		}
+		/* Attribute name */
+		cur_sz_line = _count_new_char_line(attr_sep, nb_char_tab, cur_sz_line);
+		sx_fprintf(f, C2SX("%s%s="), attr_sep, node->attributes[i].name);
+		
+		/* Attribute value */
+		(void)sx_fputc(XML_DEFAULT_QUOTE, f);
+		cur_sz_line += fprintHTML(f, node->attributes[i].value) + 2;
+		(void)sx_fputc(XML_DEFAULT_QUOTE, f);
+	}
+	
+	/* End the tag if there are no children and no text */
+	if (node->n_children == 0 && (node->text == NULL || node->text[0] == NULC)) {
+		cur_sz_line += sx_fprintf(f, C2SX("/>"));
+	} else {
+		(void)sx_fputc(C2SX('>'), f);
+		cur_sz_line++;
+	}
+
+	return cur_sz_line;
+}
+
+int XMLNode_print_header(const XMLNode* node, FILE* f, int sz_line, int nb_char_tab)
+{
+	return _XMLNode_print_header(node, f, NULL, NULL, NULL, sz_line, 0, nb_char_tab) < 0 ? false : true;
+}
+
+static int _XMLNode_print(const XMLNode* node, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, const SXML_CHAR* attr_sep, int keep_text_spaces, int sz_line, int cur_sz_line, int nb_char_tab, int depth)
+{
+	int i;
+	SXML_CHAR* p;
+	
+	if (node != NULL && node->tag_type==TAG_TEXT) { /* Text has to be printed: check if it is only spaces */
+		if (!keep_text_spaces) {
+			for (p = node->text; p != NULL && *p != NULC && sx_isspace(*p); p++) ; /* 'p' points to first non-space character, or to '\0' if only spaces */
+		} else
+			p = node->text; /* '*p' won't be '\0' */
+		if (p != NULL && *p != NULC)
+			cur_sz_line += fprintHTML(f, node->text);
+		return cur_sz_line;
+	}
+
+	if (node == NULL || f == NULL || !node->active || node->tag == NULL || node->tag[0] == NULC)
+		return -1;
+	
+	if (nb_char_tab <= 0)
+		nb_char_tab = 1;
+	
+	/* Print formatting */
+	if (depth < 0) /* UGLY HACK: 'depth' forced negative on very first line so we don't print an extra 'tag_sep' (usually "\n" when pretty-printing) */
+		depth = 0;
+	else
+		cur_sz_line = _print_formatting(node, f, tag_sep, child_sep, nb_char_tab, cur_sz_line);
+	
+	_XMLNode_print_header(node, f, tag_sep, child_sep, attr_sep, sz_line, cur_sz_line, nb_char_tab);
+
+	if (node->text != NULL && node->text[0] != NULC) {
+		/* Text has to be printed: check if it is only spaces */
+		if (!keep_text_spaces) {
+			for (p = node->text; *p != NULC && sx_isspace(*p); p++) ; /* 'p' points to first non-space character, or to '\0' if only spaces */
+		} else
+			p = node->text; /* '*p' won't be '\0' */
+		if (*p != NULC) cur_sz_line += fprintHTML(f, node->text);
+	} else if (node->n_children <= 0) /* Everything has already been printed */
+		return cur_sz_line;
+	
+	/* Recursively print children */
+	for (i = 0; i < node->n_children; i++)
+		(void)_XMLNode_print(node->children[i], f, tag_sep, child_sep, attr_sep, keep_text_spaces, sz_line, cur_sz_line, nb_char_tab, depth+1);
+	
+	/* Print tag end after children */
+		/* Print formatting */
+	if (node->n_children > 0)
+		cur_sz_line = _print_formatting(node, f, tag_sep, child_sep, nb_char_tab, cur_sz_line);
+	cur_sz_line += sx_fprintf(f, C2SX("</%s>"), node->tag);
+
+	return cur_sz_line;
+}
+
+int XMLNode_print_attr_sep(const XMLNode* node, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, const SXML_CHAR* attr_sep, int keep_text_spaces, int sz_line, int nb_char_tab)
+{
+	return _XMLNode_print(node, f, tag_sep, child_sep, attr_sep, keep_text_spaces, sz_line, 0, nb_char_tab, 0);
+}
+
+int XMLDoc_print_attr_sep(const XMLDoc* doc, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, const SXML_CHAR* attr_sep, int keep_text_spaces, int sz_line, int nb_char_tab)
+{
+	int i, depth, cur_sz_line;
+	
+	if (doc == NULL || f == NULL || doc->init_value != XML_INIT_DONE)
+		return false;
+	
+	/* Write BOM if it exist */
+	if (doc->sz_bom > 0) fwrite(doc->bom, sizeof(unsigned char), doc->sz_bom, f);
+
+	depth = -1; /* UGLY HACK: 'depth' forced negative on very first line so we don't print an extra 'tag_sep' (usually "\n") */
+	for (i = 0, cur_sz_line = 0; i < doc->n_nodes; i++) {
+		cur_sz_line = _XMLNode_print(doc->nodes[i], f, tag_sep, child_sep, attr_sep, keep_text_spaces, sz_line, cur_sz_line, nb_char_tab, depth);
+		depth = 0;
+	}
+	/* TODO: Find something more graceful than 'depth=-1', even though everyone knows I probably never will ;) */
+
+	return true;
+}
+
+/* --- */
+
+int XML_parse_attribute_to(const SXML_CHAR* str, int to, XMLAttribute* xmlattr)
+{
+	const SXML_CHAR *p;
+	int i, n0, n1, remQ = 0;
+	int ret = 1;
+	SXML_CHAR quote = '\0';
+	
+	if (str == NULL || xmlattr == NULL)
+		return 0;
+
+	if (to < 0)
+		to = sx_strlen(str) - 1;
+	
+	/* Search for the '=' */
+	/* 'n0' is where the attribute name stops, 'n1' is where the attribute value starts */
+	for (n0 = 0; n0 != to && str[n0] != C2SX('=') && !sx_isspace(str[n0]); n0++) ; /* Search for '=' or a space */
+	for (n1 = n0; n1 != to && sx_isspace(str[n1]); n1++) ; /* Search for something not a space */
+	if (str[n1] != C2SX('='))
+		return 0; /* '=' not found: malformed string */
+	for (n1++; n1 != to && sx_isspace(str[n1]); n1++) ; /* Search for something not a space */
+	if (isquote(str[n1])) { /* Remove quotes */
+		quote = str[n1];
+		remQ = 1;
+	}
+	
+	xmlattr->name = __malloc((n0+1)*sizeof(SXML_CHAR));
+	xmlattr->value = __malloc((to+1 - n1 - 2*remQ + 1) * sizeof(SXML_CHAR)); /* 2*remQ because we expect 2 quotes */
+	xmlattr->active = true;
+	if (xmlattr->name != NULL && xmlattr->value != NULL) {
+		/* Copy name */
+		sx_strncpy(xmlattr->name, str, n0);
+		xmlattr->name[n0] = NULC;
+		/* (void)str_unescape(xmlattr->name); do not unescape the name */
+		/* Copy value (p starts after the quote (if any) and stops at the end of 'str'
+		  (skipping the quote if any, hence the '*(p+remQ)') */
+		for (i = 0, p = str + n1 + remQ; i + n1 + 2*remQ < to && *(p+remQ) != NULC; i++, p++)
+			xmlattr->value[i] = *p;
+		xmlattr->value[i] = NULC;
+		(void)html2str(xmlattr->value, NULL); /* Convert HTML escape sequences, do not str_unescape(xmlattr->value) */
+		if (remQ && *p != quote)
+			ret = 2; /* Quote at the beginning but not at the end: probable presence of '>' inside attribute value, so we need to read more data! */
+	} else
+		ret = 0;
+	
+	if (ret == 0) {
+		if (xmlattr->name != NULL) {
+			__free(xmlattr->name);
+			xmlattr->name = NULL;
+		}
+		if (xmlattr->value != NULL) {
+			__free(xmlattr->value);
+			xmlattr->value = NULL;
+		}
+	}
+	
+	return ret;
+}
+
+static TagType _parse_special_tag(const SXML_CHAR* str, int len, _TAG* tag, XMLNode* node)
+{
+	if (sx_strncmp(str, tag->start, tag->len_start))
+		return TAG_NONE;
+
+	if (sx_strncmp(str + len - tag->len_end, tag->end, tag->len_end)) /* There probably is a '>' inside the tag */
+		return TAG_PARTIAL;
+
+	node->tag = __malloc((len - tag->len_start - tag->len_end + 1)*sizeof(SXML_CHAR));
+	if (node->tag == NULL)
+		return TAG_ERROR;
+	sx_strncpy(node->tag, str + tag->len_start, len - tag->len_start - tag->len_end);
+	node->tag[len - tag->len_start - tag->len_end] = NULC;
+	node->tag_type = tag->tag_type;
+
+	return node->tag_type;
+}
+
+/*
+ Reads a string that is supposed to be an xml tag like '<tag (attribName="attribValue")* [/]>' or '</tag>'.
+ Fills the 'xmlnode' structure with the tag name and its attributes.
+ Returns 'TAG_ERROR' if an error occurred (malformed 'str' or memory). 'TAG_*' when string is recognized.
+ */
+TagType XML_parse_1string(const SXML_CHAR* str, XMLNode* xmlnode)
+{
+	SXML_CHAR *p;
+	XMLAttribute* pt;
+	int n, nn, len, rc, tag_end = 0;
+	
+	if (str == NULL || xmlnode == NULL)
+		return TAG_ERROR;
+	len = sx_strlen(str);
+	
+	/* Check for malformed string */
+	if (str[0] != C2SX('<') || str[len-1] != C2SX('>'))
+		return TAG_NONE; /* Syntax error */
+
+	for (nn = 0; nn < NB_SPECIAL_TAGS; nn++) {
+		n = (int)_parse_special_tag(str, len, &_spec[nn], xmlnode);
+		switch (n) {
+			case TAG_NONE:	break;				/* Nothing found => do nothing */
+			default:		return (TagType)n;	/* Tag found => return it */
+		}
+	}
+
+	/* "<!DOCTYPE" requires a special handling because it can end with "]>" instead of ">" if a '[' is found inside */
+	if (str[1] == C2SX('!')) {
+		/* DOCTYPE */
+		if (!sx_strncmp(str, C2SX("<!DOCTYPE"), 9)) { /* 9 = sizeof("<!DOCTYPE") */
+			for (n = 9; str[n] && str[n] != C2SX('['); n++) ; /* Look for a '[' inside the DOCTYPE, which would mean that we should be looking for a "]>" tag end */
+			nn = 0;
+			if (str[n]) { /* '[' was found */
+				if (sx_strncmp(str+len-2, C2SX("]>"), 2)) /* There probably is a '>' inside the DOCTYPE */
+					return TAG_PARTIAL;
+				nn = 1;
+			}
+			xmlnode->tag = __malloc((len - 9 - nn)*sizeof(SXML_CHAR)); /* 'len' - "<!DOCTYPE" and ">" + '\0' */
+			if (xmlnode->tag == NULL)
+				return TAG_ERROR;
+			sx_strncpy(xmlnode->tag, &str[9], len - 10 - nn);
+			xmlnode->tag[len - 10 - nn] = NULC;
+			xmlnode->tag_type = TAG_DOCTYPE;
+
+			return TAG_DOCTYPE;
+		}
+	}
+	
+	/* Test user tags */
+	for (nn = 0; nn < _user_tags.n_tags; nn++) {
+		n = _parse_special_tag(str, len, &_user_tags.tags[nn], xmlnode);
+		switch (n) {
+			case TAG_ERROR:	return TAG_ERROR;	/* Error => exit */
+			case TAG_NONE:	break;				/* Not this one */
+			default:		return (TagType)n;	/* Tag found => return it */
+		}
+	}
+
+	if (str[1] == C2SX('/'))
+		tag_end = 1;
+	
+	/* tag starts at index 1 (or 2 if tag end) and ends at the first space or '/>' */
+	for (n = 1 + tag_end; str[n] != NULC && str[n] != C2SX('>') && str[n] != C2SX('/') && !sx_isspace(str[n]); n++) ;
+	xmlnode->tag = __malloc((n - tag_end)*sizeof(SXML_CHAR));
+	if (xmlnode->tag == NULL)
+		return TAG_ERROR;
+	sx_strncpy(xmlnode->tag, &str[1 + tag_end], n - 1 - tag_end);
+	xmlnode->tag[n - 1 - tag_end] = NULC;
+	if (tag_end) {
+		xmlnode->tag_type = TAG_END;
+		return TAG_END;
+	}
+	
+	/* Here, 'n' is the position of the first space after tag name */
+	while (n < len) {
+		/* Skips spaces */
+		while (sx_isspace(str[n])) n++;
+		
+		/* Check for XML end ('>' or '/>') */
+		if (str[n] == C2SX('>')) { /* Tag with children */
+			TagType type = (str[n-1] == '/' ? TAG_SELF : TAG_FATHER); /* TODO: Find something better to cope with <tag attr=v/> */
+			xmlnode->tag_type = type;
+			return type;
+		}
+		if (!sx_strcmp(str+n, C2SX("/>"))) { /* Tag without children */
+			xmlnode->tag_type = TAG_SELF;
+			return TAG_SELF;
+		}
+		
+		/* New attribute found */
+		p = sx_strchr(str+n, C2SX('='));
+		if (p == NULL) goto parse_err;
+		pt = __realloc(xmlnode->attributes, (xmlnode->n_attributes + 1) * sizeof(XMLAttribute));
+		if (pt == NULL) goto parse_err;
+		
+		pt[xmlnode->n_attributes].name = NULL;
+		pt[xmlnode->n_attributes].value = NULL;
+		pt[xmlnode->n_attributes].active = false;
+		xmlnode->n_attributes++;
+		xmlnode->attributes = pt;
+		while (*++p != NULC && sx_isspace(*p)) ; /* Skip spaces */
+		if (isquote(*p)) { /* Attribute value starts with a quote, look for next one, ignoring protected ones with '\' */
+			for (nn = p-str+1; str[nn] && str[nn] != *p; nn++) { /* CHECK UNICODE "nn = p-str+1" */
+				/* if (str[nn] == C2SX('\\')) nn++; [bugs:#7]: '\' is valid in values */
+			}
+			nn++; //* Skip quote */
+		} else { /* Attribute value stops at first space or end of XML string */
+			for (nn = p-str+1; str[nn] != NULC && !sx_isspace(str[nn]) && str[nn] != C2SX('/') && str[nn] != C2SX('>'); nn++) ; /* Go to the end of the attribute value */ /* CHECK UNICODE */
+		}
+		
+		/* Here 'str[nn]' is the character after value */
+		/* the attribute definition ('attrName="attrVal"') is between 'str[n]' and 'str[nn]' */
+		rc = XML_parse_attribute_to(&str[n], nn - n, &xmlnode->attributes[xmlnode->n_attributes - 1]);
+		if (!rc) goto parse_err;
+		if (rc == 2) { /* Probable presence of '>' inside attribute value, which is legal XML. Remove attribute to re-parse it later */
+			XMLNode_remove_attribute(xmlnode, xmlnode->n_attributes - 1);
+			return TAG_ERROR; /* was TAG_PARTIAL */
+		}
+		
+		n = nn + 1; /* Go to next attribute */
+		if (str[nn] == C2SX('>')) { /* ... or we migh have reached the end if no space is between the attribute value and the ">" or "/>" */
+			TagType type = (str[nn-1] == '/' ? TAG_SELF : TAG_FATHER); /* TODO: Find something better to cope with <tag attr=v/> */
+			xmlnode->tag_type = type;
+			return type;
+		}
+	}
+	
+	sx_fprintf(stderr, C2SX("\nWE SHOULD NOT BE HERE!\n[%s]\n\n"), str);
+	
+parse_err:
+	(void)XMLNode_free(xmlnode);
+
+	return TAG_ERROR;
+}
+
+static int _parse_data_SAX(void* in, const DataSourceType in_type, const SAX_Callbacks* sax, SAX_Data* sd)
+{
+	SXML_CHAR *line = NULL, *txt_end, *p;
+	XMLNode node;
+	int ret, exit, sz, n0, ncr;
+	TagType tag_type;
+	int (*meos)(void* ds) = (in_type == DATA_SOURCE_BUFFER ? (int(*)(void*))_beob : (int(*)(void*))sx_feof);
+
+	if (sax->start_doc != NULL && !sax->start_doc(sd))
+		return true;
+	if (sax->all_event != NULL && !sax->all_event(XML_EVENT_START_DOC, NULL, (SXML_CHAR*)sd->name, 0, sd))
+		return true;
+
+	ret = true;
+	exit = false;
+	sd->line_num = 1; /* Line counter, starts at 1 */
+	sz = 0; /* 'line' buffer size */
+	node.init_value = 0;
+	(void)XMLNode_init(&node);
+	while ((n0 = read_line_alloc(in, in_type, &line, &sz, 0, NULC, C2SX('>'), true, C2SX('\n'), &ncr)) != 0) {
+		(void)XMLNode_free(&node);
+		for (p = line; *p != NULC && sx_isspace(*p) && p - line < n0; p++) ; /* Checks if text is only spaces */
+		if (*p == NULC || p - line >= n0)
+			break;
+		sd->line_num += ncr;
+
+		/* Get text for 'father' (i.e. what is before '<') */
+		while ((txt_end = sx_strchr(line, C2SX('<'))) == NULL) { /* '<' was not found, indicating a probable '>' inside text (should have been escaped with '&gt;' but we'll handle that ;)) */
+			int n1 = read_line_alloc(in, in_type, &line, &sz, n0, 0, C2SX('>'), true, C2SX('\n'), &ncr); /* Go on reading the file from current position until next '>' */
+			sd->line_num += ncr;
+			if (n1 <= n0) {
+				ret = false;
+				if (sax->on_error == NULL && sax->all_event == NULL) {
+					sx_fprintf(stderr, C2SX("%s:%d: MEMORY ERROR.\n"), sd->name, sd->line_num);
+				} else {
+					if (sax->on_error != NULL && !sax->on_error(PARSE_ERR_MEMORY, sd->line_num, sd))
+						break;
+					if (sax->all_event != NULL && !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, PARSE_ERR_MEMORY, sd))
+						break;
+				}
+				break; /* 'txt_end' is still NULL here so we'll display the syntax error below */
+			}
+			n0 = n1;
+		}
+		if (txt_end == NULL) { /* Missing tag start */
+			ret = false;
+			if (sax->on_error == NULL && sax->all_event == NULL) {
+				sx_fprintf(stderr, C2SX("%s:%d: ERROR: Unexpected end character '>', without matching '<'!\n"), sd->name, sd->line_num);
+			} else {
+				if (sax->on_error != NULL && !sax->on_error(PARSE_ERR_UNEXPECTED_TAG_END, sd->line_num, sd))
+					break;
+				if (sax->all_event != NULL && !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, PARSE_ERR_UNEXPECTED_TAG_END, sd))
+					break;
+			}
+			break;
+		}
+		/* First part of 'line' (before '<') is to be added to 'father->text' */
+		*txt_end = NULC; /* Have 'line' be the text for 'father' */
+		if (*line != NULC && (sax->new_text != NULL || sax->all_event != NULL)) {
+			SXML_CHAR* unhtml = line;
+			if (has_html(line)) {
+				unhtml = __malloc(sx_strlen(line) * sizeof(SXML_CHAR)); /* Allocate for HTML escaping */
+				if (unhtml == NULL) {
+					if (sax->on_error != NULL && !sax->on_error(PARSE_ERR_MEMORY, sd->line_num, sd))
+						break;
+					if (sax->all_event != NULL && !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, PARSE_ERR_MEMORY, sd))
+						break;
+				}
+				html2str(line, unhtml);
+			}
+			if (sax->new_text != NULL && (exit = !sax->new_text(unhtml, sd))) /* no str_unescape(line) */
+				break;
+			if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_TEXT, NULL, unhtml, sd->line_num, sd)))
+				break;
+		}
+		*txt_end = '<'; /* Restores tag start */
+
+		switch (tag_type = XML_parse_1string(txt_end, &node)) {
+			case TAG_ERROR: /* Memory error */
+				ret = false;
+				if (sax->on_error == NULL && sax->all_event == NULL) {
+					sx_fprintf(stderr, C2SX("%s:%d: MEMORY ERROR.\n"), sd->name, sd->line_num);
+				} else {
+					if (sax->on_error != NULL && (exit = !sax->on_error(PARSE_ERR_MEMORY, sd->line_num, sd)))
+						break;
+					if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, PARSE_ERR_MEMORY, sd)))
+						break;
+				}
+				break;
+		
+			case TAG_NONE: /* Syntax error */
+				ret = false;
+				p = sx_strchr(txt_end, C2SX('\n'));
+				if (p != NULL)
+					*p = NULC;
+				if (sax->on_error == NULL && sax->all_event == NULL) {
+					sx_fprintf(stderr, C2SX("%s:%d: SYNTAX ERROR (%s%s).\n"), sd->name, sd->line_num, txt_end, p == NULL ? C2SX("") : C2SX("..."));
+					if (p != NULL)
+						*p = C2SX('\n');
+				} else {
+					if (sax->on_error != NULL && (exit = !sax->on_error(PARSE_ERR_SYNTAX, sd->line_num, sd)))
+						break;
+					if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, PARSE_ERR_SYNTAX, sd)))
+						break;
+				}
+				break;
+
+			case TAG_END:
+				if (sax->end_node != NULL || sax->all_event != NULL) {
+					if (sax->end_node != NULL && (exit = !sax->end_node(&node, sd)))
+						break;
+					if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_END_NODE, &node, NULL, sd->line_num, sd)))
+						break;
+				}
+				break;
+
+			default: /* Add 'node' to 'father' children */
+				/* If the line looks like a comment (or CDATA) but is not properly finished, loop until we find the end. */
+				while (tag_type == TAG_PARTIAL) {
+					int n1 = read_line_alloc(in, in_type, &line, &sz, n0, NULC, C2SX('>'), true, C2SX('\n'), &ncr); /* Go on reading the file from current position until next '>' */
+					sd->line_num += ncr;
+					if (n1 <= n0) {
+						ret = false;
+						if (sax->on_error == NULL && sax->all_event == NULL) {
+							sx_fprintf(stderr, C2SX("%s:%d: SYNTAX ERROR.\n"), sd->name, sd->line_num);
+						} else {
+							if (sax->on_error != NULL && (exit = !sax->on_error(meos(in) ? PARSE_ERR_EOF : PARSE_ERR_MEMORY, sd->line_num, sd)))
+								break;
+							if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, meos(in) ? PARSE_ERR_EOF : PARSE_ERR_MEMORY, sd)))
+								break;
+						}
+						break;
+					}
+					n0 = n1;
+					txt_end = sx_strchr(line, C2SX('<')); /* In case 'line' has been moved by the '__realloc' in 'read_line_alloc' */
+					tag_type = XML_parse_1string(txt_end, &node);
+					if (tag_type == TAG_ERROR) {
+						ret = false;
+						if (sax->on_error == NULL && sax->all_event == NULL) {
+							sx_fprintf(stderr, C2SX("%s:%d: PARSE ERROR.\n"), sd->name, sd->line_num);
+						} else {
+							if (sax->on_error != NULL && (exit = !sax->on_error(meos(in) ? PARSE_ERR_EOF : PARSE_ERR_SYNTAX, sd->line_num, sd)))
+								break;
+							if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_ERROR, NULL, (SXML_CHAR*)sd->name, meos(in) ? PARSE_ERR_EOF : PARSE_ERR_SYNTAX, sd)))
+								break;
+						}
+						break;
+					}
+				}
+				if (ret == false)
+					break;
+				if (sax->start_node != NULL && (exit = !sax->start_node(&node, sd)))
+					break;
+				if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_START_NODE, &node, NULL, sd->line_num, sd)))
+					break;
+				if (node.tag_type != TAG_FATHER && (sax->end_node != NULL || sax->all_event != NULL)) {
+					if (sax->end_node != NULL && (exit = !sax->end_node(&node, sd)))
+						break;
+					if (sax->all_event != NULL && (exit = !sax->all_event(XML_EVENT_END_NODE, &node, NULL, sd->line_num, sd)))
+						break;
+				}
+			break;
+		}
+		if (exit == true) /* Return false when exit is requested */
+			ret = false;
+		if (ret == false || meos(in))
+			break;
+	}
+	__free(line);
+	(void)XMLNode_free(&node);
+
+	if (sax->end_doc != NULL && !sax->end_doc(sd))
+		return ret;
+	if (sax->all_event != NULL)
+		(void)sax->all_event(XML_EVENT_END_DOC, NULL, (SXML_CHAR*)sd->name, sd->line_num, sd);
+
+	return ret;
+}
+
+int SAX_Callbacks_init(SAX_Callbacks* sax)
+{
+	if (sax == NULL)
+		return false;
+
+	sax->start_doc = NULL;
+	sax->start_node = NULL;
+	sax->end_node = NULL;
+	sax->new_text = NULL;
+	sax->on_error = NULL;
+	sax->end_doc = NULL;
+	sax->all_event = NULL;
+
+	return true;
+}
+
+int DOMXMLDoc_doc_start(SAX_Data* sd)
+{
+	DOM_through_SAX* dom = (DOM_through_SAX*)sd->user;
+
+	dom->current = NULL;
+	dom->error = PARSE_ERR_NONE;
+	dom->line_error = 0;
+
+	return true;
+}
+
+int DOMXMLDoc_node_start(const XMLNode* node, SAX_Data* sd)
+{
+	DOM_through_SAX* dom = (DOM_through_SAX*)sd->user;
+	XMLNode* new_node;
+	int i;
+
+	if ((new_node = XMLNode_dup(node, true)) == NULL) goto node_start_err; /* No real need to put 'true' for 'XMLNode_dup', but cleaner */
+	
+	if (dom->current == NULL) {
+		if ((i = _add_node(&dom->doc->nodes, &dom->doc->n_nodes, new_node)) < 0) goto node_start_err;
+
+		if (dom->doc->i_root < 0 && (node->tag_type == TAG_FATHER || node->tag_type == TAG_SELF))
+			dom->doc->i_root = i;
+	} else {
+		if (_add_node(&dom->current->children, &dom->current->n_children, new_node) < 0) goto node_start_err;
+	}
+
+	new_node->father = dom->current;
+	dom->current = new_node;
+
+	return true;
+
+node_start_err:
+	dom->error = PARSE_ERR_MEMORY;
+	dom->line_error = sd->line_num;
+	(void)XMLNode_free(new_node);
+	__free(new_node);
+
+	return false;
+}
+
+int DOMXMLDoc_node_end(const XMLNode* node, SAX_Data* sd)
+{
+	DOM_through_SAX* dom = (DOM_through_SAX*)sd->user;
+
+	if (dom->current == NULL || sx_strcmp(dom->current->tag, node->tag)) {
+		sx_fprintf(stderr, C2SX("%s:%d: ERROR - End tag </%s> was unexpected"), sd->name, sd->line_num, node->tag);
+		if (dom->current != NULL)
+			sx_fprintf(stderr, C2SX(" (</%s> was expected)\n"), dom->current->tag);
+		else
+			sx_fprintf(stderr, C2SX(" (no node to end)\n"));
+
+		dom->error = PARSE_ERR_UNEXPECTED_NODE_END;
+		dom->line_error = sd->line_num;
+
+		return false;
+	}
+
+	dom->current = dom->current->father;
+
+	return true;
+}
+
+int DOMXMLDoc_node_text(SXML_CHAR* text, SAX_Data* sd)
+{
+	SXML_CHAR* p = text;
+	DOM_through_SAX* dom = (DOM_through_SAX*)sd->user;
+
+	/* Keep text, even if it is only spaces */
+#if 0
+	while(*p != NULC && sx_isspace(*p++)) ;
+	if (*p == NULC) return true; /* Only spaces */
+#endif
+
+	/* If there is no current node to add text to, raise an error, except if text is only spaces, in which case it is probably just formatting */
+	if (dom->current == NULL) {
+		while(*p != NULC && sx_isspace(*p)) p++;
+		if (*p == NULC) /* Only spaces => probably pretty-printing */
+			return true;
+		dom->error = PARSE_ERR_TEXT_OUTSIDE_NODE;
+		dom->line_error = sd->line_num;
+		return false; /* There is some "real" text => raise an error */
+	}
+
+	if (dom->text_as_nodes) {
+		XMLNode* new_node = XMLNode_allocN(1);
+		if (new_node == NULL || (new_node->text = sx_strdup(text)) == NULL
+			|| _add_node(&dom->current->children, &dom->current->n_children, new_node) < 0) {
+			dom->error = PARSE_ERR_MEMORY;
+			dom->line_error = sd->line_num;
+			(void)XMLNode_free(new_node);
+			__free(new_node);
+			return false;
+		}
+		new_node->tag_type = TAG_TEXT;
+		new_node->father = dom->current;
+		/*dom->current->tag_type = TAG_FATHER; // OS: should parent field be forced to be TAG_FATHER? now it has at least one TAG_TEXT child. I decided not to enforce this for backward-compatibility related to tag_types*/
+		return true;
+	} else { /* Old behaviour: concatenate text to the previous one */
+		/* 'p' will point at the new text */
+		if (dom->current->text == NULL) {
+			p = sx_strdup(text);
+		} else {
+			p = __realloc(dom->current->text, (sx_strlen(dom->current->text) + sx_strlen(text) + 1)*sizeof(SXML_CHAR));
+			if (p != NULL)
+				sx_strcat(p, text);
+		}
+		if (p == NULL) {
+			dom->error = PARSE_ERR_MEMORY;
+			dom->line_error = sd->line_num;
+			return false;
+		}
+		
+		dom->current->text = p;
+	}
+
+	return true;
+}
+
+int DOMXMLDoc_parse_error(ParseError error_num, int line_number, SAX_Data* sd)
+{
+	DOM_through_SAX* dom = (DOM_through_SAX*)sd->user;
+
+	dom->error = error_num;
+	dom->line_error = line_number;
+
+	/* Complete error message will be displayed in 'DOMXMLDoc_doc_end' callback */
+
+	return false; /* Stop on error */
+}
+
+int DOMXMLDoc_doc_end(SAX_Data* sd)
+{
+	DOM_through_SAX* dom = (DOM_through_SAX*)sd->user;
+
+	if (dom->error != PARSE_ERR_NONE) {
+		SXML_CHAR* msg;
+
+		switch (dom->error) {
+			case PARSE_ERR_MEMORY:				msg = C2SX("MEMORY"); break;
+			case PARSE_ERR_UNEXPECTED_TAG_END:	msg = C2SX("UNEXPECTED_TAG_END"); break;
+			case PARSE_ERR_SYNTAX:				msg = C2SX("SYNTAX"); break;
+			case PARSE_ERR_EOF:					msg = C2SX("UNEXPECTED_END_OF_FILE"); break;
+			case PARSE_ERR_TEXT_OUTSIDE_NODE:	msg = C2SX("TEXT_OUTSIDE_NODE"); break;
+			case PARSE_ERR_UNEXPECTED_NODE_END:	msg = C2SX("UNEXPECTED_NODE_END"); break;
+			default:							msg = C2SX("UNKNOWN"); break;
+		}
+		sx_fprintf(stderr, C2SX("%s:%d: An error was found (%s(%d)), loading aborted...\n"), sd->name, dom->line_error, msg, dom->error);
+		dom->current = NULL;
+		(void)XMLDoc_free(dom->doc);
+		dom->doc = NULL;
+	}
+
+	return true;
+}
+
+int SAX_Callbacks_init_DOM(SAX_Callbacks* sax)
+{
+	if (sax == NULL)
+		return false;
+
+	sax->start_doc = DOMXMLDoc_doc_start;
+	sax->start_node = DOMXMLDoc_node_start;
+	sax->end_node = DOMXMLDoc_node_end;
+	sax->new_text = DOMXMLDoc_node_text;
+	sax->on_error = DOMXMLDoc_parse_error;
+	sax->end_doc = DOMXMLDoc_doc_end;
+	sax->all_event = NULL;
+
+	return true;
+}
+
+int XMLDoc_parse_file_SAX(const SXML_CHAR* filename, const SAX_Callbacks* sax, void* user)
+{
+	FILE* f;
+	int ret;
+	SAX_Data sd;
+	SXML_CHAR* fmode = 
+#ifndef SXMLC_UNICODE
+	C2SX("rt");
+#else
+	C2SX("rb"); /* In Unicode, open the file as binary so that further 'fgetwc' read all bytes */
+#endif
+	BOM_TYPE bom;
+
+
+	if (sax == NULL || filename == NULL || filename[0] == NULC)
+		return false;
+
+	f = sx_fopen(filename, fmode);
+	if (f == NULL)
+		return false;
+	/* Microsoft's 'ftell' returns invalid position for Unicode text files
+	   (see http://connect.microsoft.com/VisualStudio/feedback/details/369265/ftell-ftell-nolock-incorrectly-handling-unicode-text-translation)
+	   However, we're opening the file as binary in Unicode so we don't fall into that case...
+	*/
+	#if defined(SXMLC_UNICODE) && (defined(WIN32) || defined(WIN64))
+	/*setvbuf(f, NULL, _IONBF, 0);*/
+	#endif
+
+	sd.name = (SXML_CHAR*)filename;
+	sd.user = user;
+	sd.type = DATA_SOURCE_FILE;
+	sd.src  = (void*)f;
+	bom = freadBOM(f, NULL, NULL); /* Skip BOM, if any */
+	/* In Unicode, re-open the file in text-mode if there is no BOM (or UTF-8) as we assume that
+	   the file is "plain" text (i.e. 1 byte = 1 character). If opened in binary mode, 'fgetwc'
+	   would read 2 bytes for 1 character, which would not work on "plain" files. */
+	if (bom == BOM_NONE || bom == BOM_UTF_8) {
+		sx_fclose(f);
+		f = sx_fopen(filename, C2SX("rt"));
+		if (f == NULL)
+			return false;
+		if (bom == BOM_UTF_8)
+			freadBOM(f, NULL, NULL); /* Skip the UTF-8 BOM that was found */
+	}
+#ifndef SXMLC_UNICODE
+	/* Unicode BOM when Unicode support has not been compiled in. */
+	else {
+		sx_fclose(f);
+		return false;
+	}
+#endif
+
+	ret = _parse_data_SAX((void*)f, DATA_SOURCE_FILE, sax, &sd);
+	(void)sx_fclose(f);
+
+	return ret;
+}
+
+int XMLDoc_parse_buffer_SAX_len(const SXML_CHAR* buffer, int buffer_len, const SXML_CHAR* name, const SAX_Callbacks* sax, void* user)
+{
+	DataSourceBuffer dsb = { buffer, buffer_len, 0 };
+	SAX_Data sd;
+
+	if (sax == NULL || buffer == NULL)
+		return false;
+
+	sd.name = name;
+	sd.user = user;
+	sd.type = DATA_SOURCE_BUFFER;
+	sd.src  = (void*)buffer;
+	return _parse_data_SAX((void*)&dsb, DATA_SOURCE_BUFFER, sax, &sd);
+}
+
+int XMLDoc_parse_file_DOM_text_as_nodes(const SXML_CHAR* filename, XMLDoc* doc, int text_as_nodes)
+{
+	DOM_through_SAX dom;
+	SAX_Callbacks sax;
+	int ret;
+
+	if (doc == NULL || filename == NULL || filename[0] == NULC || doc->init_value != XML_INIT_DONE)
+		return false;
+
+	sx_strncpy(doc->filename, filename, SXMLC_MAX_PATH - 1);
+	doc->filename[SXMLC_MAX_PATH - 1] = NULC;
+
+	/* Read potential BOM on file */
+	{
+		/* In Unicode, open the file as binary so that further 'fgetwc' read all bytes */
+		FILE* f = sx_fopen(filename, C2SX("rb"));
+		if (f != NULL) {
+			#if defined(SXMLC_UNICODE) && (defined(WIN32) || defined(WIN64))
+			/*setvbuf(f, NULL, _IONBF, 0);*/
+			#endif
+			doc->bom_type = freadBOM(f, doc->bom, &doc->sz_bom);
+			sx_fclose(f);
+		}
+	}
+
+	dom.doc = doc;
+	dom.current = NULL;
+	dom.text_as_nodes = text_as_nodes;
+	SAX_Callbacks_init_DOM(&sax);
+
+	ret = XMLDoc_parse_file_SAX(filename, &sax, &dom);
+	if (!ret) {
+		(void)XMLDoc_free(doc);
+		dom.doc = NULL;
+		return ret;
+	}
+
+	/* TODO: Check there is no unfinished root nodes */
+	return ret;
+}
+
+int XMLDoc_parse_buffer_DOM_text_as_nodes(const SXML_CHAR* buffer, const SXML_CHAR* name, XMLDoc* doc, int text_as_nodes)
+{
+	DOM_through_SAX dom;
+	SAX_Callbacks sax;
+	int ret;
+
+	if (doc == NULL || buffer == NULL || doc->init_value != XML_INIT_DONE)
+		return false;
+
+	dom.doc = doc;
+	dom.current = NULL;
+	dom.text_as_nodes = text_as_nodes;
+	SAX_Callbacks_init_DOM(&sax);
+
+	ret = XMLDoc_parse_buffer_SAX(buffer, name, &sax, &dom);
+	if (!ret) {
+		XMLDoc_free(doc);
+		return ret;
+	}
+
+	/* TODO: Check there is no unfinished root nodes */
+	return ret;
+}
+
+
+
+/* --- Utility functions (ex sxmlutils.c) --- */
+
+#ifdef DBG_MEM
+static int nb_alloc = 0, nb_free = 0;
+
+void* __malloc(size_t sz)
+{
+	void* p = malloc(sz);
+	if (p != NULL)
+		nb_alloc++;
+	printf("0x%x: MALLOC (%d) - NA %d - NF %d = %d\n", p, sz, nb_alloc, nb_free, nb_alloc - nb_free);
+	return p;
+}
+
+void* __calloc(size_t count, size_t sz)
+{
+	void* p = calloc(count, sz);
+	if (p != NULL)
+		nb_alloc++;
+	printf("0x%x: CALLOC (%d, %d) - NA %d - NF %d = %d\n", p, count, sz, nb_alloc, nb_free, nb_alloc - nb_free);
+	return p;
+}
+
+void* __realloc(void* mem, size_t sz)
+{
+	void* p = realloc(mem, sz);
+	if (mem == NULL && p != NULL)
+		nb_alloc++;
+	else if (mem != NULL && sz == 0)
+		nb_free++;
+	printf("0x%x: REALLOC 0x%x (%d)", p, mem, sz);
+	if (mem == NULL)
+		printf(" - NA %d - NF %d = %d", nb_alloc, nb_free, nb_alloc - nb_free);
+	printf("\n");
+	return p;
+}
+
+void __free(void* mem)
+{
+	nb_free++;
+	printf("0x%x: FREE - NA %d - NF %d = %d\n", mem, nb_alloc, nb_free, nb_alloc - nb_free);
+	free(mem);
+}
+
+char* __sx_strdup(const char* s)
+{
+/* Mimic the behavior of sx_strdup(), as we can't use it directly here: DBG_MEM is defined
+   and sx_strdup is this function! (bug #5) */
+#ifdef SXMLC_UNICODE
+	char* p = wcsdup(s);
+#else
+	char* p = strdup(s);
+#endif
+	if (p != NULL)
+		nb_alloc++;
+	printf("0x%x: STRDUP (%d) - NA %d - NF %d = %d\n", p, sx_strlen(s), nb_alloc, nb_free, nb_alloc - nb_free);
+	return p;
+}
+#endif
+
+/* Dictionary of special characters and their HTML equivalent */
+static struct _html_special_dict {
+	SXML_CHAR chr;		/* Original character */
+	SXML_CHAR* html;	/* Equivalent HTML string */
+	int html_len;	/* 'sx_strlen(html)' */
+} HTML_SPECIAL_DICT[] = {
+	{ C2SX('<'), C2SX("&lt;"), 4 },
+	{ C2SX('>'), C2SX("&gt;"), 4 },
+	{ C2SX('"'), C2SX("&quot;"), 6 },
+	{ C2SX('\''), C2SX("&apos;"), 6 },
+	{ C2SX('&'), C2SX("&amp;"), 5 },
+	{ NULC, NULL, 0 }, /* Terminator */
+};
+
+int _beob(DataSourceBuffer* ds)
+{
+	if (ds == NULL || ds->buf[ds->cur_pos] == NULC || ds->cur_pos >= ds->buf_len)
+		return true;
+
+	return false;
+}
+
+int _bgetc(DataSourceBuffer* ds)
+{
+	if (_beob(ds))
+		return EOF;
+	
+	return (int)(ds->buf[ds->cur_pos++]);
+}
+
+/*
+ * \brief Read a "line" from data source, eventually (re-)allocating a given buffer. A "line" is defined
+ * as a portion starting with character `from` (usually `<`) ending at character `to` (usually `>`).
+ *
+ * Characters read will be stored in `line` starting at `i0` (this allows multiple calls to
+ * `read_line_alloc()` on the same `line` buffer without overwriting it at each call).
+ * Searches for character `from` until character `to`. If `from` is 0, starts from
+ * current position in the data source. If `to` is 0, it is replaced by `\n`.
+ *
+ * \param in The data source (either `FILE*` if `in_type` is `DATA_SOURCE_FILE` or `SXML_CHAR*`
+ * 		if `in_type` is `DATA_SOURCE_BUFFER`).
+ * \param in_type specifies the type of data source to be read.
+ * \param line can be `NULL`, in which case it will be allocated to `*sz_line` bytes. After the function
+ * 		returns, `*sz_line` is the actual buffer size. This allows multiple calls to this function using
+ * 		the same buffer (without re-allocating/freeing).
+ * \param sz_line is the size of the buffer `line` if previously allocated (in `SXML_CHAR`, not byte!).
+ * 		If `NULL` or 0, an internal value of `MEM_INCR_RLA` is used.
+ * \param i0 The position where read characters are stored in `line`.
+ * \param from The character indicating a start of line.
+ * \param to The character indicating an end of line.
+ * \param keep_fromto if 0, removes characters `from` and `to` from the line (stripping).
+ * \param interest is a special character of interest, usually `'\n'` so we can count line numbers in the
+ * 		data source (valid only if `interest_count` is not `NULL`).
+ * \param interest_count if not `NULL`, will receive the count of `interest` characters while searching.
+ * \returns the number of characters in the line or 0 if an error occurred.
+ */
+int read_line_alloc(void* in, DataSourceType in_type, SXML_CHAR** line, int* sz_line, int i0, SXML_CHAR from, SXML_CHAR to, int keep_fromto, SXML_CHAR interest, int* interest_count)
+{
+	int init_sz = 0;
+	SXML_CHAR ch, *pt;
+	int c;
+	int n, ret;
+	int (*mgetc)(void* ds) = (in_type == DATA_SOURCE_BUFFER ? (int(*)(void*))_bgetc : (int(*)(void*))sx_fgetc);
+	int (*meos)(void* ds) = (in_type == DATA_SOURCE_BUFFER ? (int(*)(void*))_beob : (int(*)(void*))sx_feof);
+	
+	if (in == NULL || line == NULL)
+		return 0;
+	
+	if (to == NULC)
+		to = C2SX('\n');
+	/* Search for character 'from' */
+	if (interest_count != NULL)
+		*interest_count = 0;
+	while (true) {
+		/* Reaching EOF before 'to' char is not an error but should trigger 'line' alloc and init to '' */
+		c = mgetc(in);
+		ch = (SXML_CHAR)c;
+		if (c == EOF)
+			break;
+		if (interest_count != NULL && ch == interest)
+			(*interest_count)++;
+		/* If 'from' is '\0', we stop here */
+		if (ch == from || from == NULC)
+			break;
+	}
+	
+	if (sz_line == NULL)
+		sz_line = &init_sz;
+	
+	if (*line == NULL || *sz_line == 0) {
+		if (*sz_line == 0) *sz_line = MEM_INCR_RLA;
+		*line = __malloc(*sz_line*sizeof(SXML_CHAR));
+		if (*line == NULL)
+			return 0;
+	}
+	if (i0 < 0)
+		i0 = 0;
+	if (i0 >= *sz_line)
+		return 0;
+	
+	n = i0;
+	if (c == CEOF) { /* EOF reached before 'to' char => return the empty string */
+		(*line)[n] = NULC;
+		return meos(in) ? n : 0; /* Error if not EOF */
+	}
+	if (ch != from || keep_fromto) {
+		(*line)[n++] = ch;
+		if (n >= *sz_line) {
+			*sz_line += MEM_INCR_RLA;
+			pt = __realloc(*line, *sz_line*sizeof(SXML_CHAR));
+			if (pt == NULL) {
+				return 0;
+			} else
+				*line = pt;
+		}
+	}
+	(*line)[n] = NULC;
+	ret = 0;
+	while (true) {
+		if ((c = mgetc(in)) == CEOF) { /* EOF or error */
+			(*line)[n] = NULC;
+			ret = meos(in) ? n : 0;
+			break;
+		}
+		ch = (SXML_CHAR)c;
+		if (interest_count != NULL && ch == interest)
+			(*interest_count)++;
+		(*line)[n] = ch;
+		if (ch != to || (keep_fromto && to != NULC && ch == to)) /* If we reached the 'to' character and we keep it, we still need to add the extra '\0' */
+			n++;
+		if (n >= *sz_line) { /* Too many characters for our line => realloc some more */
+			*sz_line += MEM_INCR_RLA;
+			pt = __realloc(*line, *sz_line*sizeof(SXML_CHAR));
+			if (pt == NULL) {
+				ret = 0;
+				break;
+			} else
+				*line = pt;
+		}
+		(*line)[n] = NULC; /* If we reached the 'to' character and we want to strip it, 'n' hasn't changed and 'line[n]' (which is 'to') will be replaced by '\0' */
+		if (ch == to) {
+			ret = n;
+			break;
+		}
+	}
+	
+#if 0 /* Automatic buffer resize is deactivated */
+	/* Resize line to the exact size */
+	pt = __realloc(*line, (n+1)*sizeof(SXML_CHAR));
+	if (pt != NULL)
+		*line = pt;
+#endif
+	
+	return ret;
+}
+
+/* --- */
+
+SXML_CHAR* strcat_alloc(SXML_CHAR** src1, const SXML_CHAR* src2)
+{
+	SXML_CHAR* cat;
+	int n;
+
+	/* Do not concatenate '*src1' with itself */
+	if (src1 == NULL || *src1 == src2)
+		return NULL;
+
+	/* Concatenate a NULL or empty string */
+	if (src2 == NULL || *src2 == NULC)
+		return *src1;
+
+	n = (*src1 == NULL ? 0 : sx_strlen(*src1)) + sx_strlen(src2) + 1;
+	cat = __realloc(*src1, n*sizeof(SXML_CHAR));
+	if (cat == NULL)
+		return NULL;
+	if (*src1 == NULL)
+		*cat = NULC;
+	*src1 = cat;
+	sx_strcat(*src1, src2);
+
+	return *src1;
+}
+
+SXML_CHAR* strip_spaces(SXML_CHAR* str, SXML_CHAR repl_sq)
+{
+	SXML_CHAR* p;
+	int i, len;
+	
+	/* 'p' to the first non-space */
+	for (p = str; *p != NULC && sx_isspace(*p); p++) ; /* No need to search for 'protect' as it is not a space */
+	len = sx_strlen(str);
+	for (i = len-1; i >= 0 && sx_isspace(str[i]); i--) ;
+	if (i >= 0 && str[i] == C2SX('\\')) /* If last non-space is the protection, keep the last space */
+		i++;
+	str[i+1] = NULC; /* New end of string to last non-space */
+	
+	if (repl_sq == NULC) {
+		if (p == str && i == len)
+			return str; /* Nothing to do */
+		for (i = 0; (str[i] = *p) != NULC; i++, p++) ; /* Copy 'p' to 'str' */
+		return str;
+	}
+	
+	/* Squeeze all spaces with 'repl_sq' */
+	i = 0;
+	while (*p != NULC) {
+		if (sx_isspace(*p)) {
+			str[i++] = repl_sq;
+			while (sx_isspace(*++p)) ; /* Skips all next spaces */
+		} else {
+			if (*p == C2SX('\\'))
+				p++;
+			str[i++] = *p++;
+		}
+	}
+	str[i] = NULC;
+	
+	return str;
+}
+
+SXML_CHAR* str_unescape(SXML_CHAR* str)
+{
+	int i, j;
+
+	if (str == NULL)
+		return NULL;
+
+	for (i = j = 0; str[j]; j++) {
+		if (str[j] == C2SX('\\'))
+			j++;
+		str[i++] = str[j];
+	}
+
+	return str;
+}
+
+int split_left_right(SXML_CHAR* str, SXML_CHAR sep, int* l0, int* l1, int* i_sep, int* r0, int* r1, int ignore_spaces, int ignore_quotes)
+{
+	int n0, n1, is;
+	SXML_CHAR quote = '\0';
+
+	if (str == NULL)
+		return false;
+
+	if (i_sep != NULL)
+		*i_sep = -1;
+
+	if (!ignore_spaces) /* No sense of ignore quotes if spaces are to be kept */
+		ignore_quotes = false;
+
+	/* Parse left part */
+
+	if (ignore_spaces) {
+		for (n0 = 0; str[n0] != NULC && sx_isspace(str[n0]); n0++) ; /* Skip head spaces, n0 points to first non-space */
+		if (ignore_quotes && isquote(str[n0])) { /* If quote is found, look for next one */
+			quote = str[n0++]; /* Quote can be '\'' or '"' */
+			for (n1 = n0; str[n1] != NULC && str[n1] != quote; n1++) {
+				if (str[n1] == C2SX('\\') && str[++n1] == NULC)
+					break; /* Escape character (can be the last) */
+			}
+			for (is = n1 + 1; str[is] != NULC && sx_isspace(str[is]); is++) ; /* '--' not to take quote into account */
+		} else {
+			for (n1 = n0; str[n1] != NULC && str[n1] != sep && !sx_isspace(str[n1]); n1++) ; /* Search for separator or a space */
+			for (is = n1; str[is] != NULC && sx_isspace(str[is]); is++) ;
+		}
+	} else {
+		n0 = 0;
+		for (n1 = 0; str[n1] != NULC && str[n1] != sep; n1++) ; /* Search for separator only */
+		is = n1;
+	}
+
+	/* Here 'n0' is the start of left member, 'n1' is the character after the end of left member */
+
+	if (l0 != NULL)
+		*l0 = n0;
+	if (l1 != NULL)
+		*l1 = n1 - 1;
+	if (i_sep != NULL)
+		*i_sep = is;
+	if (str[is] == NULC || str[is+1] == NULC) { /* No separator => empty right member */
+		if (r0 != NULL)
+			*r0 = is;
+		if (r1 != NULL)
+			*r1 = is-1;
+		if (i_sep != NULL)
+			*i_sep = (str[is] == NULC ? -1 : is);
+		return true;
+	}
+
+	/* Parse right part */
+
+	n0 = is + 1;
+	if (ignore_spaces) {
+		for (; str[n0] != NULC && sx_isspace(str[n0]); n0++) ;
+		if (ignore_quotes && isquote(str[n0]))
+			quote = str[n0];
+	}
+
+	for (n1 = ++n0; str[n1]; n1++) {
+		if (ignore_quotes && str[n1] == quote) /* Quote was reached */
+			break;
+		if (str[n1] == C2SX('\\') && str[++n1] == NULC) /* Escape character (can be the last) */
+			break;
+	}
+	if (ignore_quotes && str[n1--] != quote) /* Quote is not the same than earlier, '--' is not to take it into account */
+		return false;
+	if (!ignore_spaces)
+		while (str[++n1]) ; /* Jump down the end of the string */
+
+	if (r0 != NULL)
+		*r0 = n0;
+	if (r1 != NULL)
+		*r1 = n1;
+
+	return true;
+}
+
+BOM_TYPE freadBOM(FILE* f, unsigned char* bom, int* sz_bom)
+{
+	unsigned char c1, c2;
+	long pos;
+
+	if (f == NULL)
+		return BOM_NONE;
+
+	/* Save position and try to read and skip BOM if found. If not, go back to saved position. */
+	pos = ftell(f);
+	if (pos < 0)
+		return BOM_NONE;
+	if (fread(&c1, sizeof(char), 1, f) != 1 || fread(&c2, sizeof(char), 1, f) != 1) {
+		fseek(f, pos, SEEK_SET);
+		return BOM_NONE;
+	}
+	if (bom != NULL) {
+		bom[0] = c1;
+		bom[1] = c2;
+		bom[2] = '\0';
+		if (sz_bom != NULL)
+			*sz_bom = 2;
+	}
+	switch ((unsigned short)(c1 << 8) | c2) {
+		case (unsigned short)0xfeff:
+			return BOM_UTF_16BE;
+
+		case (unsigned short)0xfffe:
+			pos = ftell(f); /* Save current position to get it back if BOM is not UTF-32LE */
+			if (pos < 0)
+				return BOM_UTF_16LE;
+			if (fread(&c1, sizeof(char), 1, f) != 1 || fread(&c2, sizeof(char), 1, f) != 1) {
+				fseek(f, pos, SEEK_SET);
+				return BOM_UTF_16LE;
+			}
+			if (c1 == 0x00 && c2 == 0x00) {
+				if (bom != NULL)
+					bom[2] = bom[3] = bom[4] = '\0';
+				if (sz_bom != NULL)
+					*sz_bom = 4;
+				return BOM_UTF_32LE;
+			}
+			fseek(f, pos, SEEK_SET); /* fseek(f, -2, SEEK_CUR) is not garanteed on Windows (and actually fails in Unicode...) */
+			return BOM_UTF_16LE;
+
+		case (unsigned short)0x0000:
+			if (fread(&c1, sizeof(char), 1, f) == 1 && fread(&c2, sizeof(char), 1, f) == 1
+					&& c1 == 0xfe && c2 == 0xff) {
+				bom[2] = c1;
+				bom[3] = c2;
+				bom[4] = '\0';
+				if (sz_bom != NULL)
+					*sz_bom = 4;
+				return BOM_UTF_32BE;
+			}
+			fseek(f, pos, SEEK_SET);
+			return BOM_NONE;
+
+		case (unsigned short)0xefbb: /* UTF-8? */
+			if (fread(&c1, sizeof(char), 1, f) != 1 || c1 != 0xbf) { /* Not UTF-8 */
+				fseek(f, pos, SEEK_SET);
+				if (bom != NULL)
+					bom[0] = '\0';
+				if (sz_bom != NULL)
+					*sz_bom = 0;
+				return BOM_NONE;
+			}
+			if (bom != NULL) {
+				bom[2] = c1;
+				bom[3] = '\0';
+			}
+			if (sz_bom != NULL)
+				*sz_bom = 3;
+			return BOM_UTF_8;
+
+		default: /* No BOM, go back */
+			fseek(f, pos, SEEK_SET);
+			if (bom != NULL)
+				bom[0] = '\0';
+			if (sz_bom != NULL)
+				*sz_bom = 0;
+			return BOM_NONE;
+	}
+}
+
+/* --- */
+
+int has_html(SXML_CHAR* html)
+{
+	if (html == NULL || *html == NULC)
+		return false;
+
+	do {
+		if (*html++ == C2SX('&'))
+			return true;
+	} while (*html);
+	
+	return false;
+}
+
+SXML_CHAR* html2str(SXML_CHAR* html, SXML_CHAR* str)
+{
+	SXML_CHAR *ps, *pd;
+	int i;
+
+	if (html == NULL)
+		return NULL;
+
+	if (str == NULL)
+		str = html;
+	
+	/* Look for '&' and matches it to any of the recognized HTML pattern. */
+	/* If found, replaces the '&' by the corresponding char. */
+	/* 'p2' is the char to analyze, 'p1' is where to insert it */
+	for (pd = str, ps = html; *ps; ps++, pd++) {
+		if (*ps != C2SX('&')) {
+			if (pd != ps)
+				*pd = *ps;
+			continue;
+		}
+		
+		for (i = 0; HTML_SPECIAL_DICT[i].chr; i++) {
+			if (sx_strncmp(ps, HTML_SPECIAL_DICT[i].html, HTML_SPECIAL_DICT[i].html_len))
+				continue;
+			
+			*pd = HTML_SPECIAL_DICT[i].chr;
+			ps += HTML_SPECIAL_DICT[i].html_len-1;
+			break;
+		}
+		/* If no string was found, simply copy the character */
+		if (HTML_SPECIAL_DICT[i].chr == NULC && pd != ps)
+			*pd = *ps;
+	}
+	*pd = NULC;
+	
+	return str;
+}
+
+/* TODO: Allocate 'html'? */
+SXML_CHAR* str2html(SXML_CHAR* str, SXML_CHAR* html)
+{
+	SXML_CHAR *ps, *pd;
+	int i;
+
+	if (str == NULL)
+		return NULL;
+
+	if (html == str) /* Not handled (yet) */
+		return NULL;
+
+	if (html == NULL) { /* Allocate 'html' to the correct size */
+		html = __malloc(strlen_html(str) * sizeof(SXML_CHAR));
+		if (html == NULL)
+			return NULL;
+	}
+
+	for (ps = str, pd = html; *ps; ps++, pd++) {
+		for (i = 0; HTML_SPECIAL_DICT[i].chr; i++) {
+			if (*ps == HTML_SPECIAL_DICT[i].chr) {
+				sx_strcpy(pd, HTML_SPECIAL_DICT[i].html);
+				pd += HTML_SPECIAL_DICT[i].html_len - 1;
+				break;
+			}
+		}
+		if (HTML_SPECIAL_DICT[i].chr == NULC && pd != ps)
+			*pd = *ps;
+	}
+	*pd = NULC;
+
+	return html;
+}
+
+int strlen_html(SXML_CHAR* str)
+{
+	int i, j, n;
+	
+	if (str == NULL)
+		return 0;
+
+	n = 0;
+	for (i = 0; str[i] != NULC; i++) {
+		for (j = 0; HTML_SPECIAL_DICT[j].chr; j++) {
+			if (str[i] == HTML_SPECIAL_DICT[j].chr) {
+				n += HTML_SPECIAL_DICT[j].html_len;
+				break;
+			}
+		}
+		if (HTML_SPECIAL_DICT[j].chr == NULC)
+			n++;
+	}
+
+	return n;
+}
+
+int fprintHTML(FILE* f, SXML_CHAR* str)
+{
+	SXML_CHAR* p;
+	int i, n;
+	
+	for (p = str, n = 0; *p != NULC; p++) {
+		for (i = 0; HTML_SPECIAL_DICT[i].chr; i++) {
+			if (*p != HTML_SPECIAL_DICT[i].chr)
+				continue;
+			if (f != NULL)
+				sx_fputs(HTML_SPECIAL_DICT[i].html, f);
+			n += HTML_SPECIAL_DICT[i].html_len;
+			break;
+		}
+		if (HTML_SPECIAL_DICT[i].chr == NULC) {
+			if (f != NULL)
+				(void)sx_fputc(*p, f);
+			n++;
+		}
+	}
+	
+	return n;
+}
+
+int regstrcmp(SXML_CHAR* str, SXML_CHAR* pattern)
+{
+	SXML_CHAR *p, *s;
+
+	if (str == NULL && pattern == NULL)
+		return true;
+
+	if (str == NULL || pattern == NULL)
+		return false;
+
+	p = pattern;
+	s = str;
+	while (true) {
+		switch (*p) {
+			/* Any character matches, go to next one */
+			case C2SX('?'):
+				p++;
+				s++;
+				break;
+
+			/* Go to next character in pattern and wait until it is found in 'str' */
+			case C2SX('*'):
+				for (; *p != NULC; p++) { /* Squeeze '**?*??**' to '*' */
+					if (*p != C2SX('*') && *p != C2SX('?'))
+						break;
+				}
+				for (; *s != NULC; s++) {
+					if (*s == *p)
+						break;
+				}
+				break;
+
+			/* NULL character on pattern has to be matched by 'str' */
+			case 0:
+				return *s ? false : true;
+
+			default:
+				if (*p == C2SX('\\')) /* Escape character */
+					p++;
+				if (*p++ != *s++) /* Characters do not match */
+					return false;
+				break;
+		}
+	}
+
+	return false;
+}

--- a/src/ticks/sxmlc.h
+++ b/src/ticks/sxmlc.h
@@ -1,0 +1,1096 @@
+/**
+	Copyright (c) 2010, Matthieu Labas
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice,
+	   this list of conditions and the following disclaimer in the documentation
+	   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+	PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGE.
+
+	The views and conclusions contained in the software and documentation are those of the
+	authors and should not be interpreted as representing official policies, either expressed
+	or implied, of the FreeBSD Project.
+*/
+#ifndef _SXML_H_
+#define _SXML_H_
+
+/**
+ * \brief Current SXMLC version, as a `const char[]`.
+ */
+#define SXMLC_VERSION "4.5.0"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/**
+ * \brief Define this to compile unicode support.
+ */
+#ifdef SXMLC_UNICODE
+	typedef wchar_t SXML_CHAR;
+	#define C2SX(c) L ## c
+	#define CEOF WEOF
+	#define sx_strcmp wcscmp
+	#define sx_strncmp wcsncmp
+	#define sx_strlen wcslen
+	#define sx_strdup wcsdup
+	#define sx_strchr wcschr
+	#define sx_strrchr wcsrchr
+	#define sx_strcpy wcscpy
+	#define sx_strncpy wcsncpy
+	#define sx_strcat wcscat
+	#define sx_printf wprintf
+	#define sx_fprintf fwprintf
+	#define sx_sprintf swprintf
+	#define sx_fgetc fgetwc
+	#define sx_fputc fputwc
+	#define sx_puts putws
+	#define sx_fputs fputws
+    #define sx_isspace iswspace
+	#if defined(WIN32) || defined(WIN64)
+		#define sx_fopen _wfopen
+	#else
+		#define sx_fopen fopen
+	#endif
+    #define sx_fclose fclose
+	#define sx_feof feof
+#else
+	typedef char SXML_CHAR;
+	#define C2SX(c) c
+	#define CEOF EOF
+	#define sx_strcmp strcmp
+	#define sx_strncmp strncmp
+	#define sx_strlen strlen
+	#define sx_strdup __sx_strdup
+	#define sx_strchr strchr
+	#define sx_strrchr strrchr
+	#define sx_strcpy strcpy
+	#define sx_strncpy strncpy
+	#define sx_strcat strcat
+	#define sx_printf printf
+	#define sx_fprintf fprintf
+	#define sx_sprintf sprintf
+	#define sx_fgetc fgetc
+	#define sx_fputc fputc
+	#define sx_puts puts
+	#define sx_fputs fputs
+	#define sx_isspace(c) ((int)c >= 0 && (int)c <= 127 && isspace((int)c))
+	#if defined(WIN32) || defined(WIN64) // On Windows, if the filename has unicode characters in it, assume them to be UTF8 and convert it to wide char before calling _wfopen()
+		FILE* sx_fopen(const SXML_CHAR* filename, const SXML_CHAR* mode);
+	#else // On Linux, simply call fopen()
+		#define sx_fopen fopen
+	#endif
+	#define sx_fclose fclose
+	#define sx_feof feof
+#endif
+
+#ifdef DBG_MEM
+	void* __malloc(size_t sz);
+	void* __calloc(size_t count, size_t sz);
+	void* __realloc(void* mem, size_t sz);
+	void __free(void* mem);
+	char* __sx_strdup(const char* s);
+#else
+	#define __malloc malloc
+	#define __calloc calloc
+	#define __realloc realloc
+	#define __free free
+	#define __sx_strdup strdup
+#endif
+
+/**
+ * \brief The number of bytes to add to currently allocated buffer for line reading. Default to 256 characters (=512
+ * 		bytes with unicode support).
+ */
+#ifndef MEM_INCR_RLA
+#define MEM_INCR_RLA (256*sizeof(SXML_CHAR)) /* Initial buffer size and increment for memory reallocations */
+#endif
+
+#ifndef false
+#define false 0
+#endif
+
+#ifndef true
+#define true 1
+#endif
+
+#define NULC ((SXML_CHAR)C2SX('\0'))
+#define isquote(c) (((c) == C2SX('"')) || ((c) == C2SX('\'')))
+
+/**
+ * \brief Buffer data source used by 'read_line_alloc' when required. 'buf' should be 0-terminated.
+ */
+typedef struct _DataSourceBuffer {
+	const SXML_CHAR* buf;
+	int buf_len;
+	int cur_pos;
+} DataSourceBuffer;
+
+typedef FILE* DataSourceFile;
+
+/**
+ * \brief Describes the type of data source used for parsing.
+ */
+typedef enum _DataSourceType {
+	DATA_SOURCE_FILE = 0,
+	DATA_SOURCE_BUFFER,
+	DATA_SOURCE_MAX
+} DataSourceType;
+
+/**
+ * \brief Node types for `XMLNode`.
+ *
+ * Types marked *[N/A]* are *not* valid types for an `XMLNode` but are used
+ * internally by the parser.
+ */
+typedef enum _TagType {
+	TAG_ERROR = -1,
+	TAG_NONE = 0,
+	TAG_PARTIAL,	/**< Node containing a legal `>` that stopped file reading. *[N/A]* */
+	TAG_FATHER,		/**< `<tag>` - Next nodes will be children of this one. */
+	TAG_SELF,		/**< `<tag/>` - Standalone node. */
+	TAG_INSTR,		/**< `<?prolog?>` - Processing instructions, or prolog node. */
+	TAG_COMMENT,	/**< `<!--comment-->` */
+	TAG_CDATA,		/**< `<![CDATA[ ]]>` - CDATA node */
+	TAG_DOCTYPE,	/**< `<!DOCTYPE [ ]>` - DOCTYPE node */
+	TAG_END,		/**< `</tag>` - End of father node. *[N/A]* */
+	TAG_TEXT,		/**< Special node used as a text container. */
+					/**< and `node->tag` is `NULL`. */
+
+	TAG_USER = 100	/*!<  User-defined tag start */
+} TagType;
+
+/* TODO: Performance improvement with some fixed-sized strings ??? (e.g. XMLAttribute.name[64], XMLNode.tag[64]).
+ * Also better for platforms where allocations can be forbidden (e.g. embedded, space, ...). */
+
+/**
+ * \brief An XML attribute in the form `name="value"`.
+ *
+ * An attribute can be *deactivated*, in which case it will not be taken into account in functions
+ * `XMLNode_print*()`, `XMLNode_get_attribute_count()`.
+ */
+typedef struct _XMLAttribute {
+	SXML_CHAR* name;	/**< The attribute name. */
+	SXML_CHAR* value;	/**< The attribute value. */
+	int active;			/**< `true` if the attribute is active. */
+} XMLAttribute;
+
+/* Constant to know whether a struct has been initialized (XMLNode or XMLDoc)
+ * TODO: Find a better way. */
+#define XML_INIT_DONE 0x19770522 /* Happy Birthday ;) */
+
+/**
+ * \brief An XML node.
+ *
+ * For tag types `TAG_INSTR`, `TAG_COMMENT`, `TAG_CDATA` and `TAG_DOCTYPE`, the text is
+ * stored in `node->tag`, with `node->text` being `NULL`.
+ *
+ * A node can be *deactivated*, in which case it will not be taken into account in functions
+ * `XMLNode_print*()`, `XMLNode_get_children_count()`, `XMLNode_get_child()`, `XMLNode_insert_child()`, ...
+ *
+ * If `text_as_nodes` is zeroed during parsing, the `node->text` is the concatenation of
+ * all texts found under the node: `<a>text<b/>other text</a>` will show `node->tag == "a"`
+ * and `node->text == "textother text"`.
+ * If `text_as_nodes` is non-zeroed, the same node will have 3 children: child [0] type is
+ * `TAG_TEXT` (with text `"text"`), child [1] type is `TAG_SELF` and child [2] type is
+ * `TAG_TEXT` (with text `"other text"`).
+ *
+ * *N.B. that when reading a pretty-printed XML, the extra line breaks and spaces will be stored
+ * in `node->text`*.
+ */
+typedef struct _XMLNode {
+	SXML_CHAR* tag;				/**< Tag name, or text for tag types `TAG_INSTR`, `TAG_COMMENT`, `TAG_CDATA` and `TAG_DOCTYPE`. */
+	SXML_CHAR* text;			/**< Text inside the node, or `NULL` if empty. */
+	XMLAttribute* attributes;	/**< Array of attributes. */
+	int n_attributes;			/**< Number of attributes *in `attributes` array* (might not be the number of *active* attributes). */
+	
+	struct _XMLNode* father;	/**< Pointer to father node. `NULL` if root. */
+	struct _XMLNode** children; /**< Array of children nodes. */
+	int n_children;				/**< Number of nodes *in `children` array* (might not be the number of *active* children). */
+	
+	TagType tag_type;			/**< Node type. */
+	int active;					/**< 'true' to tell that node is active and should be displayed by 'XMLDoc_print_*()'. */
+
+	void* user;	/**< Pointer for user data associated to the node. */
+
+	/* Keep 'init_value' as the last member */
+	int init_value;	/**< Initialized to 'XML_INIT_DONE' to indicate that node has been initialized properly. */
+} XMLNode;
+
+#ifndef SXMLC_MAX_PATH
+#ifdef _MAX_PATH
+#define SXMLC_MAX_PATH _MAX_PATH
+#else
+#define SXMLC_MAX_PATH 256
+#endif
+#endif
+
+/**
+ * \brief Describe the types of BOM detected while reading an XML buffer.
+ */
+typedef enum _BOM_TYPE {
+	BOM_NONE = 0x00,
+	BOM_UTF_8 = 0xefbbbf,
+	BOM_UTF_16BE = 0xfeff,
+	BOM_UTF_16LE = 0xfffe,
+	BOM_UTF_32BE = 0x0000feff,
+	BOM_UTF_32LE = 0xfffe0000
+} BOM_TYPE;
+    
+/**
+ * \brief An XML document, basically an array of `XMLNode`.
+ *
+ * An sxmlc XML document can have several root nodes. It actually usually have a prolog `<?xml version="1.0" ...?>`
+ * as the first node, then maybe a few comment nodes, then the first root node, which is the last node in
+ * correctly-formed XML, but there can also be some other nodes after it.
+ */
+typedef struct _XMLDoc {
+	SXML_CHAR filename[SXMLC_MAX_PATH];
+	BOM_TYPE bom_type;		/**< BOM type (UTF-8, UTF-16*). */
+	unsigned char bom[5];	/**< First characters read that might be a BOM when unicode is used. */
+	int sz_bom;				/**< Number of bytes in BOM. */
+	XMLNode** nodes;		/* Nodes of the document, including prolog, comments and root nodes */
+	int n_nodes;			/* Number of nodes in 'nodes' */
+	int i_root;				/* Index of first root node in 'nodes', -1 if document is empty */
+
+	/* Keep 'init_value' as the last member */
+	int init_value;	/* Initialized to 'XML_INIT_DONE' to indicate that document has been initialized properly */
+} XMLDoc;
+
+/**
+ * \brief Register an XML tag, giving its 'start' and 'end' string, which should include '<' and '>'.
+ *
+ * \param tag_type is user-given and has to be less than or equal to `TAG_USER`. It will be
+ * 		returned as the `tag_type` member of the `XMLNode` struct.
+ * 		*Note that no test is performed to check for an already-existing `tag_type`*.
+ * \param start The start string used to detect such tag (e.g. `"<![CDATA["`). Should start with `<`.
+ * \param end The tag end string (e.g. `"]]>"`). Should end with `>`.
+ * \return tag index in user tags table when successful, or -1 if the `tag_type` is invalid or
+ * 		the new tag could not be registered (e.g. when `start` does not start with `<` or
+ * 		`end` does not end with `>`).
+ */
+int XML_register_user_tag(TagType tag_type, SXML_CHAR* start, SXML_CHAR* end);
+
+/**
+ * \brief Remove a registered user tag.
+ * \param i_tag The user-tag number, as returned by `XML_register_user_tag()`.
+ * \return the new number of registered user tags or -1 if `i_tag` is invalid.
+ */
+int XML_unregister_user_tag(int i_tag);
+
+/**
+ * \brief Get the number of user-defined tags
+ * \return the number of registered tags.
+ */
+int XML_get_nb_registered_user_tags(void);
+
+/**
+ * \brief Search for a user tag based on it type.
+ * \param tag_type The tag type, as given in `XML_register_user_tag()`.
+ * \return the index of first occurrence of 'tag_type' in registered user tags, or '-1' if not found.
+ */
+int XML_get_registered_user_tag(TagType tag_type);
+
+/**
+ * \brief The different reasons why parsing would fail.
+ */
+typedef enum _ParseError {
+	PARSE_ERR_NONE = 0,					/**< Success. */
+	PARSE_ERR_MEMORY = -1,				/**< Not enough memory for an `?alloc()` call. */
+	PARSE_ERR_UNEXPECTED_TAG_END = -2,	/**< When a tag end does not match the tag start (e.g. `<a></b>`). */
+	PARSE_ERR_SYNTAX = -3,				/**< General syntax error. */
+	PARSE_ERR_EOF = -4,					/**< Unexpected EOF. */
+	PARSE_ERR_TEXT_OUTSIDE_NODE = -5,	/**< During DOM loading. */
+	PARSE_ERR_UNEXPECTED_NODE_END = -6	/**< During DOM loading. */
+} ParseError;
+
+/**
+ * \brief Events that can happen when loading an XML document.
+ *
+ * These will be passed to the `all_event` callback of the SAX parser.
+ */
+typedef enum _XMLEvent {
+	XML_EVENT_START_DOC,	/**< Document parsing started. */
+	XML_EVENT_START_NODE,	/**< New node detected (all attributes are read). */
+	XML_EVENT_END_NODE,		/**< Last node ended. */
+	XML_EVENT_TEXT,			/**< Text detected in current node. */
+	XML_EVENT_ERROR,		/**< Parsing error. */
+	XML_EVENT_END_DOC		/**< Document parsing finished. */
+} XMLEvent;
+
+/**
+ * \brief Structure given as an argument for SAX callbacks to retrieve information about parsing status.
+ */
+typedef struct _SAX_Data {
+	const SXML_CHAR* name;	/**< Document name (file name or buffer name). */
+	int line_num;			/**< Current line number being processed. */
+	void* user;				/**< User-given data. */
+	DataSourceType type;	/**< Data source type [DATA_SOURCE_FILE|DATA_SOURCE_BUFFER]. */
+	void* src;				/**< Data source [DataSourceFile|DataSourceBuffer]. Depends on type. */
+} SAX_Data;
+
+/**
+ * \brief User callbacks used for SAX parsing.
+ *
+ * Return values of these callbacks should be 0 to stop parsing. Some callbacks can be set to `NULL`
+ * to disable handling of some events (e.g. everything `NULL` except `all_event()`).
+ *
+ * All parameters are pointers to structures that will no longer be available after callback returns so
+ * it is recommended that the callback uses the information and stores it in its own data structure.
+ *
+ * *WARNING! SAX PARSING DOES NOT CHECK FOR XML INTEGRITY!* e.g. a tag end without a matching tag start
+ * will not be detected by the parser and should be detected by the callbacks instead.
+ */
+typedef struct _SAX_Callbacks {
+	/**
+	 * \fn start_doc
+	 * \brief Callback called when parsing starts, *before* parsing the first node.
+	 */
+	int (*start_doc)(SAX_Data* sd);
+
+	/**
+	 * \fn start_node
+	 * \brief Callback called when a new node starts (e.g. `<tag>` or `<tag/>`).
+	 *
+	 * Attributes are read and available from `node->attributes`.
+	 * N.B. "self-contained" ndoes (e.g. `<tag/>`) will trigger an immediate call to the `end_node()` callback
+	 * after the `start_node()` callback.
+	 */
+	int (*start_node)(const XMLNode* node, SAX_Data* sd);
+
+	/**
+	 * \fn end_node
+	 * \brief Callback called when a node ends (e.g. `</tag>` or `<tag/>`).
+	 */
+	int (*end_node)(const XMLNode* node, SAX_Data* sd);
+
+	/**
+	 * \fn new_text
+	 * \brief Callback called when text has been found in the last node (e.g. `<tag>text<...`).
+	 */
+	int (*new_text)(SXML_CHAR* text, SAX_Data* sd);
+
+	/**
+	 * \fn end_doc
+	 * \brief Callback called when parsing is finished.
+	 * No other callbacks will be called after it.
+	 */
+	int (*end_doc)(SAX_Data* sd);
+
+	/**
+	 * \fn on_error
+	 * \brief Callback called when an error occurs during parsing.
+	 * \param error_num is the error number
+	 * \param line_number is the line number in the stream being read (file or buffer).
+	 */
+	int (*on_error)(ParseError error_num, int line_number, SAX_Data* sd);
+
+	/**
+	 * \fn all_event
+	 * \brief Callback called when text has been found in the last node.
+	 *
+	 * \param event is the type of event for which the callback was called:
+	 	 - `XML_EVENT_START_DOC`:
+	 	 	 - `node` is NULL.
+	 	 	 - 'text` is the file name if a file is being parsed, `NULL` if a buffer is being parsed.
+	 	 	 - `n` is 0.
+	 	 - `XML_EVENT_START_NODE`:
+	 	 	 - `node` is the node starting, with tag and all attributes initialized.
+	 	 	 - `text` is NULL.
+	 	 	 - `n` is the number of lines parsed.
+	 	 - `XML_EVENT_END_NODE`:
+	 	 	 - `node` is the node ending, with tag, attributes and text initialized.
+	 	 	 - `text` is NULL.
+	 	 	 - `n` is the number of lines parsed.
+	 	 - `XML_EVENT_TEXT`:
+	 	 	 - `node` is NULL.
+	 	 	 - `text` is the text to be added to last node started and not finished.
+	 	 	 - `n` is the number of lines parsed.
+	 	 - `XML_EVENT_ERROR`:
+	 	 	 - Everything is NULL.
+	 	 	 - `n` is one of the `PARSE_ERR_*`.
+	 	 - `XML_EVENT_END_DOC`:
+	 	 	 - `node` is `NULL`.
+	 	 	 - `text` is the file name if a file is being parsed, NULL if a buffer is being parsed.
+	 	 	 - `n` is the number of lines parsed.
+	 */
+	int (*all_event)(XMLEvent event, const XMLNode* node, SXML_CHAR* text, const int n, SAX_Data* sd);
+} SAX_Callbacks;
+
+/**
+ * \brief Helper function to initialize all `sax` members to `NULL`.
+ * \param sax The callbacks structure to initialize.
+ * \return `false` is `sax` is NULL.
+ */
+int SAX_Callbacks_init(SAX_Callbacks* sax);
+
+/**
+ * \brief Set of SAX callbacks used by `XMLDoc_parse_file_DOM()`.
+ *
+ * These are made available to be able to load an XML document using DOM implementation
+ * with user-defined code at some point (e.g. counting nodes, running search, ...).
+ *
+ * In this case, the `XMLDoc_parse_file_SAX()` has to be called instead of the `XMLDoc_parse_file_DOM()`,
+ * providing either these callbacks directly, or a functions calling these callbacks.<br>
+ * To do that, you should initialize the `doc` member of the `DOM_through_SAX` struct and call the
+ * `XMLDoc_parse_file_SAX()` giving this struct as a the `user` data pointer.
+ */
+typedef struct _DOM_through_SAX {
+	XMLDoc* doc;		/**< Document to fill up. */
+	XMLNode* current;	/**< For internal use (current father node). */
+	ParseError error;	/**< For internal use (parse status). */
+	int line_error;		/**< For internal use (line number when error occurred). */
+	int text_as_nodes;	/**< For internal use (store text inside nodes as sequential TAG_TEXT nodes). */
+} DOM_through_SAX;
+
+int DOMXMLDoc_doc_start(SAX_Data* dom);
+int DOMXMLDoc_node_start(const XMLNode* node, SAX_Data* dom);
+int DOMXMLDoc_node_text(SXML_CHAR* text, SAX_Data* dom);
+int DOMXMLDoc_node_end(const XMLNode* node, SAX_Data* dom);
+int DOMXMLDoc_parse_error(ParseError error_num, int line_number, SAX_Data* sd);
+int DOMXMLDoc_doc_end(SAX_Data* dom);
+
+/**
+ * \brief Initialize `sax` with the "official" DOM callbacks.
+ */
+int SAX_Callbacks_init_DOM(SAX_Callbacks* sax);
+
+/* --- XMLNode methods --- */
+
+/**
+ * \brief Parse an attribute to an `XMLAttribute` struct.
+ * \param str contains the string to parse, supposed like `attrName[ ]=[ ]["]attr Value["]`.
+ * \param to is the position in `str` to stop at, or `-1` to parse until the end of `str`.
+ * \param xmlattr filled with `xmlattr->name` to `attrName` and `xmlattr->value` to `attr Value`.
+ * \return 0 if not enough memory or bad parameters (`str` or `xmlattr` is `NULL`),
+		2 if last quote is missing in the attribute value,  1 if `xmlattr` was filled correctly.
+ */
+int XML_parse_attribute_to(const SXML_CHAR* str, int to, XMLAttribute* xmlattr);
+
+/**
+ * \fn XML_parse_attribute
+ * \brief Short for `XML_parse_attribute_to()` with `to=-1`.
+ */
+#define XML_parse_attribute(str, xmlattr) XML_parse_attribute_to(str, -1, xmlattr)
+
+/**
+ * \brief Reads a string that is supposed to be an xml tag like `<tag (attribName="attribValue")* [/]>` or `</tag>`.
+ * \param str The string to parse.
+ * \param xmlnode the `XMLNode` structure which tag name and attributes will be filled.
+ * \returns 0 if an error occurred (malformed `str` or memory). `TAG_*` when string is recognized.
+ */
+TagType XML_parse_1string(const SXML_CHAR* str, XMLNode* xmlnode);
+
+/**
+ * \brief Allocate and initialize XML nodes.
+ * \param n is the number of contiguous elements to allocate (to create and array).
+ * \return `NULL` if not enough memory, or the pointer to the elements otherwise.
+ */
+XMLNode* XMLNode_allocN(int n);
+
+/**
+ * \fn XMLNode_alloc
+ * \brief Shortcut to allocate one node only.
+ */
+#define XMLNode_alloc() XMLNode_allocN(1)
+
+/**
+ * \brief Allocate and initialize a new `XMLNode` of the given type, tag name and text.
+ * \param tag_type The node tag type.
+ * \param tag The node tag.
+ * \param text The node text.
+ * \return `NULL` if not enough memory, or the pointer to the node otherwise.
+ */
+
+XMLNode* XMLNode_new(const TagType tag_type, const SXML_CHAR* tag, const SXML_CHAR* text);
+
+/**
+ * \fn XMLNode_new_node_comment
+ * \brief Utility to create a comment: `<!--tag-->`
+ */
+#define XMLNode_new_node_comment(comment) XMLNode_new(TAG_COMMENT, (comment), NULL)
+/**
+ * \fn XMLNode_new_comment
+ */
+#define XMLNode_new_comment XMLNode_new_node_comment
+
+/**
+ * \fn XMLNode_new_node_text
+ * \brief Utility to create a simple node with text: `<tag>text</tag>`
+ */
+#define XMLNode_new_node_text(tag, text) XMLNode_new(TAG_TEXT, (tag), (text))
+/**
+ * \fn XMLNode_new_text
+ */
+#define XMLNode_new_text XMLNode_new_node_text
+
+/**
+ * \brief Initialize an already-allocated XMLNode.
+ */
+int XMLNode_init(XMLNode* node);
+
+/**
+ * \brief Tells whether a node is valid.
+ */
+#define XMLNode_is_valid(node) ((node) != NULL && (node)->init_value == XML_INIT_DONE)
+
+/**
+ * \brief Free a node and all its children.
+ */
+int XMLNode_free(XMLNode* node);
+
+/**
+ * \brief Copy a node to another one, optionally including its children.
+ * \param dst The node receiving the copy. N.B. thtat the node is freed first!
+ * \param src The node to duplicate. If `NULL`, `dst` is freed and initialized.
+ * \param copy_children `true` to include `src` children (recursive copy).
+ * \return `false` in case of memory error or if `dst` is `NULL` or `src` uninitialized.
+ */
+int XMLNode_copy(XMLNode* dst, const XMLNode* src, int copy_children);
+
+/**
+ * \brief Duplicate a node, potentially with its children.
+ * \param node The node to duplicate.
+ * \param copy_children `true` to include `src` children (recursive copy).
+ * \return `NULL` if not enough memory, or a pointer to the new node otherwise.
+ */
+XMLNode* XMLNode_dup(const XMLNode* node, int copy_children);
+
+/**
+ * \brief Set the active/inactive state of `node`.
+ *
+ * Set `active` to `true` to activate `node` and all its children, and enable its use
+ * in other functions (e.g. `XMLDoc_print()`, ...).
+ */
+int XMLNode_set_active(XMLNode* node, int active);
+
+/**
+ * \brief Set node tag.
+ * \param node The node to set.
+ * \param tag The tag to set in `node`. A *copy* of `tag` will be assigned to `node->tag`, using `strdup()`.
+ * \return `false` for memory error, `true` otherwise.
+ */
+int XMLNode_set_tag(XMLNode* node, const SXML_CHAR* tag);
+
+/**
+ * \brief Set the node type to one of `TagType` or any user-registered tag.
+ * \return 'false' when the node or the 'tag_type' is invalid.
+ */
+int XMLNode_set_type(XMLNode* node, const TagType tag_type);
+
+/**
+ * \brief Add an attribute to a node or update an existing one.
+ * \param node The node to which add/update an attribute.
+ * \param attr_name The attribute name. A *copy* will be assigned through `strdup()`.
+ * \param attr_value The attribute value. A *copy* will be assigned through `strdup()`.
+ * \return the new number of attributes, or -1 for memory problem.
+ */
+int XMLNode_set_attribute(XMLNode* node, const SXML_CHAR* attr_name, const SXML_CHAR* attr_value);
+
+/**
+ * \brief Retrieve an attribute value, based on its name, returning a default value if the attribute
+ * 		does not exist.
+ * \param node The node.
+ * \param attr_name The attribute name to search.
+ * \param attr_value A pointer receiving a *copy* of the attribute value (from `strdup()`).
+ * \param default_attr_value If `attr_name` does not exist in `node`, a *copy* (from `strdup()`)
+ * 		of this string will be stored in `attr_value`.
+ * \return `false` when the `node` is invalid, `attr_name` is NULL or empty, or `attr_value` is NULL.
+ */
+int XMLNode_get_attribute_with_default(XMLNode* node, const SXML_CHAR* attr_name, const SXML_CHAR** attr_value, const SXML_CHAR* default_attr_value);
+
+/**
+ * \fn XMLNode_get_attribute
+ * \brief Helper macro that retrieve an attribute value, or an empty string if the attribute does not exist.
+ */
+#define XMLNode_get_attribute(node, attr_name, attr_value) XMLNode_get_attribute_with_default(node, attr_name, attr_value, C2SX(""))
+
+/**
+ * \return the number of active attributes of 'node', or '-1' if 'node' is invalid.
+ */
+int XMLNode_get_attribute_count(const XMLNode* node);
+
+/**
+ * \brief Search for the active attribute `attr_name` in `node`, starting from index `isearch`
+ * and returns its index, or -1 if not found or error.
+ */
+int XMLNode_search_attribute(const XMLNode* node, const SXML_CHAR* attr_name, int isearch);
+
+/**
+ * \brief Remove attribute index `i_attr`.
+ * \return the new number of attributes or -1 on invalid arguments.
+ */
+int XMLNode_remove_attribute(XMLNode* node, int i_attr);
+
+/**
+ * \brief Remove all attributes from `node`.
+ */
+int XMLNode_remove_all_attributes(XMLNode* node);
+
+/**
+ * Set node text to a copy of `text` (from `strdup()`), or remove text if set to `NULL`.
+ * \return `true` when successful, `false` on error.
+ */
+int XMLNode_set_text(XMLNode* node, const SXML_CHAR* text);
+
+/**
+ * \fn XMLNode_remove_text
+ * \brief Helper macro to remove text from `node`.
+ */
+#define XMLNode_remove_text(node) XMLNode_set_text(node, NULL);
+
+/**
+ * \brief Add a child to a node.
+ * \return `false` for memory problem, `true` otherwise.
+ */
+int XMLNode_add_child(XMLNode* node, XMLNode* child);
+
+/**
+ * \brief Insert a node at a given position.
+ * \param node The node to which inserting the child node.
+ * \param child The node to insert.
+ * \param index The insert position: if `index <= 0`: will be the first child (0).
+ * 		If `index >= child->father->n_children`: will be the last child.
+ * \return 'false' if 'node' is not initialized, 'true' otherwise.
+ */
+int XMLNode_insert_child(XMLNode* node, XMLNode* child, int index);
+
+/**
+ * \fn XMLNode_insert_before
+ * \brief Insert a node before the given node (i.e. at its index).
+ */
+#define XMLNode_insert_before(node, child) XMLNode_insert_child(node, child, XMLNode_get_index(node))
+/**
+ * \fn XMLNode_insert_after
+ * \brief Insert a node after the given node.
+ */
+#define XMLNode_insert_after(node, child) XMLNode_insert_child(node, child, XMLNode_get_index(node)+1)
+
+/**
+ * \brief Move a child node among its siblings.
+ * \param node The node which children should be moved.
+ * \param from Position of the node to move.
+ * \param to Position to move to. Moved to first position if `to <= 0` or last position
+ * 		if `to >= node->n_children`.
+ * \return `false` if `node` is not initialized or `from` is invalid. `true` otherwise.
+ */
+int XMLNode_move_child(XMLNode* node, int from, int to);
+
+/**
+ * \brief Get the number of *active* children of a node.
+ * \param node The node.
+ * \return the number of active children nodes of `node`, or -1 if `node` is invalid.
+ * 		N.B. that it can be different from `node->n_children` if some nodes are deactivated!
+ */
+int XMLNode_get_children_count(const XMLNode* node);
+
+/**
+ * \brief Get the node position among its *active* siblings.
+ * \param node The node.
+ * \return `node` position among its siblings, -1 if `node` is invalid or -2 if `node` could
+ * 		not be found in its father's children (in which case I'd appreciate a bug report with
+ * 		the XML and steps that led to that situation!).
+ */
+int XMLNode_get_index(const XMLNode* node);
+
+/**
+ * \brief Get an *active* node.
+ * \param node The node.
+ * \param i_child The active node index to retrieve.
+ * \return the `i_child`th *active* node.
+ */
+XMLNode* XMLNode_get_child(const XMLNode* node, int i_child);
+
+/**
+ * \brief Remove the `i_child`th *active* child of the node.
+ * \param node The node.
+ * \param i_child The active node index to retrieve.
+ * \param free_child if `true`, free the child node itself (and its children, recursively).
+ * 		This parameter is usually `true` but should be `false` when child nodes are pointers
+ * 		to local or global variables instead of user-allocated memory.
+ * \return the new number of children or -1 on invalid arguments.
+ */
+int XMLNode_remove_child(XMLNode* node, int i_child, int free_child);
+
+/**
+ * \brief Remove (and frees) all children from the node.
+ * \param node The node.
+ * \return `true`.
+ */
+int XMLNode_remove_children(XMLNode* node);
+
+/**
+ * \param node1 The first node to test.
+ * \param node2 The second node to test.
+ * \return `true` if `node1` is the same as `node2` (i.e. same tag, same active attributes)
+ * 		but *not necessarily* the same children.
+ */
+int XMLNode_equal(const XMLNode* node1, const XMLNode* node2);
+
+/**
+ * \brief Get the next sibling node.
+ * \param node The node which sibling to retrieve.
+ * \return the next sibling of the node, or `NULL` if `node` is invalid or the last child
+ * 		or if its father could not be determined (i.e. `node` is a root node).
+ */
+XMLNode* XMLNode_next_sibling(const XMLNode* node);
+
+/**
+ * \brief Get the "next" node: first child (if any) of next sibling otherwise.
+ * \param node The node.
+ * \return the next node in XML order, or `NULL` if `node` is invalid or the last node.
+ */
+XMLNode* XMLNode_next(const XMLNode* node);
+
+
+
+/* --- XMLDoc methods --- */
+
+
+/**
+ * \brief Initializes an already-allocated XML document.
+ * \param doc The document to initialize.
+ * \return `false` if `doc` is NULL.
+ */
+int XMLDoc_init(XMLDoc* doc);
+
+/**
+ * \brief Free an XML document, including all of its nodes, recursively.
+ * \param doc The document to initialize.
+ * \return `false` if `doc` was not initialized.
+ */
+int XMLDoc_free(XMLDoc* doc);
+
+/**
+ * \brief Set the new document root node.
+ * \param doc The document to initialize.
+ * \param i_root The element index to set as root.
+ * \return `false` if `doc` is not initialized or `i_root` is invalid, `true` otherwise.
+ */
+int XMLDoc_set_root(XMLDoc* doc, int i_root);
+
+/**
+ * \brief Add a node to the document.
+ *
+ * If the node type is `TAG_FATHER`, it also sets the document root node if previously undefined.
+ * \param doc The document.
+ * \param node The node to add.
+ * \return the node index, or -1 for uninitialized `doc` or `node`, or memory error.
+ */
+int XMLDoc_add_node(XMLDoc* doc, XMLNode* node);
+
+/**
+ * \brief Remove a node from the document root nodes. Inactive nodes can be removed like this.
+ * \param doc The XML document.
+ * \param i_node The node index to remove
+ * \param free_node if `true`, free the node itself. This parameter is usually `true`
+ * 		but should be 'false' when the node is a pointer to local or global variable instead of
+ * 		user-allocated memory.
+ * \return `true` if node was removed or `false` if `doc` or `i_node` is invalid.
+ */
+int XMLDoc_remove_node(XMLDoc* doc, int i_node, int free_node);
+
+#define XMLDoc_remove_root_node XMLDoc_remove_node
+
+/**
+ * \brief Shortcut macro to retrieve root node from a document. Equivalent to `doc->nodes[doc->i_root]`,
+ *		or `NULL` if there is no root node.
+ */
+#define XMLDoc_root(doc) (((doc)->i_root) < 0 ? NULL : ((doc)->nodes[(doc)->i_root]))
+
+/**
+ * \brief Shortcut macro to add a node to 'doc' root node. Equivalent to `XMLDoc_add_child_root(XMLDoc* doc, XMLNode* child)`.
+ */
+#define XMLDoc_add_child_root(doc, child) XMLNode_add_child((doc)->nodes[(doc)->i_root], (child))
+
+/**
+ * \brief Default quote to use to print attribute value (defaults to a double. quote `"`).
+ *
+ * User can redefine it with its own character by adding a `-DXML_DEFAULT_QUOTE` compiler option.
+ */
+#ifndef XML_DEFAULT_QUOTE
+#define XML_DEFAULT_QUOTE C2SX('"')
+#endif
+
+/**
+ * \brief Print the node and its children to a file (that can be `stdout`).
+ *
+ * \param node The node to print.
+ * \param f The file to print to (can be `stdout`).
+ * \param tag_sep The string to use to separate nodes from each other (usually `"\n"`).
+ * \param child_sep The additional string to put for each child level (usually `"\t"`).
+ * \param attr_sep The additional string to put to separate attributes (usually `" "`).
+ * \param keep_text_spaces indicates that text should not be printed if it is composed of
+ * 		spaces, tabs or new lines only (e.g. when XML document spans on several lines due to
+ * 		pretty-printing).
+ * \param sz_line The maximum number of characters that can be put on a single line. The
+ * 		node remainder will be output to extra lines.
+ * \param nb_char_tab How many characters should be counted for a tab when counting characters
+ * 		in the line. It usually is 8 or 4, but at least 1.
+ * \return `false` on invalid arguments (`NULL` `node` or `f`), `true` otherwise.
+ */
+int XMLNode_print_attr_sep(const XMLNode* node, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, const SXML_CHAR* attr_sep, int keep_text_spaces, int sz_line, int nb_char_tab);
+
+/**
+ * \brief For backward compatibility (`attr_sep` is a space).
+ */
+#define XMLNode_print(node, f, tag_sep, child_sep, keep_text_spaces, sz_line, nb_char_tab) XMLNode_print_attr_sep(node, f, tag_sep, child_sep, C2SX(" "), keep_text_spaces, sz_line, nb_char_tab)
+
+/**
+ * \brief Print the node "header": `<tagname attribname="attibval" ...[/]>`, spanning it on several lines if needed.
+ * \return `false` on invalid arguments (`NULL` `node` or `f`), `true` otherwise.
+ */
+int XMLNode_print_header(const XMLNode* node, FILE* f, int sz_line, int nb_char_tab);
+
+/**
+ * \brief Prints the XML document using `XMLNode_print_attr_sep()` on all document nodes.
+ */
+int XMLDoc_print_attr_sep(const XMLDoc* doc, FILE* f, const SXML_CHAR* tag_sep, const SXML_CHAR* child_sep, const SXML_CHAR* attr_sep, int keep_text_spaces, int sz_line, int nb_char_tab);
+
+/* For backward compatibility */
+#define XMLDoc_print(doc, f, tag_sep, child_sep, keep_text_spaces, sz_line, nb_char_tab) XMLDoc_print_attr_sep(doc, f, tag_sep, child_sep, C2SX(" "), keep_text_spaces, sz_line, nb_char_tab)
+
+/**
+ * \brief Parse a file into an initialized XML document (DOM mode).
+ * \param filename The file to parse.
+ * \param doc The document to parse into.
+ * \param text_as_nodes should be non-zero to put text into separate TAG_TEXT nodes.
+ * \return `false` in case of error (memory or unavailable filename, malformed document), `true` otherwise.
+ */
+int XMLDoc_parse_file_DOM_text_as_nodes(const SXML_CHAR* filename, XMLDoc* doc, int text_as_nodes);
+
+/**
+ * \brief For backward compatibility (`text_as_nodes` is 0)
+ */
+#define XMLDoc_parse_file_DOM(filename, doc) XMLDoc_parse_file_DOM_text_as_nodes(filename, doc, 0)
+
+/**
+ * \brief Parse a memory buffer into an initialized document (DOM mode).
+ * \param buffer The memory buffer to parse.
+ * \param name The buffer name (to identify several buffers if run concurrently).
+ * \param doc The document to parse into.
+ * \param text_as_nodes should be non-zero to put text into separate TAG_TEXT nodes.
+ * \return `false` in case of error (memory or unavailable filename, malformed document), `true` otherwise.
+ */
+int XMLDoc_parse_buffer_DOM_text_as_nodes(const SXML_CHAR* buffer, const SXML_CHAR* name, XMLDoc* doc, int text_as_nodes);
+
+/**
+ * \brief For backward compatibility (`text_as_nodes` is 0)
+ */
+#define XMLDoc_parse_buffer_DOM(buffer, name, doc) XMLDoc_parse_buffer_DOM_text_as_nodes(buffer, name, doc, 0)
+
+/**
+ * \brief Parse an XML file, calling SAX callbacks.
+ * \param filename The file to parse.
+ * \param sax The SAX callbacks that will be called by the parser on each XML event.
+ * \param user A user-given pointer that will be given back to all callbacks.
+ * \return `false` in case of error (memory or unavailable filename, malformed document) or when requested
+ * 		by a SAX callback. `true` otherwise.
+ */
+int XMLDoc_parse_file_SAX(const SXML_CHAR* filename, const SAX_Callbacks* sax, void* user);
+
+/**
+ * \brief Parse an XML buffer, calling SAX callbacks.
+ * \param buffer The memory buffer to parse.
+ * \param buffer_len The buffer lenght, in *characters* (i.e. can be 2 bytes in unicode).
+ * \param name An optional buffer name.
+ * \param sax The SAX callbacks that will be called by the parser on each XML event.
+ * \param user A user-given pointer that will be given back to all callbacks.
+ * \return `false` in case of error (memory or unavailable filename, malformed document) or when requested
+ * 		by a SAX callback. `true` otherwise.
+ */
+int XMLDoc_parse_buffer_SAX_len(const SXML_CHAR* buffer, int buffer_len, const SXML_CHAR* name, const SAX_Callbacks* sax, void* user);
+
+/**
+ * \brief For backward compatibility (buffer length is `strlen(buffer)`).
+ */
+#define XMLDoc_parse_buffer_SAX(buffer, name, sax, user) XMLDoc_parse_buffer_SAX_len(buffer, sx_strlen(buffer), name, sax, user)
+
+/**
+ * \brief Parse an XML file using the DOM implementation.
+ */
+#define XMLDoc_parse_file XMLDoc_parse_file_DOM
+
+
+
+/* --- Utility functions --- */
+
+/**
+ * \brief Get next byte from data source.
+ * \return as `fgetc()` would for `FILE*`.
+ */
+int _bgetc(DataSourceBuffer* ds);
+
+/**
+ * \brief know if the end has been reached in a data source.
+ * \return as `feof()` would for `FILE*`.
+ */
+int _beob(DataSourceBuffer* ds);
+
+/**
+ * \brief Read a "line" from data source, eventually (re-)allocating a given buffer. A "line" is defined
+ * as a portion starting with character `from` (usually `<`) ending at character `to` (usually `>`).
+ *
+ * Characters read will be stored in `line` starting at `i0` (this allows multiple calls to
+ * `read_line_alloc()` on the same `line` buffer without overwriting it at each call).
+ * Searches for character `from` until character `to`. If `from` is 0, starts from
+ * current position in the data source. If `to` is 0, it is replaced by `\n`.
+ *
+ * \param in The data source (either `FILE*` if `in_type` is `DATA_SOURCE_FILE` or `SXML_CHAR*`
+ * 		if `in_type` is `DATA_SOURCE_BUFFER`).
+ * \param in_type specifies the type of data source to be read.
+ * \param line can be `NULL`, in which case it will be allocated to `*sz_line` bytes. After the function
+ * 		returns, `*sz_line` is the actual buffer size. This allows multiple calls to this function using
+ * 		the same buffer (without re-allocating/freeing).
+ * \param sz_line is the size of the buffer `line` if previously allocated (in `SXML_CHAR`, not byte!).
+ * 		If `NULL` or 0, an internal value of `MEM_INCR_RLA` is used.
+ * \param i0 The position where read characters are stored in `line`.
+ * \param from The character indicating a start of line.
+ * \param to The character indicating an end of line.
+ * \param keep_fromto if 0, removes characters `from` and `to` from the line (stripping).
+ * \param interest is a special character of interest, usually `\n` so we can count line numbers in the
+ * 		data source (valid only if `interest_count` is not `NULL`).
+ * \param interest_count if not `NULL`, will receive the count of `interest` characters while searching.
+ * \returns the number of characters in the line or 0 if an error occurred.
+ */
+int read_line_alloc(void* in, DataSourceType in_type, SXML_CHAR** line, int* sz_line, int i0, SXML_CHAR from, SXML_CHAR to, int keep_fromto, SXML_CHAR interest, int* interest_count);
+
+/**
+ * \brief Concatenates the string pointed at by `src1` with `src2` into `*src1` and return it.
+ * \return `*src1`, or `NULL` if out of memory.
+ */
+SXML_CHAR* strcat_alloc(SXML_CHAR** src1, const SXML_CHAR* src2);
+
+/**
+ * \brief Strip whitespaces at the beginning and end of a string, modifying it.
+ * \param str The string to strip.
+ * \param repl_sq if not null, squeezes spaces to an single character `repl_sq`.
+ * \returns the stripped string, which can be `str` directly if there are no whitespaces
+ * 		at the beginning.
+ * 		N.B. that if `str` was allocated, it should be freed later, *not* the returned
+ * 		reference.
+ */
+SXML_CHAR* strip_spaces(SXML_CHAR* str, SXML_CHAR repl_sq);
+
+/**
+ * \brief Remove `\` characters from `str`, modifying it.
+ * \return `str` unescaped.
+ */
+SXML_CHAR* str_unescape(SXML_CHAR* str);
+
+/**
+ * \brief Split a string into a left and right part around a given separator.
+ *
+ * The beginning and end indices of left part are stored in `l0` and `l1` while the
+ * right part's are stored in `r0` and `r1`. The separator position is stored at `i_sep`
+ * (whenever these are not `NULL`).
+ * Whenever the right member is empty (e.g. `"attrib"` or `"attrib="`), `*r0` is set to
+ * `strlen(str)` and `*r1` to `*r0-1` (crossed).
+ *
+ * \param str The string to split.
+ * \param sep The separator (e.g. `=`).
+ * \param l0 will contain the index of the left part first character in `str`.
+ * \param l1 will contain the index of left part last character in `str`.
+ * \param i_sep will contain the index of the separator in `str`, or -1 if not found.
+ * \param r0 will contain the index of the left part first character in `str`.
+ * \param r1 will contain the index of left part last character in `str`.
+ * \param ignore_spaces Is `true`, computed indexes will not take into account potential
+ *		spaces around the separator as well as before left part and after right part, so
+ *		`&quot;name=val&quot;` will be equivalent to `&quot;name = val&quot;`.
+ * \param ignore_quotes If `true`, quotes (`&quot;` or `&apos;`) will not be taken into account when parsing left
+ * 		and right members, so `&quot;name = 'val'&quot;` will be equivalent to `&quot;name = val&quot;`.
+ *
+ * \return `false` when `str` is malformed, `true` when splitting was successful.
+ */
+int split_left_right(SXML_CHAR* str, SXML_CHAR sep, int* l0, int* l1, int* i_sep, int* r0, int* r1, int ignore_spaces, int ignore_quotes);
+
+/**
+ Detect a potential BOM at the current file position and read it into 'bom' (if not NULL,
+ 'bom' should be at least 5 bytes). It also moves the 'f' beyond the BOM so it's possible to
+ skip it by calling 'freadBOM(f, NULL, NULL)'. If no BOM is found, it leaves 'f' file pointer
+ is reset to its original location.
+ If not null, 'sz_bom' is filled with how many bytes are stored in 'bom'.
+ Return the BOM type or BOM_NONE if none found (empty 'bom' in this case).
+ */
+BOM_TYPE freadBOM(FILE* f, unsigned char* bom, int* sz_bom);
+
+/**
+ * \brief Checks if the given string contains HTML escape character (`&`).
+ *
+ * It can be useful to know whether `html2str()` would need to be called on
+ * `html`.
+ *
+ * \param html The string to check.
+ *
+ * \returns `false` if `html` does not contain the HTML escape character.
+ */
+int has_html(SXML_CHAR* html);
+
+/**
+ * \brief Replace occurrences of special HTML characters escape sequences (e.g. `"&amp;"`)
+ * by its character equivalent (e.g. `"&"`).
+ *
+ * If `html == str`, replacement is made in `str` itself, overwriting it.
+ * If `str` is `NULL`, replacement is made into `html`, overwriting it.
+ *
+ * \param html The string containing the HTML escapes (e.g. `"h&ocirc;tel"`).
+ * \param str The string to receive the unescaped string (e.g. `"hôtel"`).
+ *
+ * \returns The unescaped string (`str`, or `html` if `str` was `NULL`).
+ */
+SXML_CHAR* html2str(SXML_CHAR* html, SXML_CHAR* str);
+
+/**
+ * \brief Replace occurrences of special characters (e.g. `&`) into their XML escaped
+ * equivalent (e.g. `"&amp;"`).
+ *
+ * `html` is supposed allocated to the correct size (e.g. using `__malloc(strlen_html(str)+30)`)
+ * and *different* from `str` (unlike `html2str()`), as the string will expand.
+ * If it is `NULL`, `str` will be analyzed and a string will be allocated to the exact size and
+ * returned. In that case, it is the responsibility of the caller to `free()` the result!
+ * \return `html`, or `NULL` if `str` or `html` are `NULL`, or when `html` is `str`.
+ */
+SXML_CHAR* str2html(SXML_CHAR* str, SXML_CHAR* html);
+
+/**
+ * \brief Compute the length of a string as if all its special character were replaced by their HTML
+ * escapes.
+ * \return 0 if `str` is NULL.
+ */
+int strlen_html(SXML_CHAR* str);
+
+/**
+ * \brief Print a string to a file, transforming special characters into their HTML equivalent.
+
+ * This is more efficient than a call to `fprintf(f, str2html(str))` as it does not need memory
+ * allocation; rather, it converts characters on-the-fly while writing.
+ * If `f` is NULL, does not print `str` but rather counts the number of characters that
+ * would be printed.
+ *
+ * \returns the number of output characters.
+ */
+int fprintHTML(FILE* f, SXML_CHAR* str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/ticks/sxmlsearch.c
+++ b/src/ticks/sxmlsearch.c
@@ -1,0 +1,636 @@
+/*
+	Copyright (c) 2010, Matthieu Labas
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice,
+	   this list of conditions and the following disclaimer in the documentation
+	   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+	PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGE.
+
+	The views and conclusions contained in the software and documentation are those of the
+	authors and should not be interpreted as representing official policies, either expressed
+	or implied, of the FreeBSD Project.
+*/
+#if defined(WIN32) || defined(WIN64)
+#pragma warning(disable : 4996)
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include "sxmlc.h"
+#include "sxmlsearch.h"
+
+#define INVALID_XMLNODE_POINTER ((XMLNode*)-1)
+
+/* The function used to compare a string to a pattern */
+static REGEXPR_COMPARE regstrcmp_search = regstrcmp;
+
+REGEXPR_COMPARE XMLSearch_set_regexpr_compare(REGEXPR_COMPARE fct)
+{
+	REGEXPR_COMPARE previous = regstrcmp_search;
+
+	regstrcmp_search = fct;
+
+	return previous;
+}
+
+int XMLSearch_init(XMLSearch* search)
+{
+	if (search == NULL)
+		return false;
+
+	search->tag = NULL;
+	search->text = NULL;
+	search->attributes = NULL;
+	search->n_attributes = 0;
+	search->next = NULL;
+	search->prev = NULL;
+	search->stop_at = INVALID_XMLNODE_POINTER; /* Because 'NULL' can be a valid value */
+	search->init_value = XML_INIT_DONE;
+	
+	return true;
+}
+
+int XMLSearch_free(XMLSearch* search, int free_next)
+{
+	int i;
+
+	if (search == NULL || search->init_value != XML_INIT_DONE)
+		return false;
+
+	if (search->tag != NULL) {
+		__free(search->tag);
+		search->tag = NULL;
+	}
+
+	if (search->attributes != NULL) {
+		for (i = 0; i < search->n_attributes; i++) {
+			if (search->attributes[i].name != NULL)
+				__free(search->attributes[i].name);
+			if (search->attributes[i].value != NULL)
+				__free(search->attributes[i].value);
+		}
+		__free(search->attributes);
+		search->n_attributes = 0;
+		search->attributes = NULL;
+	}
+
+	if (free_next && search->next != NULL) {
+		(void)XMLSearch_free(search->next, true);
+		__free(search->next);
+		search->next = NULL;
+	}
+	search->init_value = 0; /* Something not XML_INIT_DONE, otherwise we'll go into 'XMLSearch_free' again */
+	(void)XMLSearch_init(search);
+
+	return true;
+}
+
+int XMLSearch_search_set_tag(XMLSearch* search, const SXML_CHAR* tag)
+{
+	if (search == NULL)
+		return false;
+
+	if (tag == NULL) {
+		if (search->tag != NULL) {
+			__free(search->tag);
+			search->tag = NULL;
+		}
+		return true;
+	}
+
+	search->tag = sx_strdup(tag);
+	return (search->tag != NULL);
+}
+
+int XMLSearch_search_set_text(XMLSearch* search, const SXML_CHAR* text)
+{
+	if (search == NULL)
+		return false;
+
+	if (text == NULL) {
+		if (search->text != NULL) {
+			__free(search->text);
+			search->text = NULL;
+		}
+		return true;
+	}
+
+	search->text = sx_strdup(text);
+	return (search->text != NULL);
+}
+
+int XMLSearch_search_add_attribute(XMLSearch* search, const SXML_CHAR* attr_name, const SXML_CHAR* attr_value, int value_equal)
+{
+	int i;
+	XMLAttribute* pt;
+	SXML_CHAR* name;
+	SXML_CHAR* value;
+
+	if (search == NULL)
+		return -1;
+
+	if (attr_name == NULL || attr_name[0] == NULC)
+		return -1;
+
+	name = sx_strdup(attr_name);
+	value = (attr_value == NULL ? NULL : sx_strdup(attr_value));
+	if (name == NULL || (attr_value && value == NULL)) {
+		if (value != NULL)
+			__free(value);
+		if (name != NULL)
+			__free(name);
+	}
+
+	i = search->n_attributes;
+	pt = (XMLAttribute*)__realloc(search->attributes, (i + 1) * sizeof(XMLAttribute));
+	if (pt == NULL) {
+		if (value)
+			__free(value);
+		__free(name);
+		return -1;
+	}
+
+	pt[i].name = name;
+	pt[i].value = value;
+	pt[i].active = value_equal;
+
+	search->n_attributes = i+1;
+	search->attributes = pt;
+
+	return i;
+}
+
+int XMLSearch_search_get_attribute_index(const XMLSearch* search, const SXML_CHAR* attr_name)
+{
+	int i;
+
+	if (search == NULL || attr_name == NULL || attr_name[0] == NULC)
+		return -1;
+
+	for (i = 0; i < search->n_attributes; i++) {
+		if (!sx_strcmp(search->attributes[i].name, attr_name))
+			return i;
+	}
+
+	return -1;
+}
+
+int XMLSearch_search_remove_attribute(XMLSearch* search, int i_attr)
+{
+	XMLAttribute* pt;
+
+	if (search == NULL || i_attr < 0 || i_attr >= search->n_attributes)
+		return -1;
+
+	/* Free attribute fields first */
+	if (search->n_attributes == 1)
+		pt = NULL;
+	else {
+		pt = (XMLAttribute*)__malloc((search->n_attributes - 1) * sizeof(XMLAttribute));
+		if (pt == NULL)
+			return -1;
+	}
+	if (search->attributes[i_attr].name != NULL)
+		__free(search->attributes[i_attr].name);
+	if (search->attributes[i_attr].value != NULL)
+		__free(search->attributes[i_attr].value);
+
+	if (pt != NULL) {
+		memcpy(pt, search->attributes, i_attr * sizeof(XMLAttribute));
+		memcpy(&pt[i_attr], &search->attributes[i_attr + 1], (search->n_attributes - i_attr - 1) * sizeof(XMLAttribute));
+	}
+	if (search->attributes)
+		__free(search->attributes);
+	search->attributes = pt;
+	search->n_attributes--;
+
+	return search->n_attributes;
+}
+
+int XMLSearch_search_set_children_search(XMLSearch* search, XMLSearch* children_search)
+{
+	if (search == NULL)
+		return false;
+
+	if (search->next != NULL)
+		XMLSearch_free(search->next, true);
+
+	search->next = children_search;
+	children_search->prev = search;
+
+	return true;
+}
+
+SXML_CHAR* XMLSearch_get_XPath_string(const XMLSearch* search, SXML_CHAR** xpath, SXML_CHAR quote)
+{
+	const XMLSearch* s;
+	SXML_CHAR squote[] = C2SX("'");
+	int i, fill;
+
+	if (xpath == NULL)
+		return NULL;
+
+	/* NULL 'search' is an empty string */
+	if (search == NULL) {
+		*xpath = sx_strdup(C2SX(""));
+		if (*xpath == NULL)
+			return NULL;
+
+		return *xpath;
+	}
+
+	squote[0] = (quote == NULC ? XML_DEFAULT_QUOTE : quote);
+
+	for (s = search; s != NULL; s = s->next) {
+		if (s != search && strcat_alloc(xpath, C2SX("/")) == NULL) goto err; /* No "/" prefix for the first criteria */
+		if (strcat_alloc(xpath, s->tag == NULL || s->tag[0] == NULC ? C2SX("*"): s->tag) == NULL) goto err;
+
+		if (s->n_attributes > 0 || (s->text != NULL && s->text[0] != NULC))
+			if (strcat_alloc(xpath, C2SX("[")) == NULL) goto err;
+
+		fill = false; /* '[' has not been filled with text yet, no ", " separator should be added */
+		if (s->text != NULL && s->text[0] != NULC) {
+			if (strcat_alloc(xpath, C2SX(".=")) == NULL) goto err;
+			if (strcat_alloc(xpath, squote) == NULL) goto err;
+			if (strcat_alloc(xpath, s->text) == NULL) goto err;
+			if (strcat_alloc(xpath, squote) == NULL) goto err;
+			fill = true;
+		}
+
+		for (i = 0; i < s->n_attributes; i++) {
+			if (fill) {
+				if (strcat_alloc(xpath, C2SX(", ")) == NULL) goto err;
+			} else
+				fill = true; /* filling is being performed */
+			if (strcat_alloc(xpath, C2SX("@")) == NULL) goto err;
+			if (strcat_alloc(xpath, s->attributes[i].name) == NULL) goto err;
+			if (s->attributes[i].value == NULL) continue;
+
+			if (strcat_alloc(xpath, s->attributes[i].active ? C2SX("=") : C2SX("!=")) == NULL) goto err;
+			if (strcat_alloc(xpath, squote) == NULL) goto err;
+			if (strcat_alloc(xpath, s->attributes[i].value) == NULL) goto err;
+			if (strcat_alloc(xpath, squote) == NULL) goto err;
+		}
+		if ((s->text != NULL && s->text[0] != NULC) || s->n_attributes > 0) {
+			if (strcat_alloc(xpath, C2SX("]")) == NULL) goto err;
+		}
+	}
+
+	return *xpath;
+
+err:
+	__free(*xpath);
+	*xpath = NULL;
+
+	return NULL;
+}
+
+/*
+ Extract search information from 'xpath', where 'xpath' represents a single node
+ (i.e. no '/' inside, except escaped ones), stripped from lead and tail '/'.
+ tag[.=text, @attrib="value"] with potential spaces around '=' and ','.
+ Return 'false' if parsing failed, 'true' for success.
+ This is an internal function so we assume that arguments are valid (non-NULL).
+ */
+static int _init_search_from_1XPath(SXML_CHAR* xpath, XMLSearch* search)
+{
+	SXML_CHAR *p, *q;
+	SXML_CHAR c, c1, cc;
+	int l0, l1, is, r0, r1;
+	int ret;
+
+	XMLSearch_init(search);
+
+	/* Look for tag name */
+	for (p = xpath; *p != NULC && *p != C2SX('['); p++) ;
+	c = *p; /* Either '[' or '\0' */
+	*p = NULC;
+	ret = XMLSearch_search_set_tag(search, xpath);
+	*p = c;
+	if (!ret)
+		return false;
+
+	if (*p == NULC)
+		return true;
+
+	/* Here, '*p' is '[', we have to parse either text or attribute names/values until ']' */
+	for (p++; *p && *p != C2SX(']'); p++) {
+		for (q = p; *q && *q != C2SX(',') && *q != C2SX(']'); q++) ; /* Look for potential ',' separator to null it */
+		cc = *q;
+		if (*q == C2SX(',') || *q == C2SX(']'))
+			*q = NULC;
+		ret = true;
+		switch (*p) {
+			case C2SX('.'): /* '.[ ]=[ ]["']...["']' to search for text */
+				if (!split_left_right(p, C2SX('='), &l0, &l1, &is, &r0, &r1, true, true))
+					return false;
+				c = p[r1+1];
+				p[r1+1] = NULC;
+				ret = XMLSearch_search_set_text(search, &p[r0]);
+				p[r1+1] = c;
+				p += r1+1;
+				break;
+
+			/* Attribute name, possibly '@attrib[[ ]=[ ]"value"]' */
+			case C2SX('@'):
+				if (!split_left_right(++p, '=', &l0, &l1, &is, &r0, &r1, true, true))
+					return false;
+				c = p[l1+1];
+				c1 = p[r1+1];
+				p[l1+1] = NULC;
+				p[r1+1] = NULC;
+				ret = (XMLSearch_search_add_attribute(search, &p[l0], (is < 0 ? NULL : &p[r0]), true) < 0 ? false : true); /* 'is' < 0 when there is no '=' (i.e. check for attribute presence only */
+				p[l1+1] = c;
+				p[r1+1] = c1;
+				p += r1-1; /* Jump to next value */
+				break;
+
+			default: /* Not implemented */
+				break;
+		}
+		*q = cc; /* Restore ',' separator if any */
+		if (!ret)
+			return false;
+	}
+
+	return true;
+}
+
+int XMLSearch_init_from_XPath(const SXML_CHAR* xpath, XMLSearch* search)
+{
+	XMLSearch *search1, *search2;
+	SXML_CHAR *p, *tag, *tag0;
+	SXML_CHAR c;
+
+	if (!XMLSearch_init(search))
+		return false;
+
+	/* NULL or empty xpath is an empty (initialized only) search */
+	if (xpath == NULL || *xpath == NULC)
+		return true;
+
+	search1 = NULL;		/* Search struct to add the xpath portion to */
+	search2 = search;	/* Search struct to be filled from xpath portion */
+
+	tag = tag0 = sx_strdup(xpath); /* Create a copy of 'xpath' to be able to patch it (or segfault if 'xpath' is const, cnacu6o Sergey@sourceforge!) */
+	while (*tag != NULC) {
+		if (search2 != search) { /* Allocate a new search when the original one (i.e. 'search') has already been filled */
+			search2 = (XMLSearch*)__calloc(1, sizeof(XMLSearch));
+			if (search2 == NULL) {
+				__free(tag0);
+				(void)XMLSearch_free(search, true);
+				return false;
+			}
+		}
+		/* Skip all first '/' */
+		for (; *tag != NULC && *tag == C2SX('/'); tag++) ;
+		if (*tag == NULC) {
+			__free(tag0);
+			return false;
+		}
+
+		/* Look for the end of tag name: after '/' (to get another tag) or end of string */
+		for (p = &tag[1]; *p != NULC && *p != C2SX('/'); p++) {
+			if (*p == C2SX('\\') && *++p == NULC)
+				break; /* Escape character, '\' could be the last character... */
+		}
+		c = *p; /* Backup character before nulling it */
+		*p = NULC;
+		if (!_init_search_from_1XPath(tag, search2)) {
+			__free(tag0);
+			(void)XMLSearch_free(search, true);
+			return false;
+		}
+		*p = c;
+
+		/* 'search2' is the newly parsed tag, 'search1' is the previous tag (or NULL if 'search2' is the first tag to parse (i.e. 'search2' == 'search') */
+
+		if (search1 != NULL) search1->next = search2;
+		if (search2 != search) search2->prev = search1;
+		search1 = search2;
+		search2 = NULL; /* Will force allocation during next loop */
+		tag = p;
+	}
+
+	__free(tag0);
+	return true;
+}
+
+static int _attribute_matches(XMLAttribute* to_test, XMLAttribute* pattern)
+{
+	if (to_test == NULL && pattern == NULL)
+		return true;
+
+	if (to_test == NULL || pattern == NULL)
+		return false;
+	
+	/* No test on name => match */
+	if (pattern->name == NULL || pattern->name[0] == NULC)
+		return true;
+
+	/* Test on name fails => no match */
+	if (!regstrcmp_search(to_test->name, pattern->name))
+		return false;
+
+	/* No test on value => match */
+	if (pattern->value == NULL)
+		return true;
+
+	/* Test on value according to pattern "equal" attribute */
+	return regstrcmp_search(to_test->value, pattern->value) == pattern->active ? true : false;
+}
+
+int XMLSearch_node_matches(const XMLNode* node, const XMLSearch* search)
+{
+	int i, j;
+
+	if (node == NULL)
+		return false;
+
+	if (search == NULL)
+		return true;
+
+	/* No comments, prolog, or such type of nodes are tested */
+	if (node->tag_type != TAG_FATHER && node->tag_type != TAG_SELF)
+		return false;
+
+	/* Check tag */
+	if (search->tag != NULL && !regstrcmp_search(node->tag, search->tag))
+		return false;
+
+	/* Check text */
+	if (search->text != NULL && !regstrcmp_search(node->text, search->text))
+		return false;
+
+	/* Check attributes */
+	if (search->attributes != NULL) {
+		for (i = 0; i < search->n_attributes; i++) {
+			for (j = 0; j < node->n_attributes; j++) {
+				if (!node->attributes[j].active)
+					continue;
+				if (_attribute_matches(&node->attributes[j], &search->attributes[i]))
+					break;
+			}
+			if (j >= node->n_attributes) /* All attributes where scanned without a successful match */
+				return false;
+		}
+	}
+
+	/* 'node' matches 'search'. If there is a father search, its father must match it */
+	if (search->prev != NULL)
+		return XMLSearch_node_matches(node->father, search->prev);
+
+	/* TODO: Should a node match if search has no more 'prev' search and node father is still below the initial search ?
+	 Depends if XPath started with "//" (=> yes) or "/" (=> no).
+	 if (search->prev == NULL && node->father != search->from) return false; ? */
+		
+	return true;
+}
+
+XMLNode* XMLSearch_next(const XMLNode* from, XMLSearch* search)
+{
+	XMLNode* node;
+
+	if (search == NULL || from == NULL)
+		return NULL;
+
+	/* Go down the last child search as fathers will be tested recursively by the 'XMLSearch_node_matches' function */
+	for (; search->next != NULL; search = search->next) ;
+
+	/* Initialize the 'stop_at' node on first search, to remember where to stop as there will be multiple calls */
+	/* 'stop_at' can be NULL when 'from' is a root node, that is why it should be initialized with something else than NULL */
+	if (search->stop_at == INVALID_XMLNODE_POINTER)
+		search->stop_at = XMLNode_next_sibling(from);
+
+	for (node = XMLNode_next(from); node != search->stop_at; node = XMLNode_next(node)) { /* && node != NULL */
+		if (!XMLSearch_node_matches(node, search))
+			continue;
+
+		/* 'node' is a matching node */
+
+		/* No search to perform on 'node' children => 'node' is returned */
+		if (search->next == NULL)
+			return node;
+
+		/* Run the search on 'node' children */
+		return XMLSearch_next(node, search->next);
+	}
+
+	return NULL;
+}
+
+static SXML_CHAR* _get_XPath(const XMLNode* node, SXML_CHAR** xpath)
+{
+	int i, n, brackets, sz_xpath;
+	SXML_CHAR* p;
+
+	brackets = 0;
+	sz_xpath = sx_strlen(node->tag);
+	if (node->text != NULL) {
+		sz_xpath += strlen_html(node->text) + 4; /* 4 = '.=""' */
+		brackets = 2; /* Text has to be displayed => add '[]' */
+	}
+	for (i = 0; i < node->n_attributes; i++) {
+		if (!node->attributes[i].active)
+			continue;
+		brackets = 2; /* At least one attribute has to be displayed => add '[]' */
+		sz_xpath += strlen_html(node->attributes[i].name) + strlen_html(node->attributes[i].value) + 6; /* 6 = ', @=""' */
+	}
+	sz_xpath += brackets + 1;
+	*xpath = (SXML_CHAR*)__malloc(sz_xpath*sizeof(SXML_CHAR));
+
+	if (*xpath == NULL)
+		return NULL;
+
+	sx_strcpy(*xpath, node->tag);
+	if (node->text != NULL) {
+		sx_strcat(*xpath, C2SX("[.=\""));
+		(void)str2html(node->text, &(*xpath[sx_strlen(*xpath)]));
+		sx_strcat(*xpath, C2SX("\""));
+		n = 1; /* Indicates '[' has been put */
+	} else
+		n = 0;
+
+	for (i = 0; i < node->n_attributes; i++) {
+		if (!node->attributes[i].active)
+			continue;
+
+		if (n == 0) {
+			sx_strcat(*xpath, C2SX("["));
+			n = 1;
+		} else
+			sx_strcat(*xpath, C2SX(", "));
+		p = &(*xpath)[sx_strlen(*xpath)];
+
+		/* Standard and Unicode versions of 'sprintf' do not have the same signature! :( */
+		sx_sprintf(p,
+#ifdef SXMLC_UNICODE
+			sz_xpath,
+#endif
+			C2SX("@%s=%c"), node->attributes[i].name, XML_DEFAULT_QUOTE);
+
+		(void)str2html(node->attributes[i].value, p);
+		sx_strcat(*xpath, C2SX("\""));
+	}
+	if (n > 0)
+		sx_strcat(*xpath, C2SX("]"));
+
+	return *xpath;
+}
+
+SXML_CHAR* XMLNode_get_XPath(XMLNode* node, SXML_CHAR** xpath, int incl_parents)
+{
+	SXML_CHAR* xp = NULL;
+	SXML_CHAR* xparent;
+	XMLNode* parent;
+
+	if (node == NULL || node->init_value != XML_INIT_DONE || xpath == NULL)
+		return NULL;
+
+	if (!incl_parents) {
+		if (_get_XPath(node, &xp) == NULL) {
+			*xpath = NULL;
+			return NULL;
+		}
+		return *xpath = xp;
+	}
+
+	/* Go up to root node */
+	parent = node;
+	do {
+		xparent = NULL;
+		if (_get_XPath(parent, &xparent) == NULL) goto xp_err;
+		if (xp != NULL) {
+			if (strcat_alloc(&xparent, C2SX("/")) == NULL) goto xp_err;
+			if (strcat_alloc(&xparent, xp) == NULL) goto xp_err;
+		}
+		xp = xparent;
+		parent = parent->father;
+	} while (parent != NULL);
+	if ((*xpath = sx_strdup(C2SX("/"))) == NULL || strcat_alloc(xpath, xp) == NULL) goto xp_err;
+
+	return *xpath;
+
+xp_err:
+	if (xp != NULL) __free(xp);
+	*xpath = NULL;
+
+	return NULL;
+}

--- a/src/ticks/sxmlsearch.h
+++ b/src/ticks/sxmlsearch.h
@@ -1,0 +1,274 @@
+/**
+	Copyright (c) 2010, Matthieu Labas
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification,
+	are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice,
+	   this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice,
+	   this list of conditions and the following disclaimer in the documentation
+	   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+	NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+	PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+	OF SUCH DAMAGE.
+
+	The views and conclusions contained in the software and documentation are those of the
+	authors and should not be interpreted as representing official policies, either expressed
+	or implied, of the FreeBSD Project.
+*/
+#ifndef _SXMLCSEARCH_H_
+#define _SXMLCSEARCH_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sxmlc.h"
+
+/**
+ * \brief XML search parameters. Can be initialized from an XPath string.
+ */
+typedef struct _XMLSearch {
+
+	SXML_CHAR* tag; /**< Search for nodes which tag match this `tag` field. */
+					/**< If NULL or an empty string, all nodes will be matching. */
+
+	XMLAttribute* attributes;	/**< Search for nodes which attributes match all the ones described. */
+								/**< If NULL, all nodes will be matching. */
+								/**<  The `attribute->name` should not be NULL. If corresponding `attribute->value` */
+								/**< is NULL or an empty-string, search will return the first node with an attribute */
+								/**< `attribute->name`, no matter what its value is. */
+								/**< If `attribute->value` is not NULL, a matching node should have an attribute */
+								/**< `attribute->name` with the corresponding value `attribute->value`. */
+								/**< When `attribute->value` is not NULL, the `attribute->active` should be `true` */
+								/**< to specify that values should be equal, or `false` to specify that values should */
+								/**< be different. */
+	int n_attributes;	/**< The size of `attributes`array. */
+
+	SXML_CHAR* text;	/**< Search for nodes which text match this `text` field. */
+						/**< If NULL or an empty string, all nodes will be matching (i.e. not used). */
+
+	struct _XMLSearch* next;	/**< Next search to perform on children of a node matching current struct. */
+								/**< Used to search for nodes children of specific nodes (used in XPath queries). */
+	struct _XMLSearch* prev;
+
+	XMLNode* stop_at;	/**< Internal use only. Must be initialized to 'INVALID_XMLNODE_POINTER' prior to first search. */
+
+	/* Keep 'init_value' as the last member */
+	int init_value;	/**< Initialized to 'XML_INIT_DONE' to indicate that document has been initialized properly */
+} XMLSearch;
+
+/**
+ * \brief The prototype used by the regular expression handler.
+ * The default regex function can be overriden by user code through `XMLSearch_set_regexpr_compare()`.
+ * \param str The string to match on `pattern`.
+ * \param pattern The pattern to match `str` to.
+ * \return `true` if `str` matches `pattern`.
+ */
+typedef int (*REGEXPR_COMPARE)(SXML_CHAR* str, SXML_CHAR* pattern);
+
+/**
+ * \brief Set a new comparison function to evaluate whether a string matches a given pattern.
+ *
+ * The default one is `regstrcmp()` which handles limited regular expressions (<code>'?'</code>
+ * and <code>'*'</code> wildcards).
+ *
+ * \return The previous function used for matching.
+ */
+REGEXPR_COMPARE XMLSearch_set_regexpr_compare(REGEXPR_COMPARE fct);
+
+/**
+ * \brief Initialize an empty search. No memory freeing is performed.
+ * \param search The search parameters.
+ * \return `false` when `search` is NULL.
+ */
+int XMLSearch_init(XMLSearch* search);
+
+/**
+ * \brief Free all search members except for the `search->next` member that should be freed
+ * by its creator, unless `free_next` is `true`.
+ *
+ * It is recommended that `free_next` is positioned to `true` only when the creator did not
+ * handle the whole memory allocation chain, e.g. when using `XMLSearch_init_from_XPath()`
+ * that allocates all search structs.
+ *
+ * \param search The search parameters.
+ * \param free_next `false` in order *not* to free the `search->next` structures.
+ *
+ * \return `false` when `search` is NULL.
+ */
+int XMLSearch_free(XMLSearch* search, int free_next);
+
+/**
+ * \brief Set the search based on tag.
+ * \param search The search parameters.
+ * \param tag should be NULL or empty to search for any node (e.g. search based on attributes
+ * only). In this case, the previous tag is freed.
+ * \return `true` upon successful completion, `false` for memory error.
+ */
+int XMLSearch_search_set_tag(XMLSearch* search, const SXML_CHAR* tag);
+
+/**
+ * \brief Add an attribute search criteria.
+ * \param search The search parameters.
+ * \param attr_name is the attribute name to search. Mandatory.
+ * \param attr_value should be NULL to test for attribute presence only
+ * 		(no test on value). An empty string means the attribute should exist
+ * 		with an empty value.
+ * \param value_equal should be specified to test for attribute value equality (`true`) or
+ *		difference (`false`).
+ * \return the index of the new attribute, or -1 for memory error.
+ */
+int XMLSearch_search_add_attribute(XMLSearch* search, const SXML_CHAR* attr_name, const SXML_CHAR* attr_value, int value_equal);
+
+/**
+ * \brief Retrieve attribute search parameters on attribute `attr_name`.
+ * \param search The search parameters.
+ * \param attr_name The attribute name to look for.
+ * \return The attribute search index or -1 if not found.
+ */
+int XMLSearch_search_get_attribute_index(const XMLSearch* search, const SXML_CHAR* attr_name);
+
+/**
+ * \brief Remove the attribute search parameters by index.
+ * \param search The search parameters.
+ * \param i_attr The search attribute index.
+ * \return the number of search attributes parameters left.
+ */
+int XMLSearch_search_remove_attribute(XMLSearch* search, int i_attr);
+
+/**
+ * \brief Set the search based on text content.
+ * \param search The search parameters.
+ * \param text should be NULL or empty to search for any node (e.g. search based on attributes
+ * 		only). In this case, the previous text is freed.
+ *
+ * \return `true` upon successful completion, `false` for memory error.
+ */
+int XMLSearch_search_set_text(XMLSearch* search, const SXML_CHAR* text);
+
+/**
+ * \brief Set an additional search on children nodes of a previously matching node.
+ *
+ * Search struct are chained to finally return the node matching the last search struct,
+ * which father node matches the previous search struct, and so on.
+ * This allows describing more complex search queries like XPath
+ * `"//FatherTag[@attrib=val]/ChildTag/"`.
+ *
+ * In this case, a first search struct would have `search->tag = "FatherTag"` and
+ * `search->attributes[0] = { "attrib", "val" }` and a second search struct with
+ * `search->tag = "ChildTag"`.
+ * If `children_search` is NULL, next search is removed. Freeing previous search is to be
+ * performed by its owner.
+ * In any case, if `search` next search is not NULL, it is freed.
+ *
+ * \param search The search parameters.
+ * \param children_search The search parameters to be applied to children of nodes
+ * 		matching `search`.
+ *
+ * \return `true` when association has been made, `false` when an error occurred.
+ */
+int XMLSearch_search_set_children_search(XMLSearch* search, XMLSearch* children_search);
+
+/**
+ * \brief Compute an XPath-equivalent string of the search criteria.
+ *
+ * \param search The search parameters. NULL will return an empty string.
+ * \param xpath is a pointer to a string that will be allocated by the function and should
+ *		be freed after use.
+ * \param quote is the quote character to be used (e.g. `"` or `'`). If <code>'\0'</code>,
+ * 		`XML_DEFAULT_QUOTE` will be used.
+ *
+ * \return `false` for a memory problem, `true` otherwise.
+ */
+SXML_CHAR* XMLSearch_get_XPath_string(const XMLSearch* search, SXML_CHAR** xpath, SXML_CHAR quote);
+
+/**
+ * \brief Initialize a search struct from an XPath-like query. "XPath-like" means that
+ * it does not fully comply to XPath standard.
+ *
+ * \param xpath should be like <code>"tag[.=text, @attrib="value", @attrib!='value', ...]/tag..."</code>.
+ * 		*Warning*: the XPath query on node text like `father[child="text"]` should be
+ * 		re-written `father/child[.="text"]` instead (which should be XPath-compliant as well).
+ * \param search The search parameters.
+ *
+ *
+ * \return `true` when `search` was correctly initialized, `false` in case of memory
+ * 		problem or malformed `xpath`.
+ */
+int XMLSearch_init_from_XPath(const SXML_CHAR* xpath, XMLSearch* search);
+
+/**
+ * \brief Check whether a node matches a search criteria.
+ *
+ * If `search->prev` is not NULL (i.e. has a father search), `node->father` is also
+ * tested, recursively (i.e. grand-father and so on).
+ *
+ * \param node The node to test. `tag_type` should be `TAG_FATHER` or `TAG_SELF` only.
+ * \param search The search parameters.
+ *
+ * \return `false` when `node` does not match or for invalid arguments, `true`
+ * 		if `node` is a match.
+ */
+int XMLSearch_node_matches(const XMLNode* node, const XMLSearch* search);
+
+/**
+ * \brief Search next matching node, according to search parameters.
+ *
+ * Search starts from node `from` by scanning all its children, and going up to siblings,
+ * uncles and so on.
+ *
+ * Searching for the next matching node is performed by running the search again on the last
+ * matching node. So `search` has to be initialized by `XMLSearch_init()` prior to the first
+ * call, to memorize the initial `from` node and know where to stop search.
+ * `from` ITSELF IS NOT CHECKED! Direct call to `XMLSearch_node_matches(from, search)` should
+ * be made if necessary.
+ *
+ * If the document has several root nodes, a complete search in the document should be performed
+ * by manually calling `XMLSearch_next()` on each root node in a for loop.
+ * Note that `search` should be the initial search struct (i.e. `search->prev` should be NULL). This
+ * cannot be checked corrected by the function itself as it is partly recursive.
+ *
+ * \param from The node to start searching from.
+ * \param search The search parameters.
+ *
+ * \return the next matching node according to `search` criteria, or NULL when no more nodes match
+ * 		or when an error occurred.
+ */
+XMLNode* XMLSearch_next(const XMLNode* from, XMLSearch* search);
+
+/**
+ * \brief Get node XPath-like equivalent: `tag[.="text", @attribute="value", ...]`, potentially
+ * including father nodes XPathes.
+ *
+ * The computed XPath is stored in a dynamically-allocated string.
+ *
+ * \return the XPath, or NULL if `node` is invalid or on memory error.
+ */
+SXML_CHAR* XMLNode_get_XPath(XMLNode* node, SXML_CHAR** xpath, int incl_parents);
+
+/**
+ * Checks whether a string corresponds to a pattern.
+ * \param str The string to check.
+ * \param pattern can use wildcads such as `*` (any potentially empty string) or
+ * 		`?` (any character) and use `\` as an escape character.
+ * \returns `true` when `str` matches `pattern`, `false` otherwise.
+ */
+int regstrcmp(SXML_CHAR* str, SXML_CHAR* pattern);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -995,7 +995,10 @@ int main (int argc, char **argv){
 
   do{
     char buf[256];
-    if ( ih ) debugger();
+    if ( ih ) {
+        debugger_process_signals();
+        debugger();
+    }
     if( pc==start )
       st= 0,
       stint= intr,


### PR DESCRIPTION
This PR implements a new tool that extends from z88dk-ticks, z88dk-gdb. Its frontend looks the same as ticks, but it is expecting a gdbserver to connect to.
Currently, [mame](https://www.mamedev.org/) supports gdbserver when run like so:
```
./mame spectrum -window -nomaximize -resolution0 768x576 -debug -debugger gdbstub -debugger_port 1337
```
Additionally, there's work to implement gdbserver for [Fuse](https://github.com/desertkun/fuse/commits/gdbserver).

Usage: `z88dk-gdb -h <connect host> -p <connect port> -x <debug symbols> [-x <debug symbols>] [-v]`
Currently, only `z80` is supported and it is expected for target to already have the program deployed. Probably, a future enhancements will follow.