### PR TITLE
z88dk-gdb: restore command (upload binary to the machine)

### DIFF
--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -10,6 +10,7 @@ typedef uint16_t (*get_uint16_cb)();
 typedef long long (*get_longlong_cb)();
 typedef int (*get_int_cb)();
 typedef void (*reset_paging_cb)();
+typedef uint8_t (*restore_cb)(const char* file_path, uint16_t at);
 typedef void (*out_cb)(int port, int value);
 typedef void (*debugger_write_memory_cb)(int addr, uint8_t val);
 typedef void (*debugger_read_memory_cb)(int addr);
@@ -46,6 +47,7 @@ typedef struct {
     void_cb next;
     void_cb step;
     void_cb detach;
+    restore_cb restore;
     breakpoint_cb add_breakpoint;
     breakpoint_cb remove_breakpoint;
     breakpoint_cb disable_breakpoint;

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -118,6 +118,7 @@ static int cmd_out(int argc, char **argv);
 static int cmd_trace(int argc, char **argv);
 static int cmd_hotspot(int argc, char **argv);
 static int cmd_list(int argc, char **argv);
+static int cmd_restore(int argc, char **argv);
 static int cmd_help(int argc, char **argv);
 static int cmd_quit(int argc, char **argv);
 static void print_hotspots();
@@ -144,6 +145,7 @@ static command commands[] = {
     { "hotspot",cmd_hotspot,       "<on/off>", "Track address counts and write to hotspots file"},
     { "list",   cmd_list,          "[<address>]",   "List the source code at location given or pc"},
     { "help",   cmd_help,          "",   "Display this help text" },
+    { "restore",cmd_restore,       "<path> [<address>]",   "Upload binary into machine memory"},
     { "quit",   cmd_quit,          "",   "Quit ticks"},
     { NULL, NULL, NULL }
 };
@@ -948,7 +950,7 @@ static int cmd_set(int argc, char **argv)
     } else {
         printf("Incorrect number of arguments\n");
     }
-    return 0;
+    return 1;
 }
 
 
@@ -1038,7 +1040,26 @@ static int cmd_quit(int argc, char **argv)
     exit(0);
 }
 
+static int cmd_restore(int argc, char **argv)
+{
+    int address;
+    if ( argc == 3 ) {
+        address = parse_address(argv[2]);
+    } else {
+        address = symbol_resolve("__head");
+        if (address == -1) {
+            printf("Warning: could not resolve starting address and no address is provided.\n");
+            return 0;
+        }
+    }
 
+    if (bk.restore(argv[1], address))
+    {
+        return 0;
+    }
+
+    return 1;
+}
 
 static int cmd_list(int argc, char **argv)
 {

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -126,6 +126,10 @@ void invalidate() {}
 void break_() {}
 void resume() {}
 void detach() {}
+uint8_t restore(const char* file_path, uint16_t at) {
+    printf("Not supported.\n");
+    return 1;
+}
 void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
 void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
 void disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
@@ -193,6 +197,7 @@ backend_t ticks_debugger_backend = {
     .next = &next,
     .step = &step,
     .detach = &detach,
+    .restore = &restore,
     .add_breakpoint = &add_breakpoint,
     .remove_breakpoint = &remove_breakpoint,
     .disable_breakpoint = &disable_breakpoint,


### PR DESCRIPTION
This adds command to deploy a binary onto debugged machine. That way, a debugging session gone wrong, can be just "restored". The second parameter is an optional restore address, when omitted, the `__head` symbol is used from the debugging information.

Also, fixed a bug: `set <register> xxxx` did not work as it sent twice the data.