### PR TITLE
TVC time() fixed for ticks of system (instead of ticks * 65536)

### DIFF
--- a/libsrc/target/tvc/time/clock.asm
+++ b/libsrc/target/tvc/time/clock.asm
@@ -15,7 +15,6 @@
 .clock
 ._clock
 	ld hl,(INTINC) ; count of 20.096ms from start (can count up to almost 22mins)
-	ex de,hl
-    ld h,0
-    ld l,h
+    ld d,0
+    ld e,d
 	ret

--- a/libsrc/target/tvc/time/clock.asm
+++ b/libsrc/target/tvc/time/clock.asm
@@ -15,6 +15,5 @@
 .clock
 ._clock
 	ld hl,(INTINC) ; count of 20.096ms from start (can count up to almost 22mins)
-    ld d,0
-    ld e,d
+    ld de,0
 	ret


### PR DESCRIPTION
fix for TVC time()