### PR TITLE
Ticks breaking

### DIFF
--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -42,6 +42,7 @@ typedef struct {
     debugger_write_memory_cb debugger_write_memory;
     debugger_read_memory_cb debugger_read_memory;
     void_cb invalidate;
+    uint8_t breakable;
     void_cb break_;
     void_cb resume;
     void_cb next;

--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -10,7 +10,7 @@ typedef uint16_t (*get_uint16_cb)();
 typedef long long (*get_longlong_cb)();
 typedef int (*get_int_cb)();
 typedef void (*reset_paging_cb)();
-typedef uint8_t (*restore_cb)(const char* file_path, uint16_t at);
+typedef uint8_t (*restore_cb)(const char* file_path, uint16_t at, uint8_t set_pc);
 typedef void (*out_cb)(int port, int value);
 typedef void (*debugger_write_memory_cb)(int addr, uint8_t val);
 typedef void (*debugger_read_memory_cb)(int addr);

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -276,6 +276,8 @@ static void completion(const char *buf, linenoiseCompletions *lc, void *ctx)
     }
 }
 
+static uint8_t confirm(const char* message);
+
 void debugger_process_signals()
 {
     if (break_required)
@@ -284,7 +286,10 @@ void debugger_process_signals()
             printf("Requesting a break...\n");
             bk.break_();
         } else {
-            printf("Warning: cannot request a break, use other means\n");
+            if (confirm("Cannot request a break, would you like to quit instead?"))
+            {
+                exit(1);
+            }
         }
         break_required = 0;
         return;

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -280,8 +280,12 @@ void debugger_process_signals()
 {
     if (break_required)
     {
-        printf("Requesting a break...\n");
-        bk.break_();
+        if (bk.breakable) {
+            printf("Requesting a break...\n");
+            bk.break_();
+        } else {
+            printf("Warning: cannot request a break, use other means\n");
+        }
         break_required = 0;
         return;
     }

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -699,6 +699,9 @@ static uint8_t process_packet()
 
     if (checksum != (hex(inbuf[packetend + 1]) << 4 | hex(inbuf[packetend + 2])))
     {
+        if (verbose) {
+            printf("Warning: incorrect checksum, expected: %02x\n", checksum);
+        }
         inbuf_erase_head(packetend + 3);
         return 1;
     }

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -603,6 +603,7 @@ static backend_t gdb_backend = {
     .debugger_write_memory = &debugger_write_memory,
     .debugger_read_memory = &debugger_read_memory,
     .invalidate = &invalidate,
+    .breakable = 1,
     .break_ = &debugger_break,
     .resume = &debugger_resume,
     .next = &debugger_next,
@@ -854,6 +855,11 @@ int main(int argc, char **argv) {
         {
             printf("Remote target does not support qXfer:features:read+\n");
             goto shutdown;
+        }
+
+        if (strstr(supported, "NonBreakable")) {
+            printf("Warning: remote is not breakable; cannot request execution to stop from here\n");
+            bk.breakable = 0;
         }
     }
 

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -546,7 +546,7 @@ void debugger_step()
     debugger_active = 0;
 }
 
-uint8_t debugger_restore(const char* file_path, uint16_t at)
+uint8_t debugger_restore(const char* file_path, uint16_t at, uint8_t set_pc)
 {
     FILE *f = fopen(file_path, "rb");
     if (f == NULL)
@@ -589,14 +589,16 @@ uint8_t debugger_restore(const char* file_path, uint16_t at)
 
     printf("OK\n");
 
-    // zero out all registers except for pc
-    struct debugger_regs_t regs;
-    bk.get_regs(&regs);
-    int sp = regs.sp;
-    memset(&regs, 0, sizeof(regs));
-    regs.pc = at;
-    regs.sp = sp;
-    set_regs(&regs);
+    if (set_pc) {
+        // zero out all registers except for pc
+        struct debugger_regs_t regs;
+        bk.get_regs(&regs);
+        int sp = regs.sp;
+        memset(&regs, 0, sizeof(regs));
+        regs.pc = at;
+        regs.sp = sp;
+        set_regs(&regs);
+    }
     return 0;
 }
 

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -923,7 +923,6 @@ int main(int argc, char **argv) {
 
         XMLDoc_free(&xml);
 
-        uint8_t got_ix = 0;
         uint8_t got_sp = 0;
         uint8_t got_pc = 0;
         if (verbose) {
@@ -932,10 +931,6 @@ int main(int argc, char **argv) {
         for (int i = 0; i < register_mappings_count; i++) {
             if (verbose) {
                 printf(" %s", register_mapping_names[register_mappings[i]]);
-            }
-            if (register_mappings[i] == REGISTER_MAPPING_IX) {
-                got_ix = 1;
-                continue;
             }
             if (register_mappings[i] == REGISTER_MAPPING_SP) {
                 got_sp = 1;
@@ -949,7 +944,7 @@ int main(int argc, char **argv) {
         if (verbose) {
             printf("\n");
         }
-        if (got_ix == 0 || got_pc == 0 || got_sp == 0) {
+        if (got_pc == 0 || got_sp == 0) {
             printf("Insufficient register information.\n");
         }
     }

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -580,6 +580,7 @@ uint8_t debugger_restore(const char* file_path, uint16_t at)
 
     // zero out all registers except for pc
     struct debugger_regs_t regs;
+    bk.get_regs(&regs);
     int sp = regs.sp;
     memset(&regs, 0, sizeof(regs));
     regs.pc = at;

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -193,6 +193,7 @@ backend_t ticks_debugger_backend = {
     .debugger_write_memory = &debugger_write_memory,
     .debugger_read_memory = &debugger_read_memory,
     .invalidate = &invalidate,
+    .breakable = 1,
     .break_ = &break_,
     .resume = &resume,
     .next = &next,

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -127,7 +127,7 @@ void invalidate() {}
 void break_() {debugger_active=1; }
 void resume() {}
 void detach() {}
-uint8_t restore(const char* file_path, uint16_t at) {
+uint8_t restore(const char* file_path, uint16_t at, uint8_t set_pc) {
     printf("Not supported.\n");
     return 1;
 }


### PR DESCRIPTION
I think I have figured out a way to do real hardware debugging, e.g. a gdbserver run on spectrum itself (via spectranet).

That would require slight spectranet change, though, while I am going to try and make the change, I need these.

1. Remote is "NonBreakable", means you can not break execution by pressing CTRL+C, you'd have to press the NMI button on the hardware.
2. Memory is limited and thus packet size is reduced, we have to respect that.
3. That debugger is going to support only sp, pc, hl, de, bc and af for now, and thus ix is optional for debugging (since we have __debug_framepointer anyway)
4. Restore did not respect sp (whoops)