### PR TITLE
fix: unconditionally define memory map for banks in ZX crt0

### DIFF
--- a/lib/target/zx/classic/spec_crt0.asm
+++ b/lib/target/zx/classic/spec_crt0.asm
@@ -398,10 +398,9 @@ romsvc:         defs    10  ; Pointer to the end of the sysdefvars
 ENDIF
 
 
-IF __MMAP != -1
-    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-    ; Define Memory Banks
-    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Define Memory Banks
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
     IFNDEF CRT_ORG_BANK_0
         defc CRT_ORG_BANK_0 = 0xc000
@@ -499,4 +498,3 @@ IF __MMAP != -1
     SECTION DATA_7
     SECTION BSS_7
     SECTION BANK_7_END
-ENDIF


### PR DESCRIPTION
Base address definitions for memory banks in Classic are defined conditionally only if no custom memory map is used. But they are defined unconditionally in NEWLIB, and in Classic for ZXN...

Since they are only definitions (they do not occupy space) and they are always the same (banking on the ZX is always done at 0xC000), they should be defined unconditionally.