### PR TITLE
Prevent ELIF, ELIFDEF, and ELIFNDEF from being treated as labels

### DIFF
--- a/src/z80asm/asmpp.pl
+++ b/src/z80asm/asmpp.pl
@@ -320,7 +320,7 @@ sub add_label_suffix {
 	return 
 		imap {
 			for ($_->{text}) {
-				if ( $_ =~ /^\s*(IF|IFDEF|IFNDEF|ELSE|ENDIF)/i ) { next; }
+				if ( $_ =~ /^\s*(IF|IFDEF|IFNDEF|ELSE|ELIF|ELIFDEF|ELIFNDEF|ENDIF)/i ) { next; }
 				s/^(\w+)\s+(\w+)/$1: $2/;
 				s/^(\w+)\s*$/$1:/;
 			}


### PR DESCRIPTION
This change prevents ELIF, ELIFDEF, and ELIFNDEF from being treated as labels if they are at the beginning of a line.
