### PR TITLE
ticks - using map file option -x enables also symbols for -pc,-start,-end

### DIFF
--- a/src/ticks/disassembler_main.c
+++ b/src/ticks/disassembler_main.c
@@ -34,7 +34,7 @@ static void usage(char *program)
     printf("  -mgbz80        Disassemble Gameboy z80 code\n");
     printf("  -m8080         Disassemble 8080 code (with z80 mnenomics)\n");
     printf("  -m8085         Disassemble 8085 code (with z80 mnenomics)\n");
-    printf("  -x <file>      Symbol file to read\n");
+    printf("  -x <file>      Symbol file to read (enables symbols for -o,-s,-e)\n");
 
     exit(1);
 }
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     uint16_t    org = 0;
     int         start = -1;
     uint16_t    end = 65535;
-    int    loaded = 0;
+    int    loaded = 0, symbol_addr = -1;
 
     mem = calloc(1,65536);
 
@@ -65,18 +65,21 @@ int main(int argc, char **argv)
         if( argv[1][0] == '-' && argv[2] ) {
             switch (argc--, argv++[1][1]){
             case 'o':
-                org = strtol(argv[1], &endp, 0);
+                symbol_addr = symbol_resolve(argv[1]);
+                org = (-1 == symbol_addr) ? strtol(argv[1], &endp, 0) : symbol_addr;
                 if ( start == -1 ) {
                     start = org;
                 }
                 argc--; argv++;
                 break;
             case 's':
-                start = strtol(argv[1], &endp, 0);
+                symbol_addr = symbol_resolve(argv[1]);
+                start = (-1 == symbol_addr) ? strtol(argv[1], &endp, 0) : symbol_addr;
                 argc--; argv++;
                 break;
             case 'e':
-                end = strtol(argv[1], &endp, 0);
+                symbol_addr = symbol_resolve(argv[1]);
+                end = (-1 == symbol_addr) ? strtol(argv[1], &endp, 0) : symbol_addr;
                 argc--; argv++;
                 break;
             case 'i':

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -712,7 +712,7 @@ void setf(int a){
 extern backend_t ticks_debugger_backend;
 
 int main (int argc, char **argv){
-  int size= 0, start= 0, end= 0, intr= 0, tap= 0, alarmtime = 0, load_address = 0;
+  int size= 0, start= 0, end= 0, intr= 0, tap= 0, alarmtime = 0, load_address = 0, symbol_addr = -1;
   char * output= NULL;
   char  *memory_model = "standard";
   FILE * fh;
@@ -746,7 +746,7 @@ int main (int argc, char **argv){
     printf("  -mr3k          Emulate a Rabbit 3000\n"),
     printf("  -mz80n         Emulate a Spectrum Next z80n\n"),
     printf("  -mez80         Emulate an ez80 (z80 mode)\n"),
-    printf("  -x <file>      Symbol file to read\n"),
+    printf("  -x <file>      Symbol file to read (enables symbols for -pc,-start,-end)\n"),
     printf("  -ide0 <file>   Set file to be ide device 0\n"),
     printf("  -ide1 <file>   Set file to be ide device 1\n"),
     printf("  -iochar X      Set port X to be character input/output\n"),
@@ -766,13 +766,16 @@ int main (int argc, char **argv){
           memory_model = argv[1];
           break;
         case 'p':
-          pc= strtol(argv[1], NULL, 16);
+          symbol_addr= symbol_resolve(argv[1]);
+          pc= (-1 == symbol_addr) ? strtol(argv[1], NULL, 16) : symbol_addr;
           break;
         case 's':
-          start= strtol(argv[1], NULL, 16);
+          symbol_addr= symbol_resolve(argv[1]);
+          start= (-1 == symbol_addr) ? strtol(argv[1], NULL, 16) : symbol_addr;
           break;
         case 'e':
-          end= strtol(argv[1], NULL, 16);
+          symbol_addr= symbol_resolve(argv[1]);
+          end= (-1 == symbol_addr) ? strtol(argv[1], NULL, 16) : symbol_addr;
           break;
         case 'r':
           rom_size= strtol(argv[1], NULL, 16);


### PR DESCRIPTION
new feature to make benchmarking simpler (to automate by scripting,
without extracting the hexa address from .map file some other way)

so previously usage like:

`z88dk-ticks sort-ran-20.bin -start 0385 -end 0398 -w 40`

can be now also (the -x must be ahead of using symbols as values):

`z88dk-ticks sort-ran-20.bin -x sort-ran-20.map -start TIMER_START -end
TIMER_STOP -w 40`