### PR TITLE
Fixed bugs in section name handling

### DIFF
--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -5,12 +5,6 @@
 #include "ticks.h"
 #include "debug.h"
 
-#if defined(_WIN32) || defined(WIN32)
-#ifndef strncasecmp
-#define strncasecmp(a,b,c) strnicmp(a,b,c)
-#endif
-#endif
-
 static symbol  *symbols[65536] = {0};
 static symbol  *symbols_byname = NULL;
 

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -5,6 +5,12 @@
 #include "ticks.h"
 #include "debug.h"
 
+#if defined(_WIN32) || defined(WIN32)
+#ifndef strncasecmp
+#define strncasecmp(a,b,c) strnicmp(a,b,c)
+#endif
+#endif
+
 static symbol  *symbols[65536] = {0};
 static symbol  *symbols_byname = NULL;
 

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -96,7 +96,7 @@ void read_symbol_file(char *filename)
                                 section *sect = calloc(1,sizeof(*sect));
                                 sect->start = start;
                                 sect->end = start + size;
-                                sect->name = duplen(argv[0] + 2, len - 5);
+                                sect->name = duplen(argv[0] + 2, len - 5 - 2);
                                 LL_APPEND(sections, sect);
                             }
                         }
@@ -352,7 +352,7 @@ int address_is_code(int addr)
 
     while ( sect != NULL ) {
         if ( addr >= sect->start && addr < sect->end) {
-            return (strncmp(sect->name, "code_",5) == 0 || strncmp(sect->name, "smc_",4) == 0 );
+            return (strncasecmp(sect->name, "code_",5) == 0 || strncasecmp(sect->name, "smc_",4) == 0 );
         }
         sect = sect->next;
     }

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -8,15 +8,6 @@
 #include "debugger.h"
 #include "backend.h"
 
-#if defined(_WIN32) || defined(WIN32)
-#ifndef strcasecmp
-#define strcasecmp(a,b) stricmp(a,b)
-#endif
-#endif
-
-
-
-
 // fr = zero, ff&256 = carry, ff&128 = s/p
 
 // TODO: Setting P flag

--- a/src/ticks/ticks.h
+++ b/src/ticks/ticks.h
@@ -13,6 +13,18 @@
 #include "uthash.h"
 #include "utlist.h"
 
+#if defined(_WIN32) || defined(WIN32)
+
+#ifndef strcasecmp
+#define strcasecmp(a,b) stricmp(a,b)
+#endif
+
+#ifndef strncasecmp
+#define strncasecmp(a,b,c) strnicmp(a,b,c)
+#endif
+
+#endif
+
 extern unsigned char a,b,c,d,e,h,l;
 extern unsigned char a_,b_,c_,d_,e_,h_,l_;
 extern unsigned char xh, xl, yh, yl;


### PR DESCRIPTION
Two fixes:

1) Ignore case when searching for section names
2) When adding a new section, subtract 2 from the name length to account for removing the first 2 characters of the string
