### PR TITLE
ticks: complex compressions evaluation with “print” (or “p”)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,11 @@
 **/*.lib
 **/*.lis
 **/*.map
+**/*.tab.*
 **/*.o
 **/*.orig
+**/*.yy.c
+**/*.output
 **/*.vcxproj.user
 **/.prove*
 **/.vscode/

--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -8,14 +8,18 @@ endif
 
 include ../Make.common
 
-OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
-GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o debugger.o debugger_gdb.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
-DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o backend.o
+OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o exp_engine.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
+GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o debugger_gdb.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
+DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o exp_engine.o backend.o
+LEXOBJS = lex.yy.o expressions.tab.o
 
 DEPENDS         := $(OBJS:.o=.d) $(DISOBJS:.o=.d) $(GDBOBJS:.o=.d)
 
 INSTALL ?= install
 
+LEX     = flex
+YACC    = bison -y
+YFLAGS  = -d
 GDBLDFLAGS = -lpthread
 CFLAGS += -I../../ext/uthash/src/ -g -MMD $(UNIXem_CFLAGS)
 LDFLAGS = -lm
@@ -27,11 +31,11 @@ endif
 
 all: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX) z88dk-gdb$(EXESUFFIX)
 
-z88dk-ticks$(EXESUFFIX):	$(OBJS)
-	$(CC) -o $@ $(CFLAGS) $(OBJS) $(LDFLAGS)
+z88dk-ticks$(EXESUFFIX):	$(OBJS) $(LEXOBJS)
+	$(CC) -o $@ $(CFLAGS) $(OBJS) $(LEXOBJS) $(LDFLAGS)
 
-z88dk-gdb$(EXESUFFIX):	$(GDBOBJS)
-	$(CC) -o $@ $(CFLAGS) $(GDBOBJS) $(LDFLAGS) $(GDBLDFLAGS)
+z88dk-gdb$(EXESUFFIX):	$(GDBOBJS) $(LEXOBJS)
+	$(CC) -o $@ $(CFLAGS) $(GDBOBJS) $(LEXOBJS) $(LDFLAGS) $(GDBLDFLAGS)
 
 z88dk-dis$(EXESUFFIX):	$(DISOBJS)
 	$(CC) -o $@ $(CFLAGS) $(DISOBJS)
@@ -41,11 +45,20 @@ install: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX) z88dk-gdb$(EXESUFFIX)
 	$(INSTALL) z88dk-dis$(EXESUFFIX) $(PREFIX)/bin/z88dk-dis$(EXESUFFIX)
 	$(INSTALL) z88dk-gdb$(EXESUFFIX) $(PREFIX)/bin/z88dk-gdb$(EXESUFFIX)
 
+expressions.tab.c expressions.tab.h: expressions.y
+	bison -t -v -d expressions.y
+
+lex.yy.c: expressions.l expressions.tab.h
+	flex expressions.l
+
 clean:
 	$(RM) z88dk-ticks$(EXESUFFIX) $(OBJS) core
 	$(RM) z88dk-dis$(EXESUFFIX) $(DISOBJS) core
 	$(RM) z88dk-gdb$(EXESUFFIX) $(GDBOBJS) core
 	$(RM) $(DEPENDS)
+	$(RM) lex.yy.c
+	$(RM) expressions.output
+	$(RM) expressions.tab.*
 	$(RM) -rf Debug Release
 
 -include $(DEPENDS)

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -949,30 +949,6 @@ void debug_resolve_expression_element(type_record* record, enum resolve_chain_va
     }
 }
 
-static int debug_resolve_chain_value_as_string(debug_sym_symbol *sym, uint16_t frame_pointer, char *target, size_t targetlen) {
-    struct expression_result_t result = {};
-    debug_resolve_expression_element(&sym->type_record, RESOLVE_BY_POINTER, frame_pointer, &result);
-    int offs;
-    if (is_expression_result_error(&result)) {
-        offs = snprintf(target, targetlen, "<error:%s>", result.as_error);
-    } else {
-        offs = expression_result_value_to_string(&result, target, targetlen);
-    }
-    expression_result_free(&result);
-    return offs;
-}
-
-uint8_t debug_get_symbol_value_as_string(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, char *target, size_t targetlen) {
-    if (sym->address_space.address_space == 'B') {
-        return debug_resolve_chain_value_as_string(sym, frame_pointer->frame_pointer + sym->address_space.b, target,
-            targetlen);
-    } else {
-        return 1;
-    }
-
-    return 0;
-}
-
 static int debug_get_symbol_address(debug_sym_symbol *s) {
     int address = symbol_resolve(s->symbol_name);
     if (address >= 0) {

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -814,17 +814,17 @@ int get_type_memory_size(type_chain* chain) {
     }
 }
 
-void debug_resolve_expression_element(type_record* record, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into) {
+void debug_resolve_expression_element(type_record* record, type_chain* chain, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into) {
     int offs = 0;
     if (record == NULL) {
         return;
     }
     into->type = *record;
-    into->type.first = copy_type_chain(record->first);
-    if (record->first == NULL) {
+    into->type.first = copy_type_chain(chain);
+    if (chain == NULL) {
         return;
     }
-    switch ( record->first->type_ ) {
+    switch ( chain->type_ ) {
         case TYPE_CHAR: {
             char ch;
             switch (resolve_by) {
@@ -969,7 +969,7 @@ static int debug_get_symbol_address(debug_sym_symbol *s) {
 void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, struct expression_result_t* into) {
     switch (sym->address_space.address_space) {
         case 'B': {
-            return debug_resolve_expression_element(&sym->type_record, RESOLVE_BY_POINTER, frame_pointer->frame_pointer + sym->address_space.b, into);
+            return debug_resolve_expression_element(&sym->type_record, sym->type_record.first, RESOLVE_BY_POINTER, frame_pointer->frame_pointer + sym->address_space.b, into);
         }
         case 'E': {
             int addr = debug_get_symbol_address(sym);
@@ -977,7 +977,7 @@ void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointe
                 into->type.first = malloc_type(TYPE_UNKNOWN);
                 return;
             }
-            return debug_resolve_expression_element(&sym->type_record, RESOLVE_BY_POINTER, addr, into);
+            return debug_resolve_expression_element(&sym->type_record, sym->type_record.first, RESOLVE_BY_POINTER, addr, into);
         }
         default: {
             sprintf(into->as_error, "Incorrect address space (not implemented)");

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -141,10 +141,18 @@ extern int debug_resolve_source(char *name);
 extern int debug_resolve_source_forward(const char *filename, const char* within_function, int lineno);
 
 extern type_chain* copy_type_chain(type_chain* from);
+extern int count_allocated_types();
+extern type_chain* malloc_type(enum type_record_type type);
+extern void free_type(type_chain* type);
+extern uint8_t is_primitive_integer_type(type_chain* type);
+extern uint8_t is_type_a_pointer(type_chain* type);
+extern uint8_t are_type_chains_same(type_chain* a, type_chain* b);
+extern uint8_t are_type_records_same(type_record* a, type_record* b);
+extern int get_type_memory_size(type_chain* chain);
 struct expression_result_t;
 
 extern debug_sym_function* debug_find_function(const char* function_name, const char* file_name);
-extern void debug_resolve_expression_element(type_chain* chain, char issigned, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
+extern void debug_resolve_expression_element(type_record* record, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
 extern uint8_t debug_get_symbol_value_as_string(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, char *target, size_t targetlen);
 extern void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, struct expression_result_t* into);
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -153,7 +153,6 @@ struct expression_result_t;
 
 extern debug_sym_function* debug_find_function(const char* function_name, const char* file_name);
 extern void debug_resolve_expression_element(type_record* record, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
-extern uint8_t debug_get_symbol_value_as_string(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, char *target, size_t targetlen);
 extern void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, struct expression_result_t* into);
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);
 extern debug_sym_symbol* cdb_get_first_symbol();

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -140,10 +140,16 @@ extern void debug_add_cline(const char *filename, const char *function, int line
 extern int debug_resolve_source(char *name);
 extern int debug_resolve_source_forward(const char *filename, const char* within_function, int lineno);
 
+extern type_chain* copy_type_chain(type_chain* from);
+struct expression_result_t;
+
 extern debug_sym_function* debug_find_function(const char* function_name, const char* file_name);
-extern int debug_print_element(type_chain* chain, char issigned, enum resolve_chain_value_kind resolve_by, uint32_t data, char *target, size_t targetlen);
-extern uint8_t debug_get_symbol_value(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, char *target, size_t targetlen);
+extern void debug_resolve_expression_element(type_chain* chain, char issigned, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
+extern uint8_t debug_get_symbol_value_as_string(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, char *target, size_t targetlen);
+extern void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, struct expression_result_t* into);
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);
+extern debug_sym_symbol* cdb_get_first_symbol();
+extern debug_sym_symbol* cdb_find_symbol(const char* cname);
 
 extern debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, struct debugger_regs_t* regs, uint16_t limit);
 extern debug_frame_pointer* debug_stack_frames_at(debug_frame_pointer* first, size_t frame);

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -152,7 +152,7 @@ extern int get_type_memory_size(type_chain* chain);
 struct expression_result_t;
 
 extern debug_sym_function* debug_find_function(const char* function_name, const char* file_name);
-extern void debug_resolve_expression_element(type_record* record, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
+extern void debug_resolve_expression_element(type_record* record, type_chain* chain, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
 extern void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, struct expression_result_t* into);
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);
 extern debug_sym_symbol* cdb_get_first_symbol();

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -373,12 +373,12 @@ void debugger()
                             } else {
                                 if (ttt->type_ != TYPE_VOID) {
                                     struct expression_result_t result = {};
-                                    debug_resolve_expression_element(&temp_br->callee->type_record,
+                                    debug_resolve_expression_element(&temp_br->callee->type_record, ttt,
                                         RESOLVE_BY_VALUE, return_value, &result);
                                     if (is_expression_result_error(&result)) {
                                         printf("function %s errored: %s\n", temp_br->callee->function_name, result.as_error);
                                     } else {
-                                        char resolved_result[128];
+                                        char resolved_result[128] = "<unknown>";
                                         expression_result_value_to_string(&result, resolved_result, 128);
                                         printf("function %s returned: %s\n", temp_br->callee->function_name, resolved_result);
                                     }

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -19,6 +19,7 @@
 #include "syms.h"
 #include "linenoise.h"
 #include "srcfile.h"
+#include "exp_engine.h"
 
 
 #define HISTORY_FILE ".ticks_history.txt"
@@ -167,6 +168,20 @@ static command commands[] = {
     { NULL, NULL, NULL }
 };
 
+static void print_breakpoints();
+static void info_section_locals();
+static void info_section_globals();
+
+static struct {
+    const char* name;
+    const char* help;
+    void (*cb)();
+} cmd_info_sections[] = {
+    {"breakpoints",     "show breakpoints",                     print_breakpoints},
+    {"locals",          "show local variables",                 info_section_locals},
+    {"variables",       "show static/global variables",         info_section_globals},
+    {NULL, NULL}
+};
 
 breakpoint *breakpoints;
 breakpoint *watchpoints;
@@ -357,11 +372,16 @@ void debugger()
                                 printf("Warning: unknown callee return type, DEHL returned %08x.\n", return_value);
                             } else {
                                 if (ttt->type_ != TYPE_VOID) {
-                                    char resolved_result[128];
-                                    debug_print_element(ttt, temp_br->callee->type_record.signed_,
-                                        RESOLVE_BY_VALUE, return_value, resolved_result, 128);
-                                    printf("function %s returned: %s\n", temp_br->callee->function_name,
-                                        resolved_result);
+                                    struct expression_result_t result = {};
+                                    debug_resolve_expression_element(ttt, temp_br->callee->type_record.signed_,
+                                        RESOLVE_BY_VALUE, return_value, &result);
+                                    if (is_expression_result_error(&result)) {
+                                        printf("function %s errored: %s\n", temp_br->callee->function_name, result.as_error);
+                                    } else {
+                                        char resolved_result[128];
+                                        expression_result_value_to_string(&result, resolved_result, 128);
+                                        printf("function %s returned: %s\n", temp_br->callee->function_name, resolved_result);
+                                    }
                                 }
                             }
                         } else {
@@ -670,13 +690,25 @@ static void print_frame(debug_frame_pointer *fp, debug_frame_pointer *current, u
                 if (!first_arg) {
                     strcat(function_args, ", ");
                 }
-                char arg_text[64];
-                char arg_value[20];
-                if (debug_get_symbol_value(s, fp, arg_value, sizeof(arg_value))) {
-                    strcpy(arg_value, "unknown");
+                char arg_text[255];
+
+                struct expression_result_t exp = {};
+                debug_get_symbol_value_expression(s, fp, &exp);
+
+                if (is_expression_result_error(&exp)) {
+                    sprintf(arg_text, "<error>%s", s->symbol_name);
+                    strcat(function_args, arg_text);
+                } else {
+                    char exp_type[128] = "unknown";
+                    char exp_value[128] = "???";
+
+                    expression_result_type_to_string(&exp.type, is_expression_signed(&exp), exp_type);
+                    expression_result_value_to_string(&exp, exp_value, sizeof(exp_value));
+
+                    snprintf(arg_text, sizeof(arg_text), "<%s>%s = %s", exp_type, s->symbol_name, exp_value);
+                    strcat(function_args, arg_text);
                 }
-                sprintf(arg_text, "%s=%s", s->symbol_name, arg_value);
-                strcat(function_args, arg_text);
+
                 first_arg = 0;
                 arg = arg->next;
             }
@@ -751,49 +783,223 @@ static int cmd_down(int argc, char **argv)
     return cmd_frame(0, NULL);
 }
 
+void debug_lookup_symbol(struct lookup_t* lookup, struct expression_result_t* result) {
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint16_t stack = regs.sp;
+    uint16_t initial_stack = stack;
+    uint16_t at = bk.pc();
+
+    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 0);
+    debug_frame_pointer* fp = debug_stack_frames_at(first_frame_pointer, current_frame);
+
+    debug_sym_function* fn = fp->function;
+    if (fn != NULL) {
+        char function_args[255] = {0};
+        debug_sym_function_argument* arg = fn->arguments;
+        while (arg) {
+            debug_sym_symbol* s = arg->symbol;
+            if (strcmp(s->symbol_name, lookup->symbol_name) == 0) {
+                if (!debug_symbol_valid(s, initial_stack, fp)) {
+                    arg = arg->next;
+                    continue;
+                }
+                debug_get_symbol_value_expression(s, fp, result);
+                debug_stack_frames_free(first_frame_pointer);
+                return;
+            }
+            arg = arg->next;
+        }
+
+        // try static locals
+        char sname[128];
+        sprintf(sname, "st_%s_%s", fn->function_name, lookup->symbol_name);
+        debug_sym_symbol *s = cdb_find_symbol(sname);
+        if (s != NULL && s->address_space.address_space == 'E') {
+            debug_get_symbol_value_expression(s, fp, result);
+            debug_stack_frames_free(first_frame_pointer);
+            return;
+        }
+    }
+
+    // try globals
+    debug_sym_symbol *s = cdb_find_symbol(lookup->symbol_name);
+    if (s != NULL && s->address_space.address_space == 'E') {
+        debug_get_symbol_value_expression(s, fp, result);
+        debug_stack_frames_free(first_frame_pointer);
+        return;
+    }
+
+    debug_stack_frames_free(first_frame_pointer);
+
+    sprintf(result->as_error, "Cannot resolve symbol: %s", lookup->symbol_name);
+    result->flags |= EXPRESSION_ERROR;
+}
+
 static int cmd_print(int argc, char **argv)
 {
+    if (argc < 2)
+    {
+        return 0;
+    }
+
+    char* call = malloc(255);
+    strcpy(call, argv[1]);
+
+    for (int i = 2; i < argc; i++)
+    {
+        strcat(call, " ");
+        strcat(call, argv[i]);
+    }
+
+    evaluate_expression_string(call);
+    free(call);
+
+    struct expression_result_t* result = get_expression_result();
+    if (is_expression_result_error(result))
+    {
+        printf("Error: %s\n", result->as_error);
+        return 0;
+    }
+
+    char type[128] = "unknown";
+    char value[128] = "???";
+    expression_result_type_to_string(&result->type, is_expression_signed(result), type);
+    expression_result_value_to_string(result, value, sizeof(value));
+
+    printf("Result: <%s> %s\n", type, value);
+
     return 0;
+}
+
+static void print_breakpoints() {
+    breakpoint *elem;
+    int         i = 1;
+    LL_FOREACH(breakpoints, elem) {
+        if ( elem->type == BREAK_PC) {
+            const char *sym = find_symbol(elem->value, SYM_ADDRESS);
+            printf("%d:\tPC = $%04x (%s) %s\n",i, elem->value,sym ? sym : "<unknown>", elem->enabled ? "" : " (disabled)");
+        } else if ( elem->type == BREAK_CHECK8 ) {
+            printf("%d\t%s = $%02x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
+        } else if ( elem->type == BREAK_CHECK16 ) {
+            printf("%d\t%s = $%04x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
+        }  else if ( elem->type == BREAK_REGISTER ) {
+            struct reg* r = &registers[elem->lcheck_arg];
+            if (r->high == NULL && r->word == NULL) {
+                printf("%d\t%s = $%02x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
+            } else {
+                printf("%d\t%s = $%04x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
+            }
+        }
+        i++;
+    }
+}
+
+static void info_section_locals() {
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint16_t stack = regs.sp;
+    uint16_t initial_stack = stack;
+    uint16_t at = bk.pc();
+
+    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 0);
+    debug_frame_pointer* fp = debug_stack_frames_at(first_frame_pointer, current_frame);
+
+    debug_sym_function* fn = fp->function;
+    if (fn != NULL) {
+        char function_args[255] = {0};
+        debug_sym_function_argument* arg = fn->arguments;
+        while (arg) {
+            debug_sym_symbol* s = arg->symbol;
+            if (debug_symbol_valid(s, initial_stack, fp)) {
+                struct expression_result_t exp = {};
+                debug_get_symbol_value_expression(s, fp, &exp);
+                if (is_expression_result_error(&exp)) {
+                    printf("  %s = <error>\n", s->symbol_name);
+                } else {
+                    char exp_type[128] = "unknown";
+                    char exp_value[128] = "???";
+                    expression_result_type_to_string(&exp.type, is_expression_signed(&exp), exp_type);
+                    expression_result_value_to_string(&exp, exp_value, sizeof(exp_value));
+                    printf("  <%s>%s = %s\n", exp_type, s->symbol_name, exp_value);
+                }
+            } else {
+                printf("  %s = <invalid>\n", s->symbol_name);
+            }
+            arg = arg->next;
+        }
+    }
+
+    debug_stack_frames_free(first_frame_pointer);
+}
+
+static void info_section_globals() {
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint16_t stack = regs.sp;
+    uint16_t initial_stack = stack;
+    uint16_t at = bk.pc();
+
+    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 0);
+    debug_frame_pointer* fp = debug_stack_frames_at(first_frame_pointer, current_frame);
+
+    for (debug_sym_symbol *s = cdb_get_first_symbol(); s != NULL; s = s->hh.next) {
+        // globals only
+        if (s->address_space.address_space != 'E') {
+            continue;
+        }
+        if (s->type_record.first == NULL || (s->type_record.first->type_ == TYPE_FUNCTION)) {
+            continue;
+        }
+
+        struct expression_result_t exp = {};
+        debug_get_symbol_value_expression(s, fp, &exp);
+
+        if (is_expression_result_error(&exp)) {
+            continue;
+        }
+
+        char exp_type[128] = "unknown";
+        char exp_value[128] = "???";
+        expression_result_type_to_string(&exp.type, is_expression_signed(&exp), exp_type);
+        expression_result_value_to_string(&exp, exp_value, sizeof(exp_value));
+        printf("  <%s>%s = %s\n", exp_type, s->symbol_name, exp_value);
+    }
+
+    debug_stack_frames_free(first_frame_pointer);
 }
 
 static int cmd_info(int argc, char **argv)
 {
-    if (argc < 2) {
-        return 0;
-    }
+    int matches_total = 0;
+    int matched_section = -1;
 
-    if (strcmp(argv[1], "locals") == 0) {
-        struct debugger_regs_t regs;
-        bk.get_regs(&regs);
-
-        uint16_t stack = regs.sp;
-        uint16_t initial_stack = stack;
-        uint16_t at = bk.pc();
-
-        debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 0);
-        debug_frame_pointer* fp = debug_stack_frames_at(first_frame_pointer, current_frame);
-
-        debug_sym_function* fn = fp->function;
-        if (fn != NULL) {
-            char function_args[255] = {0};
-            debug_sym_function_argument* arg = fn->arguments;
-            while (arg) {
-                debug_sym_symbol* s = arg->symbol;
-
-                char arg_text[128];
-                char arg_value[128];
-
-                if (!debug_symbol_valid(s, initial_stack, fp)) {
-                    strcpy(arg_value, "<invalid>");
-                } else if (debug_get_symbol_value(s, fp, arg_value, sizeof(arg_value))) {
-                    strcpy(arg_value, "<unknown>");
-                }
-                printf("  %s=%s\n", s->symbol_name, arg_value);
-                arg = arg->next;
+    if (argc >= 2) {
+        for (int i = 0; cmd_info_sections[i].cb; i++) {
+            if (strstr(cmd_info_sections[i].name, argv[1]) == cmd_info_sections[i].name) {
+                matches_total++;
+                matched_section = i;
             }
         }
 
-        debug_stack_frames_free(first_frame_pointer);
+        if (matches_total == 1) {
+            cmd_info_sections[matched_section].cb();
+            return 0;
+        }
+
+        if (matches_total > 1) {
+            printf("Warning: ambiguous information section, please elaborate.\n");
+            return 0;
+        }
+    }
+
+    printf("Warning: cannot identify information section. Available sections are:\n");
+
+    for (int i = 0; cmd_info_sections[i].cb; i++) {
+        printf("  %s - %s\n", cmd_info_sections[i].name, cmd_info_sections[i].help);
     }
 
     return 0;
@@ -1106,28 +1312,8 @@ static int cmd_break(int argc, char **argv)
     const unsigned short pc = bk.pc();
 
     if ( argc == 1 ) {
-        breakpoint *elem;
-        int         i = 1;
-
         /* Just show the breakpoints */
-        LL_FOREACH(breakpoints, elem) {
-            if ( elem->type == BREAK_PC) {
-                const char *sym = find_symbol(elem->value, SYM_ADDRESS);
-                printf("%d:\tPC = $%04x (%s) %s\n",i, elem->value,sym ? sym : "<unknown>", elem->enabled ? "" : " (disabled)");
-            } else if ( elem->type == BREAK_CHECK8 ) {
-                printf("%d\t%s = $%02x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
-            } else if ( elem->type == BREAK_CHECK16 ) {
-                printf("%d\t%s = $%04x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
-            }  else if ( elem->type == BREAK_REGISTER ) {
-                struct reg* r = &registers[elem->lcheck_arg];
-                if (r->high == NULL && r->word == NULL) {
-                    printf("%d\t%s = $%02x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
-                } else {
-                    printf("%d\t%s = $%04x%s\n",i, elem->text, elem->value, elem->enabled ? "" : " (disabled)");
-                }
-            }
-            i++;
-        }
+        print_breakpoints();
     } else if ( argc == 2 ) {
         char *end;
         const char *sym;

--- a/src/ticks/exp_engine.c
+++ b/src/ticks/exp_engine.c
@@ -359,6 +359,9 @@ int expression_result_value_to_string(struct expression_result_t* result, char* 
         case TYPE_UNKNOWN: {
             return snprintf(buffer, buffer_len, "<unknown>");
         }
+        case TYPE_FUNCTION: {
+            return snprintf(buffer, buffer_len, "<function>");
+        }
         case TYPE_ARRAY: {
             int maxlen = Max(10,Min(10, result->type.size));
             int offs = snprintf(buffer, buffer_len, "%#04x [%d] = { ", result->as_pointer.ptr, result->type.size);
@@ -366,7 +369,7 @@ int expression_result_value_to_string(struct expression_result_t* result, char* 
             for ( int i = 0; i < maxlen; i++ ) {
                 offs += snprintf(buffer + offs, buffer_len - offs, "%s[%d] = ", i != 0 ? ", " : "", i);
                 struct expression_result_t elr = {};
-                debug_resolve_expression_element(&result->type, RESOLVE_BY_POINTER, ptr, &elr);
+                debug_resolve_expression_element(&result->type, result->type.first, RESOLVE_BY_POINTER, ptr, &elr);
                 if (is_expression_result_error(&elr)) {
                     offs += snprintf(buffer + offs, buffer_len - offs, "<error:%s>", elr.as_error);
                     break;
@@ -439,7 +442,7 @@ int expression_result_value_to_string(struct expression_result_t* result, char* 
             }
         }
         default: {
-            return 0;
+            return snprintf(buffer, buffer_len, "<unknown:%d>", result->type.first->type_);
         }
     }
     return 0;

--- a/src/ticks/exp_engine.c
+++ b/src/ticks/exp_engine.c
@@ -1,0 +1,541 @@
+#include "exp_engine.h"
+#include "backend.h"
+#include "debug.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+struct expression_result_t expression_result;
+
+struct {
+    const char* type_name;
+    uint8_t is_signed;
+    enum type_record_type type_of;
+} primitive_types[] = {
+    {"void",            0,              TYPE_VOID},
+    {"char",            1,              TYPE_CHAR},
+    {"int8_t",          1,              TYPE_CHAR},
+    {"uint8_t",         0,              TYPE_CHAR},
+    {"unsigned char",   0,              TYPE_CHAR},
+    {"int16_t",         1,              TYPE_INT},
+    {"int",             1,              TYPE_INT},
+    {"short",           1,              TYPE_INT},
+    {"uint16_t",        0,              TYPE_INT},
+    {"unsigned int",    0,              TYPE_INT},
+    {"unsigned short",  0,              TYPE_INT},
+    {"int32_t",         1,              TYPE_LONG},
+    {"long",            1,              TYPE_LONG},
+    {"uint32_t",        0,              TYPE_LONG},
+    {"unsigned long",   0,              TYPE_LONG},
+    {"float",           0,              TYPE_FLOAT},
+    {NULL,              0,              TYPE_UNKNOWN},
+};
+
+uint8_t is_expression_result_error(struct expression_result_t* result) {
+    return result->flags & EXPRESSION_ERROR;
+}
+
+void set_expression_result_error(struct expression_result_t* result, const char* error) {
+    result->flags |= EXPRESSION_ERROR;
+    strcpy(result->as_error, error);
+}
+
+void reset_expression_result(struct expression_result_t* result) {
+    result->flags = EXPRESSION_UNKNOWN;
+}
+
+void expression_result_free_typechain(struct expression_result_t* result)
+{
+    type_chain* next = result->type.next;
+    while (next) {
+        type_chain* next_next = next->next;
+        free(next);
+        next = next_next;
+    }
+}
+
+static uint8_t is_expression_a_pointer(struct expression_result_t *exp) {
+    return exp->type.type_ == TYPE_GENERIC_POINTER ||  exp->type.type_ == TYPE_CODE_POINTER;
+}
+
+uint8_t is_expression_signed(struct expression_result_t *exp) {
+    return exp->flags & EXPRESSION_TYPE_SIGNED;
+}
+
+void set_expression_signed(struct expression_result_t *exp, uint8_t is_signed) {
+    if (is_signed) {
+        exp->flags |= EXPRESSION_TYPE_SIGNED;
+    } else {
+        exp->flags &= ~EXPRESSION_TYPE_SIGNED;
+    }
+}
+
+void expression_value_to_pointer(struct expression_result_t *from, struct expression_result_t *to, type_chain* pointer_type, uint8_t is_signed) {
+    if (is_expression_a_pointer(from)) {
+        *to = *from;
+        to->type.type_ = TYPE_GENERIC_POINTER;
+        to->type.next = copy_type_chain(pointer_type);
+        set_expression_signed(to, is_signed);
+        return;
+    }
+
+    type_chain* type_of = copy_type_chain(pointer_type);
+    set_expression_signed(to, is_signed);
+    to->type.type_ = TYPE_GENERIC_POINTER;
+    to->type.next = type_of;
+
+    switch (from->type.type_) {
+        case TYPE_FLOAT: {
+            to->as_pointer.ptr = (uint16_t)from->as_float;
+            to->as_pointer.element_size = from->memory_size;
+            return;
+        }
+        case TYPE_SHORT:
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            to->as_pointer.ptr = (uint16_t)from->as_int;
+            to->as_pointer.element_size = from->memory_size;
+            return;
+        }
+        default: {
+            to->flags |= EXPRESSION_ERROR;
+            char tp[128];
+            expression_result_type_to_string(&from->type, is_expression_signed(from), tp);
+            sprintf(to->as_error, "Cannot convert type %s to a pointer", tp);
+            return;
+        }
+    }
+}
+
+void expression_dereference_pointer(struct expression_result_t *from, struct expression_result_t *to) {
+    extern backend_t bk;
+    if (!(is_expression_a_pointer(from))) {
+        to->flags = EXPRESSION_ERROR;
+        char tp[128];
+        expression_result_type_to_string(&from->type, is_expression_signed(from), tp);
+        sprintf(to->as_error, "Cannot dereference type: %s", tp);
+        return;
+    }
+
+    if (from->type.next == NULL) {
+        to->flags |= EXPRESSION_ERROR;
+        sprintf(to->as_error, "Cannot dereference void");
+        return;
+    }
+
+    to->type = *from->type.next;
+    to->type.next = copy_type_chain(to->type.next);
+    to->memory_location = from->as_pointer.ptr;
+    to->memory_size = from->as_pointer.element_size;
+
+    int16_t data = from->as_pointer.ptr;
+
+    switch (to->type.type_) {
+        case TYPE_VOID: {
+            to->flags |= EXPRESSION_ERROR;
+            sprintf(to->as_error, "Cannot dereference void");
+            return;
+        }
+        case TYPE_CHAR: {
+            to->as_int = bk.get_memory(data);
+            break;
+        }
+        case TYPE_INT: {
+            to->as_int = (bk.get_memory(data + 1) << 8) + bk.get_memory(data);
+            break;
+        }
+        case TYPE_LONG:{
+            to->as_int = (bk.get_memory(data + 3) << 24) + (bk.get_memory(data + 2) << 16) + (bk.get_memory(data + 1) << 8) + bk.get_memory(data);
+            break;
+        }
+        case TYPE_FLOAT: {
+            to->flags |= EXPRESSION_ERROR;
+            sprintf(to->as_error, "Cannot dereference float (not implemented)");
+            break;
+        }
+        default: {
+            to->flags |= EXPRESSION_ERROR;
+            char tp[128];
+            expression_result_type_to_string(&from->type, is_expression_signed(from), tp);
+            sprintf(to->as_error, "Cannot dereference type (not implemented): %s", tp);
+            break;
+        }
+    }
+}
+
+type_chain expression_string_get_type(const char* str, uint8_t* is_signed) {
+    type_chain result = {};
+    for (int i = 0; primitive_types[i].type_name; i++) {
+        if (strcmp(str, primitive_types[i].type_name) == 0) {
+            *is_signed = primitive_types[i].is_signed;
+            result.type_ = primitive_types[i].type_of;
+            return result;
+        }
+    }
+    *is_signed = 0;
+    result.type_ = TYPE_UNKNOWN;
+    return result;
+}
+
+void expression_result_type_to_string(type_chain* type, uint8_t is_signed, char* buffer) {
+    for (int i = 0; primitive_types[i].type_name; i++) {
+        if (primitive_types[i].is_signed == is_signed && primitive_types[i].type_of == type->type_) {
+            strcpy(buffer, primitive_types[i].type_name);
+            return;
+        }
+    }
+
+    switch (type->type_) {
+        case TYPE_GENERIC_POINTER: {
+            if (type->next == NULL) {
+                sprintf(buffer, "void*");
+            } else {
+                char pointer_type[128];
+                expression_result_type_to_string(type->next, is_signed, pointer_type);
+                sprintf(buffer, "%s*", pointer_type);
+            }
+            break;
+        }
+        case TYPE_STRUCTURE: {
+            sprintf(buffer, "struct %s", type->data);
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+static uint8_t are_exp_same_type(struct expression_result_t* a, type_chain* ta,
+    struct expression_result_t* b, type_chain* tb)
+{
+    if (is_expression_signed(a) != is_expression_signed(b)) {
+        return 0;
+    }
+    if (ta->type_ != tb->type_) {
+        return 0;
+    }
+    if (is_expression_a_pointer(a)) {
+        if (ta->next == NULL || tb->next == NULL) {
+            return 0;
+        }
+        return are_exp_same_type(a, ta->next, b, tb->next);
+    }
+    return 1;
+}
+
+void expression_math_add(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result) {
+    if (!(are_exp_same_type(a, &a->type, b, &b->type))) {
+        struct expression_result_t local_3 = {};
+        convert_expression(b, &local_3, a->type.type_, is_expression_signed(b));
+        expression_math_add(a, &local_3, result);
+        return;
+    }
+
+    switch (a->type.type_) {
+        case TYPE_FLOAT: {
+            result->as_float = a->as_float + b->as_float;
+            return;
+        }
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            if (is_expression_signed(a)) {
+                result->as_int = a->as_int + b->as_int;
+            } else {
+                result->as_uint = (uint32_t)((uint32_t)a->as_int + (uint32_t)b->as_int);
+            }
+            return;
+        }
+        default: {
+            result->flags |= EXPRESSION_ERROR;
+            char tp[128];
+            expression_result_type_to_string(&a->type, is_expression_signed(a), tp);
+            sprintf(result->as_error, "Cannot perform math '+' on type %s", tp);
+            break;
+        }
+    }
+}
+
+void expression_math_sub(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result) {
+    if (!(are_exp_same_type(a, &a->type, b, &b->type))) {
+        struct expression_result_t local_3 = {};
+        convert_expression(b, &local_3, a->type.type_, is_expression_signed(b));
+        expression_math_sub(a, &local_3, result);
+        return;
+    }
+
+    switch (a->type.type_) {
+        case TYPE_FLOAT: {
+            result->as_float = a->as_float - b->as_float;
+            return;
+        }
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            if (is_expression_signed(a)) {
+                result->as_int = a->as_int - b->as_int;
+            } else {
+                result->as_uint = (uint32_t)((uint32_t)a->as_int - (uint32_t)b->as_int);
+            }
+            return;
+        }
+        default: {
+            result->flags |= EXPRESSION_ERROR;
+            char tp[128];
+            expression_result_type_to_string(&a->type, is_expression_signed(a), tp);
+            sprintf(result->as_error, "Cannot perform math '+' on type %s", tp);
+            break;
+        }
+    }
+}
+
+void expression_math_mul(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result) {
+    if (!(are_exp_same_type(a, &a->type, b, &b->type))) {
+        struct expression_result_t local_3 = {};
+        convert_expression(b, &local_3, a->type.type_, is_expression_signed(b));
+        expression_math_mul(a, &local_3, result);
+        return;
+    }
+
+    switch (a->type.type_) {
+        case TYPE_FLOAT: {
+            result->as_float = a->as_float * b->as_float;
+            return;
+        }
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            if (is_expression_signed(a)) {
+                result->as_int = a->as_int * b->as_int;
+            } else {
+                result->as_uint = (uint32_t)((uint32_t)a->as_int * (uint32_t)b->as_int);
+            }
+            return;
+        }
+        default: {
+            result->flags |= EXPRESSION_ERROR;
+            char tp[128];
+            expression_result_type_to_string(&a->type, is_expression_signed(a), tp);
+            sprintf(result->as_error, "Cannot perform math '+' on type %s", tp);
+            break;
+        }
+    }
+}
+
+void expression_math_div(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result) {
+    if (!(are_exp_same_type(a, &a->type, b, &b->type))) {
+        struct expression_result_t local_3 = {};
+        convert_expression(b, &local_3, a->type.type_, is_expression_signed(b));
+        expression_math_div(a, &local_3, result);
+        return;
+    }
+
+    switch (a->type.type_) {
+        case TYPE_FLOAT: {
+            result->as_float = a->as_float / b->as_float;
+            return;
+        }
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            if (is_expression_signed(a)) {
+                result->as_int = a->as_int / b->as_int;
+            } else {
+                result->as_uint = (uint32_t)((uint32_t)a->as_int / (uint32_t)b->as_int);
+            }
+            return;
+        }
+        default: {
+            result->flags |= EXPRESSION_ERROR;
+            char tp[128];
+            expression_result_type_to_string(&a->type, is_expression_signed(a), tp);
+            sprintf(result->as_error, "Cannot perform math '+' on type %s", tp);
+            break;
+        }
+    }
+}
+
+uint8_t is_primitive_integer_type(struct expression_result_t* exp) {
+    switch (exp->type.type_) {
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            return 1;
+        }
+        default: {
+            return 0;
+        }
+    }
+}
+
+static int Min(int a, int b) { if (a < b ) return a; else return b;}
+static int Max(int a, int b) { if (a > b ) return a; else return b;}
+
+int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len) {
+    switch (result->type.type_) {
+        case TYPE_UNKNOWN: {
+            return snprintf(buffer, buffer_len, "<unknown>");
+        }
+        case TYPE_ARRAY: {
+            int maxlen = Max(10,Min(10, result->type.size));
+            int offs = snprintf(buffer, buffer_len, "%#04x [%d] = { ", result->as_pointer.ptr, result->type.size);
+            uint16_t ptr = result->as_pointer.ptr;
+            for ( int i = 0; i < maxlen; i++ ) {
+                offs += snprintf(buffer + offs, buffer_len - offs, "%s[%d] = ", i != 0 ? ", " : "", i);
+                struct expression_result_t elr = {};
+                debug_resolve_expression_element(result->type.next, is_expression_signed(result), RESOLVE_BY_POINTER, ptr, &elr);
+                if (is_expression_result_error(&elr)) {
+                    offs += snprintf(buffer + offs, buffer_len - offs, "<error:%s>", elr.as_error);
+                    break;
+                } else {
+                    offs += expression_result_value_to_string(&elr, buffer + offs, buffer_len - offs);
+                    ptr += elr.memory_size;
+                }
+            }
+            offs += snprintf(buffer + offs, buffer_len - offs,"%s }", maxlen != result->type.size ? " ..." : "");
+            return offs;
+        }
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            if (is_expression_signed(result)) {
+                return snprintf(buffer, buffer_len, "%i", result->as_int);
+            } else {
+                return snprintf(buffer, buffer_len, "%u", result->as_uint);
+            }
+        }
+        case TYPE_FLOAT: {
+            return snprintf(buffer, buffer_len, "%f", result->as_float);
+        }
+        case TYPE_STRUCTURE: {
+            return snprintf(buffer, buffer_len, "{%#04x}", result->as_pointer.ptr);
+        }
+        case TYPE_GENERIC_POINTER:
+        case TYPE_CODE_POINTER: {
+            if (result->type.next == NULL) {
+                return snprintf(buffer, buffer_len, "%#04x", result->as_pointer.ptr);
+            }
+            switch (result->type.next->type_) {
+                case TYPE_INT:
+                case TYPE_LONG:
+                {
+                    struct expression_result_t local = {};
+                    expression_dereference_pointer(result, &local);
+                    char buff[128];
+                    expression_result_value_to_string(&local, buff, 128);
+                    return snprintf(buffer, buffer_len, "%#04x(%s)", result->as_pointer.ptr, buff);
+                }
+                case TYPE_CHAR: {
+                    char buff [128];
+
+                    int i = 0;
+                    while (i < 128) {
+                        char c = bk.get_memory(result->as_pointer.ptr + i);
+                        if (c == 0) {
+                            break;
+                        }
+                        if (isprint(c)) {
+                            buff[i++] = c;
+                        } else {
+                            buff[i++] = '.';
+                        }
+                    }
+                    return snprintf(buffer, buffer_len, "%#04x(\"%s\")", result->as_pointer.ptr, buff);
+                }
+                default: {
+                    return snprintf(buffer, buffer_len, "%#04x", result->as_pointer.ptr);
+                }
+            }
+        }
+        default: {
+            return 0;
+        }
+    }
+    return 0;
+}
+
+void convert_expression(struct expression_result_t* from, struct expression_result_t* to,
+    enum type_record_type type, uint8_t is_signed
+) {
+    to->type.type_ = type;
+    to->type.next = NULL;
+    set_expression_signed(to, is_signed);
+    to->memory_location = from->memory_location;
+    switch (from->type.type_) {
+        case TYPE_FLOAT: {
+            switch (type) {
+                case TYPE_FLOAT: {
+                    to->as_float = from->as_float;
+                    break;
+                }
+                case TYPE_CHAR:
+                case TYPE_INT:
+                case TYPE_LONG: {
+                    to->as_int = (int32_t)from->as_float;
+                    break;
+                }
+                default:
+                {
+                    break;
+                }
+            }
+            break;
+        }
+        case TYPE_CHAR:
+        case TYPE_INT:
+        case TYPE_LONG: {
+            switch (type) {
+                case TYPE_FLOAT: {
+                    to->as_float = (int32_t)from->as_int;
+                    break;
+                }
+                case TYPE_CHAR:
+                case TYPE_INT:
+                case TYPE_LONG: {
+                    to->as_int = from->as_int;
+                    break;
+                }
+                case TYPE_GENERIC_POINTER:
+                case TYPE_CODE_POINTER: {
+                    to->as_pointer.ptr = (uint16_t)from->as_int;
+                    to->as_pointer.element_size = from->memory_size;
+                    to->type.next = NULL;
+                }
+                default: {
+                    break;
+                }
+            }
+            break;
+        }
+
+        case TYPE_GENERIC_POINTER:
+        case TYPE_CODE_POINTER: {
+            switch (type) {
+                case TYPE_FLOAT: {
+                    to->as_float = (float)from->as_pointer.ptr;
+                    break;
+                }
+                case TYPE_CHAR:
+                case TYPE_INT:
+                case TYPE_LONG: {
+                    to->as_int = (int32_t)from->as_pointer.ptr;
+                    break;
+                }
+                default:
+                {
+                    break;
+                }
+            }
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+struct expression_result_t* get_expression_result() {
+    return &expression_result;
+}

--- a/src/ticks/exp_engine.h
+++ b/src/ticks/exp_engine.h
@@ -1,0 +1,61 @@
+#ifndef EXPRESSION_H
+#define EXPRESSION_H
+
+#include <inttypes.h>
+#include "debug.h"
+
+enum expression_flags_t {
+    EXPRESSION_TYPE_SIGNED = 0x01u,
+    EXPRESSION_ERROR = 0x02u,
+    EXPRESSION_UNKNOWN = 0x04u,
+};
+
+struct expression_result_t {
+    union {
+        int32_t as_int;
+        uint32_t as_uint;
+        float as_float;
+        struct {
+            uint16_t element_size;
+            uint16_t ptr;
+        } as_pointer;
+    };
+
+    char as_error[128];
+
+    uint16_t memory_location;
+    uint16_t memory_size;
+
+    type_chain type;
+    uint8_t flags;
+};
+
+extern void evaluate_expression_string(const char* expr);
+extern uint8_t is_expression_result_error(struct expression_result_t* result);
+extern void set_expression_result_error(struct expression_result_t* result, const char* error);
+
+extern void expression_result_free_typechain(struct expression_result_t* result);
+extern void convert_expression(struct expression_result_t* from, struct expression_result_t* to, enum type_record_type type, uint8_t is_signed);
+extern void expression_result_type_to_string(type_chain* type, uint8_t is_signed, char* buffer);
+extern void expression_dereference_pointer(struct expression_result_t *from, struct expression_result_t *to);
+extern void expression_value_to_pointer(struct expression_result_t *from, struct expression_result_t *to, type_chain* pointer_type, uint8_t is_signed);
+extern void expression_math_add(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
+extern void expression_math_sub(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
+extern void expression_math_mul(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
+extern void expression_math_div(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
+extern type_chain expression_string_get_type(const char* str, uint8_t* is_signed);
+extern uint8_t is_primitive_integer_type(struct expression_result_t* exp);
+extern int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len);
+extern void reset_expression_result(struct expression_result_t* result);
+extern struct expression_result_t* get_expression_result();
+extern uint8_t is_expression_signed(struct expression_result_t *exp);
+extern void set_expression_signed(struct expression_result_t *exp, uint8_t is_signed);
+
+    struct lookup_t {
+    const char* symbol_name;
+};
+
+extern void debug_lookup_symbol(struct lookup_t* lookup, struct expression_result_t* result);
+
+
+#endif

--- a/src/ticks/exp_engine.h
+++ b/src/ticks/exp_engine.h
@@ -5,9 +5,8 @@
 #include "debug.h"
 
 enum expression_flags_t {
-    EXPRESSION_TYPE_SIGNED = 0x01u,
-    EXPRESSION_ERROR = 0x02u,
-    EXPRESSION_UNKNOWN = 0x04u,
+    EXPRESSION_ERROR = 0x01u,
+    EXPRESSION_UNKNOWN = 0x02u,
 };
 
 struct expression_result_t {
@@ -16,7 +15,6 @@ struct expression_result_t {
         uint32_t as_uint;
         float as_float;
         struct {
-            uint16_t element_size;
             uint16_t ptr;
         } as_pointer;
     };
@@ -24,9 +22,7 @@ struct expression_result_t {
     char as_error[128];
 
     uint16_t memory_location;
-    uint16_t memory_size;
-
-    type_chain type;
+    type_record type;
     uint8_t flags;
 };
 
@@ -34,22 +30,19 @@ extern void evaluate_expression_string(const char* expr);
 extern uint8_t is_expression_result_error(struct expression_result_t* result);
 extern void set_expression_result_error(struct expression_result_t* result, const char* error);
 
-extern void expression_result_free_typechain(struct expression_result_t* result);
-extern void convert_expression(struct expression_result_t* from, struct expression_result_t* to, enum type_record_type type, uint8_t is_signed);
-extern void expression_result_type_to_string(type_chain* type, uint8_t is_signed, char* buffer);
+extern void expression_result_free(struct expression_result_t* result);
+extern void convert_expression(struct expression_result_t* from, struct expression_result_t* to, type_record* type);
+extern void expression_result_type_to_string(type_record* root, type_chain* type, char* buffer);
 extern void expression_dereference_pointer(struct expression_result_t *from, struct expression_result_t *to);
-extern void expression_value_to_pointer(struct expression_result_t *from, struct expression_result_t *to, type_chain* pointer_type, uint8_t is_signed);
+extern void expression_value_to_pointer(struct expression_result_t *from, struct expression_result_t *to, type_record* pointer_type);
 extern void expression_math_add(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_math_sub(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_math_mul(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_math_div(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
-extern type_chain expression_string_get_type(const char* str, uint8_t* is_signed);
-extern uint8_t is_primitive_integer_type(struct expression_result_t* exp);
+extern void expression_string_get_type(const char* str, type_record* type);
 extern int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len);
 extern void reset_expression_result(struct expression_result_t* result);
 extern struct expression_result_t* get_expression_result();
-extern uint8_t is_expression_signed(struct expression_result_t *exp);
-extern void set_expression_signed(struct expression_result_t *exp, uint8_t is_signed);
 
     struct lookup_t {
     const char* symbol_name;

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -18,58 +18,73 @@ multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
 %%
 
 [ \t]	; // ignore all whitespace
--?[0-9]+\.[0-9]+ 	{ yylval.val.type.type_ = TYPE_FLOAT; yylval.val.as_float = atof(yytext); return T_PRIMITIVE_VALUE; }
--?[0-9]+		    { yylval.val.type.type_ = TYPE_LONG; yylval.val.flags |= EXPRESSION_TYPE_SIGNED; yylval.val.as_int = atoi(yytext); return T_PRIMITIVE_VALUE; }
-0x[0-9a-fA-F]+		{ yylval.val.type.type_ = TYPE_LONG; yylval.val.flags |= EXPRESSION_TYPE_SIGNED; sscanf(yytext + 2, "%x", &yylval.val.as_int); return T_PRIMITIVE_VALUE; }
+-?[0-9]+\.[0-9]+ 	{
+    memset(&yylval.val.type, 0, sizeof(yylval.val.type));
+    yylval.val.type.first = malloc_type(TYPE_FLOAT);
+    yylval.val.as_float = atof(yytext);
+    return T_PRIMITIVE_VALUE;
+}
+-?[0-9]+		    {
+    memset(&yylval.val.type, 0, sizeof(yylval.val.type));
+    yylval.val.type.first = malloc_type(TYPE_LONG);
+    yylval.val.type.signed_ = 1;
+    yylval.val.as_int = atoi(yytext);
+    return T_PRIMITIVE_VALUE;
+}
+0x[0-9a-fA-F]+		{
+    memset(&yylval.val.type, 0, sizeof(yylval.val.type));
+    yylval.val.type.first = malloc_type(TYPE_LONG);
+    yylval.val.type.signed_ = 1;
+    sscanf(yytext + 2, "%x", &yylval.val.as_int);
+    return T_PRIMITIVE_VALUE;
+}
 "&"		            { return T_AMPERSAND; }
 {multiple_words}	{ return lookup_word(); }
 {word}		        { return lookup_word(); }
-"+"		            {return T_PLUS;}
-"-"		            {return T_MINUS;}
-"*"		            {return T_STAR;}
-"/"		            {return T_SLASH;}
-"("		            {return T_LEFT;}
-")"		            {return T_RIGHT;}
+"+"		            { return T_PLUS; }
+"-"		            { return T_MINUS; }
+"*"		            { return T_STAR; }
+"/"		            { return T_SLASH; }
+"("		            { return T_LEFT; }
+")"		            { return T_RIGHT; }
 
 %%
 
 int lookup_word() {
     // it it a type?
     {
-        uint8_t is_signed = 0;
-        type_chain type = expression_string_get_type(yytext, &is_signed);
-        if (type.type_ != TYPE_UNKNOWN) {
-            yylval.type.type = type;
-            yylval.type.is_signed = is_signed;
+        type_record type = {};
+        expression_string_get_type(yytext, &type);
+        if (type.first->type_ != TYPE_UNKNOWN) {
+            yylval.type = type;
             return T_PRIMITIVE_TYPE;
         }
+        free_type(type.first);
     }
 
     struct expression_result_t result = {};
     struct lookup_t lookup;
     lookup.symbol_name = yytext;
     debug_lookup_symbol(&lookup, &result);
-
     if (is_expression_result_error(&result)) {
         strcpy(yylval.errval, result.as_error);
         return T_ERROR;
     }
-
-    switch (result.type.type_)
-    {
-        case TYPE_UNKNOWN:
-        {
+    if (result.type.first == NULL) {
+        yylval.val = result;
+        return T_PRIMITIVE_VALUE;
+    }
+    switch (result.type.first->type_) {
+        case TYPE_UNKNOWN: {
             strcpy(yylval.errval, "<unknown>");
             return T_ERROR;
         }
         case TYPE_GENERIC_POINTER:
-        case TYPE_CODE_POINTER:
-        {
+        case TYPE_CODE_POINTER: {
             yylval.val = result;
             return T_POINTER;
         }
-        default:
-        {
+        default: {
             yylval.val = result;
             return T_PRIMITIVE_VALUE;
         }

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -1,0 +1,79 @@
+%option noyywrap
+
+%{
+#include <stdio.h>
+
+#define YY_DECL int yylex()
+
+#include "exp_engine.h"
+#include "expressions.tab.h"
+
+int lookup_word();
+
+%}
+
+word [a-zA-Z_][a-zA-Z0-9_]*
+multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
+
+%%
+
+[ \t]	; // ignore all whitespace
+-?[0-9]+\.[0-9]+ 	{ yylval.val.type.type_ = TYPE_FLOAT; yylval.val.as_float = atof(yytext); return T_PRIMITIVE_VALUE; }
+-?[0-9]+		    { yylval.val.type.type_ = TYPE_LONG; yylval.val.flags |= EXPRESSION_TYPE_SIGNED; yylval.val.as_int = atoi(yytext); return T_PRIMITIVE_VALUE; }
+0x[0-9a-fA-F]+		{ yylval.val.type.type_ = TYPE_LONG; yylval.val.flags |= EXPRESSION_TYPE_SIGNED; sscanf(yytext + 2, "%x", &yylval.val.as_int); return T_PRIMITIVE_VALUE; }
+"&"		            { return T_AMPERSAND; }
+{multiple_words}	{ return lookup_word(); }
+{word}		        { return lookup_word(); }
+"+"		            {return T_PLUS;}
+"-"		            {return T_MINUS;}
+"*"		            {return T_STAR;}
+"/"		            {return T_SLASH;}
+"("		            {return T_LEFT;}
+")"		            {return T_RIGHT;}
+
+%%
+
+int lookup_word() {
+    // it it a type?
+    {
+        uint8_t is_signed = 0;
+        type_chain type = expression_string_get_type(yytext, &is_signed);
+        if (type.type_ != TYPE_UNKNOWN) {
+            yylval.type.type = type;
+            yylval.type.is_signed = is_signed;
+            return T_PRIMITIVE_TYPE;
+        }
+    }
+
+    struct expression_result_t result = {};
+    struct lookup_t lookup;
+    lookup.symbol_name = yytext;
+    debug_lookup_symbol(&lookup, &result);
+
+    if (is_expression_result_error(&result)) {
+        strcpy(yylval.errval, result.as_error);
+        return T_ERROR;
+    }
+
+    switch (result.type.type_)
+    {
+        case TYPE_UNKNOWN:
+        {
+            strcpy(yylval.errval, "<unknown>");
+            return T_ERROR;
+        }
+        case TYPE_GENERIC_POINTER:
+        case TYPE_CODE_POINTER:
+        {
+            yylval.val = result;
+            return T_POINTER;
+        }
+        default:
+        {
+            yylval.val = result;
+            return T_PRIMITIVE_VALUE;
+        }
+    }
+
+    return T_PRIMITIVE_VALUE;
+}

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -47,6 +47,8 @@ multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
 "/"		            { return T_SLASH; }
 "("		            { return T_LEFT; }
 ")"		            { return T_RIGHT; }
+"["		            { return T_LEFT_BRACKET; }
+"]"		            { return T_RIGHT_BRACKET; }
 
 %%
 

--- a/src/ticks/expressions.y
+++ b/src/ticks/expressions.y
@@ -1,0 +1,120 @@
+%{
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "exp_engine.h"
+
+extern int yylex();
+extern int yyparse();
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+extern YY_BUFFER_STATE yy_scan_string (const char * yystr);
+extern void yy_delete_buffer (YY_BUFFER_STATE  b );
+
+void yyerror(const char* s);
+%}
+
+%union {
+    struct expression_result_t val;
+    struct {
+    	type_chain type;
+    	uint8_t is_signed;
+    } type;
+    char cval[128];
+    char errval[128];
+}
+
+%token<val> T_PRIMITIVE_VALUE
+%token<ptr> T_POINTER
+%token<cval> T_STRING
+
+%token<errval> T_ERROR
+%token T_PRIMITIVE_TYPE
+%token T_PLUS T_MINUS T_STAR T_DIVIDE T_LEFT T_RIGHT
+%token T_AMPERSAND
+%left T_PLUS T_MINUS
+%left T_STAR T_SLASH
+%left T_AMPERSAND
+
+%type<val> value_expression
+%type<type> type_expression
+%type<val> pointer_expression
+%type<errval> error_expression
+
+%destructor {
+	expression_result_free_typechain(&$$);
+} value_expression pointer_expression
+
+%start calculation
+
+%%
+
+calculation:
+	| value_expression 							{ *get_expression_result() = $1; }
+	| pointer_expression 							{ *get_expression_result() = $1; }
+	| error_expression 							{ set_expression_result_error(get_expression_result(), $1); }
+;
+
+pointer_expression: T_POINTER
+	| T_AMPERSAND value_expression						{
+		$$.type.type_ = TYPE_GENERIC_POINTER;
+		$$.as_pointer.ptr = $2.memory_location;
+		$$.as_pointer.element_size = $2.memory_size;
+		$$.type.next = copy_type_chain(&$2.type);
+		set_expression_signed(&$$, is_expression_signed(&$2));
+	 }
+	| T_LEFT type_expression T_STAR T_RIGHT pointer_expression		{ expression_value_to_pointer(&$5, &$$, &$2.type, $2.is_signed); }
+	| T_LEFT type_expression T_STAR T_RIGHT value_expression		{ expression_value_to_pointer(&$5, &$$, &$2.type, $2.is_signed); }
+	| T_LEFT pointer_expression T_RIGHT					{ $$ = $2; }
+	| pointer_expression T_PLUS value_expression				{
+		$$ = $1;
+		if (is_primitive_integer_type(&$3)) {
+			$$.as_pointer.ptr += $3.as_int * $$.as_pointer.element_size;
+		} else {
+			$$.flags |= EXPRESSION_ERROR;
+			sprintf($$.as_error, "Cannot do math with non-integer");
+		}
+	 }
+	 | pointer_expression T_MINUS value_expression				{
+		$$ = $1;
+		if (is_primitive_integer_type(&$3)) {
+			$$.as_pointer.ptr -= $3.as_int * $$.as_pointer.element_size;
+		} else {
+			$$.flags |= EXPRESSION_ERROR;
+			sprintf($$.as_error, "Cannot do math with non-integer");
+		}
+	 }
+;
+
+type_expression: T_PRIMITIVE_TYPE
+;
+
+value_expression: T_PRIMITIVE_VALUE
+	| T_STAR pointer_expression						{ expression_dereference_pointer(&$2, &$$); }
+	| T_LEFT type_expression T_RIGHT value_expression			{ convert_expression(&$4, &$$, $2.type.type_, $2.is_signed); }
+	| T_LEFT value_expression T_RIGHT					{ $$ = $2; }
+	| value_expression T_PLUS value_expression				{ expression_math_add(&$1, &$3, &$$); }
+	| value_expression T_MINUS value_expression				{ expression_math_sub(&$1, &$3, &$$); }
+	| value_expression T_SLASH value_expression				{ expression_math_div(&$1, &$3, &$$); }
+	| value_expression T_STAR value_expression				{ expression_math_mul(&$1, &$3, &$$); }
+
+error_expression: T_ERROR							{ strcpy($$, $1); }
+;
+
+%%
+
+void evaluate_expression_string(const char* expr)
+{
+    reset_expression_result(get_expression_result());
+    YY_BUFFER_STATE st = yy_scan_string (expr);
+    yyparse();
+    yy_delete_buffer(st);
+}
+
+void yyerror(const char* s)
+{
+    if (!is_expression_result_error(get_expression_result()))
+    {
+    	set_expression_result_error(get_expression_result(), s);
+    }
+}

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -47,7 +47,7 @@ static int symbol_compare(const void *p1, const void *p2)
 
 void read_symbol_file(char *filename)
 {
-    char  buf[256];
+    char  buf[512];
     FILE *fp = fopen(filename,"r");
 
     if ( fp != NULL ) {


### PR DESCRIPTION
This change adds implementation to the `print` command of ticks, which was unimplemented prior to this.
It uses flex/bison to parse expression according to `expressions.l`/`expressions.y` and with help of `exp_engine.c` becomes able to do C stuff like referencing, de-referencing, pointer math, type cast, etc.

**How to test it**
- Pull this example project: https://github.com/desertkun/z88dk-debug-error-minimum-example
- compile it with make
- run `z88dk-ticks -x example.map -d -l 0x8000 -pc 0x8000 example__.bin`
- but a breakpoint over method "check" `b check`
- continue `c`
- `info locals`
- `p kek`
- `p test`
- `p (uint8_t)1`
- `p *kek + 10`
- `p (uint8_t*)test`
- etc

**Limitations**
- Structs are not yet supported, only primitive types
- No pointers of pointers
- ~~Only local variables can be printed out as of now, but that's not a limitation of evaluation but rather inability to obtain global variables at all~~