### PR TITLE
fix for `asm_zx_saddrcright` and zx screen address optimisations

### DIFF
--- a/libsrc/_DEVELOPMENT/arch/ts2068/display/z80/asm_tshc_pxy2aaddr.asm
+++ b/libsrc/_DEVELOPMENT/arch/ts2068/display/z80/asm_tshc_pxy2aaddr.asm
@@ -19,13 +19,6 @@ EXTERN asm0_zx_pxy2saddr
 
 asm_tshc_pxy2aaddr:
 
-   ld a,h
-   and $07
-
-IF __USE_SPECTRUM_128_SECOND_DFILE
-   or $e0
-ELSE
-   or $60
-ENDIF
+   scf
 
    jp asm0_zx_pxy2saddr

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_pxy2aaddr.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_pxy2aaddr.asm
@@ -30,22 +30,19 @@ asm_zx_pxy2aaddr:
    srl l
 
    ld a,h
-   rlca
-   rlca
-   ld h,a
-   
+
+IF __USE_SPECTRUM_128_SECOND_DFILE
+   ld h,$d8/4
+ELSE
+   ld h,$58/4
+ENDIF
+
+   rla
+   rl h
+   rla
+   rl h
+
    and $e0
    or l
    ld l,a
-   
-   ld a,h
-   and $03
-
-IF __USE_SPECTRUM_128_SECOND_DFILE
-   or $d8
-ELSE
-   or $58
-ENDIF
-
-   ld h,a   
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_pxy2saddr.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_pxy2saddr.asm
@@ -28,40 +28,37 @@ asm_zx_pxy2saddr:
    ;
    ; uses  : af, de, hl
    
-   ld a,h
-   and $07
-
-IF __USE_SPECTRUM_128_SECOND_DFILE
-   or $c0
-ELSE
-   or $40
-ENDIF
+   or a
 
 asm0_zx_pxy2saddr:
 
-   ld d,a
-   
    ld a,h
    rra
+   scf
    rra
+IF __USE_SPECTRUM_128_SECOND_DFILE
+   ; target $c0 or $e0 (CF 0/1 at asm0_zx_pxy2saddr)
+   scf
+ELSE
+   ; target $40 or $60 (CF 0/1 at asm0_zx_pxy2saddr)
+   or a
+ENDIF
    rra
-   and $18
-   or d
-   ld d,a
-   
-   ld a,l
-   rra
-   rra
-   rra
-   and $1f
    ld e,a
-   
-   ld a,h
-   add a,a
-   add a,a
-   and $e0
 
-   or e
+   xor h
+   and %11111000
+   xor h
+   ld d,a
+
+   ld a,l
+   xor e
+   and %11111000
+   xor e
+
+   rrca
+   rrca
+   rrca
    ld e,a
 
    ex de,hl

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddr2cy.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddr2cy.asm
@@ -20,13 +20,10 @@ asm_zx_saddr2cy:
    rlca
    rlca
    rlca
+   xor h
    and $07
-   ld l,a
-   
-   ld a,h
-   and $18
-   or l
-   
+   xor h
+   and $1f
    ld l,a
 
 IF __SCCZ80

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddr2py.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddr2py.asm
@@ -21,24 +21,21 @@ asm_zx_saddr2py:
    ; exit  :  l = pixel y coordinate
    ;
    ; uses  : af, l
-   
-   ld a,l
-   rra
-   rra
-   and $38
-   ld l,a
-   
+
+   rr l
+   rr l ; L = XX'rrr'XXX (char *R*ow)
+
    ld a,h
    add a,a
    add a,a
    add a,a
+   xor h
    and $c0
-   or l
-   ld l,a
-   
-   ld a,h
-   and $07
-   or l
+   xor h ; A = tt'XXX'lll (*T*hird, *L*ine)
+
+   xor l
+   and $c7
+   xor l ; A = tt'rrr'lll
    ld l,a
 
 IF __SCCZ80

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcdown.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcdown.asm
@@ -33,7 +33,5 @@ asm_zx_saddrcdown:
    ld h,a
 
    and $18
-   cp $18
-
-   ccf
+   add a,$e8
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcleft.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcleft.asm
@@ -34,7 +34,5 @@ asm_zx_saddrcleft:
    ld h,a
 
    and $18
-   cp $18
-
-   ccf
+   add a,$e8
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcright.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcright.asm
@@ -24,6 +24,7 @@ asm_zx_saddrcright:
    ;
    ; uses  : af, hl
 
+   or a
    inc l
    ret nz
    
@@ -32,7 +33,5 @@ asm_zx_saddrcright:
    ld h,a
 
    and $18
-   cp $18
-
-   ccf
+   add a,$e8
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcup.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrcup.asm
@@ -33,7 +33,5 @@ asm_zx_saddrcup:
    ld h,a
    
    and $18
-   cp $18
-
-   ccf
+   add a,$e8
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpdown.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpdown.asm
@@ -46,7 +46,5 @@ asm0_zx_saddrpdown:
    ld h,a
 
    and $18
-   cp $18
-
-   ccf
+   add a,$e8
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpleft.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpleft.asm
@@ -35,7 +35,5 @@ asm_zx_saddrpleft:
    ret nz
 
    inc l
-   ld e,$80
-   
-   scf 
+   rrc e ; set carry and restore $80 in e
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpright.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpright.asm
@@ -35,7 +35,5 @@ asm_zx_saddrpright:
    ret nz
    
    dec l
-   ld e,$01
-   
-   scf
+   rlc e
    ret

--- a/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpup.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/display/z80/asm_zx_saddrpup.asm
@@ -42,7 +42,5 @@ asm_zx_saddrpup:
    ld h,a
 
    and $18
-   cp $18
-
-   ccf
+   add a,$e8
    ret


### PR DESCRIPTION
I did verify functionality of code only externally with sjasmplus in my custom tests, but I didn't try to actually build it with z88dk z80asm (as I don't use z88dk personally).

It *should* work, but I have no idea if you have these under automated testing or not, if not, maybe doing sanity check before merge by someone using z88dk would be good idea, just in case.