### PR TITLE
allow redefinition of CRT_ORG_CODE

### DIFF
--- a/lib/target/sol20/classic/sol20_crt0.asm
+++ b/lib/target/sol20/classic/sol20_crt0.asm
@@ -41,7 +41,7 @@
 	defc	CONSOLE_COLUMNS = 64
         INCLUDE "crt/classic/crt_rules.inc"
 
-     IFNDEF CRT_ORG_CODE
+     IF !DEFINED_CRT_ORG_CODE
         defc CRT_ORG_CODE = 0x0000
      ENDIF
 

--- a/lib/target/sol20/classic/sol20_crt0.asm
+++ b/lib/target/sol20/classic/sol20_crt0.asm
@@ -41,7 +41,9 @@
 	defc	CONSOLE_COLUMNS = 64
         INCLUDE "crt/classic/crt_rules.inc"
 
+     IFNDEF CRT_ORG_CODE
         defc CRT_ORG_CODE = 0x0000
+     ENDIF
 
 	org	  CRT_ORG_CODE
 


### PR DESCRIPTION
(I'm not sure this is the best way to do it) this allows redefinition of `CRT_ORG_CODE` in order to change the starting address of the program via compiler switch `-pragma-define`. I tried `-zorg` but it didn't work.