### PR TITLE
(debug) backtrace with __z88dk_params_offset

### DIFF
--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -804,29 +804,29 @@ int debug_print_element(type_chain* chain, char issigned, enum resolve_chain_val
     return offs;
 }
 
-static uint8_t debug_resolve_chain_value(debug_sym_symbol *sym, uint16_t addr, char *target, size_t targetlen) {
+static uint8_t debug_resolve_chain_value(debug_sym_symbol *sym, uint16_t frame_pointer, char *target, size_t targetlen) {
     type_chain *chain = sym->type_record.first;
     int         offs = 0;
 
     switch (chain->type_) {
         case TYPE_ARRAY: {
             int maxlen = max(10,min(10, chain->size));
-            offs += snprintf(target + offs, targetlen - offs, "%#04x [%d] = { ", addr, chain->size);
+            offs += snprintf(target + offs, targetlen - offs, "%#04x [%d] = { ", frame_pointer, chain->size);
             for ( int i = 0; i < maxlen; i++ ) {
                 offs += snprintf(target + offs, targetlen - offs, "%s[%d] = ", i != 0 ? ", " : "", i);
                 switch ( chain->next->type_) {
                 case TYPE_CHAR:
-                    offs += debug_print_element(chain->next, sym->type_record.signed_, RESOLVE_BY_POINTER, addr, target + offs, targetlen - offs);
-                    addr++;
+                    offs += debug_print_element(chain->next, sym->type_record.signed_, RESOLVE_BY_POINTER, frame_pointer, target + offs, targetlen - offs);
+                    frame_pointer++;
                     break;
                 case TYPE_INT:
                 case TYPE_SHORT:
-                    offs += debug_print_element(chain->next, sym->type_record.signed_, RESOLVE_BY_POINTER, addr, target + offs, targetlen - offs);
-                    addr += 2;
+                    offs += debug_print_element(chain->next, sym->type_record.signed_, RESOLVE_BY_POINTER, frame_pointer, target + offs, targetlen - offs);
+                    frame_pointer += 2;
                     break;
                 case TYPE_LONG:
-                    offs += debug_print_element(chain->next, sym->type_record.signed_, RESOLVE_BY_POINTER, addr, target + offs, targetlen - offs);
-                    addr += 4;
+                    offs += debug_print_element(chain->next, sym->type_record.signed_, RESOLVE_BY_POINTER, frame_pointer, target + offs, targetlen - offs);
+                    frame_pointer += 4;
                     break;
                 default:
                     break;
@@ -841,7 +841,7 @@ static uint8_t debug_resolve_chain_value(debug_sym_symbol *sym, uint16_t addr, c
         case TYPE_LONG:
         case TYPE_GENERIC_POINTER:
         case TYPE_CODE_POINTER:
-            debug_print_element(chain, sym->type_record.signed_, RESOLVE_BY_POINTER, addr, target + offs, targetlen - offs);
+            debug_print_element(chain, sym->type_record.signed_, RESOLVE_BY_POINTER, frame_pointer, target + offs, targetlen - offs);
             return 0;
 
         default: {
@@ -901,8 +901,31 @@ size_t debug_stack_frames_count(debug_frame_pointer *first)
     return count;
 }
 
-debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, uint16_t fp, uint16_t limit)
+static uint16_t get_current_framepointer(struct debugger_regs_t *regs, size_t* invalidate_stack_offset)
 {
+    // If the symbol __debug_framepointer is defined, then extract the value from there
+    // The rest of the stack can be walked as normal since the value is pushed onto
+    // the stack as usual
+    int where = symbol_resolve("__debug_framepointer");
+
+    if ( where != -1 ) {
+        // call l_debug_push_frame
+        *invalidate_stack_offset = 3;
+        uint16_t ret = bk.get_memory(where) + (bk.get_memory(where+1)*256);
+        return ret;
+    }
+
+    // push	ix; ld ix,0; add ix,sp
+    *invalidate_stack_offset = 8;
+    return wrap_reg(regs->xh, regs->xl);
+}
+
+
+debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, struct debugger_regs_t* regs, uint16_t limit)
+{
+    size_t invalidate_stack_after;
+    uint16_t frame_pointer = get_current_framepointer(regs, &invalidate_stack_after);
+
     debug_frame_pointer* first = NULL;
     debug_frame_pointer* last = NULL;
 
@@ -938,21 +961,23 @@ debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, uint
         }
         last = new_frame;
 
-        uint16_t frame_pointer;
+        uint16_t new_frame_pointer;
         if (offset == 0) {
-            frame_pointer = stack - 2;
-        } else if (offset < 8) {
-            // we've pushed old fp but haven't inited old one
-            frame_pointer = stack;
+            // fp of this function hasn't been pushed yet, so we pretend it did,
+            // cause variables offset off frame pointer, even if it doesn't exist yet
+            new_frame_pointer = stack - 2;
+        } else if (offset < invalidate_stack_after) {
+            // we've pushed old ix but haven't inited old one
+            new_frame_pointer = stack;
         } else {
-            frame_pointer = fp;
+            new_frame_pointer = frame_pointer;
         }
 
         const char *filename;
         int   lineno;
 
         new_frame->next = NULL;
-        new_frame->frame_pointer = frame_pointer;
+        new_frame->frame_pointer = new_frame_pointer;
         new_frame->offset = offset;
         new_frame->address = at;
         new_frame->function = fn;
@@ -966,23 +991,58 @@ debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, uint
             new_frame->lineno = lineno;
         }
 
+        if (fn->address_space.b) {
+            debug_frame_pointer* unknown_entry = malloc(sizeof(debug_frame_pointer));
+            new_frame->next = unknown_entry;
+
+            uint16_t caller = wrap_reg(bk.get_memory(new_frame_pointer + 3), bk.get_memory(new_frame_pointer + 2));
+            uint16_t unknown_offset;
+            symbol* s = symbol_find_lower(caller, SYM_ADDRESS, &unknown_offset);
+
+            unknown_entry->next = NULL;
+            unknown_entry->frame_pointer = 0xFFFFFFFF;
+            unknown_entry->symbol = s;
+            unknown_entry->offset = unknown_offset;
+            unknown_entry->address = caller;
+            unknown_entry->function = NULL;
+
+            if (debug_find_source_location(caller, &filename, &lineno) < 0) {
+                unknown_entry->filename = NULL;
+                unknown_entry->lineno = 0;
+            } else {
+                unknown_entry->filename = filename;
+                unknown_entry->lineno = lineno;
+            }
+
+            last = unknown_entry;
+        }
+
         if (offset == 0) {
+            if (fn->address_space.b) {
+                stack += fn->address_space.b;
+            }
             // we're exactly at beginning of the function
             uint16_t caller = wrap_reg(bk.get_memory(stack + 1), bk.get_memory(stack));
             at = caller;
             // unwind ret
             stack += 2;
-        } else if (offset < 8) {
-            // we've pushed old fp but haven't inited old one
+        } else if (offset < invalidate_stack_after) {
+            if (fn->address_space.b) {
+                stack += fn->address_space.b;
+            }
+            // we've pushed old ix but haven't inited old one
             uint16_t caller = wrap_reg(bk.get_memory(stack + 3), bk.get_memory(stack + 2));
             at = caller;
-            // unwind ret and fp
+            // unwind ret and ix
             stack += 4;
         } else {
             // fp should point to sp at beginning of the function
-            stack = fp;
+            stack = frame_pointer;
+            if (fn->address_space.b) {
+                stack += fn->address_space.b;
+            }
             // last thing pushed is frame pointer of the caller (its fp)
-            fp = wrap_reg(bk.get_memory(fp + 1), bk.get_memory(fp));
+            frame_pointer = wrap_reg(bk.get_memory(frame_pointer + 1), bk.get_memory(frame_pointer));
             // then goes ret
             stack += 2;
             uint16_t caller = wrap_reg(bk.get_memory(stack + 1), bk.get_memory(stack));

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -589,7 +589,18 @@ void debug_add_cline(const char *filename, const char *function, int lineno, int
 
 int debug_find_source_location(int address, const char **filename, int *lineno)
 {
+    uint16_t offset;
+    symbol *original_sym = symbol_find_lower(address, SYM_ADDRESS, &offset);
+    if (original_sym == NULL) {
+        // no symbol - no address!
+        return -1;
+    }
+    int topmost_address = original_sym->address;
+
     while ( clines[address] == NULL && address > 0 ) {
+        if (address < topmost_address) {
+            return -1;
+        }
         address--;
     }
     if ( clines[address] == NULL) return -1;

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -114,7 +114,7 @@ struct debug_frame_pointer_s {
     uint16_t                offset;
     uint16_t                address;
     uint16_t                return_address;
-    uint16_t                frame_pointer;
+    uint32_t                frame_pointer;
     const char*             filename;
     int                     lineno;
     debug_frame_pointer*    next;
@@ -123,6 +123,14 @@ struct debug_frame_pointer_s {
 enum resolve_chain_value_kind {
     RESOLVE_BY_POINTER,
     RESOLVE_BY_VALUE
+};
+
+struct debugger_regs_t {
+    uint16_t pc, sp;
+    unsigned char a,b,c,d,e,h,l;
+    unsigned char a_,b_,c_,d_,e_,h_,l_;
+    unsigned char f, f_;
+    unsigned char xh, xl, yh, yl;
 };
 
 // debug
@@ -137,7 +145,7 @@ extern int debug_print_element(type_chain* chain, char issigned, enum resolve_ch
 extern uint8_t debug_get_symbol_value(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, char *target, size_t targetlen);
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);
 
-extern debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, uint16_t ix, uint16_t limit);
+extern debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, struct debugger_regs_t* regs, uint16_t limit);
 extern debug_frame_pointer* debug_stack_frames_at(debug_frame_pointer* first, size_t frame);
 extern size_t debug_stack_frames_count(debug_frame_pointer* first);
 extern void debug_stack_frames_free(debug_frame_pointer* stack_frames);

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -690,10 +690,16 @@ static void print_frame(debug_frame_pointer *fp, debug_frame_pointer *current, u
         }
 
     } else {
-        if (sym) {
-            printf("%s%s+%d\n       at unknown location\n", frame_marker, sym->name, fp->offset);
+        char location[FILENAME_MAX + 4];
+        if (fp->filename) {
+            sprintf(location, "%s:%d", fp->filename, fp->lineno);
         } else {
-            printf("%s$%04x\n       at unknown location\n", frame_marker, fp->address);
+            sprintf(location, "%s", "unknown location");
+        }
+        if (sym) {
+            printf("%s%s+%d\n       at %s\n", frame_marker, sym->name, fp->offset, location);
+        } else {
+            printf("%s$%04x\n       at %s\n", frame_marker, fp->address, location);
         }
     }
 }

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -330,7 +330,7 @@ void debugger()
                                 }
                             }
                         } else {
-                            printf("Warning: unknown callee, DEHL returned %08x.\n", return_value);
+                            printf("Warning: returned from a function without frame pointer.\n");
                         }
                         cmd_list(0, NULL);
                         break;

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -102,11 +102,11 @@ typedef struct {
 } command;
 
 
-
 static void completion(const char *buf, linenoiseCompletions *lc, void *ctx);
 static int cmd_next(int argc, char **argv);
 static int cmd_next_source(int argc, char **argv);
 static int cmd_step(int argc, char **argv);
+static int cmd_step_source(int argc, char **argv);
 static int cmd_continue(int argc, char **argv);
 static int cmd_frame(int argc, char **argv);
 static int cmd_up(int argc, char **argv);
@@ -115,7 +115,7 @@ static int cmd_print(int argc, char **argv);
 static int cmd_info(int argc, char **argv);
 static int cmd_backtrace(int argc, char **argv);
 static int cmd_disassemble(int argc, char **argv);
-static int cmd_fin(int argc, char **argv);
+static int cmd_finish(int argc, char **argv);
 static int cmd_registers(int argc, char **argv);
 static int cmd_break(int argc, char **argv);
 static int cmd_watch(int argc, char **argv);
@@ -132,36 +132,38 @@ static void print_hotspots();
 static const char *resolve_to_label(int addr);
 
 static command commands[] = {
-    { "s",      cmd_step,          "",  NULL },
-    { "ni",     cmd_next,          "",  NULL },
-    { "n",      cmd_next_source,   "",  NULL },
-    { "bt",     cmd_backtrace,     "",  NULL },
-    { "p",      cmd_print,         "",  NULL },
-    { "b",      cmd_break,         "",  NULL },
-    { "nexti",  cmd_next,          "",  "Step the instruction (over calls)" },
-    { "next",   cmd_next_source,   "",  "Step one source line" },
-    { "step",   cmd_step,          "",  "Step the instruction (including into calls)" },
-    { "cont",   cmd_continue,      "",  "Continue execution" },
-    { "backtrace",cmd_backtrace,   "",  "Show the execution stack" },
-    { "frame",  cmd_frame,         "[<num>]",  "Set or see current frame" },
-    { "up",     cmd_up,            "",  "Go one frame up" },
-    { "down",   cmd_down,          "",  "Go one frame down" },
-    { "print",  cmd_print,         "<expression>",  "Print an expression" },
-    { "info",   cmd_info,         "locals,...",  "Get info request" },
-    { "dis",    cmd_disassemble,   "[<address>]",  "Disassemble from pc/<address>" },
-    { "fin",    cmd_fin,           "",  "Exit current function (and print result if any)" },
-    { "reg",    cmd_registers,     "",  "Display the registers" },
-    { "break",  cmd_break,         "<address/label>",  "Handle breakpoints" },
-    { "watch",  cmd_watch,         "<address/label>",  "Handle watchpoints" },
-    { "x",      cmd_examine,       "<address>",   "Examine memory" },
-    { "set",    cmd_set,           "<hl/h/l/...> <value>",  "Set registers" },
-    { "out",    cmd_out,           "<address> <value>", "Send to IO bus"},
-    { "trace",  cmd_trace,         "<on/off>", "Disassemble every instruction"},
-    { "hotspot",cmd_hotspot,       "<on/off>", "Track address counts and write to hotspots file"},
-    { "list",   cmd_list,          "[<address>]",   "List the source code at location given or pc"},
-    { "help",   cmd_help,          "",   "Display this help text" },
-    { "restore",cmd_restore,       "<path> [<address>]",   "Upload binary into machine memory"},
-    { "quit",   cmd_quit,          "",   "Quit ticks"},
+    { "si",        cmd_step,        "",  NULL },
+    { "s",         cmd_step_source, "",  NULL },
+    { "ni",        cmd_next,        "",  NULL },
+    { "n",         cmd_next_source, "",  NULL },
+    { "bt",        cmd_backtrace,   "",  NULL },
+    { "p",         cmd_print,       "",  NULL },
+    { "b",         cmd_break,       "",  NULL },
+    { "nexti",     cmd_next,        "",  "Step the instruction (over calls)" },
+    { "next",      cmd_next_source, "",                     "Step one source line" },
+    { "stepi",     cmd_step,        "",                     "Step the instruction (including into calls)" },
+    { "step",      cmd_step_source, "",                     "Step one source line (including into calls)" },
+    { "cont",      cmd_continue,    "",                     "Continue execution" },
+    { "backtrace", cmd_backtrace,   "",                     "Show the execution stack" },
+    { "frame",     cmd_frame,       "[<num>]",              "Set or see current frame" },
+    { "up",        cmd_up,          "",                     "Go one frame up" },
+    { "down",      cmd_down,        "",                     "Go one frame down" },
+    { "print",     cmd_print,       "<expression>",         "Print an expression" },
+    { "info",      cmd_info,        "locals,...",           "Get info request" },
+    { "dis",       cmd_disassemble, "[<address>]",          "Disassemble from pc/<address>" },
+    { "finish",    cmd_finish,      "",                     "Exit current function (and print result if any)" },
+    { "reg",       cmd_registers,   "",                     "Display the registers" },
+    { "break",     cmd_break,       "<address/label>",      "Handle breakpoints" },
+    { "watch",     cmd_watch,       "<address/label>",      "Handle watchpoints" },
+    { "x",         cmd_examine,     "<address>",            "Examine memory" },
+    { "set",       cmd_set,         "<hl/h/l/...> <value>", "Set registers" },
+    { "out",       cmd_out,         "<address> <value>",    "Send to IO bus"},
+    { "trace",     cmd_trace,       "<on/off>",             "Disassemble every instruction"},
+    { "hotspot",   cmd_hotspot,     "<on/off>",             "Track address counts and write to hotspots file"},
+    { "list",      cmd_list,        "[<address>]",          "List the source code at location given or pc"},
+    { "help",      cmd_help,        "",                     "Display this help text" },
+    { "restore",   cmd_restore,     "<path> [<address>]",   "Upload binary into machine memory"},
+    { "quit",      cmd_quit,        "",   "Quit ticks"},
     { NULL, NULL, NULL }
 };
 
@@ -173,6 +175,7 @@ breakpoint *watchpoints;
        int break_required = 0;
        int next_address = -1;
        int trace = 0;
+       int trace_source = 0;
 static int hotspot = 0;
 static int max_hotspot_addr = 0;
 static int last_hotspot_addr;
@@ -186,12 +189,16 @@ typedef enum {
     TMP_REASON_UNKNOWN = 0,
     TMP_REASON_FIN,
     TMP_REASON_STEP_SOURCE_LINE,
+    TMP_REASON_NEXT_SOURCE_LINE,
 } temporary_breakpoint_reason_t;
 
 typedef struct temporary_breakpoint_t {
     temporary_breakpoint_reason_t   reason;
     uint32_t                        at;
     debug_sym_function*             callee;
+    const char*                     source_file;
+    int                             source_line;
+    uint8_t                         external;
     struct temporary_breakpoint_t*  next;
 } temporary_breakpoint_t;
 
@@ -261,6 +268,34 @@ void debugger_process_signals()
     }
 }
 
+static void add_temporary_internal_breakpoint(uint32_t address, temporary_breakpoint_reason_t reason,
+    const char *source_filename, int source_lineno)
+{
+    temporary_breakpoint_t* tmp_step = malloc(sizeof(temporary_breakpoint_t));
+    tmp_step->at = address;
+    tmp_step->callee = NULL;
+    tmp_step->external = 0;
+    tmp_step->source_file = source_filename;
+    tmp_step->source_line = source_lineno;
+    tmp_step->reason = reason;
+    LL_APPEND(temporary_breakpoints, tmp_step);
+}
+
+static void remove_temp_breakpoints()
+{
+    next_address = -1;
+
+    // regardless of the reason we've stopped, all temp breakpoints have to be removed
+    while (temporary_breakpoints) {
+        if (temporary_breakpoints->external) {
+            bk.remove_breakpoint(BK_BREAKPOINT_SOFTWARE, temporary_breakpoints->at, 1);
+        }
+        temporary_breakpoint_t* next = temporary_breakpoints->next;
+        free(temporary_breakpoints);
+        temporary_breakpoints = next;
+    }
+}
+
 void debugger()
 {
     static char *last_line = NULL;
@@ -297,15 +332,15 @@ void debugger()
         last_hotspot_st = st;
     }
 
-    if ( bk.breakpoints_check() ) {
-        int         i = 1;
-        int         dodebug = 0;
+    int dodebug = 0;
 
+    {
         temporary_breakpoint_t *temp_br;
         LL_FOREACH(temporary_breakpoints, temp_br) {
-            if (bk.pc() == temp_br->at) {
+            if ((temp_br->at == 0xFFFFFFFF) || (bk.pc() == temp_br->at)) {
                 dodebug = 1;
-                switch (temp_br->reason) {
+                temporary_breakpoint_reason_t reason = temp_br->reason;
+                switch (reason) {
                     case TMP_REASON_FIN: {
                         struct debugger_regs_t regs;
                         bk.get_regs(&regs);
@@ -332,11 +367,38 @@ void debugger()
                         } else {
                             printf("Warning: returned from a function without frame pointer.\n");
                         }
-                        cmd_list(0, NULL);
                         break;
                     }
-                    case TMP_REASON_STEP_SOURCE_LINE: {
-                        cmd_list(0, NULL);
+                    case TMP_REASON_STEP_SOURCE_LINE:
+                    case TMP_REASON_NEXT_SOURCE_LINE: {
+                        const char *filename;
+                        int   lineno;
+                        const unsigned short pc = bk.pc();
+                        if (debug_find_source_location(pc, &filename, &lineno) < 0) {
+                            // don't know where we are, keep going
+                            if (reason == TMP_REASON_STEP_SOURCE_LINE) {
+                                bk.step();
+                            } else {
+                                bk.next();
+                            }
+                            return;
+                        }
+                        // we're still on the same source line
+                        if ((strcmp(filename, temp_br->source_file) == 0) && (lineno == temp_br->source_line)) {
+                            remove_temp_breakpoints();
+                            if (reason == TMP_REASON_STEP_SOURCE_LINE) {
+                                add_temporary_internal_breakpoint(0xFFFFFFFF, reason, filename, lineno);
+                                bk.step();
+                            } else {
+                                char  b[100];
+                                int len = disassemble2(pc, b, sizeof(b), 0);
+                                add_temporary_internal_breakpoint(pc + len, reason, filename, lineno);
+                                bk.next();
+                            }
+                            return;
+                        } else {
+                            trace_source = 1;
+                        }
                         break;
                     }
                     default: {
@@ -348,15 +410,12 @@ void debugger()
         }
 
         if (dodebug) {
-            // regardless of the reason we've stopped, all temp breakpoints have to be removed
-            while (temporary_breakpoints) {
-                bk.remove_breakpoint(BK_BREAKPOINT_SOFTWARE, temporary_breakpoints->at, 1);
-                temporary_breakpoint_t* next = temporary_breakpoints->next;
-                free(temporary_breakpoints);
-                temporary_breakpoints = next;
-            }
+            remove_temp_breakpoints();
         }
+    }
 
+    if ( bk.breakpoints_check() ) {
+        int         i = 1;
         breakpoint *elem;
         LL_FOREACH(breakpoints, elem) {
             if ( elem->enabled == 0 ) {
@@ -419,19 +478,30 @@ void debugger()
             }
             i++;
         }
-        if (debugger_active == 0)
-        {
-            if ( bk.pc() == next_address ) {
-                next_address = -1;
-                dodebug = 1;
-            }
-            /* Check breakpoints */
-            if ( dodebug == 0 ) return;
-        }
     }
 
+    if (debugger_active == 0)
+    {
+        if ( bk.pc() == next_address ) {
+            next_address = -1;
+            dodebug = 1;
+        }
+        /* Check breakpoints */
+        if ( dodebug == 0 ) return;
+    }
 
-    if (trace ==0) { // Prevent two lines with the same information
+    if (trace_source) {
+        trace_source = 0;
+        const char *filename;
+        int   lineno;
+        if ( debug_find_source_location(bk.pc(), &filename, &lineno) < 0 ) {
+            disassemble2(bk.pc(), buf, sizeof(buf), 0);
+            printf("%s\n",buf);
+        } else {
+            printf("%s:\n", filename);
+            srcfile_display(filename, lineno - 1, 2, lineno);
+        }
+    } else if (trace == 0) { // Prevent two lines with the same information
         disassemble2(bk.pc(), buf, sizeof(buf), 0);
         printf("%s\n",buf);
     }
@@ -530,56 +600,23 @@ static int cmd_next(int argc, char **argv)
 
 static int cmd_next_source(int argc, char **argv)
 {
-    struct debugger_regs_t regs;
-    bk.get_regs(&regs);
-
-    uint16_t stack = regs.sp;
-    uint16_t initial_stack = stack;
-    uint16_t at = bk.pc();
-
-    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 1);
-
-    if (first_frame_pointer == NULL || first_frame_pointer->function == NULL ||
-            first_frame_pointer->return_address == 0 ||
-            first_frame_pointer->filename == NULL) {
-        debug_stack_frames_free(first_frame_pointer);
-        printf("Warning: return address or source line is unknown, cannot next. Use nexti instead.\n");
+    const char *filename;
+    int   lineno;
+    const unsigned short pc = bk.pc();
+    if (debug_find_source_location(pc, &filename, &lineno) < 0) {
+        printf("Warning: cannot obtain current source line.\n");
         return 0;
     }
-
-    int next_address = debug_resolve_source_forward(first_frame_pointer->filename,
-        first_frame_pointer->function->function_name, first_frame_pointer->lineno + 1);
-    if (next_address < 0) {
-        debug_stack_frames_free(first_frame_pointer);
-        printf("Warning: return address or source line is unknown, cannot next. Use nexti instead.\n");
-        return 0;
-    }
-
+    uint16_t break_at;
     {
-        temporary_breakpoint_t* tmp_next = malloc(sizeof(temporary_breakpoint_t));
-        tmp_next->at = next_address;
-        tmp_next->callee = first_frame_pointer->function;
-        tmp_next->reason = TMP_REASON_STEP_SOURCE_LINE;
-        LL_APPEND(temporary_breakpoints, tmp_next);
-        bk.add_breakpoint(BK_BREAKPOINT_SOFTWARE, tmp_next->at, 1);
+        char  buf[100];
+        int len = disassemble2(pc, buf, sizeof(buf), 0);
+        break_at = pc + len;
     }
-
-    {
-        temporary_breakpoint_t* tmp_fin = malloc(sizeof(temporary_breakpoint_t));
-        tmp_fin->at = first_frame_pointer->return_address;
-        tmp_fin->callee = first_frame_pointer->function;
-        tmp_fin->reason = TMP_REASON_FIN;
-        LL_APPEND(temporary_breakpoints, tmp_fin);
-        bk.add_breakpoint(BK_BREAKPOINT_SOFTWARE, tmp_fin->at, 1);
-    }
-
-    debug_stack_frames_free(first_frame_pointer);
-    debugger_active = 0;
-    bk.resume();
+    add_temporary_internal_breakpoint(break_at, TMP_REASON_NEXT_SOURCE_LINE, filename, lineno);
+    bk.next();
     return 1;
 }
-
-
 
 static int cmd_step(int argc, char **argv)
 {
@@ -587,7 +624,20 @@ static int cmd_step(int argc, char **argv)
     return 1;  /* We should exit the loop */
 }
 
+static int cmd_step_source(int argc, char **argv)
+{
+    const char *filename;
+    int   lineno;
+    const unsigned short pc = bk.pc();
+    if (debug_find_source_location(pc, &filename, &lineno) < 0) {
+        printf("Warning: cannot obtain current source line.\n");
+        return 0;
+    }
 
+    add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_STEP_SOURCE_LINE, filename, lineno);
+    bk.step();
+    return 1;
+}
 
 static int cmd_continue(int argc, char **argv)
 {
@@ -1011,7 +1061,7 @@ static int cmd_watch(int argc, char **argv)
     return 0;
 }
 
-static int cmd_fin(int argc, char **argv)
+static int cmd_finish(int argc, char **argv)
 {
     struct debugger_regs_t regs;
     bk.get_regs(&regs);
@@ -1027,12 +1077,14 @@ static int cmd_fin(int argc, char **argv)
         temporary_breakpoint_t* tmp = malloc(sizeof(temporary_breakpoint_t));
         tmp->at = first_frame_pointer->return_address;
         tmp->callee = first_frame_pointer->function;
+        tmp->external = 1;
         tmp->reason = TMP_REASON_FIN;
         LL_APPEND(temporary_breakpoints, tmp);
 
         bk.add_breakpoint(BK_BREAKPOINT_SOFTWARE, first_frame_pointer->return_address, 1);
         debug_stack_frames_free(first_frame_pointer);
         debugger_active = 0;
+        trace_source = 1;
         bk.resume();
         return 1;
     } else {

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -24,14 +24,6 @@ typedef struct breakpoint {
     struct breakpoint  *next;
 } breakpoint;
 
-struct debugger_regs_t {
-    uint16_t pc, sp;
-    unsigned char a,b,c,d,e,h,l;
-    unsigned char a_,b_,c_,d_,e_,h_,l_;
-    unsigned char f, f_;
-    unsigned char xh, xl, yh, yl;
-};
-
 extern int debugger_active;
 extern void      debugger_init();
 extern void      debugger();

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -1,5 +1,6 @@
 #include "debugger.h"
 #include "backend.h"
+#include "debug.h"
 #include "disassembler.h"
 #include "syms.h"
 #include <string.h>

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -2,6 +2,7 @@
 
 #include "debugger.h"
 #include "ticks.h"
+#include "debug.h"
 #include "backend.h"
 #include "disassembler.h"
 


### PR DESCRIPTION
n, ni, s, si, fin, now work as with regular gdb
n, s and fin, unlike ni and si, print out source lines instead of assembly, when executed
n and s work by placing a temporary breakpoint on next instruction and comparing source line at that location. if it doesn't change, then another temporary breakpoint is placed, until the source location changes. 