### PR TITLE
Ticks misc improvements

### DIFF
--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -16,6 +16,7 @@ typedef void (*debugger_write_memory_cb)(int addr, uint8_t val);
 typedef void (*debugger_read_memory_cb)(int addr);
 typedef void (*get_regs_cb)(struct debugger_regs_t* regs);
 typedef void (*void_cb)();
+typedef uint8_t (*uint8_t_cb)();
 typedef uint8_t (*breakpoints_check_cb)();
 typedef void (*breakpoint_cb)(uint8_t type, uint16_t at, uint8_t sz);
 
@@ -55,6 +56,7 @@ typedef struct {
     breakpoint_cb disable_breakpoint;
     breakpoint_cb enable_breakpoint;
     breakpoints_check_cb breakpoints_check;
+    uint8_t_cb is_verbose;
 } backend_t;
 
 extern backend_t bk;

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -694,7 +694,9 @@ void debug_add_info_encoded(char *encoded)
         }
     }
 
-    printf("Decoded cdb: <%s>\n",encoded);
+    if (bk.is_verbose()) {
+        printf("Decoded cdb: <%s>\n",encoded);
+    }
 }
 
 

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -807,6 +807,14 @@ int main(int argc, char **argv) {
     char* connect_host = NULL;
     int connect_port = 0;
 
+    printf("----------------------------------\n"
+           "z88dk-gdb, a gdb client for z88dk.\n"
+           "----------------------------------\n"
+           "\n"
+           "See the following for a list of compatible gdb servers: "
+           "https://github.com/z88dk/z88dk/wiki/Tool-z88dk-gdb\n"
+           "\n");
+
     set_backend(gdb_backend);
 
     for (int i = 1; i < argc; i++) {
@@ -829,7 +837,6 @@ int main(int argc, char **argv) {
     }
 
     if (connect_port == 0 || connect_host == NULL) {
-        printf("z88dk-gdb, a gdb client.\n");
         printf("Usage: z88dk-gdb -h <connect host> -p <connect port> -x <debug symbols> [-x <debug symbols>] [-v]\n");
         return 1;
     }

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -24,7 +24,7 @@ struct network_op
     struct network_op* prev;
 };
 
-uint8_t verbose = 0;
+static uint8_t verbose = 0;
 int c_autolabel = 0;
 static uint8_t registers_invalidated = 1;
 static sem_t* req_response_mutex = NULL;
@@ -290,6 +290,11 @@ uint16_t get_ff()
     return 0;
 }
 
+uint8_t is_verbose()
+{
+    return verbose;
+}
+
 uint16_t get_pc()
 {
     return fetch_registers()->pc;
@@ -323,7 +328,7 @@ uint8_t get_memory(uint16_t at)
         mem_requested_amount = (uint16_t)(0x10000 - (int)mem_requested_at);
     }
 
-    if (verbose)
+    if (bk.is_verbose())
     {
         printf("Fetching a chunk of %d bytes starting from address %d.\n", mem_requested_amount, mem_requested_at);
     }
@@ -630,7 +635,8 @@ static backend_t gdb_backend = {
     .remove_breakpoint = &remove_breakpoint,
     .disable_breakpoint = &disable_breakpoint,
     .enable_breakpoint = &enable_breakpoint,
-    .breakpoints_check = &breakpoints_check
+    .breakpoints_check = &breakpoints_check,
+    .is_verbose = is_verbose
 };
 
 static void execute_on_main_thread(trapped_action_t call, const void* data, void* response)
@@ -669,7 +675,7 @@ void remote_execution_stopped(const void* data, void* response)
         return;
     }
 
-    if (verbose)
+    if (bk.is_verbose())
     {
         printf("Execution stopped.\n");
     }
@@ -687,14 +693,14 @@ static uint8_t process_packet()
     }
 
     if (inbuf_size > 0 && *inbuf == '+') {
-        if (verbose) {
+        if (bk.is_verbose()) {
             printf("ack.\n");
         }
         inbuf_erase_head(1);
         return 1;
     }
 
-    if (verbose) {
+    if (bk.is_verbose()) {
         printf("r: %.*s\n", inbuf_size, inbuf);
     }
 
@@ -713,7 +719,7 @@ static uint8_t process_packet()
 
     if (checksum != (hex(inbuf[packetend + 1]) << 4 | hex(inbuf[packetend + 2])))
     {
-        if (verbose) {
+        if (bk.is_verbose()) {
             printf("Warning: incorrect checksum, expected: %02x\n", checksum);
         }
         inbuf_erase_head(packetend + 3);
@@ -801,6 +807,8 @@ int main(int argc, char **argv) {
     char* connect_host = NULL;
     int connect_port = 0;
 
+    set_backend(gdb_backend);
+
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-p") == 0) {
             connect_port = atoi(argv[++i]);
@@ -808,9 +816,13 @@ int main(int argc, char **argv) {
             connect_host = argv[++i];
         } else if (strcmp(argv[i], "-x") == 0) {
             char* debug_symbols = argv[++i];
-            printf("Reading debug symbols...");
+            if (bk.is_verbose()) {
+                printf("Reading debug symbols...");
+            }
             read_symbol_file(debug_symbols);
-            printf("OK\n");
+            if (bk.is_verbose()) {
+                printf("OK\n");
+            }
         } else if (strcmp(argv[i], "-v") == 0) {
             verbose = 1;
         }
@@ -823,7 +835,6 @@ int main(int argc, char **argv) {
     }
 
     debugger_init();
-    set_backend(gdb_backend);
 
     connection_socket = socket(AF_INET, SOCK_STREAM, 0);
 

--- a/src/ticks/debugger_gdb_packets.c
+++ b/src/ticks/debugger_gdb_packets.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include "backend.h"
 #include "debugger_gdb_packets.h"
 
 struct packet_buf
@@ -121,12 +122,10 @@ void write_packet_bytes(const uint8_t *data, size_t num_bytes)
     write_hex(checksum);
 }
 
-extern uint8_t verbose;
-
 void write_packet(const char *data)
 {
     write_packet_bytes((const uint8_t *)data, strlen(data));
-    if (verbose)
+    if (bk.is_verbose())
     {
         printf("w: %s\n", data);
     }

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -6,6 +6,8 @@
 #include "backend.h"
 #include "disassembler.h"
 
+uint8_t verbose = 0;
+
 long long get_st()
 {
     return st;
@@ -29,6 +31,11 @@ uint16_t get_sp()
 uint8_t get_ticks_memory(uint16_t at)
 {
     return get_memory(at);
+}
+
+uint8_t is_verbose()
+{
+    return verbose;
 }
 
 void get_regs(struct debugger_regs_t* regs)
@@ -205,5 +212,6 @@ backend_t ticks_debugger_backend = {
     .remove_breakpoint = &remove_breakpoint,
     .disable_breakpoint = &disable_breakpoint,
     .enable_breakpoint = &enable_breakpoint,
-    .breakpoints_check = &breakpoints_check
+    .breakpoints_check = &breakpoints_check,
+    .is_verbose = is_verbose
 };

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -108,8 +108,20 @@ void read_symbol_file(char *filename)
                     symbol *sym = calloc(1,sizeof(*sym));
                     sym->name = strdup(argv[0]);
                     sym->address = strtol(!isxdigit(argv[2][0]) ? &argv[2][1] : argv[2], NULL, 16);
-                    sym->symtype = SYM_ADDRESS;
-                    LL_APPEND(symbols[sym->address % SYM_TAB_SIZE], sym);
+                    if (argc >= 5) {
+                        if (strstr(argv[4], "const")) {
+                            sym->symtype = SYM_CONST;
+                        } else {
+                            sym->symtype = SYM_ADDRESS;
+                        }
+                    } else {
+                        sym->symtype = SYM_ADDRESS;
+                    }
+                    if (sym->symtype == SYM_ADDRESS) {
+                        if ( sym->address >= 0 && sym->address <= 65535 ) {
+                            LL_APPEND(symbols[sym->address % SYM_TAB_SIZE], sym);
+                        }
+                    }
                     HASH_ADD_KEYPTR(hh, symbols_byname, sym->name, strlen(sym->name), sym);
                 }
                 free(argv);

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -725,6 +725,7 @@ int main (int argc, char **argv){
     printf("  -counter X     X in decimal is another condition to exit\n"),
     printf("  -int X         X in decimal are number of cycles for periodic interrupts\n"),
     printf("  -d             Enable debugger\n"),
+    printf("  -v             Verbose logging\n"),
     printf("  -l X           Load file to address\n"),
     printf("  -b <model>     Memory model (zxn/zx/z180)\n"),
     printf("  -m8080         Emulate an 8080\n"),
@@ -793,6 +794,11 @@ int main (int argc, char **argv){
         case 'd':
           debugger_active = 1;
           debugger_init();
+          argv--;
+          argc++;
+          break;
+        case 'v':
+          verbose = 1;
           argv--;
           argc++;
           break;

--- a/src/ticks/ticks.h
+++ b/src/ticks/ticks.h
@@ -39,6 +39,8 @@ extern int rom_size;		/* amount of memory in low addresses that is read-only */
 extern int ioport;
 extern int rc2014_mode;
 
+extern uint8_t verbose;
+
 /* Break down flags */
 extern int f(void);
 extern int f_(void);


### PR DESCRIPTION
Commit messages say it all. The most notable is addition of `stack` command:

```
> stack
Examining stack (8 values) starting from $614a:
Values: 6cd8 0000 61c2 0000 0000 0000 0000 0000
Detail:
  $614a (offset 0): 6cd8
    $6c9d _main (+59)
  $614c (offset 2): 0000
    ?
  $614e (offset 4): 61c2
    $61c2 cleanup (+0)
  $6150 (offset 6): 0000
    ?
  $6152 (offset 8): 0000
    ?
  $6154 (offset 10): 0000
    ?
  $6156 (offset 12): 0000
    ?
  $6158 (offset 14): 0000
    ?
```

Also, fixed symbol parsing, due to an error a lot of const symbols were attributed as an addr symbol and thus show up in stack examinations especially near the $0000 address.