### PR TITLE
classic - differentiate signed vs unsigned multiply

### DIFF
--- a/lib/z80_crt0.hdr
+++ b/lib/z80_crt0.hdr
@@ -97,6 +97,7 @@
 	EXTERN    l_bcneg
 	EXTERN    l_case	;Integer case
 	EXTERN    l_mult	;Integer hl = hl * de
+	EXTERN    l_mult_u	;Integer unsigned *
 	EXTERN    l_div		;Integer signed / hl=de/hl, de=de%hl
 	EXTERN    l_div_u	;Integer unsigned /
 	EXTERN    l_mod		;Integer % (for gbz80) hl=de%hl
@@ -148,6 +149,7 @@
 	EXTERN	l_long_mod
 	EXTERN	l_long_mod_u
 	EXTERN	l_long_mult
+	EXTERN	l_long_mult_u
 	EXTERN	l_long_asr_u	;Long unsigned >>
 	EXTERN	l_long_asr_uo	;Long unsigned >> shift in c
 	EXTERN	l_long_case
@@ -307,6 +309,7 @@
 	EXTERN	l_i64_add
 	EXTERN	l_i64_sub
 	EXTERN	l_i64_mult
+	EXTERN	l_i64_mult_u
 	EXTERN	l_i64_mod
 	EXTERN	l_i64_mod_u
 	EXTERN	l_i64_div

--- a/libsrc/_DEVELOPMENT/l/sccz80/4-r2k/l_mult.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/4-r2k/l_mult.asm
@@ -3,6 +3,7 @@ SECTION code_clib
 SECTION code_l_sccz80
 
 PUBLIC  l_mult
+PUBLIC  l_mult_u
 PUBLIC  l_mult_0
 
 ; Entry: hl = value1
@@ -10,6 +11,7 @@ PUBLIC  l_mult_0
 ; Exit:  hl = value1 * value2
 
 .l_mult
+.l_mult_u
     ld      bc,hl
 .l_mult_0
     defb    0xf7    ; mul : hlbc = bc * de

--- a/libsrc/_DEVELOPMENT/l/sccz80/4-z180/l_mult.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/4-z180/l_mult.asm
@@ -3,6 +3,7 @@
 SECTION code_clib
 SECTION code_l_sccz80
 PUBLIC  l_mult
+PUBLIC  l_mult_u
 
 PUBLIC  l_mult_0
 
@@ -17,6 +18,7 @@ PUBLIC  l_mult_0
 ; Exit:  hl = value1 * value2
 
 .l_mult
+.l_mult_u
     ld  a,d     ; a = xh
     ld  d,h     ; d = yh
     ld  h,a     ; h = xh

--- a/libsrc/_DEVELOPMENT/l/sccz80/5-z80/i64/l_i64_mult_u.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/5-z80/i64/l_i64_mult_u.asm
@@ -1,22 +1,22 @@
 
     SECTION code_l_sccz80
-    PUBLIC  l_i64_mult
+    PUBLIC  l_i64_mult_u
     EXTERN  __i64_acc
     EXTERN  __i64_extra
-    EXTERN  l_muls_64_64x64
+    EXTERN  l_mulu_64_64x64
     EXTERN  l_store_64_dehldehl_mbc
 
 ; Entry: acc = RHS (divisor)
 ;        sp+2 = LHS (dividend)
 ; Exit:  acc = LHS * RHS
-l_i64_mult:
+l_i64_mult_u:
 	ld	hl,2
 	add	hl,sp
 	ld	de,__i64_extra
 	ld	bc,8
 	ldir
 	ld	ix,__i64_extra
-	call	l_muls_64_64x64
+	call	l_mulu_64_64x64
 	;dehl'dehl = remainder, copy it into fac
 	ld	bc,__i64_acc
 	call	l_store_64_dehldehl_mbc

--- a/libsrc/_DEVELOPMENT/l/sccz80/z80.lst
+++ b/libsrc/_DEVELOPMENT/l/sccz80/z80.lst
@@ -14,6 +14,7 @@ ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_eq
 ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_lneg
 ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_and
 ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_mult
+${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_mult_u
 ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_push_under_int
 ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_uge
 ${NEWLIB_ROOT}l/sccz80/5-z80/i64/l_i64_ule

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -2216,12 +2216,18 @@ void mult(LVALUE* lval)
 {
     switch (lval->val_type) {
     case KIND_LONGLONG:
-        callrts("l_i64_mult");
+        if (ulvalue(lval))
+            callrts("l_i64_mult_u");
+        else
+            callrts("l_i64_mult");
         Zsp += 8;
         break;
     case KIND_LONG:
     case KIND_CPTR:
-        callrts("l_long_mult");
+        if (ulvalue(lval))
+            callrts("l_long_mult_u");
+        else
+            callrts("l_long_mult");
         Zsp += 4;
         break;
     case KIND_FLOAT16:
@@ -2256,7 +2262,10 @@ void mult(LVALUE* lval)
             }
         }
     default:
-        callrts("l_mult"); 
+        if (ulvalue(lval))
+            callrts("l_mult_u");
+        else
+            callrts("l_mult");
     }
 }
 

--- a/testsuite/results/Issue_1623_stdcbench_issues.opt
+++ b/testsuite/results/Issue_1623_stdcbench_issues.opt
@@ -91,7 +91,7 @@
 	ld	bc,20480
 	push	bc
 	call	l_long_div_u
-	call	l_long_mult
+	call	l_long_mult_u
 	push	de
 	push	hl
 	ld	hl,100	;const

--- a/testsuite/results/z180/Issue_481_multiply_char.opt
+++ b/testsuite/results/z180/Issue_481_multiply_char.opt
@@ -51,7 +51,7 @@
 	ld	d,0
 	pop	hl
 	push	hl
-	call	l_mult
+	call	l_mult_u
 	inc	sp
 	pop	bc
 	ret
@@ -67,7 +67,7 @@
 	add	hl,sp
 	ld	l,(hl)
 	ld	h,0
-	call	l_mult
+	call	l_mult_u
 	inc	sp
 	pop	bc
 	ret


### PR DESCRIPTION
When the result of a multiply is the same size as the multiplicands there's no reason to differentiate on signed or unsigned, except where the algorithm is trying to optimise on zeros, or to avoid sign handling overhead.

The newlib integer and long fast math libraries do this for z80, by [making the multiplicands positive](https://github.com/z88dk/z88dk/blob/master/libsrc/_DEVELOPMENT/math/integer/fast/l_fast_muls_16_16x16.asm#L47) before multiplication, so it makes sense to allow sccz80 to use the correct unsigned multiply where appropriate (eg. for pointers that could look negative although they're just large) to avoid the overhead of double `l_neg` handling.

Aside from z80 case, the sccz80 signed `l_mult` and unsigned `l_mult_u` (etc) implementations are identical.
Or at least they are today.