### PR TITLE
fix: add .gitignore entries for zsdcc_*_src.tar.gz and include/alloc/malloc.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,5 @@ win32/Release/
 win32/ipch/
 win32/z88dk.VC.VC.opendb
 win32/z88dk.VC.db
+zsdcc_*_src.tar.gz
+include/alloc/malloc.h


### PR DESCRIPTION
fix: add .gitignore entries for zsdcc_*_src.tar.gz and include/alloc/malloc.h