### PR TITLE
ticks: setting a breakpoint on incomplete filename

### DIFF
--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -748,7 +748,7 @@ int debug_find_source_location(int address, const char **filename, int *lineno)
     return 0;
 }
 
-int debug_resolve_source(char *name)
+int debug_resolve_source(char *name, const char** corrected_name)
 {
     char *ptr;
 
@@ -769,6 +769,31 @@ int debug_resolve_source(char *name)
 
             if ( cl != NULL ) {
                 return cl->address;
+            }
+        } else {
+            // try and do partial match
+            cfile *elem, *tmp;
+            uint32_t filename_len = strlen(filename);
+            HASH_ITER(hh, cfiles, elem, tmp) {
+                uint32_t elem_file_len = strlen(elem->file);
+
+                if (elem_file_len < filename_len)
+                    continue;
+
+                if (memcmp(filename, elem->file + elem_file_len - filename_len, filename_len) != 0)
+                    continue;
+
+                cline *cl;
+                HASH_FIND_INT(elem->lines, &line, cl);
+
+                if ( cl != NULL ) {
+                    if (corrected_name) {
+                        *corrected_name = elem->file;
+                    }
+                    return cl->address;
+                }
+
+                break;
             }
         }
     }

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -467,7 +467,13 @@ static debug_sym_symbol* debug_parse_symbol_info(const char* encoded, const char
     int end;
 
     if (sscanf(encoded, "%[^$]$%[^$]$%[^(](%[^)]),%n", symbol_name, level, block, type_record, &end) != 4) {
-        goto err;
+        if (sscanf(encoded, "$%[^$]$%[^(](%[^)]),%n", level, block, type_record, &end) == 3) {
+            static int anon_id = 1;
+            // we've got anonymous type, so come up with something
+            sprintf(symbol_name, "anon_%d", anon_id++);
+        } else {
+            goto err;
+        }
     }
     s->symbol_name = strdup(symbol_name);
     encoded += end;

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -154,7 +154,7 @@ struct debugger_regs_t {
 extern void debug_add_info_encoded(char *encoded);
 extern int debug_find_source_location(int address, const char **filename, int *lineno);
 extern void debug_add_cline(const char *filename, const char *function, int lineno, int level, int scope, const char *address);
-extern int debug_resolve_source(char *name);
+extern int debug_resolve_source(char *name, const char** corrected_name);
 extern int debug_resolve_source_forward(const char *filename, const char* within_function, int lineno);
 
 extern type_chain* copy_type_chain(type_chain* from);


### PR DESCRIPTION
Some projects, like mine, generate `.map` with very long filenames. That makes setting a breakpoint on those cumbersome, as currently exact filename is required.

This change allows partial matching, if nothing matches verbatim.

```
b client.c:71
Adding breakpoint at '/Users/desertkun/Documents/Work/zx-sandbox/client/src/client.c' $6a03 (_client_message_sync_obj+268)
i b
1:	PC = $6a03 (_client_message_sync_obj+268) 
```

Also, added support for anonymous types

```
struct map_object_t
{
    uint16_t object_id;
    uint16_t x;
    uint16_t y;
    map_object_type_t type;
    union
    {
        uint8_t payload;
        uint8_t client_id;
    };
};
```
is processed as such
```
$2 = <struct map_object_t> {object_id=3, x=94, y=17, type=1, anon_3={payload=2, client_id=2}}
```