### PR TITLE
tests - stdlib - adding qsort tests for classic and new lib

### DIFF
--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/Makefile
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/Makefile
@@ -1,0 +1,56 @@
+
+.PHONY: all clean
+
+SOURCES += $(wildcard *.c)
+
+all:	benchmark.txt
+
+STYLES_VAL=0 1 2 3
+STYLES_NAME=ran ord rev equ
+
+CFLAGS += -D__Z88DK
+
+# EXESUFFIX is passed when cross-compiling Win32 on Linux
+ifeq ($(OS),Windows_NT)
+  EXESUFFIX 		:= .exe
+else
+  EXESUFFIX 		?=
+endif
+
+MACHINE = z88dk-ticks$(EXESUFFIX) -counter 999999999999
+
+define compile_classic_sccz80	# arg1 = binary name, arg2 = extra defines, arg3 = extra linking options
+	zcc +test -vn $(2) $(CFLAGS) -O2 $< -o $(1) -lndos $(3) -m
+endef
+
+define compile_classic_zsdcc	# arg1 = binary name, arg2 = extra defines, arg3 = extra linking options
+	zcc +test -vn $(2) $(CFLAGS) -compiler=sdcc -SO3 --max-allocs-per-node200000 $< -o $(1) -lndos $(3) -m
+endef
+
+define benchmark_case	# arg1 = compiler, arg2 = binary name, arg3 = extra defines, arg4 = extra linking options
+	$(call compile_classic_$(1),$(2),-DTIMER $(3),$(4))
+	@echo -n "$(2:%.bin=%) " >> $@
+	@# run sort + verification + no timing for exit status (FAIL), if OK, run again for timing
+	$(MACHINE) $(2) > /dev/null \
+	&& $(MACHINE) -x $(2:%.bin=%.map) -start TIMER_START -end TIMER_STOP $(2) >> $@ \
+	|| echo " FAIL" >> $@
+
+endef
+
+define benchmark_styles # arg1 = compiler, arg2 = numbers-count
+	$(foreach STYLE_IDX,1 2 3 4,\
+		$(call benchmark_case,$(1),sort-$(1)-$(word $(STYLE_IDX),$(STYLES_NAME))-$(2).bin,-DNUM=$(2) -DSTYLE=$(word $(STYLE_IDX),$(STYLES_VAL))))
+	@echo "" >> $@;
+endef
+
+benchmark.txt: sort.c Makefile
+	@echo `date +"%Y-%m-%d %H:%M:%S"` " Starting test\n" > $@
+	@echo "classic / sccz80\n`tail -1 ../../../../../../src/config.h`\n" >> $@
+	$(foreach NUM,20 5000,$(call benchmark_styles,sccz80,$(NUM)))
+	@echo "classic / zsdcc\n`z88dk-zsdcc --version | grep Build`\n" >> $@
+	$(foreach NUM,20 5000,$(call benchmark_styles,zsdcc,$(NUM)))
+	@echo `date +"%Y-%m-%d %H:%M:%S"` " Test completed" >> $@
+	cat $@
+
+clean:
+	rm -f sort-*.bin sort-*.map benchmark.txt *~

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/benchmark.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/benchmark.txt
@@ -1,0 +1,29 @@
+2022-03-14 19:43:48  Starting test
+
+classic / sccz80
+#define Z88DK_VERSION "19388-38ebdf3b7-20220307"
+
+sort-sccz80-ran-20 82618
+sort-sccz80-ord-20 52586
+sort-sccz80-rev-20 74474
+sort-sccz80-equ-20 52586
+
+sort-sccz80-ran-5000 93581395
+sort-sccz80-ord-5000 41378393
+sort-sccz80-rev-5000 63352461
+sort-sccz80-equ-5000 41378393
+
+classic / zsdcc
+Build: 4.2.0 #13081 (Linux) Mar 10 2022
+
+sort-zsdcc-ran-20 76591
+sort-zsdcc-ord-20 48639
+sort-zsdcc-rev-20 69357
+sort-zsdcc-equ-20 48639
+
+sort-zsdcc-ran-5000 86069623
+sort-zsdcc-ord-5000 37803151
+sort-zsdcc-rev-5000 58230674
+sort-zsdcc-equ-5000 37803151
+
+2022-03-14 19:44:13  Test completed

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/readme.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/readme.txt
@@ -79,35 +79,35 @@ All programs are very close in size.
 RESULT
 ======
 
-Z88DK March 25, 2017
-classic / sccz80
-1029 bytes less page zero
+Z88DK March 14, 2022
+classic / sccz80 Version: 19388-38ebdf3b7-20220307
+1743 bytes less page zero
 
                cycle count    time @ 4MHz
 
-sort-ran-20          81544     0.0204 sec
-sort-ord-20          53944     0.0135 sec
-sort-rev-20          75472     0.0189 sec
-sort-equ-20          53944     0.0135 sec
+sort-ran-20          82618     0.0207 sec
+sort-ord-20          52586     0.0131 sec
+sort-rev-20          74474     0.0186 sec
+sort-equ-20          52586     0.0131 sec
 
-sort-ran-5000     80957310    20.2393 sec
-sort-ord-5000     41381930    10.3455 sec
-sort-rev-5000     63068198    15.7670 sec
-sort-equ-5000     41381930    10.3455 sec
+sort-ran-5000     93581395    23.3953 sec
+sort-ord-5000     41378393    10.3446 sec
+sort-rev-5000     63352461    15.8381 sec
+sort-equ-5000     41378393    10.3446 sec
 
 
-Z88DK March 25, 2017
-classic / zsdcc #9852
-995 bytes less page zero
+Z88DK March 14, 2022
+classic / zsdcc Build: 4.2.0 #13081
+1711 bytes less page zero
 
                cycle count    time @ 4MHz
 
-sort-ran-20          77922     0.0195 sec
-sort-ord-20          50242     0.0126 sec
-sort-rev-20          70672     0.0177 sec
-sort-equ-20          50242     0.0126 sec
+sort-ran-20          76591     0.0191 sec
+sort-ord-20          48639     0.0122 sec
+sort-rev-20          69357     0.0173 sec
+sort-equ-20          48639     0.0122 sec
 
-sort-ran-5000     85903658    21.4759 sec
-sort-ord-5000     38026708     9.5067 sec
-sort-rev-5000     58261603    14.5654 sec
-sort-equ-5000     38026708     9.5067 sec
+sort-ran-5000     86069623    21.5174 sec
+sort-ord-5000     37803151     9.4508 sec
+sort-rev-5000     58230674    14.5577 sec
+sort-equ-5000     37803151     9.4508 sec

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/sort.c
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-classic/sort.c
@@ -108,8 +108,8 @@ int main(void)
       PRINTF2("%u, ", numbers[i]);
       if ((i > 0) && (numbers[i] < numbers[i-1]))
       {
-         PRINTF1("\n\nFAIL");
-         break;
+         PRINTF1("\n\nFAIL\n\n\n");
+         return 1;
       }
    }
    

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/Makefile
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/Makefile
@@ -5,7 +5,7 @@ SOURCES += $(wildcard *.c)
 
 # the sort implementation is included directly during compilation to make it amendable by config_private.inc
 # overshadowing the pre-compiled newlib data (avoiding full rebuild of newlib for each test case)
-EXTRA_ASM_SOURCE = $(wildcard ../../../../stdlib/z80/sort/*.asm) ../../../../stdlib/z80/asm_qsort.asm
+EXTRA_ASM_SOURCE = $(wildcard ../../../../stdlib/z80/sort/*.asm) asm_handwritten.asm
 
 all:	benchmark.txt
 
@@ -19,7 +19,9 @@ NUM_OPTIONS=20 5000
 # quick common options
 SORT_OPTS=1+0 2+0xc
 # complete test (takes several minutes)
-# SORT_OPTS=0+0 1+0 2+0x0 2+0x1 2+0x4 2+0x5 2+0x8 2+0x9 2+0xc 2+0xd
+# SORT_OPTS=0+0 1+0 2+0x0 2+0x1 2+0x4 2+0x5 2+0x8 2+0x9 2+0xc 2+0xd 3+0
+### the option "3+0" is not part of the newlib, and selects hand-written hard-coded quick sort
+### for size=2 and uint16_t compare of elements in array (not using compare function)
 
 # CFLAGS +=
 

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/Makefile
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/Makefile
@@ -1,0 +1,58 @@
+
+.PHONY: all clean
+
+SOURCES += $(wildcard *.c)
+
+all:	benchmark.txt
+
+STYLES_VAL=0 1 2 3
+STYLES_NAME=ran ord rev equ
+
+# CFLAGS +=
+
+# EXESUFFIX is passed when cross-compiling Win32 on Linux
+ifeq ($(OS),Windows_NT)
+  EXESUFFIX 		:= .exe
+else
+  EXESUFFIX 		?=
+endif
+
+MACHINE = z88dk-ticks$(EXESUFFIX) -counter 999999999999
+
+define compile_newlib_sccz80	# arg1 = binary name w/o extension, arg2 = extra defines, arg3 = extra linking options
+	zcc +z80 -vn -startup=0 $(2) $(CFLAGS) -clib=new -O2 $< -o $(1) $(3) -m -create-app
+	@rm $(1)_CODE.bin $(1)_UNASSIGNED.bin
+endef
+
+define compile_newlib_zsdcc	# arg1 = binary name w/o extension, arg2 = extra defines, arg3 = extra linking options
+	zcc +z80 -vn -startup=0 $(2) $(CFLAGS) -clib=sdcc_iy -SO3 --max-allocs-per-node200000 $< -o $(1) $(3) -m -create-app
+	@rm $(1)_CODE.bin $(1)_UNASSIGNED.bin
+endef
+
+define benchmark_case	# arg1 = compiler, arg2 = binary name, arg3 = extra defines, arg4 = extra linking options
+	$(call compile_newlib_$(1),$(2:%.bin=%),-DTIMER $(3),$(4))
+	@echo -n "$(2:%.bin=%) " >> $@
+	@# run sort + verification + no timing for exit status (FAIL), if OK, run again for timing
+	$(MACHINE) $(2) > /dev/null \
+	&& $(MACHINE) -x $(2:%.bin=%.map) -start TIMER_START -end TIMER_STOP $(2) >> $@ \
+	|| echo " FAIL" >> $@
+
+endef
+
+define benchmark_styles # arg1 = compiler, arg2 = numbers-count
+	$(foreach STYLE_IDX,1 2 3 4,\
+		$(call benchmark_case,$(1),sort-$(1)-$(word $(STYLE_IDX),$(STYLES_NAME))-$(2).bin,-DNUM=$(2) -DSTYLE=$(word $(STYLE_IDX),$(STYLES_VAL))))
+	@echo "" >> $@;
+endef
+
+benchmark.txt: sort.c Makefile
+	@echo `date +"%Y-%m-%d %H:%M:%S"` " Starting test\n" > $@
+	@echo "classic / sccz80\n`tail -1 ../../../../../../src/config.h`\n" >> $@
+	$(foreach NUM,20 5000,$(call benchmark_styles,sccz80,$(NUM)))
+	@echo "classic / zsdcc\n`z88dk-zsdcc --version | grep Build`\n" >> $@
+	$(foreach NUM,20 5000,$(call benchmark_styles,zsdcc,$(NUM)))
+	@echo `date +"%Y-%m-%d %H:%M:%S"` " Test completed" >> $@
+	cat $@
+
+clean:
+	rm -f sort-*.bin sort-*.map benchmark.txt *~

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/Makefile
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/Makefile
@@ -3,10 +3,23 @@
 
 SOURCES += $(wildcard *.c)
 
+# the sort implementation is included directly during compilation to make it amendable by config_private.inc
+# overshadowing the pre-compiled newlib data (avoiding full rebuild of newlib for each test case)
+EXTRA_ASM_SOURCE = $(wildcard ../../../../stdlib/z80/sort/*.asm) ../../../../stdlib/z80/asm_qsort.asm
+
 all:	benchmark.txt
+
+SCCZ80_VERSION = $(shell grep -o -e 'Z88DK_VERSION.*' ../../../../../../src/config.h)
+ZSDCC_VERSION = $(shell z88dk-zsdcc --version | grep Build)
 
 STYLES_VAL=0 1 2 3
 STYLES_NAME=ran ord rev equ
+NUM_OPTIONS=20 5000
+
+# quick common options
+SORT_OPTS=1+0 2+0xc
+# complete test (takes several minutes)
+# SORT_OPTS=0+0 1+0 2+0x0 2+0x1 2+0x4 2+0x5 2+0x8 2+0x9 2+0xc 2+0xd
 
 # CFLAGS +=
 
@@ -20,12 +33,12 @@ endif
 MACHINE = z88dk-ticks$(EXESUFFIX) -counter 999999999999
 
 define compile_newlib_sccz80	# arg1 = binary name w/o extension, arg2 = extra defines, arg3 = extra linking options
-	zcc +z80 -vn -startup=0 $(2) $(CFLAGS) -clib=new -O2 $< -o $(1) $(3) -m -create-app
+	zcc +z80 -vn -startup=0 $(2) $(CFLAGS) -clib=new -O2 $(EXTRA_ASM_SOURCE) $< -o $(1) $(3) -m -create-app
 	@rm $(1)_CODE.bin $(1)_UNASSIGNED.bin
 endef
 
 define compile_newlib_zsdcc	# arg1 = binary name w/o extension, arg2 = extra defines, arg3 = extra linking options
-	zcc +z80 -vn -startup=0 $(2) $(CFLAGS) -clib=sdcc_iy -SO3 --max-allocs-per-node200000 $< -o $(1) $(3) -m -create-app
+	zcc +z80 -vn -startup=0 $(2) $(CFLAGS) -clib=sdcc_iy -SO3 --max-allocs-per-node200000 $(EXTRA_ASM_SOURCE) $< -o $(1) $(3) -m -create-app
 	@rm $(1)_CODE.bin $(1)_UNASSIGNED.bin
 endef
 
@@ -45,14 +58,25 @@ define benchmark_styles # arg1 = compiler, arg2 = numbers-count
 	@echo "" >> $@;
 endef
 
+define benchmark_configs # arg1 = compiler, arg2 = OPT_SORT+OPT_SORT_QSORT values
+	@echo "defc __CLIB_OPT_SORT = $(word 1,$(subst +, ,$(2)))\ndefc __CLIB_OPT_SORT_QSORT = $(word 2,$(subst +, ,$(2)))\n" > config_private.inc
+	@cat config_private.inc
+	@cat config_private.inc >> $@
+	$(foreach NUM,$(NUM_OPTIONS),$(call benchmark_styles,$(1),$(NUM)))
+
+endef
+
 benchmark.txt: sort.c Makefile
 	@echo `date +"%Y-%m-%d %H:%M:%S"` " Starting test\n" > $@
-	@echo "classic / sccz80\n`tail -1 ../../../../../../src/config.h`\n" >> $@
-	$(foreach NUM,20 5000,$(call benchmark_styles,sccz80,$(NUM)))
-	@echo "classic / zsdcc\n`z88dk-zsdcc --version | grep Build`\n" >> $@
-	$(foreach NUM,20 5000,$(call benchmark_styles,zsdcc,$(NUM)))
+	@echo "----------------------------------------------------------------------\nnew c library / sccz80\n$(SCCZ80_VERSION)\n"
+	@echo "----------------------------------------------------------------------\nnew c library / sccz80\n$(SCCZ80_VERSION)\n" >> $@
+	$(foreach S_OPTS,$(SORT_OPTS),$(call benchmark_configs,sccz80,$(S_OPTS)))
+	@echo "----------------------------------------------------------------------\nnew c library / zsdcc\n$(ZSDCC_VERSION)\n"
+	@echo "----------------------------------------------------------------------\nnew c library / zsdcc\n$(ZSDCC_VERSION)\n" >> $@
+	$(foreach S_OPTS,$(SORT_OPTS),$(call benchmark_configs,zsdcc,$(S_OPTS)))
 	@echo `date +"%Y-%m-%d %H:%M:%S"` " Test completed" >> $@
+	@rm config_private.inc
 	cat $@
 
 clean:
-	rm -f sort-*.bin sort-*.map benchmark.txt *~
+	rm -f sort-*.bin sort-*.tap sort-*.map config_private.inc benchmark.txt *~

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/asm_handwritten.asm
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/asm_handwritten.asm
@@ -1,0 +1,206 @@
+
+; ===============================================================
+; replacing newlib stdlib/z80/asm_qsort.asm file, to enable extra
+; __CLIB_OPT_SORT == 3 for hand-written hard-coded assembly.
+; ===============================================================
+
+INCLUDE "config_private.inc"
+
+SECTION code_clib
+SECTION code_stdlib
+
+PUBLIC asm_qsort
+
+   ; enter : ix = int (*compar)(de=const void *, hl=const void *)
+   ;         bc = void *base
+   ;         hl = size_t nmemb
+   ;         de = size_t size
+   ;
+   ; exit  : none
+   ;
+   ;         if an error below occurs, no sorting is done.
+   ;
+   ;         einval if size == 0
+   ;         einval if array size > 64k
+   ;         erange if array wraps 64k boundary
+   ;
+   ; uses  : af, bc, de, hl, compare function
+
+IF __CLIB_OPT_SORT = 0
+
+   ; insertion sort selected
+
+   EXTERN asm_insertion_sort
+   defc asm_qsort = asm_insertion_sort
+
+ENDIF
+
+IF __CLIB_OPT_SORT = 1
+
+   ; shellsort selected
+
+   EXTERN asm_shellsort
+   defc asm_qsort = asm_shellsort
+
+ENDIF
+
+IF __CLIB_OPT_SORT = 2
+
+   ; quicksort selected
+
+   EXTERN asm_quicksort
+   defc asm_qsort = asm_quicksort
+
+ENDIF
+
+IF __CLIB_OPT_SORT = 3
+
+   ; ===============================================================
+   ; selecting the benchmark "extras", hand-written routine with
+   ; fixed size=2 and uint16_t compare of elements, ignoring ix argument
+   ; ===============================================================
+
+   defc asm_qsort = asm_handwritten_qsort
+
+asm_handwritten_qsort:
+
+   ; enter : ~~ix = int (*compar)(de=const void *, hl=const void *)~~ (IGNORED!)
+   ;         bc = void *base
+   ;         hl = size_t nmemb
+   ;         ~~de = size_t size~~  (must be two, otherwise error is reported)
+   ;
+   ; exit  : none
+   ;
+   ;         if an error below occurs, no sorting is done.
+   ;
+   ;         einval if size != 2
+   ;         einval if array size > 64k
+   ;         erange if array wraps 64k boundary
+   ;
+   ; uses  : af, bc, de, hl
+
+EXTERN __sort_parameters
+
+   ; handwritten qsort is hard-coded to size==2, if not de==2, report invalid arg
+   ld a,e
+   sub 2
+   or d
+   jr z, size_is_two          ; de == 2 -> ok
+   ld de,0  ; make __sort_parameters fail on size
+size_is_two:
+   call __sort_parameters
+   ret c                       ; if error
+
+   ; de = array_lo
+   ; hl = array_hi
+   ; bc = size (2 enforced)
+   ; ix = compare
+
+quicksort_a:
+
+    ; convert arguments to HL=A.begin(), DE=A.end() and continue with quicksort_a_impl
+    ex      de,hl
+    inc     de
+    inc     de
+
+;--------------------------------------------------------------------------------------------------------------------
+; Quicksort implementation, inputs:
+; HL = uint16_t* A.begin() (pointer to beginning of array)
+; DE = uint16_t* A.end() (pointer beyond array)
+; modifies: AF, A'F', BC, HL (DE is preserved)
+quicksort_a_impl:
+    ; array must be located within 0x0002..0xFFFD
+    ld      c,l
+    ld      b,h         ; BC = A.begin()
+    ; if (len < 2) return; -> if (end <= begin+2) return;
+    inc     hl
+    inc     hl
+    or      a
+    sbc     hl,de       ; HL = -(2*len-2), len = (2-HL)/2
+    ret     nc          ; case: begin+2 >= end <=> (len < 2)
+
+    push    de          ; preserve A.end() for recursion
+    push    bc          ; preserve A.begin() for recursion
+
+    ; uint16_t pivot = A[len / 2];
+    rr      h
+    rr      l
+    dec     hl
+    res     0,l
+    add     hl,de
+    ld      a,(hl)
+    inc     hl
+    ld      l,(hl)
+    ld      h,b
+    ld      b,l
+    ld      l,c
+    ld      c,a         ; HL = A.begin(), DE = A.end(), BC = pivot
+
+    ; flip HL/DE meaning, it makes simpler the recursive tail and (A[j] > pivot) test
+    ex      de,hl       ; DE = A.begin(), HL = A.end(), BC = pivot
+    dec     de          ; but keep "from" address (related to A[i]) at -1 as "default" state
+
+    ; for (i = 0, j = len - 1; ; i++, j--) { ; DE = (A+i-1).hi, HL = A+j+1
+find_next_swap:
+
+    ; while (A[j] > pivot) j--;
+find_j:
+    dec     hl
+    ld      a,b
+    sub     (hl)
+    dec     hl          ; HL = A+j (finally)
+    jr      c,find_j    ; if cf=1, A[j].hi > pivot.hi
+    jr      nz,j_found  ; if zf=0, A[j].hi < pivot.hi
+    ld      a,c         ; if (A[j].hi == pivot.hi) then A[j].lo vs pivot.lo is checked
+    sub     (hl)
+    jr      c,find_j
+j_found:
+
+    ; while (A[i] < pivot) i++;
+find_i:
+    inc     de
+    ld      a,(de)
+    inc     de          ; DE = (A+i).hi (ahead +0.5 for swap)
+    sub     c
+    ld      a,(de)
+    sbc     a,b
+    jr      c,find_i    ; cf=1 -> A[i] < pivot
+
+    ; if (i >= j) break; // DE = (A+i).hi, HL = A+j, BC=pivot
+    sbc     hl,de       ; cf=0 since `jr c,.find_i`
+    jr      c,swaps_done
+    add     hl,de       ; DE = (A+i).hi, HL = A+j
+
+    ; swap(A[i], A[j]);
+    inc     hl
+    ld      a,(de)
+    ldd
+    ex      af,af'
+    ld      a,(de)
+    ldi
+    ex      af,af'
+    ld      (hl),a      ; Swap(A[i].hi, A[j].hi) done
+    dec     hl
+    ex      af,af'
+    ld      (hl),a      ; Swap(A[i].lo, A[j].lo) done
+
+    inc     bc
+    inc     bc          ; pivot value restored (was -=2 by ldd+ldi)
+    ; --j; HL = A+j is A+j+1 for next loop (ready)
+    ; ++i; DE = (A+i).hi is (A+i-1).hi for next loop (ready)
+    jp      find_next_swap
+
+swaps_done:
+    ; i >= j, all elements were already swapped WRT pivot, call recursively for the two sub-parts
+    dec     de          ; DE = A+i
+
+    ; quicksort_c(A, i);
+    pop     hl          ; HL = A
+    call    quicksort_a_impl
+
+    ; quicksort_c(A + i, len - i);
+    ex      de,hl       ; HL = A+i
+    pop     de          ; DE = end() (and return it preserved)
+    jp      quicksort_a_impl
+
+ENDIF

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
@@ -1,0 +1,271 @@
+2022-03-19 12:54:33  Starting test
+
+----------------------------------------------------------------------
+new c library / sccz80
+Z88DK_VERSION 19388-38ebdf3b7-20220307
+
+defc __CLIB_OPT_SORT = 0
+defc __CLIB_OPT_SORT_QSORT = 0
+
+sort-sccz80-ran-20 91026
+sort-sccz80-ord-20 12904
+sort-sccz80-rev-20 143263
+sort-sccz80-equ-20 12904
+
+sort-sccz80-ran-5000 4620720172
+sort-sccz80-ord-5000 3155801
+sort-sccz80-rev-5000 9211268810
+sort-sccz80-equ-5000 3155801
+
+defc __CLIB_OPT_SORT = 1
+defc __CLIB_OPT_SORT_QSORT = 0
+
+sort-sccz80-ran-20 77971
+sort-sccz80-ord-20 49795
+sort-sccz80-rev-20 69289
+sort-sccz80-equ-20 49795
+
+sort-sccz80-ran-5000 90766660
+sort-sccz80-ord-5000 40823704
+sort-sccz80-rev-5000 61513903
+sort-sccz80-equ-5000 40823704
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x0
+
+sort-sccz80-ran-20 65658
+sort-sccz80-ord-20 52667
+sort-sccz80-rev-20 61835
+sort-sccz80-equ-20 146923
+
+sort-sccz80-ran-5000 45968704
+sort-sccz80-ord-5000 35201614
+sort-sccz80-rev-5000 37739795
+sort-sccz80-equ-5000 7195803365
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x1
+
+sort-sccz80-ran-20 90662
+sort-sccz80-ord-20 70053
+sort-sccz80-rev-20 81189
+sort-sccz80-equ-20 166972
+
+sort-sccz80-ran-5000 56678552
+sort-sccz80-ord-5000 49621048
+sort-sccz80-rev-5000 49621288
+sort-sccz80-equ-5000 7199716280
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x4
+
+sort-sccz80-ran-20 74023
+sort-sccz80-ord-20 28240
+sort-sccz80-rev-20 41967
+sort-sccz80-equ-20 117319
+
+sort-sccz80-ran-5000 45228851
+sort-sccz80-ord-5000 30186144
+sort-sccz80-rev-5000 34161288
+sort-sccz80-equ-5000 7199025104
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x5
+
+sort-sccz80-ran-20 59290
+sort-sccz80-ord-20 49480
+sort-sccz80-rev-20 59332
+sort-sccz80-equ-20 162226
+
+sort-sccz80-ran-5000 51835670
+sort-sccz80-ord-5000 43787154
+sort-sccz80-rev-5000 49965386
+sort-sccz80-equ-5000 7202957003
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x8
+
+sort-sccz80-ran-20 66282
+sort-sccz80-ord-20 53339
+sort-sccz80-rev-20 62363
+sort-sccz80-equ-20 59613
+
+sort-sccz80-ran-5000  FAIL
+sort-sccz80-ord-5000  FAIL
+sort-sccz80-rev-5000  FAIL
+sort-sccz80-equ-5000 44535896
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x9
+
+sort-sccz80-ran-20 83018
+sort-sccz80-ord-20 81882
+sort-sccz80-rev-20 87499
+sort-sccz80-equ-20 75193
+
+sort-sccz80-ran-5000  FAIL
+sort-sccz80-ord-5000  FAIL
+sort-sccz80-rev-5000  FAIL
+sort-sccz80-equ-5000 48048439
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0xc
+
+sort-sccz80-ran-20 74471
+sort-sccz80-ord-20 28528
+sort-sccz80-rev-20 41983
+sort-sccz80-equ-20 41698
+
+sort-sccz80-ran-5000 78830728
+sort-sccz80-ord-5000 55083569
+sort-sccz80-rev-5000 42342683
+sort-sccz80-equ-5000 39997378
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0xd
+
+sort-sccz80-ran-20 59912
+sort-sccz80-ord-20 51423
+sort-sccz80-rev-20 60248
+sort-sccz80-equ-20 54268
+
+sort-sccz80-ran-5000 89049741
+sort-sccz80-ord-5000 106561400
+sort-sccz80-rev-5000 73810651
+sort-sccz80-equ-5000 43791980
+
+----------------------------------------------------------------------
+new c library / zsdcc
+Build: 4.2.0 #13081 (Linux) Mar 10 2022
+
+defc __CLIB_OPT_SORT = 0
+defc __CLIB_OPT_SORT_QSORT = 0
+
+sort-zsdcc-ran-20 83401
+sort-zsdcc-ord-20 11745
+sort-zsdcc-rev-20 131673
+sort-zsdcc-equ-20 11745
+
+sort-zsdcc-ran-5000 4238228822
+sort-zsdcc-ord-5000 2850862
+sort-zsdcc-rev-5000 8448921310
+sort-zsdcc-equ-5000 2850862
+
+defc __CLIB_OPT_SORT = 1
+defc __CLIB_OPT_SORT_QSORT = 0
+
+sort-zsdcc-ran-20 72237
+sort-zsdcc-ord-20 46013
+sort-zsdcc-rev-20 64409
+sort-zsdcc-equ-20 46013
+
+sort-zsdcc-ran-5000 83717073
+sort-zsdcc-ord-5000 37468399
+sort-zsdcc-rev-5000 56707225
+sort-zsdcc-equ-5000 37468399
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x0
+
+sort-zsdcc-ran-20 61327
+sort-zsdcc-ord-20 49373
+sort-zsdcc-rev-20 58175
+sort-zsdcc-equ-20 135333
+
+sort-zsdcc-ran-5000 41991138
+sort-zsdcc-ord-5000 32040472
+sort-zsdcc-rev-5000 34480199
+sort-zsdcc-equ-5000 6433455865
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x1
+
+sort-zsdcc-ran-20 75239
+sort-zsdcc-ord-20 67715
+sort-zsdcc-rev-20 79142
+sort-zsdcc-equ-20 155298
+
+sort-zsdcc-ran-5000 47149856
+sort-zsdcc-ord-5000 45254014
+sort-zsdcc-rev-5000 44925497
+sort-zsdcc-equ-5000 6437369764
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x4
+
+sort-zsdcc-ran-20 68106
+sort-zsdcc-ord-20 25922
+sort-zsdcc-rev-20 38673
+sort-zsdcc-equ-20 107315
+
+sort-zsdcc-ran-5000 41051388
+sort-zsdcc-ord-5000 27197998
+sort-zsdcc-rev-5000 30892542
+sort-zsdcc-equ-5000 6436375410
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x5
+
+sort-zsdcc-ran-20 63106
+sort-zsdcc-ord-20 49968
+sort-zsdcc-rev-20 54499
+sort-zsdcc-equ-20 150084
+
+sort-zsdcc-ran-5000 44358513
+sort-zsdcc-ord-5000 42280667
+sort-zsdcc-rev-5000 42763731
+sort-zsdcc-equ-5000 6440305624
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x8
+
+sort-zsdcc-ran-20 61951
+sort-zsdcc-ord-20 50045
+sort-zsdcc-rev-20 58703
+sort-zsdcc-equ-20 58441
+
+sort-zsdcc-ran-5000  FAIL
+sort-zsdcc-ord-5000  FAIL
+sort-zsdcc-rev-5000  FAIL
+sort-zsdcc-equ-5000 38053067
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0x9
+
+sort-zsdcc-ran-20 79987
+sort-zsdcc-ord-20 64336
+sort-zsdcc-rev-20 92555
+sort-zsdcc-equ-20 71798
+
+sort-zsdcc-ran-5000  FAIL
+sort-zsdcc-ord-5000  FAIL
+sort-zsdcc-rev-5000  FAIL
+sort-zsdcc-equ-5000 40748333
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0xc
+
+sort-zsdcc-ran-20 68554
+sort-zsdcc-ord-20 26210
+sort-zsdcc-rev-20 38689
+sort-zsdcc-equ-20 36372
+
+sort-zsdcc-ran-5000 63818273
+sort-zsdcc-ord-5000 53105886
+sort-zsdcc-rev-5000 37242403
+sort-zsdcc-equ-5000 32361491
+
+defc __CLIB_OPT_SORT = 2
+defc __CLIB_OPT_SORT_QSORT = 0xd
+
+sort-zsdcc-ran-20 68747
+sort-zsdcc-ord-20 65088
+sort-zsdcc-rev-20 61328
+sort-zsdcc-equ-20 43072
+
+sort-zsdcc-ran-5000 69909265
+sort-zsdcc-ord-5000 85979273
+sort-zsdcc-rev-5000 63200683
+sort-zsdcc-equ-5000 36277532
+
+2022-03-19 13:06:24  Test completed

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
@@ -1,4 +1,4 @@
-2022-03-21 19:03:51  Starting test
+2022-03-23 20:08:02  Starting test
 
 ----------------------------------------------------------------------
 new c library / sccz80
@@ -20,15 +20,15 @@ sort-sccz80-equ-5000 3155801
 defc __CLIB_OPT_SORT = 1
 defc __CLIB_OPT_SORT_QSORT = 0
 
-sort-sccz80-ran-20 77971
-sort-sccz80-ord-20 49795
-sort-sccz80-rev-20 69289
-sort-sccz80-equ-20 49795
+sort-sccz80-ran-20 76307
+sort-sccz80-ord-20 48291
+sort-sccz80-rev-20 67641
+sort-sccz80-equ-20 48291
 
-sort-sccz80-ran-5000 90766660
-sort-sccz80-ord-5000 40823704
-sort-sccz80-rev-5000 61513903
-sort-sccz80-equ-5000 40823704
+sort-sccz80-ran-5000 89193784
+sort-sccz80-ord-5000 39503536
+sort-sccz80-rev-5000 60078615
+sort-sccz80-equ-5000 39503536
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x0
@@ -46,15 +46,15 @@ sort-sccz80-equ-5000 7190919971
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x1
 
-sort-sccz80-ran-20 90662
-sort-sccz80-ord-20 70053
-sort-sccz80-rev-20 81189
-sort-sccz80-equ-20 166972
+sort-sccz80-ran-20 92432
+sort-sccz80-ord-20 69445
+sort-sccz80-rev-20 74452
+sort-sccz80-equ-20 167008
 
-sort-sccz80-ran-5000 56678552
-sort-sccz80-ord-5000 49621048
-sort-sccz80-rev-5000 49621288
-sort-sccz80-equ-5000 7199716280
+sort-sccz80-ran-5000 53959119
+sort-sccz80-ord-5000 46927635
+sort-sccz80-rev-5000 49921356
+sort-sccz80-equ-5000 7199717747
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x4
@@ -72,15 +72,15 @@ sort-sccz80-equ-5000 7194371928
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x5
 
-sort-sccz80-ran-20 62146
-sort-sccz80-ord-20 51547
-sort-sccz80-rev-20 60590
-sort-sccz80-equ-20 162081
+sort-sccz80-ran-20 86701
+sort-sccz80-ord-20 51755
+sort-sccz80-rev-20 71145
+sort-sccz80-equ-20 162063
 
-sort-sccz80-ran-5000 52091983
-sort-sccz80-ord-5000 44073485
-sort-sccz80-rev-5000 47428398
-sort-sccz80-equ-5000 7203010420
+sort-sccz80-ran-5000 50508046
+sort-sccz80-ord-5000 44903450
+sort-sccz80-rev-5000 47157605
+sort-sccz80-equ-5000 7203009169
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x8
@@ -98,15 +98,15 @@ sort-sccz80-equ-5000 41972168
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x9
 
-sort-sccz80-ran-20 83018
-sort-sccz80-ord-20 81882
-sort-sccz80-rev-20 87499
-sort-sccz80-equ-20 75193
+sort-sccz80-ran-20 76746
+sort-sccz80-ord-20 66362
+sort-sccz80-rev-20 73304
+sort-sccz80-equ-20 69255
 
 sort-sccz80-ran-5000  FAIL
 sort-sccz80-ord-5000  FAIL
 sort-sccz80-rev-5000  FAIL
-sort-sccz80-equ-5000 48048439
+sort-sccz80-equ-5000 48027515
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xc
@@ -124,15 +124,15 @@ sort-sccz80-equ-5000 36069168
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xd
 
-sort-sccz80-ran-20 70018
-sort-sccz80-ord-20 64520
-sort-sccz80-rev-20 58439
-sort-sccz80-equ-20 54228
+sort-sccz80-ran-20 61036
+sort-sccz80-ord-20 51761
+sort-sccz80-rev-20 59730
+sort-sccz80-equ-20 48368
 
-sort-sccz80-ran-5000 130562654
-sort-sccz80-ord-5000 133000205
-sort-sccz80-rev-5000 80905257
-sort-sccz80-equ-5000 43862662
+sort-sccz80-ran-5000 77031677
+sort-sccz80-ord-5000 112060164
+sort-sccz80-rev-5000 95419783
+sort-sccz80-equ-5000 43936982
 
 defc __CLIB_OPT_SORT = 3
 defc __CLIB_OPT_SORT_QSORT = 0
@@ -167,15 +167,15 @@ sort-zsdcc-equ-5000 2850862
 defc __CLIB_OPT_SORT = 1
 defc __CLIB_OPT_SORT_QSORT = 0
 
-sort-zsdcc-ran-20 72237
-sort-zsdcc-ord-20 46013
-sort-zsdcc-rev-20 64409
-sort-zsdcc-equ-20 46013
+sort-zsdcc-ran-20 70573
+sort-zsdcc-ord-20 44509
+sort-zsdcc-rev-20 62761
+sort-zsdcc-equ-20 44509
 
-sort-zsdcc-ran-5000 83717073
-sort-zsdcc-ord-5000 37468399
-sort-zsdcc-rev-5000 56707225
-sort-zsdcc-equ-5000 37468399
+sort-zsdcc-ran-5000 82144197
+sort-zsdcc-ord-5000 36148231
+sort-zsdcc-rev-5000 55271937
+sort-zsdcc-equ-5000 36148231
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x0
@@ -193,15 +193,15 @@ sort-zsdcc-equ-5000 6428572471
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x1
 
-sort-zsdcc-ran-20 75239
-sort-zsdcc-ord-20 67715
-sort-zsdcc-rev-20 79142
-sort-zsdcc-equ-20 155298
+sort-zsdcc-ran-20 73998
+sort-zsdcc-ord-20 63629
+sort-zsdcc-rev-20 79529
+sort-zsdcc-equ-20 155364
 
-sort-zsdcc-ran-5000 47149856
-sort-zsdcc-ord-5000 45254014
-sort-zsdcc-rev-5000 44925497
-sort-zsdcc-equ-5000 6437369764
+sort-zsdcc-ran-5000 48332199
+sort-zsdcc-ord-5000 42814712
+sort-zsdcc-rev-5000 45826191
+sort-zsdcc-equ-5000 6437369911
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x4
@@ -219,15 +219,15 @@ sort-zsdcc-equ-5000 6431736325
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x5
 
-sort-zsdcc-ran-20 63826
-sort-zsdcc-ord-20 42771
-sort-zsdcc-rev-20 60133
-sort-zsdcc-equ-20 149954
+sort-zsdcc-ran-20 70696
+sort-zsdcc-ord-20 45773
+sort-zsdcc-rev-20 48149
+sort-zsdcc-equ-20 149930
 
-sort-zsdcc-ran-5000 46754443
-sort-zsdcc-ord-5000 38878693
-sort-zsdcc-rev-5000 43497945
-sort-zsdcc-equ-5000 6440358471
+sort-zsdcc-ran-5000 45520020
+sort-zsdcc-ord-5000 40781765
+sort-zsdcc-rev-5000 43402964
+sort-zsdcc-equ-5000 6440356809
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x8
@@ -245,15 +245,15 @@ sort-zsdcc-equ-5000 34447113
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x9
 
-sort-zsdcc-ran-20 79987
-sort-zsdcc-ord-20 64336
-sort-zsdcc-rev-20 92555
-sort-zsdcc-equ-20 71798
+sort-zsdcc-ran-20 70976
+sort-zsdcc-ord-20 66118
+sort-zsdcc-rev-20 76643
+sort-zsdcc-equ-20 70785
 
 sort-zsdcc-ran-5000  FAIL
 sort-zsdcc-ord-5000  FAIL
 sort-zsdcc-rev-5000  FAIL
-sort-zsdcc-equ-5000 40748333
+sort-zsdcc-equ-5000 40875988
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xc
@@ -271,15 +271,15 @@ sort-zsdcc-equ-5000 28291376
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xd
 
-sort-zsdcc-ran-20 73576
-sort-zsdcc-ord-20 52376
-sort-zsdcc-rev-20 57923
-sort-zsdcc-equ-20 49182
+sort-zsdcc-ran-20 67605
+sort-zsdcc-ord-20 62947
+sort-zsdcc-rev-20 61391
+sort-zsdcc-equ-20 50037
 
-sort-zsdcc-ran-5000 70017281
-sort-zsdcc-ord-5000 123359223
-sort-zsdcc-rev-5000 81691589
-sort-zsdcc-equ-5000 36197091
+sort-zsdcc-ran-5000 63968607
+sort-zsdcc-ord-5000 86051871
+sort-zsdcc-rev-5000 80218092
+sort-zsdcc-equ-5000 36187578
 
 defc __CLIB_OPT_SORT = 3
 defc __CLIB_OPT_SORT_QSORT = 0
@@ -294,4 +294,4 @@ sort-zsdcc-ord-5000 4666984
 sort-zsdcc-rev-5000 5020592
 sort-zsdcc-equ-5000 8919440
 
-2022-03-21 19:16:03  Test completed
+2022-03-23 20:20:13  Test completed

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
@@ -1,4 +1,4 @@
-2022-03-19 12:54:33  Starting test
+2022-03-20 18:37:44  Starting test
 
 ----------------------------------------------------------------------
 new c library / sccz80
@@ -33,15 +33,15 @@ sort-sccz80-equ-5000 40823704
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x0
 
-sort-sccz80-ran-20 65658
-sort-sccz80-ord-20 52667
-sort-sccz80-rev-20 61835
-sort-sccz80-equ-20 146923
+sort-sccz80-ran-20 54131
+sort-sccz80-ord-20 41143
+sort-sccz80-rev-20 48408
+sort-sccz80-equ-20 128641
 
-sort-sccz80-ran-5000 45968704
-sort-sccz80-ord-5000 35201614
-sort-sccz80-rev-5000 37739795
-sort-sccz80-equ-5000 7195803365
+sort-sccz80-ran-5000 42713399
+sort-sccz80-ord-5000 32351355
+sort-sccz80-rev-5000 34278594
+sort-sccz80-equ-5000 7190919971
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x1
@@ -59,41 +59,41 @@ sort-sccz80-equ-5000 7199716280
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x4
 
-sort-sccz80-ran-20 74023
-sort-sccz80-ord-20 28240
-sort-sccz80-rev-20 41967
-sort-sccz80-equ-20 117319
+sort-sccz80-ran-20 69138
+sort-sccz80-ord-20 25608
+sort-sccz80-rev-20 39335
+sort-sccz80-equ-20 57871
 
-sort-sccz80-ran-5000 45228851
-sort-sccz80-ord-5000 30186144
-sort-sccz80-rev-5000 34161288
-sort-sccz80-equ-5000 7199025104
+sort-sccz80-ran-5000 46865250
+sort-sccz80-ord-5000 29266655
+sort-sccz80-rev-5000 32143302
+sort-sccz80-equ-5000 7194371928
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x5
 
-sort-sccz80-ran-20 59290
-sort-sccz80-ord-20 49480
-sort-sccz80-rev-20 59332
-sort-sccz80-equ-20 162226
+sort-sccz80-ran-20 62146
+sort-sccz80-ord-20 51547
+sort-sccz80-rev-20 60590
+sort-sccz80-equ-20 162081
 
-sort-sccz80-ran-5000 51835670
-sort-sccz80-ord-5000 43787154
-sort-sccz80-rev-5000 49965386
-sort-sccz80-equ-5000 7202957003
+sort-sccz80-ran-5000 52091983
+sort-sccz80-ord-5000 44073485
+sort-sccz80-rev-5000 47428398
+sort-sccz80-equ-5000 7203010420
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x8
 
-sort-sccz80-ran-20 66282
-sort-sccz80-ord-20 53339
-sort-sccz80-rev-20 62363
-sort-sccz80-equ-20 59613
+sort-sccz80-ran-20 54755
+sort-sccz80-ord-20 41815
+sort-sccz80-rev-20 48936
+sort-sccz80-equ-20 50869
 
 sort-sccz80-ran-5000  FAIL
 sort-sccz80-ord-5000  FAIL
 sort-sccz80-rev-5000  FAIL
-sort-sccz80-equ-5000 44535896
+sort-sccz80-equ-5000 41972168
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x9
@@ -111,28 +111,28 @@ sort-sccz80-equ-5000 48048439
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xc
 
-sort-sccz80-ran-20 74471
-sort-sccz80-ord-20 28528
-sort-sccz80-rev-20 41983
-sort-sccz80-equ-20 41698
+sort-sccz80-ran-20 69298
+sort-sccz80-ord-20 25896
+sort-sccz80-rev-20 39351
+sort-sccz80-equ-20 27242
 
-sort-sccz80-ran-5000 78830728
-sort-sccz80-ord-5000 55083569
-sort-sccz80-rev-5000 42342683
-sort-sccz80-equ-5000 39997378
+sort-sccz80-ran-5000 54966037
+sort-sccz80-ord-5000 56231253
+sort-sccz80-rev-5000 42450934
+sort-sccz80-equ-5000 36069168
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xd
 
-sort-sccz80-ran-20 59912
-sort-sccz80-ord-20 51423
-sort-sccz80-rev-20 60248
-sort-sccz80-equ-20 54268
+sort-sccz80-ran-20 70018
+sort-sccz80-ord-20 64520
+sort-sccz80-rev-20 58439
+sort-sccz80-equ-20 54228
 
-sort-sccz80-ran-5000 89049741
-sort-sccz80-ord-5000 106561400
-sort-sccz80-rev-5000 73810651
-sort-sccz80-equ-5000 43791980
+sort-sccz80-ran-5000 130562654
+sort-sccz80-ord-5000 133000205
+sort-sccz80-rev-5000 80905257
+sort-sccz80-equ-5000 43862662
 
 ----------------------------------------------------------------------
 new c library / zsdcc
@@ -167,15 +167,15 @@ sort-zsdcc-equ-5000 37468399
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x0
 
-sort-zsdcc-ran-20 61327
-sort-zsdcc-ord-20 49373
-sort-zsdcc-rev-20 58175
-sort-zsdcc-equ-20 135333
+sort-zsdcc-ran-20 49800
+sort-zsdcc-ord-20 37849
+sort-zsdcc-rev-20 44748
+sort-zsdcc-equ-20 117051
 
-sort-zsdcc-ran-5000 41991138
-sort-zsdcc-ord-5000 32040472
-sort-zsdcc-rev-5000 34480199
-sort-zsdcc-equ-5000 6433455865
+sort-zsdcc-ran-5000 38735833
+sort-zsdcc-ord-5000 29190213
+sort-zsdcc-rev-5000 31018998
+sort-zsdcc-equ-5000 6428572471
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x1
@@ -193,41 +193,41 @@ sort-zsdcc-equ-5000 6437369764
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x4
 
-sort-zsdcc-ran-20 68106
-sort-zsdcc-ord-20 25922
-sort-zsdcc-rev-20 38673
-sort-zsdcc-equ-20 107315
+sort-zsdcc-ran-20 63282
+sort-zsdcc-ord-20 23290
+sort-zsdcc-rev-20 36041
+sort-zsdcc-equ-20 52442
 
-sort-zsdcc-ran-5000 41051388
-sort-zsdcc-ord-5000 27197998
-sort-zsdcc-rev-5000 30892542
-sort-zsdcc-equ-5000 6436375410
+sort-zsdcc-ran-5000 42464039
+sort-zsdcc-ord-5000 26278509
+sort-zsdcc-rev-5000 28962396
+sort-zsdcc-equ-5000 6431736325
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x5
 
-sort-zsdcc-ran-20 63106
-sort-zsdcc-ord-20 49968
-sort-zsdcc-rev-20 54499
-sort-zsdcc-equ-20 150084
+sort-zsdcc-ran-20 63826
+sort-zsdcc-ord-20 42771
+sort-zsdcc-rev-20 60133
+sort-zsdcc-equ-20 149954
 
-sort-zsdcc-ran-5000 44358513
-sort-zsdcc-ord-5000 42280667
-sort-zsdcc-rev-5000 42763731
-sort-zsdcc-equ-5000 6440305624
+sort-zsdcc-ran-5000 46754443
+sort-zsdcc-ord-5000 38878693
+sort-zsdcc-rev-5000 43497945
+sort-zsdcc-equ-5000 6440358471
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x8
 
-sort-zsdcc-ran-20 61951
-sort-zsdcc-ord-20 50045
-sort-zsdcc-rev-20 58703
-sort-zsdcc-equ-20 58441
+sort-zsdcc-ran-20 50424
+sort-zsdcc-ord-20 38521
+sort-zsdcc-rev-20 45276
+sort-zsdcc-equ-20 43471
 
 sort-zsdcc-ran-5000  FAIL
 sort-zsdcc-ord-5000  FAIL
 sort-zsdcc-rev-5000  FAIL
-sort-zsdcc-equ-5000 38053067
+sort-zsdcc-equ-5000 34447113
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x9
@@ -245,27 +245,27 @@ sort-zsdcc-equ-5000 40748333
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xc
 
-sort-zsdcc-ran-20 68554
-sort-zsdcc-ord-20 26210
-sort-zsdcc-rev-20 38689
-sort-zsdcc-equ-20 36372
+sort-zsdcc-ran-20 63442
+sort-zsdcc-ord-20 23578
+sort-zsdcc-rev-20 36057
+sort-zsdcc-equ-20 24948
 
-sort-zsdcc-ran-5000 63818273
-sort-zsdcc-ord-5000 53105886
-sort-zsdcc-rev-5000 37242403
-sort-zsdcc-equ-5000 32361491
+sort-zsdcc-ran-5000 51266468
+sort-zsdcc-ord-5000 47774963
+sort-zsdcc-rev-5000 39164351
+sort-zsdcc-equ-5000 28291376
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xd
 
-sort-zsdcc-ran-20 68747
-sort-zsdcc-ord-20 65088
-sort-zsdcc-rev-20 61328
-sort-zsdcc-equ-20 43072
+sort-zsdcc-ran-20 73576
+sort-zsdcc-ord-20 52376
+sort-zsdcc-rev-20 57923
+sort-zsdcc-equ-20 49182
 
-sort-zsdcc-ran-5000 69909265
-sort-zsdcc-ord-5000 85979273
-sort-zsdcc-rev-5000 63200683
-sort-zsdcc-equ-5000 36277532
+sort-zsdcc-ran-5000 70017281
+sort-zsdcc-ord-5000 123359223
+sort-zsdcc-rev-5000 81691589
+sort-zsdcc-equ-5000 36197091
 
-2022-03-19 13:06:24  Test completed
+2022-03-20 18:49:27  Test completed

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
@@ -1,4 +1,4 @@
-2022-03-23 20:08:02  Starting test
+2022-03-23 22:59:12  Starting test
 
 ----------------------------------------------------------------------
 new c library / sccz80
@@ -7,14 +7,14 @@ Z88DK_VERSION 19388-38ebdf3b7-20220307
 defc __CLIB_OPT_SORT = 0
 defc __CLIB_OPT_SORT_QSORT = 0
 
-sort-sccz80-ran-20 91026
+sort-sccz80-ran-20 89648
 sort-sccz80-ord-20 12904
-sort-sccz80-rev-20 143263
+sort-sccz80-rev-20 140964
 sort-sccz80-equ-20 12904
 
-sort-sccz80-ran-5000 4620720172
+sort-sccz80-ran-5000 4539270597
 sort-sccz80-ord-5000 3155801
-sort-sccz80-rev-5000 9211268810
+sort-sccz80-rev-5000 9048846301
 sort-sccz80-equ-5000 3155801
 
 defc __CLIB_OPT_SORT = 1
@@ -46,41 +46,41 @@ sort-sccz80-equ-5000 7190919971
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x1
 
-sort-sccz80-ran-20 92432
-sort-sccz80-ord-20 69445
-sort-sccz80-rev-20 74452
-sort-sccz80-equ-20 167008
+sort-sccz80-ran-20 84217
+sort-sccz80-ord-20 74125
+sort-sccz80-rev-20 77868
+sort-sccz80-equ-20 166963
 
-sort-sccz80-ran-5000 53959119
-sort-sccz80-ord-5000 46927635
-sort-sccz80-rev-5000 49921356
-sort-sccz80-equ-5000 7199717747
+sort-sccz80-ran-5000 53968159
+sort-sccz80-ord-5000 47178338
+sort-sccz80-rev-5000 51327955
+sort-sccz80-equ-5000 7199716451
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x4
 
-sort-sccz80-ran-20 69138
+sort-sccz80-ran-20 68384
 sort-sccz80-ord-20 25608
-sort-sccz80-rev-20 39335
+sort-sccz80-rev-20 39123
 sort-sccz80-equ-20 57871
 
-sort-sccz80-ran-5000 46865250
+sort-sccz80-ran-5000 46663655
 sort-sccz80-ord-5000 29266655
-sort-sccz80-rev-5000 32143302
+sort-sccz80-rev-5000 32090258
 sort-sccz80-equ-5000 7194371928
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x5
 
-sort-sccz80-ran-20 86701
-sort-sccz80-ord-20 51755
-sort-sccz80-rev-20 71145
-sort-sccz80-equ-20 162063
+sort-sccz80-ran-20 63457
+sort-sccz80-ord-20 59212
+sort-sccz80-rev-20 63419
+sort-sccz80-equ-20 162123
 
-sort-sccz80-ran-5000 50508046
-sort-sccz80-ord-5000 44903450
-sort-sccz80-rev-5000 47157605
-sort-sccz80-equ-5000 7203009169
+sort-sccz80-ran-5000 50973330
+sort-sccz80-ord-5000 47789920
+sort-sccz80-rev-5000 47462823
+sort-sccz80-equ-5000 7203009433
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x8
@@ -98,41 +98,41 @@ sort-sccz80-equ-5000 41972168
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x9
 
-sort-sccz80-ran-20 76746
-sort-sccz80-ord-20 66362
-sort-sccz80-rev-20 73304
-sort-sccz80-equ-20 69255
+sort-sccz80-ran-20 79452
+sort-sccz80-ord-20 64338
+sort-sccz80-rev-20 77633
+sort-sccz80-equ-20 73613
 
 sort-sccz80-ran-5000  FAIL
 sort-sccz80-ord-5000  FAIL
 sort-sccz80-rev-5000  FAIL
-sort-sccz80-equ-5000 48027515
+sort-sccz80-equ-5000 48036039
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xc
 
-sort-sccz80-ran-20 69298
+sort-sccz80-ran-20 68544
 sort-sccz80-ord-20 25896
-sort-sccz80-rev-20 39351
+sort-sccz80-rev-20 39139
 sort-sccz80-equ-20 27242
 
-sort-sccz80-ran-5000 54966037
-sort-sccz80-ord-5000 56231253
-sort-sccz80-rev-5000 42450934
+sort-sccz80-ran-5000 54653916
+sort-sccz80-ord-5000 55753490
+sort-sccz80-rev-5000 42224444
 sort-sccz80-equ-5000 36069168
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xd
 
-sort-sccz80-ran-20 61036
-sort-sccz80-ord-20 51761
-sort-sccz80-rev-20 59730
-sort-sccz80-equ-20 48368
+sort-sccz80-ran-20 62810
+sort-sccz80-ord-20 56281
+sort-sccz80-rev-20 70852
+sort-sccz80-equ-20 49377
 
-sort-sccz80-ran-5000 77031677
-sort-sccz80-ord-5000 112060164
-sort-sccz80-rev-5000 95419783
-sort-sccz80-equ-5000 43936982
+sort-sccz80-ran-5000 73381958
+sort-sccz80-ord-5000 80138099
+sort-sccz80-rev-5000 74795563
+sort-sccz80-equ-5000 43810489
 
 defc __CLIB_OPT_SORT = 3
 defc __CLIB_OPT_SORT_QSORT = 0
@@ -154,14 +154,14 @@ Build: 4.2.0 #13081 (Linux) Mar 10 2022
 defc __CLIB_OPT_SORT = 0
 defc __CLIB_OPT_SORT_QSORT = 0
 
-sort-zsdcc-ran-20 83401
+sort-zsdcc-ran-20 82023
 sort-zsdcc-ord-20 11745
-sort-zsdcc-rev-20 131673
+sort-zsdcc-rev-20 129374
 sort-zsdcc-equ-20 11745
 
-sort-zsdcc-ran-5000 4238228822
+sort-zsdcc-ran-5000 4156779247
 sort-zsdcc-ord-5000 2850862
-sort-zsdcc-rev-5000 8448921310
+sort-zsdcc-rev-5000 8286498801
 sort-zsdcc-equ-5000 2850862
 
 defc __CLIB_OPT_SORT = 1
@@ -193,41 +193,41 @@ sort-zsdcc-equ-5000 6428572471
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x1
 
-sort-zsdcc-ran-20 73998
-sort-zsdcc-ord-20 63629
-sort-zsdcc-rev-20 79529
-sort-zsdcc-equ-20 155364
+sort-zsdcc-ran-20 66860
+sort-zsdcc-ord-20 66249
+sort-zsdcc-rev-20 78819
+sort-zsdcc-equ-20 155319
 
-sort-zsdcc-ran-5000 48332199
-sort-zsdcc-ord-5000 42814712
-sort-zsdcc-rev-5000 45826191
-sort-zsdcc-equ-5000 6437369911
+sort-zsdcc-ran-5000 49500788
+sort-zsdcc-ord-5000 44931976
+sort-zsdcc-rev-5000 44773123
+sort-zsdcc-equ-5000 6437369872
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x4
 
-sort-zsdcc-ran-20 63282
+sort-zsdcc-ran-20 62528
 sort-zsdcc-ord-20 23290
-sort-zsdcc-rev-20 36041
+sort-zsdcc-rev-20 35829
 sort-zsdcc-equ-20 52442
 
-sort-zsdcc-ran-5000 42464039
+sort-zsdcc-ran-5000 42262444
 sort-zsdcc-ord-5000 26278509
-sort-zsdcc-rev-5000 28962396
+sort-zsdcc-rev-5000 28909352
 sort-zsdcc-equ-5000 6431736325
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x5
 
-sort-zsdcc-ran-20 70696
-sort-zsdcc-ord-20 45773
-sort-zsdcc-rev-20 48149
-sort-zsdcc-equ-20 149930
+sort-zsdcc-ran-20 57411
+sort-zsdcc-ord-20 48021
+sort-zsdcc-rev-20 53181
+sort-zsdcc-equ-20 149960
 
-sort-zsdcc-ran-5000 45520020
-sort-zsdcc-ord-5000 40781765
-sort-zsdcc-rev-5000 43402964
-sort-zsdcc-equ-5000 6440356809
+sort-zsdcc-ran-5000 47731810
+sort-zsdcc-ord-5000 40375772
+sort-zsdcc-rev-5000 42854699
+sort-zsdcc-equ-5000 6440358510
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x8
@@ -245,41 +245,41 @@ sort-zsdcc-equ-5000 34447113
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0x9
 
-sort-zsdcc-ran-20 70976
-sort-zsdcc-ord-20 66118
-sort-zsdcc-rev-20 76643
-sort-zsdcc-equ-20 70785
+sort-zsdcc-ran-20 77447
+sort-zsdcc-ord-20 70071
+sort-zsdcc-rev-20 75615
+sort-zsdcc-equ-20 66109
 
 sort-zsdcc-ran-5000  FAIL
 sort-zsdcc-ord-5000  FAIL
 sort-zsdcc-rev-5000  FAIL
-sort-zsdcc-equ-5000 40875988
+sort-zsdcc-equ-5000 40789511
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xc
 
-sort-zsdcc-ran-20 63442
+sort-zsdcc-ran-20 62688
 sort-zsdcc-ord-20 23578
-sort-zsdcc-rev-20 36057
+sort-zsdcc-rev-20 35845
 sort-zsdcc-equ-20 24948
 
-sort-zsdcc-ran-5000 51266468
-sort-zsdcc-ord-5000 47774963
-sort-zsdcc-rev-5000 39164351
+sort-zsdcc-ran-5000 50916067
+sort-zsdcc-ord-5000 47359197
+sort-zsdcc-rev-5000 38926382
 sort-zsdcc-equ-5000 28291376
 
 defc __CLIB_OPT_SORT = 2
 defc __CLIB_OPT_SORT_QSORT = 0xd
 
-sort-zsdcc-ran-20 67605
-sort-zsdcc-ord-20 62947
-sort-zsdcc-rev-20 61391
-sort-zsdcc-equ-20 50037
+sort-zsdcc-ran-20 69970
+sort-zsdcc-ord-20 62003
+sort-zsdcc-rev-20 58085
+sort-zsdcc-equ-20 49193
 
-sort-zsdcc-ran-5000 63968607
-sort-zsdcc-ord-5000 86051871
-sort-zsdcc-rev-5000 80218092
-sort-zsdcc-equ-5000 36187578
+sort-zsdcc-ran-5000 67951932
+sort-zsdcc-ord-5000 70350709
+sort-zsdcc-rev-5000 56672913
+sort-zsdcc-equ-5000 36233700
 
 defc __CLIB_OPT_SORT = 3
 defc __CLIB_OPT_SORT_QSORT = 0
@@ -294,4 +294,4 @@ sort-zsdcc-ord-5000 4666984
 sort-zsdcc-rev-5000 5020592
 sort-zsdcc-equ-5000 8919440
 
-2022-03-23 20:20:13  Test completed
+2022-03-23 23:11:22  Test completed

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/benchmark.txt
@@ -1,4 +1,4 @@
-2022-03-20 18:37:44  Starting test
+2022-03-21 19:03:51  Starting test
 
 ----------------------------------------------------------------------
 new c library / sccz80
@@ -134,6 +134,19 @@ sort-sccz80-ord-5000 133000205
 sort-sccz80-rev-5000 80905257
 sort-sccz80-equ-5000 43862662
 
+defc __CLIB_OPT_SORT = 3
+defc __CLIB_OPT_SORT_QSORT = 0
+
+sort-sccz80-ran-20 14370
+sort-sccz80-ord-20 11730
+sort-sccz80-rev-20 13080
+sort-sccz80-equ-20 17550
+
+sort-sccz80-ran-5000 7366677
+sort-sccz80-ord-5000 4666984
+sort-sccz80-rev-5000 5020592
+sort-sccz80-equ-5000 8919440
+
 ----------------------------------------------------------------------
 new c library / zsdcc
 Build: 4.2.0 #13081 (Linux) Mar 10 2022
@@ -268,4 +281,17 @@ sort-zsdcc-ord-5000 123359223
 sort-zsdcc-rev-5000 81691589
 sort-zsdcc-equ-5000 36197091
 
-2022-03-20 18:49:27  Test completed
+defc __CLIB_OPT_SORT = 3
+defc __CLIB_OPT_SORT_QSORT = 0
+
+sort-zsdcc-ran-20 14370
+sort-zsdcc-ord-20 11730
+sort-zsdcc-rev-20 13080
+sort-zsdcc-equ-20 17550
+
+sort-zsdcc-ran-5000 7366677
+sort-zsdcc-ord-5000 4666984
+sort-zsdcc-rev-5000 5020592
+sort-zsdcc-equ-5000 8919440
+
+2022-03-21 19:16:03  Test completed

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/readme.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/readme.txt
@@ -97,33 +97,33 @@ RESULT
 
 Z88DK March 21, 2022
 new c library / sccz80 19388-38ebdf3b7-20220307 / __CLIB_OPT_SORT = 2, __CLIB_OPT_SORT_QSORT = 0xc
-1468 bytes less page zero
+1464 bytes less page zero
 
                cycle count    time @ 4MHz
 
-sort-ran-20          69298     0.0173 sec
+sort-ran-20          68544     0.0171 sec
 sort-ord-20          25896     0.0065 sec
-sort-rev-20          39351     0.0098 sec
+sort-rev-20          39139     0.0098 sec
 sort-equ-20          27242     0.0068 sec
 
-sort-ran-5000     54966037    13.7415 sec
-sort-ord-5000     56231253    14.0578 sec
-sort-rev-5000     42450934    10.6127 sec
+sort-ran-5000     54653916    13.6635 sec
+sort-ord-5000     55753490    13.9384 sec
+sort-rev-5000     42224444    10.5561 sec
 sort-equ-5000     36069168     9.0173 sec
 
 
 Z88DK March 21, 2022
 new c library / zsdcc 4.2.0 #13081 / __CLIB_OPT_SORT = 2, __CLIB_OPT_SORT_QSORT = 0xc
-1395 bytes less page zero
+1391 bytes less page zero
 
                cycle count    time @ 4MHz
 
-sort-ran-20          63442     0.0159 sec
+sort-ran-20          62688     0.0157 sec
 sort-ord-20          23578     0.0059 sec
-sort-rev-20          36057     0.0090 sec
+sort-rev-20          35845     0.0090 sec
 sort-equ-20          24948     0.0062 sec
 
-sort-ran-5000     51266468    12.8166 sec
-sort-ord-5000     47774963    11.9437 sec
-sort-rev-5000     39164351     9.7911 sec
+sort-ran-5000     50916067    12.7290 sec
+sort-ord-5000     47359197    11.8398 sec
+sort-rev-5000     38926382     9.7316 sec
 sort-equ-5000     28291376     7.0728 sec

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/readme.txt
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/readme.txt
@@ -5,6 +5,13 @@ CHANGES TO SOURCE CODE
 status code in ticks. (the return from main in new-lib z80 target does
 end with `di : halt : jr $` infinite loop)
 
+And optimised the newlib implementation itself to avoid divu call for every
+new middle-pivot selection.
+
+And added (to satisfy my own curiosity) extra hard-coded hand-written assembly
+example using size=2 and inlined compare for uint16_t case (ignoring
+the compare function), it's hidden under invalid OPT_SORT=3 option.
+
 VERIFY CORRECT RESULT
 =====================
 
@@ -88,35 +95,35 @@ All programs are very close in size.
 RESULT
 ======
 
-Z88DK March 19, 2022
+Z88DK March 21, 2022
 new c library / sccz80 19388-38ebdf3b7-20220307 / __CLIB_OPT_SORT = 2, __CLIB_OPT_SORT_QSORT = 0xc
-1531 bytes less page zero
+1468 bytes less page zero
 
                cycle count    time @ 4MHz
 
-sort-ran-20          74471     0.0186 sec
-sort-ord-20          28528     0.0071 sec
-sort-rev-20          41983     0.0105 sec
-sort-equ-20          41698     0.0104 sec
+sort-ran-20          69298     0.0173 sec
+sort-ord-20          25896     0.0065 sec
+sort-rev-20          39351     0.0098 sec
+sort-equ-20          27242     0.0068 sec
 
-sort-ran-5000     78830728    19.7077 sec
-sort-ord-5000     55083569    13.7709 sec
-sort-rev-5000     42342683    10.5857 sec
-sort-equ-5000     39997378     9.9993 sec
+sort-ran-5000     54966037    13.7415 sec
+sort-ord-5000     56231253    14.0578 sec
+sort-rev-5000     42450934    10.6127 sec
+sort-equ-5000     36069168     9.0173 sec
 
 
-Z88DK March 19, 2022
+Z88DK March 21, 2022
 new c library / zsdcc 4.2.0 #13081 / __CLIB_OPT_SORT = 2, __CLIB_OPT_SORT_QSORT = 0xc
-1458 bytes less page zero
+1395 bytes less page zero
 
                cycle count    time @ 4MHz
 
-sort-ran-20          68554     0.0171 sec
-sort-ord-20          26210     0.0066 sec
-sort-rev-20          38689     0.0097 sec
-sort-equ-20          36372     0.0091 sec
+sort-ran-20          63442     0.0159 sec
+sort-ord-20          23578     0.0059 sec
+sort-rev-20          36057     0.0090 sec
+sort-equ-20          24948     0.0062 sec
 
-sort-ran-5000     63818273    15.9546 sec
-sort-ord-5000     53105886    13.2765 sec
-sort-rev-5000     37242403     9.3106 sec
-sort-equ-5000     32361491     8.0904 sec
+sort-ran-5000     51266468    12.8166 sec
+sort-ord-5000     47774963    11.9437 sec
+sort-rev-5000     39164351     9.7911 sec
+sort-equ-5000     28291376     7.0728 sec

--- a/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/sort.c
+++ b/libsrc/_DEVELOPMENT/EXAMPLES/benchmarks/sorting/z88dk-new/sort.c
@@ -66,6 +66,14 @@ TIMER_START();
 TIMER_STOP();
 }
 
+static void ticks_exit(int status) __z88dk_fastcall
+{
+   __asm
+      xor a
+      defb 0xed, 0xfe
+   __endasm;
+}
+
 int main(void)
 {
    PRINTF1("\nFilling the array with numbers.\n\n");
@@ -104,13 +112,15 @@ int main(void)
       PRINTF2("%u, ", numbers[i]);
       if ((i > 0) && (numbers[i] < numbers[i-1]))
       {
-         PRINTF1("\n\nFAIL");
-         break;
+         PRINTF1("\n\nFAIL\n\n\n");
+         ticks_exit(1);
+         return 1;
       }
    }
    
    PRINTF1("\n\n\n");
    
+   ticks_exit(0);
    return 0;
 }
 

--- a/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_insertion_sort.asm
+++ b/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_insertion_sort.asm
@@ -48,16 +48,16 @@ asm0_insertion_sort:
    add hl,bc
    push hl                     ; save array_hi + 1
    
-   ld l,e
-   ld h,d
+   ex de,hl
    
    add hl,bc
-   ex de,hl                    ; hl = array_lo, de = array_lo + 1
+   ld e,l
+   ld d,h                      ; hl = array_lo + 1, de = array_lo + 1 = i
 
 array_loop:
 
    ; de = i
-   ; hl = array_lo
+   ; hl = array_lo + 1
    ; bc = size
    ; ix = compare
    ; stack = array_hi + 1
@@ -74,22 +74,22 @@ array_loop:
 
 begin_loop:
 
-   ex (sp),hl                  ; hl = array_lo
+   ex (sp),hl                  ; hl = array_lo + 1
    
    push de
    push hl   
+   or a                        ; carry=0 for insert_loop
 
 insert_loop:
 
    ; de = j
    ; bc = size
    ; ix = compare
-   ; stack = array_hi + 1, i, array_lo
+   ; stack = array_hi + 1, i, array_lo + 1
 
    ld l,e
    ld h,d
    
-   or a
    sbc hl,bc                   ; hl = j-1
 
    call l_compare_de_hl
@@ -99,24 +99,25 @@ insert_loop:
    call asm0_memswap           ; swap(j, j-1, size)
    pop bc
    
-   ld e,l
-   ld d,h                      ; de = j-1
+   ex de,hl                    ; de = j-1
    
-   pop hl                      ; hl = array_lo
+   pop hl                      ; hl = array_lo + 1
    push hl
 
-   or a
-   sbc hl,de
-   
-   jr nz, insert_loop          ; if more elements in array
+   ld a,e
+   sub l
+   ld a,d
+   sbc a,h
+
+   jp nc, insert_loop          ; if more elements in array (j-1 >= array_lo + 1)
 
 insert_exit:
 
    ; bc = size
    ; ix = compare
-   ; stack = array_hi + 1, i, array_lo
+   ; stack = array_hi + 1, i, array_lo + 1
 
-   pop de                      ; de = array_lo
+   pop de                      ; de = array_lo + 1
    pop hl                      ; hl = i
    
    add hl,bc

--- a/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_quicksort.asm
+++ b/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_quicksort.asm
@@ -184,13 +184,11 @@ IF (__CLIB_OPT_SORT_QSORT & $03) = 0
    
       ; insertion sort small partitions
       
-      inc h
-      dec h
-      jr nz, partition_size_large
-      
-      ld a,l
-      cp 5                     ; chosen by trial and error
-      jr nc, partition_size_large
+      ld a,4                   ; chosen by trial and error
+      cp l
+      sbc a,a                  ; a = (4 < l) ? 0xFF : 0x00
+      or h
+      jr nz, partition_size_large ; 4 < ((j-i)/2)/size
       
    partition_size_small:
    
@@ -254,13 +252,11 @@ ELSE
       ; do not have number of items so using
       ; byte size of interval as poor substitute
       
-      inc h
-      dec h
-      jr nz, partition_size_large
-      
-      ld a,l
-      cp 10
-      jr nc, partition_size_large
+      ld a,9
+      cp l
+      sbc a,a                  ; a = (9 < l) ? 0xFF : 0x00
+      or h
+      jr nz, partition_size_large ; 9 < j-i
       
    partition_size_small:
 

--- a/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_shellsort.asm
+++ b/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_shellsort.asm
@@ -98,22 +98,20 @@ asm_shellsort:
 	; for (i = t2; i <= t1; i += width)
 .shs_i8
 	ld	(__stdlib_shellsort_i),hl
-	ld	de,(__stdlib_shellsort_t1)
+	ex	de,hl
+	ld	hl,(__stdlib_shellsort_t1)
 	
-	; hl = i, de = t1
+	; de = i, hl = t1, carry=0 from "add hl,de" in both paths
 	
-	scf
 	sbc hl,de
-	jr nc, shs_i3    ; if i-t1-1 >= 0 (if i>t1)
+	jr c, shs_i3    ; if t1-i < 0 (if i>t1)
 
 	; for (j =  i - t2..
-	ld	de,(__stdlib_shellsort_i)
 	ld	hl,(__stdlib_shellsort_t2)
-
+	ex	de,hl
 .shs_i11
-	ex	de,hl		; same subtraction is used twice in the for loop
 	and	a
-	sbc	hl,de
+	sbc	hl,de		; same subtraction is used twice in the for loop
 	ld	(__stdlib_shellsort_j),hl
 
 	; for ..; j>0; ..
@@ -147,8 +145,8 @@ asm_shellsort:
 	call	asm0_memswap
 
 	; for ... j -= gap)
-	ld	de,(__stdlib_shellsort_j)
-	ld	hl,(__stdlib_shellsort_gap)
+	ld	hl,(__stdlib_shellsort_j)
+	ld	de,(__stdlib_shellsort_gap)
 	jr	shs_i11
 
 

--- a/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_shellsort.asm
+++ b/libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_shellsort.asm
@@ -50,7 +50,7 @@ asm_shellsort:
 	ld	(__stdlib_shellsort_t1),hl
 
 	; for (ngap = nel / 2; ngap > 0; ngap /= 2) {
-.i_3
+.shs_i3
 	pop de	; width
 	pop hl  ; ngap
 	srl h			; _ngap/2 ..bit rotation
@@ -85,9 +85,9 @@ asm_shellsort:
 	add	hl,de
 	ld	(__stdlib_shellsort_jd),hl
 	pop hl			; t2
-	jr	i_8
+	jr	shs_i8
 	
-.i_6
+.shs_i6
 	ld	de,(__stdlib_shellsort_i)
 	pop hl
 	push hl
@@ -96,7 +96,7 @@ asm_shellsort:
 	;ld	(__stdlib_shellsort_i),hl
 
 	; for (i = t2; i <= t1; i += width)
-.i_8
+.shs_i8
 	ld	(__stdlib_shellsort_i),hl
 	ld	de,(__stdlib_shellsort_t1)
 	
@@ -104,20 +104,20 @@ asm_shellsort:
 	
 	scf
 	sbc hl,de
-	jr nc, i_3    ; if i-t1-1 >= 0 (if i>t1)
+	jr nc, shs_i3    ; if i-t1-1 >= 0 (if i>t1)
 
 	; for (j =  i - t2..
 	ld	de,(__stdlib_shellsort_i)
 	ld	hl,(__stdlib_shellsort_t2)
 
-.i_11
+.shs_i11
 	ex	de,hl		; same subtraction is used twice in the for loop
 	and	a
 	sbc	hl,de
 	ld	(__stdlib_shellsort_j),hl
 
 	; for ..; j>0; ..
-	jp	m,i_6
+	jp	m,shs_i6
  
         ; hl = j
         
@@ -135,7 +135,7 @@ asm_shellsort:
         ; if ((*compar)(base+j, jd+j) <=0) break;
 
         call l_compare_de_hl   ; compare(de = jd+j, hl = base+j)
-        jp p, i_6              ; if *(jd+j) >= *(base+j)
+        jp p, shs_i6              ; if *(jd+j) >= *(base+j)
 
         ; de = jd + j (2nd arg)
         ; hl = base + j (1st arg)
@@ -149,7 +149,7 @@ asm_shellsort:
 	; for ... j -= gap)
 	ld	de,(__stdlib_shellsort_j)
 	ld	hl,(__stdlib_shellsort_gap)
-	jr	i_11
+	jr	shs_i11
 
 
 SECTION bss_clib

--- a/test/suites/stdlib/main.c
+++ b/test/suites/stdlib/main.c
@@ -13,6 +13,10 @@ int main(int argc, char *argv[])
 #endif
     res += test_strtol();
     res += test_unbcd();
+#ifndef __8080__
+    res += test_qsort();
+    res += test_qsort_newlib();
+#endif
 
     return res;
 }

--- a/test/suites/stdlib/qsort.c
+++ b/test/suites/stdlib/qsort.c
@@ -1,0 +1,89 @@
+
+#ifndef __8080__
+
+#include "stdlib_tests.h"
+#include <stdint.h>
+
+#define NUM 550L
+
+static uint16_t i;
+static int16_t numbers[NUM];
+
+static void init_numbers(int16_t val0, int16_t v_add)
+{
+   // not pseudo random numbers, but keeping the performance of all init styles same
+   printf("Numbers: %d %+d & 0x3fff: ", val0, v_add);
+   for (i = 0; i < NUM; ++i, val0 += v_add) numbers[i] = val0 & 0x3fff;
+   for (i = 0; i < 3; ++i) printf("%d, ", numbers[i]);
+   printf("...\n");
+}
+
+static int ascending_order(int16_t *a, int16_t *b)
+{
+   // signed comparison is only good for |num| < 32768
+   return *a - *b;
+}
+
+static struct qsort_init_data {
+   int16_t val0, v_add;
+   int16_t result_first, result_last;
+   int32_t sum;
+   const char name[4];
+} data[] = {
+   { 1, +197, 0, 16352, 4331041, "ran" },
+   { 1, +1, 1, NUM, (NUM*(NUM+1))>>1, "ord" },
+   { NUM, -1, 1, NUM, (NUM*(NUM+1))>>1, "rev" },
+   { NUM>>1, +0, NUM>>1, NUM>>1, (NUM*(NUM>>1)), "equ" },
+};
+
+static void qsort_test_case(struct qsort_init_data *test)
+{
+   printf("[%s]: ", test->name);
+   // init numbers array
+   init_numbers(test->val0, test->v_add);
+   // perform qsort
+   printf("qsort running. ");
+   qsort(numbers, NUM, sizeof(int16_t), ascending_order);
+   printf("done: %d, %d, ..., %d, %d\n", numbers[0], numbers[1], numbers[NUM-2], numbers[NUM-1]);
+   // verify result
+   int32_t sum = (int32_t)numbers[0];
+   for (i = 1; i < NUM; ++i) {
+      sum += (int32_t)numbers[i];
+      Assert(numbers[i-1] <= numbers[i], "Sort failed");
+   }
+   Assert(test->result_first == numbers[0], "Sort failed [first]");
+   Assert(test->result_last == numbers[NUM-1], "Sort failed [last]");
+   Assert(test->sum == sum, "Sort failed [sum]");
+}
+
+static void qsort_test_case_ran()
+{
+    qsort_test_case(data+0);
+}
+
+static void qsort_test_case_ord()
+{
+    qsort_test_case(data+1);
+}
+
+static void qsort_test_case_rev()
+{
+    qsort_test_case(data+2);
+}
+
+static void qsort_test_case_equ()
+{
+    qsort_test_case(data+3);
+}
+
+int test_qsort()
+{
+    suite_setup("classic-lib qsort() tests");
+    suite_add_test(qsort_test_case_ran);
+    suite_add_test(qsort_test_case_ord);
+    suite_add_test(qsort_test_case_rev);
+    suite_add_test(qsort_test_case_equ);
+    return suite_run();
+}
+
+#endif

--- a/test/suites/stdlib/qsort_newlib.c
+++ b/test/suites/stdlib/qsort_newlib.c
@@ -1,0 +1,163 @@
+
+#ifndef __8080__
+
+#include "stdlib_tests.h"
+#include <stdint.h>
+
+#define NUM 550L
+
+typedef void (*exec_sort)(void *base,size_t nmemb,size_t size,void *compar) __smallc;
+
+static uint16_t i;
+static int16_t numbers[NUM];
+
+static int ascending_order(int16_t *a, int16_t *b)
+{
+   // signed comparison is only good for |num| < 32768
+   return *a - *b;
+}
+
+static struct qsort_init_data {
+   int16_t val0, v_add;
+   int16_t result_first, result_last;
+   int32_t sum;
+   const char name[4];
+} data[] = {
+   { 1, +197, 0, 16352, 4331041, "ran" },
+   { 1, +1, 1, NUM, (NUM*(NUM+1))>>1, "ord" },
+   { NUM, -1, 1, NUM, (NUM*(NUM+1))>>1, "rev" },
+   { NUM>>1, +0, NUM>>1, NUM>>1, (NUM*(NUM>>1)), "equ" },
+};
+
+const char* isort_name = "insertion";
+const char* ssort_name = "shell";
+#ifndef __RCMX000__
+   const char* qsort_name = "quick 0x0c";    // middle-pivot, insertion-sort enabled, equality dispersal enabled
+#else
+   const char* qsort_name = "quick 0x04";    // Rabbit has no R register used for equality distribution
+#endif
+
+// include newlib implementation of various sorts
+static void dummy()
+{
+#asm
+   // configure quicksort implementation
+#ifndef __RCMX000__
+   DEFC __CLIB_OPT_SORT_QSORT = 0x0c   ; middle-pivot, insertion-sort enabled, equality dispersal enabled
+#else
+   DEFC __CLIB_OPT_SORT_QSORT = 0x04   ; middle-pivot, insertion-sort enabled, equality dispersal disabled (missing R reg)
+#endif
+
+   ; Include newlib sorts
+   INCLUDE "../../../libsrc/_DEVELOPMENT/stdlib/z80/sort/__sort_parameters.asm"
+   INCLUDE "../../../libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_insertion_sort.asm"
+   INCLUDE "../../../libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_shellsort.asm"
+   INCLUDE "../../../libsrc/_DEVELOPMENT/stdlib/z80/sort/asm_quicksort.asm"
+
+   #define read_qsort_small_c_args \
+         pop af \ pop ix \ pop de \ pop hl \ pop bc \ \
+         push bc \ push hl \ push de \ push ix \ push af \ \
+         ; enter : ix = int (*compar)(de=const void *, hl=const void *) \
+         ;         bc = void *base \
+         ;         hl = size_t nmemb \
+         ;         de = size_t size
+
+#endasm
+}
+
+// execute insertion sort directly
+static void exec_newlib_isort(void *base,size_t nmemb,size_t size,void *compar) __smallc __naked
+{
+#asm
+   read_qsort_small_c_args
+   call asm_insertion_sort
+   ret
+#endasm
+}
+
+// execute shell sort directly
+static void exec_newlib_ssort(void *base,size_t nmemb,size_t size,void *compar) __smallc __naked
+{
+#asm
+   read_qsort_small_c_args
+   call asm_shellsort
+   ret
+#endasm
+}
+
+// execute quick sort directly
+static void exec_newlib_qsort(void *base,size_t nmemb,size_t size,void *compar) __smallc __naked
+{
+#asm
+   read_qsort_small_c_args
+   call asm_quicksort
+   ret
+#endasm
+}
+
+static void init_numbers(int16_t val0, int16_t v_add)
+{
+   // not pseudo random numbers, but keeping the performance of all init styles same
+   printf("Numbers: %d %+d & 0x3fff: ", val0, v_add);
+   for (i = 0; i < NUM; ++i, val0 += v_add) numbers[i] = val0 & 0x3fff;
+   for (i = 0; i < 3; ++i) printf("%d, ", numbers[i]);
+   printf("...\n");
+}
+
+static void qsort_test_case(struct qsort_init_data *test, exec_sort exec_sort_fn, const char* sort_name)
+{
+   printf("[%s][%s]: ", sort_name, test->name);
+   // init numbers array
+   init_numbers(test->val0, test->v_add);
+   // perform sort
+   printf("sort running. ");
+   exec_sort_fn(numbers, NUM, sizeof(int16_t), ascending_order);
+   printf("done: %d, %d, ..., %d, %d\n", numbers[0], numbers[1], numbers[NUM-2], numbers[NUM-1]);
+   // verify result
+   int32_t sum = (int32_t)numbers[0];
+   for (i = 1; i < NUM; ++i) {
+      sum += (int32_t)numbers[i];
+      Assert(numbers[i-1] <= numbers[i], "Sort failed");
+   }
+   Assert(test->result_first == numbers[0], "Sort failed [first]");
+   Assert(test->result_last == numbers[NUM-1], "Sort failed [last]");
+   Assert(test->sum == sum, "Sort failed [sum]");
+}
+
+static void isort_test_case_ran() { qsort_test_case(data+0, &exec_newlib_isort, isort_name); }
+static void isort_test_case_ord() { qsort_test_case(data+1, &exec_newlib_isort, isort_name); }
+static void isort_test_case_rev() { qsort_test_case(data+2, &exec_newlib_isort, isort_name); }
+static void isort_test_case_equ() { qsort_test_case(data+3, &exec_newlib_isort, isort_name); }
+
+static void ssort_test_case_ran() { qsort_test_case(data+0, &exec_newlib_ssort, ssort_name); }
+static void ssort_test_case_ord() { qsort_test_case(data+1, &exec_newlib_ssort, ssort_name); }
+static void ssort_test_case_rev() { qsort_test_case(data+2, &exec_newlib_ssort, ssort_name); }
+static void ssort_test_case_equ() { qsort_test_case(data+3, &exec_newlib_ssort, ssort_name); }
+
+static void qsort_test_case_ran() { qsort_test_case(data+0, &exec_newlib_qsort, qsort_name); }
+static void qsort_test_case_ord() { qsort_test_case(data+1, &exec_newlib_qsort, qsort_name); }
+static void qsort_test_case_rev() { qsort_test_case(data+2, &exec_newlib_qsort, qsort_name); }
+static void qsort_test_case_equ() { qsort_test_case(data+3, &exec_newlib_qsort, qsort_name); }
+
+int test_qsort_newlib()
+{
+    suite_setup("newlib insertion/shell/quick sorts tests");
+
+    suite_add_test(isort_test_case_ran);
+    suite_add_test(isort_test_case_ord);
+    suite_add_test(isort_test_case_rev);
+    suite_add_test(isort_test_case_equ);
+
+    suite_add_test(ssort_test_case_ran);
+    suite_add_test(ssort_test_case_ord);
+    suite_add_test(ssort_test_case_rev);
+    suite_add_test(ssort_test_case_equ);
+
+    suite_add_test(qsort_test_case_ran);
+    suite_add_test(qsort_test_case_ord);
+    suite_add_test(qsort_test_case_rev);
+    suite_add_test(qsort_test_case_equ);
+    return suite_run();
+}
+
+#endif

--- a/test/suites/stdlib/stdlib_tests.h
+++ b/test/suites/stdlib/stdlib_tests.h
@@ -1,7 +1,7 @@
 
 
-#ifndef STRING_TESTS_H
-#define STRING_TESTS_H
+#ifndef STDLIB_TESTS_H
+#define STDLIB_TESTS_H
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -13,6 +13,8 @@ extern int test_isqrt();
 extern int test_isqrt2();
 extern int test_strtol();
 extern int test_unbcd();
+extern int test_qsort();
+extern int test_qsort_newlib();
 
 
 #endif


### PR DESCRIPTION
Adding some tests before tampering with newlib sort implementation a bit more.

The modification of labels in shellsort asm is because they were clashing with local labels emitted in the test C file itself, which is including the asm files (technique copied from test/suites/zx, otherwise I have no idea how to better test newlib stuff, as it has no +test target, plus the config ahead of building library is getting into way of testing various configurations, so including the sources directly seems to be pretty effective, until they contain generic `i_#` labels which are used also by the compiler itself...).