### PR TITLE
ticks: structs debug

### DIFF
--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -47,6 +47,7 @@ typedef struct {
     void_cb next;
     void_cb step;
     void_cb detach;
+    uint8_t confirm_detach_w_breakpoints;
     restore_cb restore;
     breakpoint_cb add_breakpoint;
     breakpoint_cb remove_breakpoint;

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -12,6 +12,8 @@ typedef struct type_chain_s type_chain;
 typedef struct address_space_s address_space;
 typedef struct debug_sym_function_s debug_sym_function;
 typedef struct debug_sym_symbol_s debug_sym_symbol;
+typedef struct debug_sym_type_s debug_sym_type;
+typedef struct debug_sym_type_member_s debug_sym_type_member;
 typedef struct debug_sym_function_argument_s debug_sym_function_argument;
 typedef struct debug_frame_pointer_s debug_frame_pointer;
 
@@ -40,7 +42,8 @@ enum function_scope_t {
 enum symbol_scope_t {
     SYMBOL_SCOPE_GLOBAL = 0,
     SYMBOL_SCOPE_FILE,
-    SYMBOL_SCOPE_LOCAL
+    SYMBOL_SCOPE_LOCAL,
+    SYMBOL_SCOPE_SYMBOL
 };
 
 enum type_record_type {
@@ -108,6 +111,20 @@ struct debug_sym_symbol_s {
     UT_hash_handle          hh;
 };
 
+struct debug_sym_type_member_s {
+    uint16_t                    offset;
+    debug_sym_symbol*           symbol;
+    debug_sym_type_member*      next;
+};
+
+struct debug_sym_type_s {
+    char                        name[128];
+    enum symbol_scope_t         scope;
+    const char*                 scope_value;
+    debug_sym_type_member*      first_child;
+    UT_hash_handle              hh;
+};
+
 struct debug_frame_pointer_s {
     symbol*                 symbol;
     debug_sym_function*     function;
@@ -157,6 +174,7 @@ extern void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);
 extern debug_sym_symbol* cdb_get_first_symbol();
 extern debug_sym_symbol* cdb_find_symbol(const char* cname);
+extern debug_sym_type* cdb_find_type(const char* tname);
 
 extern debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, struct debugger_regs_t* regs, uint16_t limit);
 extern debug_frame_pointer* debug_stack_frames_at(debug_frame_pointer* first, size_t frame);

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -806,6 +806,7 @@ static int cmd_down(int argc, char **argv)
 }
 
 void debug_lookup_symbol(struct lookup_t* lookup, struct expression_result_t* result) {
+    zero_expression_result(result);
     struct debugger_regs_t regs;
     bk.get_regs(&regs);
 
@@ -856,7 +857,7 @@ void debug_lookup_symbol(struct lookup_t* lookup, struct expression_result_t* re
     debug_stack_frames_free(first_frame_pointer);
 
     sprintf(result->as_error, "Cannot resolve symbol: %s", lookup->symbol_name);
-    result->flags |= EXPRESSION_ERROR;
+    set_expression_result_error(result);
 }
 
 static int cmd_print(int argc, char **argv)
@@ -1693,12 +1694,14 @@ static int cmd_help(int argc, char **argv)
 
 static int cmd_quit(int argc, char **argv)
 {
-    breakpoint* elem;
-    int count;
-    LL_COUNT(breakpoints, elem, count);
-    if (count > 0) {
-        if (confirm("You have breakpoint(s) set. Would you like to remove them before you detach?")) {
-            delete_all_breakpoints();
+    if (bk.confirm_detach_w_breakpoints) {
+        breakpoint* elem;
+        int count;
+        LL_COUNT(breakpoints, elem, count);
+        if (count > 0) {
+            if (confirm("You have breakpoint(s) set. Would you like to remove them before you detach?")) {
+                delete_all_breakpoints();
+            }
         }
     }
     bk.detach();

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -704,12 +704,14 @@ static void print_frame(debug_frame_pointer *fp, debug_frame_pointer *current, u
                     strcat(function_args, arg_text);
                 } else {
                     char exp_type[128] = "unknown";
-                    char exp_value[128] = "???";
+                    char* exp_value = malloc(2048);
+                    strcpy(exp_value, "???");
 
                     expression_result_type_to_string(&exp.type, exp.type.first, exp_type);
-                    expression_result_value_to_string(&exp, exp_value, sizeof(exp_value));
+                    expression_result_value_to_string(&exp, exp_value, 2048);
 
                     snprintf(arg_text, sizeof(arg_text), "<%s>%s = %s", exp_type, s->symbol_name, exp_value);
+                    free(exp_value);
                     strcat(function_args, arg_text);
                 }
 
@@ -894,11 +896,13 @@ static int cmd_print(int argc, char **argv)
     }
 
     char type[128] = "unknown";
-    char value[128] = "???";
+    char* value = malloc(2048);
+    strcpy(value, "???");
     expression_result_type_to_string(&result->type, result->type.first, type);
-    expression_result_value_to_string(result, value, sizeof(value));
+    expression_result_value_to_string(result, value, 2048);
 
     printf("Result: <%s> %s\n", type, value);
+    free(value);
 
     expression_result_free(result);
     int new_types = count_allocated_types();
@@ -956,10 +960,12 @@ static void info_section_locals() {
                     printf("  %s = <error>\n", s->symbol_name);
                 } else {
                     char exp_type[128] = "unknown";
-                    char exp_value[128] = "???";
+                    char* exp_value = malloc(2048);
+                    strcpy(exp_value, "???");
                     expression_result_type_to_string(&exp.type, exp.type.first, exp_type);
-                    expression_result_value_to_string(&exp, exp_value, sizeof(exp_value));
+                    expression_result_value_to_string(&exp, exp_value, 2048);
                     printf("  <%s>%s = %s\n", exp_type, s->symbol_name, exp_value);
+                    free(exp_value);
                 }
                 expression_result_free(&exp);
             } else {
@@ -1000,10 +1006,12 @@ static void info_section_globals() {
         }
 
         char exp_type[128] = "unknown";
-        char exp_value[128] = "???";
+        char* exp_value = malloc(2048);
+        strcpy(exp_value, "???");
         expression_result_type_to_string(&exp.type, exp.type.first, exp_type);
-        expression_result_value_to_string(&exp, exp_value, sizeof(exp_value));
+        expression_result_value_to_string(&exp, exp_value, 2048);
         printf("  <%s>%s = %s\n", exp_type, s->symbol_name, exp_value);
+        free(exp_value);
         expression_result_free(&exp);
     }
 

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -607,6 +607,7 @@ static backend_t gdb_backend = {
     .resume = &debugger_resume,
     .next = &debugger_next,
     .step = &debugger_step,
+    .confirm_detach_w_breakpoints = 1,
     .detach = &debugger_detach,
     .restore = &debugger_restore,
     .add_breakpoint = &add_breakpoint,

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -197,6 +197,7 @@ backend_t ticks_debugger_backend = {
     .resume = &resume,
     .next = &next,
     .step = &step,
+    .confirm_detach_w_breakpoints = 0,
     .detach = &detach,
     .restore = &restore,
     .add_breakpoint = &add_breakpoint,

--- a/src/ticks/exp_engine.c
+++ b/src/ticks/exp_engine.c
@@ -228,6 +228,16 @@ void expression_resolve_struct_member(struct expression_result_t *struct_, const
 }
 
 void expression_string_get_type(const char* str, type_record* type) {
+    if (strstr(str, "struct ") == str) {
+        str += 7;
+        debug_sym_type* t = cdb_find_type(str);
+        if (t != NULL) {
+            type->signed_ = 0;
+            type->first = malloc_type(TYPE_STRUCTURE);
+            type->first->data = t->name;
+            return;
+        }
+    }
     for (int i = 0; primitive_types[i].type_name; i++) {
         if (strcmp(str, primitive_types[i].type_name) == 0) {
             type->signed_ = primitive_types[i].is_signed;

--- a/src/ticks/exp_engine.c
+++ b/src/ticks/exp_engine.c
@@ -264,6 +264,16 @@ void expression_result_type_to_string(type_record* root, type_chain* type, char*
             }
             break;
         }
+        case TYPE_ARRAY: {
+            if (type->next == NULL) {
+                sprintf(buffer, "void*");
+            } else {
+                char array_type[128];
+                expression_result_type_to_string(root, type->next, array_type);
+                sprintf(buffer, "%s[]", array_type);
+            }
+            break;
+        }
         case TYPE_STRUCTURE: {
             sprintf(buffer, "struct %s", type->data);
             break;
@@ -488,7 +498,7 @@ int expression_result_value_to_string(struct expression_result_t* result, char* 
             for ( int i = 0; i < maxlen; i++ ) {
                 offs += snprintf(buffer + offs, buffer_len - offs, "%s[%d] = ", i != 0 ? ", " : "", i);
                 struct expression_result_t elr = {};
-                debug_resolve_expression_element(&result->type, result->type.first, RESOLVE_BY_POINTER, ptr, &elr);
+                debug_resolve_expression_element(&result->type, result->type.first->next, RESOLVE_BY_POINTER, ptr, &elr);
                 if (is_expression_result_error(&elr)) {
                     offs += snprintf(buffer + offs, buffer_len - offs, "<error:%s>", elr.as_error);
                     break;

--- a/src/ticks/exp_engine.h
+++ b/src/ticks/exp_engine.h
@@ -28,12 +28,15 @@ struct expression_result_t {
 
 extern void evaluate_expression_string(const char* expr);
 extern uint8_t is_expression_result_error(struct expression_result_t* result);
-extern void set_expression_result_error(struct expression_result_t* result, const char* error);
+extern void set_expression_result_error(struct expression_result_t* result);
+extern void set_expression_result_error_str(struct expression_result_t* result, const char* error);
 
 extern void expression_result_free(struct expression_result_t* result);
 extern void convert_expression(struct expression_result_t* from, struct expression_result_t* to, type_record* type);
 extern void expression_result_type_to_string(type_record* root, type_chain* type, char* buffer);
 extern void expression_dereference_pointer(struct expression_result_t *from, struct expression_result_t *to);
+extern void expression_resolve_struct_member(struct expression_result_t *struct_, const char *member, struct expression_result_t* result);
+extern void expression_resolve_struct_member_ptr(struct expression_result_t *struct_ptr, const char *member, struct expression_result_t* result);
 extern void expression_value_to_pointer(struct expression_result_t *from, struct expression_result_t *to, type_record* pointer_type);
 extern void expression_math_add(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_math_sub(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
@@ -42,9 +45,10 @@ extern void expression_math_div(struct expression_result_t* a, struct expression
 extern void expression_string_get_type(const char* str, type_record* type);
 extern int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len);
 extern void reset_expression_result(struct expression_result_t* result);
+extern void zero_expression_result(struct expression_result_t* result);
 extern struct expression_result_t* get_expression_result();
 
-    struct lookup_t {
+struct lookup_t {
     const char* symbol_name;
 };
 

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -19,26 +19,28 @@ multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
 
 [ \t]	; // ignore all whitespace
 -?[0-9]+\.[0-9]+ 	{
-    memset(&yylval.val.type, 0, sizeof(yylval.val.type));
+    zero_expression_result(&yylval.val);
     yylval.val.type.first = malloc_type(TYPE_FLOAT);
     yylval.val.as_float = atof(yytext);
     return T_PRIMITIVE_VALUE;
 }
 -?[0-9]+		    {
-    memset(&yylval.val.type, 0, sizeof(yylval.val.type));
+    zero_expression_result(&yylval.val);
     yylval.val.type.first = malloc_type(TYPE_LONG);
     yylval.val.type.signed_ = 1;
     yylval.val.as_int = atoi(yytext);
     return T_PRIMITIVE_VALUE;
 }
 0x[0-9a-fA-F]+		{
-    memset(&yylval.val.type, 0, sizeof(yylval.val.type));
+    zero_expression_result(&yylval.val);
     yylval.val.type.first = malloc_type(TYPE_LONG);
     yylval.val.type.signed_ = 1;
     sscanf(yytext + 2, "%x", &yylval.val.as_int);
     return T_PRIMITIVE_VALUE;
 }
 "&"		            { return T_AMPERSAND; }
+"."		            { return T_DOT; }
+"->"		        { return T_ARROW; }
 {multiple_words}	{ return lookup_word(); }
 {word}		        { return lookup_word(); }
 "+"		            { return T_PLUS; }
@@ -64,33 +66,6 @@ int lookup_word() {
         free_type(type.first);
     }
 
-    struct expression_result_t result = {};
-    struct lookup_t lookup;
-    lookup.symbol_name = yytext;
-    debug_lookup_symbol(&lookup, &result);
-    if (is_expression_result_error(&result)) {
-        strcpy(yylval.errval, result.as_error);
-        return T_ERROR;
-    }
-    if (result.type.first == NULL) {
-        yylval.val = result;
-        return T_PRIMITIVE_VALUE;
-    }
-    switch (result.type.first->type_) {
-        case TYPE_UNKNOWN: {
-            strcpy(yylval.errval, "<unknown>");
-            return T_ERROR;
-        }
-        case TYPE_GENERIC_POINTER:
-        case TYPE_CODE_POINTER: {
-            yylval.val = result;
-            return T_POINTER;
-        }
-        default: {
-            yylval.val = result;
-            return T_PRIMITIVE_VALUE;
-        }
-    }
-
-    return T_PRIMITIVE_VALUE;
+    strcpy(yylval.cval, yytext);
+    return T_STRING;
 }

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -13,6 +13,7 @@ int lookup_word();
 %}
 
 word [a-zA-Z_][a-zA-Z0-9_]*
+struct_word "struct "[a-zA-Z_][a-zA-Z0-9_]*
 multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
 
 %%
@@ -43,6 +44,7 @@ multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
 "->"		        { return T_ARROW; }
 {multiple_words}	{ return lookup_word(); }
 {word}		        { return lookup_word(); }
+{struct_word}       { return lookup_word(); }
 "+"		            { return T_PLUS; }
 "-"		            { return T_MINUS; }
 "*"		            { return T_STAR; }

--- a/src/ticks/expressions.y
+++ b/src/ticks/expressions.y
@@ -22,25 +22,22 @@ void yyerror(const char* s);
 }
 
 %token<val> T_PRIMITIVE_VALUE
-%token<ptr> T_POINTER
 %token<cval> T_STRING
 
 %token<errval> T_ERROR
 %token T_PRIMITIVE_TYPE
 %token T_PLUS T_MINUS T_STAR T_DIVIDE T_LEFT T_RIGHT T_LEFT_BRACKET T_RIGHT_BRACKET
-%token T_AMPERSAND
+%token T_AMPERSAND T_DOT T_ARROW
 %left T_PLUS T_MINUS
 %left T_STAR T_SLASH
 %left T_AMPERSAND
 
 %type<val> value_expression
 %type<type> type_expression
-%type<val> pointer_expression
 %type<errval> error_expression
 
 %destructor { expression_result_free(&$$); } T_PRIMITIVE_VALUE
 %destructor { expression_result_free(&$$); } value_expression
-%destructor { expression_result_free(&$$); } pointer_expression
 %destructor { free_type($$.first); } type_expression
 
 %start calculation
@@ -49,11 +46,49 @@ void yyerror(const char* s);
 
 calculation:
 	| value_expression 							{ *get_expression_result() = $1; }
-	| pointer_expression 							{ *get_expression_result() = $1; }
-	| error_expression 							{ set_expression_result_error(get_expression_result(), $1); }
+	| error_expression 							{ set_expression_result_error_str(get_expression_result(), $1); }
 ;
 
-pointer_expression: T_POINTER
+type_expression: T_PRIMITIVE_TYPE
+;
+
+value_expression: T_PRIMITIVE_VALUE
+	| T_STRING								{
+    		zero_expression_result(&$$);
+    		struct lookup_t lookup = {};
+    		lookup.symbol_name = $1;
+    		debug_lookup_symbol(&lookup, &$$);
+	}
+	| value_expression T_DOT T_STRING					{ expression_resolve_struct_member(&$1, $3, &$$); expression_result_free(&$1); }
+	| value_expression T_ARROW T_STRING					{ expression_resolve_struct_member_ptr(&$1, $3, &$$); expression_result_free(&$1); }
+	| T_STAR value_expression						{ expression_dereference_pointer(&$2, &$$); expression_result_free(&$2); }
+	| T_LEFT type_expression T_RIGHT value_expression			{ convert_expression(&$4, &$$, &$2); free_type($2.first); expression_result_free(&$4); }
+	| T_LEFT value_expression T_RIGHT					{ $$ = $2; }
+	| value_expression T_PLUS value_expression				{ expression_math_add(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
+	| value_expression T_MINUS value_expression				{ expression_math_sub(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
+	| value_expression T_SLASH value_expression				{ expression_math_div(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
+	| value_expression T_STAR value_expression				{ expression_math_mul(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
+	| value_expression T_LEFT_BRACKET value_expression T_RIGHT_BRACKET    {
+		if (is_type_a_pointer($1.type.first)) {
+			if ($3.type.first == NULL) {
+				$$.flags |= EXPRESSION_ERROR;
+				sprintf($$.as_error, "Cannot do math with void");
+			} else {
+				if (is_primitive_integer_type($3.type.first)) {
+					$1.as_pointer.ptr += $3.as_int * get_type_memory_size($1.type.first->next);
+					expression_dereference_pointer(&$1, &$$);
+					expression_result_free(&$1);
+					expression_result_free(&$3);
+				} else {
+					$$.flags |= EXPRESSION_ERROR;
+					sprintf($$.as_error, "Cannot index pointer by non-integer");
+				}
+			}
+		} else {
+			$$.flags |= EXPRESSION_ERROR;
+			sprintf($$.as_error, "Cannot index non-pointer");
+		}
+	}
 	| T_AMPERSAND value_expression						{
 		$$.type = $2.type;
 		$$.type.first = malloc_type(TYPE_GENERIC_POINTER);
@@ -61,75 +96,7 @@ pointer_expression: T_POINTER
 		$$.as_pointer.ptr = $2.memory_location;
 		expression_result_free(&$2);
 	 }
-	| T_AMPERSAND pointer_expression					{
-		$$.type = $2.type;
-		$$.type.first = malloc_type(TYPE_GENERIC_POINTER);
-		$$.type.first->next = copy_type_chain($2.type.first);
-		$$.as_pointer.ptr = $2.memory_location;
-		expression_result_free(&$2);
-	 }
-	| T_LEFT type_expression T_STAR T_RIGHT pointer_expression		{ expression_value_to_pointer(&$5, &$$, &$2); free_type($2.first); expression_result_free(&$5); }
 	| T_LEFT type_expression T_STAR T_RIGHT value_expression		{ expression_value_to_pointer(&$5, &$$, &$2); free_type($2.first); expression_result_free(&$5); }
-	| T_LEFT pointer_expression T_RIGHT					{ $$ = $2; }
-	| pointer_expression T_PLUS value_expression				{
-		$$ = $1;
-		if ($3.type.first == NULL) {
-			$$.flags |= EXPRESSION_ERROR;
-			sprintf($$.as_error, "Cannot do void pointer math");
-		} else {
-			if (is_primitive_integer_type($3.type.first)) {
-				$$.as_pointer.ptr += $3.as_int * get_type_memory_size($1.type.first->next);
-				expression_result_free(&$3);
-			} else {
-				$$.flags |= EXPRESSION_ERROR;
-				sprintf($$.as_error, "Cannot do pointer math with non-integers");
-			}
-		}
-	 }
-	 | pointer_expression T_MINUS value_expression				{
-		$$ = $1;
-		if ($3.type.first == NULL) {
-			$$.flags |= EXPRESSION_ERROR;
-			sprintf($$.as_error, "Cannot do void pointer math");
-		} else {
-			if (is_primitive_integer_type($3.type.first)) {
-				$$.as_pointer.ptr -= $3.as_int * get_type_memory_size($1.type.first->next);
-				expression_result_free(&$3);
-			} else {
-				$$.flags |= EXPRESSION_ERROR;
-				sprintf($$.as_error, "Cannot do pointer math with non-integers");
-			}
-		}
-	 }
-;
-
-type_expression: T_PRIMITIVE_TYPE
-;
-
-value_expression: T_PRIMITIVE_VALUE
-	| T_STAR pointer_expression						{ expression_dereference_pointer(&$2, &$$); expression_result_free(&$2); }
-	| T_LEFT type_expression T_RIGHT value_expression			{ convert_expression(&$4, &$$, &$2); free_type($2.first); expression_result_free(&$4); }
-	| T_LEFT value_expression T_RIGHT					{ $$ = $2; }
-	| value_expression T_PLUS value_expression				{ expression_math_add(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
-	| value_expression T_MINUS value_expression				{ expression_math_sub(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
-	| value_expression T_SLASH value_expression				{ expression_math_div(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
-	| value_expression T_STAR value_expression				{ expression_math_mul(&$1, &$3, &$$); expression_result_free(&$1); expression_result_free(&$3); }
-	| pointer_expression T_LEFT_BRACKET value_expression T_RIGHT_BRACKET    {
-		if ($3.type.first == NULL) {
-			$$.flags |= EXPRESSION_ERROR;
-			sprintf($$.as_error, "Cannot do math with void");
-		} else {
-			if (is_primitive_integer_type($3.type.first)) {
-				$1.as_pointer.ptr += $3.as_int * get_type_memory_size($1.type.first->next);
-				expression_dereference_pointer(&$1, &$$);
-				expression_result_free(&$1);
-				expression_result_free(&$3);
-			} else {
-				$$.flags |= EXPRESSION_ERROR;
-				sprintf($$.as_error, "Cannot index pointer by non-integer");
-			}
-		}
-	}
 
 error_expression: T_ERROR							{ strcpy($$, $1); }
 ;
@@ -148,6 +115,6 @@ void yyerror(const char* s)
 {
     if (!is_expression_result_error(get_expression_result()))
     {
-    	set_expression_result_error(get_expression_result(), s);
+    	set_expression_result_error_str(get_expression_result(), s);
     }
 }

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -42,18 +42,16 @@ static int symbol_compare(const void *p1, const void *p2)
     return s2->address - s1->address;
 }
 
-
-
+static char read_symbol_buf[2048];
 
 void read_symbol_file(char *filename)
 {
-    char  buf[512];
     FILE *fp = fopen(filename,"r");
 
     if ( fp != NULL ) {
-        while ( fgets(buf, sizeof(buf), fp) != NULL ) {
+        while ( fgets(read_symbol_buf, sizeof(read_symbol_buf), fp) != NULL ) {
             int argc;
-            char **argv = parse_words(buf,&argc);
+            char **argv = parse_words(read_symbol_buf,&argc);
 
             // Ignore
             if ( argc < 10 ) {


### PR DESCRIPTION
This change implements loading type information from CDB, aka
```
Decoded cdb: <T:F/usr/local/share/z88dk/lib/config/../..//include/arch/zx/spectrum.h$dirent[({0}S:S$d_ino$0_0$0({2}SI:U),Z,0,0)({2}S:S$d_name$0_0$0({12}DA12x,SC:S),Z,0,0)]>
Decoded cdb: <T:F/usr/local/share/z88dk/lib/config/../..//include/stdio.h$f0xx[({0}S:S$fd$0_0$0({2}SI:S),Z,0,0)({0}S:S$ptr$0_0$0({2}DG,SC:U),Z,0,0)]>
Decoded cdb: <T:Fmain.c$test_t[({0}S:S$vv1$0_0$0({2}SI:S),Z,0,0)({2}S:S$vv2$0_0$0({1}SC:S),Z,0,0)]>
```
(the loading code is pure garbage, but it works and I don't have energy to make it pretty)

Then, structs can be decoded, its child properties can be referenced.

```
    $8282    (_check+0)> p kek
Result: <struct test_t*> 0x9073

    $8282    (_check+0)> p *kek
Result: <struct test_t> {vv1=20, vv2=0}

    $8282    (_check+0)> p kek->vv1
Result: <int16_t> 20

    $8282    (_check+0)> p v
Result: <struct test_t> {vv1=20, vv2=0}

    $8282    (_check+0)> p &v
Result: <struct test_t*> 0x9073

    $8282    (_check+0)> p v.vv2
Result: <char> 0

    $8282    (_check+0)> p v.garbage
Error: Cannot find child member 'garbage' on an type <struct test_t>

    $8282    (_check+0)> p 4->haha
Error: Cannot do arrow (->) on a non-pointer type <int32_t>
```

Please use https://github.com/desertkun/z88dk-debug-error-minimum-example as an example.
At this point, only misc stuff (like enums) is left. Also, the Readme.md does not reflect existence of z88dk-gdb tool.