### PR TITLE
(intel/gb) memswap optimisation for size >= 2

### DIFF
--- a/libsrc/_DEVELOPMENT/string/z80/asm_memswap.asm
+++ b/libsrc/_DEVELOPMENT/string/z80/asm_memswap.asm
@@ -41,23 +41,26 @@ IF __CPU_INTEL__ || __CPU_GBZ80__
    inc b
    inc c
 
+   ld a,b
+loop_a:
+   push af
+
 loop:
-   push bc
-
    ld a,(de)
-   ld c,a
+   ld b,(hl)
 
-   ld a,(hl)
+   ld (hl+),a
+   ld a,b
    ld (de+),a
 
-   ld a,c
-   ld (hl+),a
-
-   pop bc
    dec c
    jr NZ,loop
-   dec b
-   jr NZ,loop
+
+   pop af
+   dec a
+   jr NZ,loop_a
+
+   ld b,a
 
 ELSE
 


### PR DESCRIPTION
for size == 1 it is +4T (to produce bc=0 upon exit)

Question: the bc=0 on exit (`asm_memswap`) seems to be unused by the library code, are those ABI described in comments mandatory and locked, or may it be worth to break it and say BC is just modified? If it would be possible to drop bc=0 on exit, then the `ld b,a` before `ret` can be removed too and the routine will have same performance for size==1 as current one.

I'm also planning to add few more changes optimising some GB paths, so draft PR at this moment, but I did want to ask about that bc=0, as it's a bit annoying there's +4T for size==1.