### PR TITLE
ticks: history variables

### DIFF
--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -838,20 +838,12 @@ type_chain* copy_type_chain(type_chain* from) {
     return result;
 }
 
-static int s_allocated_types = 0;
-
-int count_allocated_types()
-{
-    return s_allocated_types;
-}
-
 type_chain* malloc_type(enum type_record_type type) {
     type_chain* result = malloc(sizeof(type_chain));
     result->next = NULL;
     result->data = NULL;
     result->type_ = type;
     result->size = get_type_memory_size(result);
-    s_allocated_types++;
     return result;
 }
 
@@ -859,7 +851,6 @@ void free_type(type_chain* type) {
     while (type) {
         type_chain* next_next = type->next;
         free(type);
-        s_allocated_types--;
         type = next_next;
     }
 }

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -158,7 +158,6 @@ extern int debug_resolve_source(char *name);
 extern int debug_resolve_source_forward(const char *filename, const char* within_function, int lineno);
 
 extern type_chain* copy_type_chain(type_chain* from);
-extern int count_allocated_types();
 extern type_chain* malloc_type(enum type_record_type type);
 extern void free_type(type_chain* type);
 extern uint8_t is_primitive_integer_type(type_chain* type);

--- a/src/ticks/exp_engine.c
+++ b/src/ticks/exp_engine.c
@@ -6,7 +6,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-struct expression_result_t expression_result;
+struct expression_result_t expression_result = {};
+struct history_expression_t* history_expressions = NULL;
 
 struct {
     const char* type_name;
@@ -44,11 +45,6 @@ void set_expression_result_error(struct expression_result_t* result) {
 void set_expression_result_error_str(struct expression_result_t* result, const char* error) {
     result->flags |= EXPRESSION_ERROR;
     strcpy(result->as_error, error);
-    expression_result_free(result);
-}
-
-void reset_expression_result(struct expression_result_t* result) {
-    result->flags = EXPRESSION_UNKNOWN;
     expression_result_free(result);
 }
 

--- a/src/ticks/exp_engine.h
+++ b/src/ticks/exp_engine.h
@@ -26,6 +26,14 @@ struct expression_result_t {
     uint8_t flags;
 };
 
+struct history_expression_t {
+    char                        name[128];
+    struct expression_result_t  result;
+    UT_hash_handle              hh;
+};
+
+extern struct history_expression_t* history_expressions;
+
 extern void evaluate_expression_string(const char* expr);
 extern uint8_t is_expression_result_error(struct expression_result_t* result);
 extern void set_expression_result_error(struct expression_result_t* result);
@@ -44,7 +52,6 @@ extern void expression_math_mul(struct expression_result_t* a, struct expression
 extern void expression_math_div(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_string_get_type(const char* str, type_record* type);
 extern int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len);
-extern void reset_expression_result(struct expression_result_t* result);
 extern void zero_expression_result(struct expression_result_t* result);
 extern struct expression_result_t* get_expression_result();
 
@@ -53,6 +60,7 @@ struct lookup_t {
 };
 
 extern void debug_lookup_symbol(struct lookup_t* lookup, struct expression_result_t* result);
+extern void debug_lookup_history(const char* history, struct expression_result_t* result);
 
 
 #endif

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -12,6 +12,7 @@ int lookup_word();
 
 %}
 
+history_expr $[0-9]+
 word [a-zA-Z_][a-zA-Z0-9_]*
 struct_word "struct "[a-zA-Z_][a-zA-Z0-9_]*
 multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
@@ -42,6 +43,7 @@ multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"
 "&"		            { return T_AMPERSAND; }
 "."		            { return T_DOT; }
 "->"		        { return T_ARROW; }
+{history_expr}		{ strcpy(yylval.cval, yytext); return T_HISTORY_STRING; }
 {multiple_words}	{ return lookup_word(); }
 {word}		        { return lookup_word(); }
 {struct_word}       { return lookup_word(); }

--- a/src/ticks/expressions.y
+++ b/src/ticks/expressions.y
@@ -23,6 +23,7 @@ void yyerror(const char* s);
 
 %token<val> T_PRIMITIVE_VALUE
 %token<cval> T_STRING
+%token<cval> T_HISTORY_STRING
 
 %token<errval> T_ERROR
 %token T_PRIMITIVE_TYPE
@@ -58,6 +59,10 @@ value_expression: T_PRIMITIVE_VALUE
     		struct lookup_t lookup = {};
     		lookup.symbol_name = $1;
     		debug_lookup_symbol(&lookup, &$$);
+	}
+	| T_HISTORY_STRING							{
+    		zero_expression_result(&$$);
+    		debug_lookup_history($1, &$$);
 	}
 	| value_expression T_DOT T_STRING					{ expression_resolve_struct_member(&$1, $3, &$$); expression_result_free(&$1); }
 	| value_expression T_ARROW T_STRING					{ expression_resolve_struct_member_ptr(&$1, $3, &$$); expression_result_free(&$1); }
@@ -105,7 +110,6 @@ error_expression: T_ERROR							{ strcpy($$, $1); }
 
 void evaluate_expression_string(const char* expr)
 {
-    reset_expression_result(get_expression_result());
     YY_BUFFER_STATE st = yy_scan_string (expr);
     yyparse();
     yy_delete_buffer(st);


### PR DESCRIPTION
Every `p <x>` generates a `$nnnn` variable which can be later reused.

```
    $0038    (ASMDISP_RECV_CALLEE+49)> p (struct gdbserver_state_t*)0x3b02
$1 = <struct gdbserver_state_t*> 0x3b02

    $0038    (ASMDISP_RECV_CALLEE+49)> p $1
$2 = <struct gdbserver_state_t*> 0x3b02

    $0038    (ASMDISP_RECV_CALLEE+49)> p *$1
$3 = <struct gdbserver_state_t> {server_socket=20, client_socket=0, loop_running=0, incoming_buffer=0x3b07 [128] = { [0] = 0, [1] = 0, [2] = 0, [3] = 0, [4] = 0, [5] = 0, [6] = 0, [7] = 0, [8] = 0, [9] = 0 ... }}

    $0038    (ASMDISP_RECV_CALLEE+49)> p $7
Error: Cannot find item <$7> in history
```