### PR TITLE
Ensure nextreg immediates are processed in the correct order

### DIFF
--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -618,9 +618,9 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
                                     else if ( b == 0x90 ) BUF_PRINTF("outinb  ");
                                     else if ( b == 0x91 ) {
                                         // Ensure nextreg regNum,value immediates are processed in the correct order
-                                        char *regNum = handle_immed8(state, opbuf1, sizeof(opbuf1));
-                                        char *value = handle_immed8(state, opbuf2, sizeof(opbuf2));
-                                        BUF_PRINTF("nextreg %s,%s",regNum, value);
+                                        handle_immed8(state, opbuf1, sizeof(opbuf1));
+                                        handle_immed8(state, opbuf2, sizeof(opbuf2));
+                                        BUF_PRINTF("nextreg %s,%s",opbuf1, opbuf2);
                                     } else if ( b == 0x92 ) BUF_PRINTF("nextreg %s,a",handle_immed8(state, opbuf1, sizeof(opbuf1)));
                                     else if ( b == 0x93 ) BUF_PRINTF("pixeldn");
                                     else if ( b == 0x94 ) BUF_PRINTF("pixelad");

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -617,12 +617,11 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
                                     if ( b == 0x8a ) BUF_PRINTF("push    %s", handle_immed16_be(state, opbuf1, sizeof(opbuf1)));
                                     else if ( b == 0x90 ) BUF_PRINTF("outinb  ");
                                     else if ( b == 0x91 ) {
-					// Ensure nextreg regNum,value immediates are processed in the correct order
-					char *regNum = handle_immed8(state, opbuf1, sizeof(opbuf1));
-					char *value = handle_immed8(state, opbuf2, sizeof(opbuf2));
-					BUF_PRINTF("nextreg %s,%s",regNum, value);
-				    }
-                                    else if ( b == 0x92 ) BUF_PRINTF("nextreg %s,a",handle_immed8(state, opbuf1, sizeof(opbuf1)));
+                                        // Ensure nextreg regNum,value immediates are processed in the correct order
+                                        char *regNum = handle_immed8(state, opbuf1, sizeof(opbuf1));
+                                        char *value = handle_immed8(state, opbuf2, sizeof(opbuf2));
+                                        BUF_PRINTF("nextreg %s,%s",regNum, value);
+                                    } else if ( b == 0x92 ) BUF_PRINTF("nextreg %s,a",handle_immed8(state, opbuf1, sizeof(opbuf1)));
                                     else if ( b == 0x93 ) BUF_PRINTF("pixeldn");
                                     else if ( b == 0x94 ) BUF_PRINTF("pixelad");
                                     else if ( b == 0x95 ) BUF_PRINTF("setae");

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -616,7 +616,12 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
                                 } else if ( c_cpu & CPU_Z80N ) {
                                     if ( b == 0x8a ) BUF_PRINTF("push    %s", handle_immed16_be(state, opbuf1, sizeof(opbuf1)));
                                     else if ( b == 0x90 ) BUF_PRINTF("outinb  ");
-                                    else if ( b == 0x91 ) BUF_PRINTF("nextreg %s,%s",handle_immed8(state, opbuf1, sizeof(opbuf1)), handle_immed8(state, opbuf2, sizeof(opbuf2)));
+                                    else if ( b == 0x91 ) {
+					// Ensure nextreg regNum,value immediates are processed in the correct order
+					char *regNum = handle_immed8(state, opbuf1, sizeof(opbuf1));
+					char *value = handle_immed8(state, opbuf2, sizeof(opbuf2));
+					BUF_PRINTF("nextreg %s,%s",regNum, value);
+				    }
                                     else if ( b == 0x92 ) BUF_PRINTF("nextreg %s,a",handle_immed8(state, opbuf1, sizeof(opbuf1)));
                                     else if ( b == 0x93 ) BUF_PRINTF("pixeldn");
                                     else if ( b == 0x94 ) BUF_PRINTF("pixelad");


### PR DESCRIPTION
Variable arguments to BUF_PRINTF seem to be processed in reverse order causing the 2 immediates for nextreg n,n' to be displayed in reverse order. This change forces the 2 immediates to be displayed in the same order as z80n memory.