### PR TITLE
PX-8: Add ADCVRT BIOS call & 7508 sub-CPU support.

### DIFF
--- a/examples/px8/Makefile
+++ b/examples/px8/Makefile
@@ -1,0 +1,19 @@
+EMUL_DIR = ~/emul
+
+adcvrt: ADCVRT.ROM
+
+ADCVRT.ROM: adcvrt.c
+	zcc +cpm -subtype=px8 -create-app -oadcvrt adcvrt.c
+
+adcvrt.com: adcvrt.c
+	zcc +cpm -subtype=px8 -oadcvrt.com adcvrt.c
+
+run: ADCVRT.ROM
+	cp ADCVRT.ROM $(EMUL_DIR)/BASIC.ROM
+	wine $(EMUL_DIR)/px8.exe
+
+clean:
+	rm *.com
+	rm *.ROM
+
+ALL: adcvrt

--- a/examples/px8/adcvrt.c
+++ b/examples/px8/adcvrt.c
@@ -1,0 +1,62 @@
+#include <arch/px8.h>
+#include <graphics.h>
+#include <string.h>
+#include <stdio.h>
+
+// minfrom = maxto * 10; maxfrom = minto * 10
+#define MAP_DOWN_X10(minfrom, maxfrom, minto, maxto, value) (maxto * 10 - (value - minfrom) * (maxto - minto) * 10 / (maxfrom - minfrom))
+
+void print_sw(int sw) {
+  for (int i = 0; i < 8; ++i) {
+    printf("%s", sw & 0x1 ? "^" : "v");
+    sw >>= 1;
+  }
+}
+
+int main() {
+  unsigned int status = 0;
+  subcpu_7508(0x2C, 0, NULL, 1, &status);
+  printf("Analog input:\tADCVRT: %d\t\t7508: %d\n", adcvrt(CH_ANALOG) >> 2, status >> 2);
+
+  subcpu_7508(0x3C, 0, NULL, 1, &status);
+  printf("Barcode reader:\tADCVRT: %d\t\t7508: %d\n", adcvrt(CH_BARCODE) >> 2, status >> 2);
+
+  subcpu_7508(0x0A, 0, NULL, 1, &status);
+  int sw = adcvrt(CH_DIP_SW);
+  printf("DIP SW:\t\tADCVRT: ");
+  print_sw(sw);
+  printf("\t7508: ");
+  print_sw(status);
+  printf("\n");
+
+  int voltage = adcvrt(CH_BATTERY) * 57 / 255;
+  subcpu_7508(0x0C, 0, NULL, 1, &status);
+  status = status * 57 / 255;
+  printf("Battery:\tADCVRT: %d.%dv\t\t7508: %d.%dv\n", voltage / 10, voltage % 10, status / 10, status % 10);
+
+  READ_TEMPERATURE(&status);
+  printf("RAW Temp:\t0x%X\t\t\tTemp: ", status);
+
+  // Real PX-8 is kinda messed up, can't declare large functions before main.
+  // 20h = 90
+  // 40h = 65
+  // 60h = 50 --
+  // 80h = 40   more or less linear
+  // A0h = 30
+  // C0h = 20 --
+  // E0h = 15
+  if (status >= 0x60 && status <= 0xC0) {
+    unsigned int temp_x10 = MAP_DOWN_X10(0x60, 0xC0, 20, 50, status);
+    printf("%d.%d", temp_x10 / 10, temp_x10 % 10);
+  } else {
+    printf("???");
+  }
+  printf(" C\n");
+
+  int pwr = adcvrt(CH_BUTTONS);
+  subcpu_7508(0x08, 0, NULL, 1, &status);
+  printf("ADCVRT: Power is %s; trigger is %s; 7508: Power is %s; trigger is %s\n",
+      pwr & 1 ? "ON" : "OFF", pwr & 2 ? "ON" : "OFF",
+      status & 1 ? "ON" : "OFF", status & 2 ? "ON" : "OFF");
+  getc(stdin);
+}

--- a/include/arch/px8.h
+++ b/include/arch/px8.h
@@ -151,4 +151,21 @@ extern int __LIB__ subcpu_function(int rcvpkt_sz, void *rcvpkt, int sndpkt_sz, v
 extern int __LIB__ esc_sequence(void *cmdsequence) __z88dk_fastcall;
 
 
+// ADCVRT and 7508 sub-cpu functions
+
+// 60h = 50 C; C0h = 20 C, everything in between is more or less linear
+#define READ_TEMPERATURE(temp) (subcpu_7508(0x1C, 0, NULL, 1, &temp))
+
+typedef enum {
+    CH_ANALOG=0,
+    CH_BARCODE,
+    CH_DIP_SW,
+    CH_BATTERY,
+    CH_BUTTONS
+} adcvrt_channel_t;
+
+extern int __LIB__ adcvrt(adcvrt_channel_t channel) __z88dk_fastcall;
+
+extern void __LIB__ subcpu_7508(char cmd, char out_sz, void* out_buf, char in_sz, void* in_buf) __z88dk_sdccdecl;
+
 #endif

--- a/libsrc/target/px8/adcvrt.asm
+++ b/libsrc/target/px8/adcvrt.asm
@@ -1,0 +1,134 @@
+    SECTION code_clib
+
+    PUBLIC  adcvrt
+    PUBLIC  _adcvrt
+
+    PUBLIC subcpu_7508
+    PUBLIC _subcpu_7508
+
+adcvrt:
+_adcvrt:
+    ; BIOS ADCVRT call, Analog to digital conversion
+    ex      de,hl
+    ld      hl,(1)          ; Use WBOOT address to find the first entry in the BIOS jp table
+    ld      a,$6f           ; ADCVRT offset
+    add     l
+    ld      l,a
+    ld      c,e             ; Channel ID
+    ld      de,retaddr
+    push    de
+    jp      (hl)
+.retaddr
+    ld      l,a             ; Return status from ADCVRT call
+    ld      h,0
+    ld      de,0
+    ret
+
+
+maski:
+_maski:
+    ; Calls PX-8 BIOS MASKI function
+    ; b: 1 = Enable; 0 = Disable
+    ; c: Interrupts bitmask
+    ;   bit 0: 7508
+    ;   bit 1: 8251
+    ;   bit 2: DCD
+    ;   bit 3: ICF
+    ;   bit 4: OVF
+    ;   bit 5: EXT
+    ld      hl,(1)          ; Use WBOOT address to find the first entry in the BIOS jp table
+    ld      a,$57           ; MASKI offset
+    add     l
+    ld      l,a
+    jp      (hl)
+
+
+write_byte:
+    ; Writes byte to 7508 subcpu
+    ; c = byte to write
+    in      a,(5)           ; Check whether 7508 is accessible
+    and     8               ; Bit 3 = control signal
+    jz      write_byte
+    ld      a,c
+    out     (6),a
+    jp      reset_signal
+
+
+read_byte:
+    ; Reads byte from 7508 subcpu.
+    ; Caller should call reset_signal after every read_byte except last one
+    ; return a = read byte
+    in      a,(5)           ; Check whether 7508 is accessible
+    and     8               ; Bit 3 = control signal
+    jz      read_byte
+    in      a,(6)
+    ret
+
+
+reset_signal:
+    ; Resets 7508 control signal
+    ld      a,2             ; Reset control signal
+    out     (1),a
+    ret
+
+
+subcpu_7508:
+_subcpu_7508:
+    ; Performs 7508 subcpu command
+    ; subcpu_7508(char cmd, char out_sz, void* out_buf, char in_sz, void* in_buf) __z88dk_sdccdecl
+    ld      b,0             ; Disable interrupts from 7508
+    ld      c,1
+    call    maski
+    ld      hl,2
+    add     hl,sp
+    ld      c,(hl)          ; Command
+    call    write_byte
+    inc     hl
+    ld      a,(hl)          ; a = out_sz
+    cp      0
+    jz      skip_write
+    inc     hl
+    ld      e,(hl)
+    inc     hl
+    ld      d,(hl)         ; de = out_buf address
+.next_write
+    push    af
+    ld      a,(de)
+    ld      c,a
+    call    write_byte
+    inc     de
+    pop     af
+    dec     a
+    cp      0
+    jnz     next_write
+    jr      read_data
+.skip_write
+    inc     hl
+    inc     hl              ; skip out_buf
+.read_data
+    inc     hl
+    ld      a,(hl)          ; a = in_sz
+    cp      0
+    jz      done
+    inc     hl
+    ld      e,(hl)
+    inc     hl
+    ld      d,(hl)          ; de = in_buf address
+.next_read
+    push    af
+    call    read_byte
+    ld      (de),a
+    inc     de
+    pop     af
+    dec     a
+    cp      0
+    jz      done
+    ld      b,a
+    call    reset_signal
+    ld      a,b
+    jp      next_read
+.done
+    ld      b,1             ; Enable interrupts from 7508
+    ld      c,1
+    call    maski
+    ret

--- a/libsrc/target/px8/px8.lst
+++ b/libsrc/target/px8/px8.lst
@@ -1,6 +1,7 @@
 target/px8/subcpu_call
 target/px8/subcpu_command
 target/px8/subcpu_function
+target/px8/adcvrt
 target/px8/esc_sequence
 target/px8/lcd_set_udg
 target/px8/px8_break


### PR DESCRIPTION
Implement BIOS call to access builtin analog-to-digital converter. It
can:
* Read voltages from analog input & Barcode reader port
* Read DIP switches states
* Read battery voltage
* Read switches (Power & trigger) states.
See examples/px8/adcvrt.c

ADCVRT itself uses 7508 sub-CPU. Using 7508 directly allows to do
everything ADCVRT does, with some extra options, like:
* Read device temperature
* Enable/Disable/Set/Read alarm
* Various keyboard-related functions
* etc
Read OS Reference Manual chapter 11 for full 7508 reference.

Signed-off-by: Kirill Leyfer <leyfer.kirill@gmail.com>