### PR TITLE
Handle nested include files.

### DIFF
--- a/src/z80asm/asmpp.pl
+++ b/src/z80asm/asmpp.pl
@@ -338,7 +338,7 @@ sub parse_include_it {
 			defined(my $line = <$in>) or return;
 			if ( $line->{text} =~ 
 				/^ [\#\*]? \s* INCLUDE \s+ $QFILE_RE /ix ) {
-				return read_file_it($1);
+				return parse_include_it(read_file_it($1));
 			}
 			return $line;
 		};


### PR DESCRIPTION
Without this change, only the first level of include files are flattened
and the file name for the nested INCLUDE directives are converted to hex
which causes the assembler to barf.