### PR TITLE
ticks: fix step/next

### DIFF
--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -8,8 +8,8 @@ endif
 
 include ../Make.common
 
-OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o exp_engine.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
-GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o debugger_gdb.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
+OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o breakpoints.o exp_engine.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
+GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o breakpoints.o debugger_gdb.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
 DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o exp_engine.o backend.o
 LEXOBJS = lex.yy.o expressions.tab.o
 

--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -1,6 +1,7 @@
 #ifndef BACKEND_H
 #define BACKEND_H
 
+#include "breakpoints.h"
 #include <inttypes.h>
 
 struct debugger_regs_t;
@@ -19,14 +20,6 @@ typedef void (*void_cb)();
 typedef uint8_t (*uint8_t_cb)();
 typedef uint8_t (*breakpoints_check_cb)();
 typedef void (*breakpoint_cb)(uint8_t type, uint16_t at, uint8_t sz);
-
-enum bk_breakpoint_type
-{
-    BK_BREAKPOINT_SOFTWARE = 0,
-    BK_BREAKPOINT_HARDWARE = 1,
-    BK_BREAKPOINT_WATCHPOINT = 2,
-    BK_BREAKPOINT_REGISTER = 2,
-};
 
 typedef struct {
     get_longlong_cb st;

--- a/src/ticks/breakpoints.c
+++ b/src/ticks/breakpoints.c
@@ -1,0 +1,149 @@
+#include "breakpoints.h"
+#include "backend.h"
+#include "exp_engine.h"
+#include "debugger.h"
+
+#include <stddef.h>
+#include <utlist.h>
+#include <stdlib.h>
+#include <printf.h>
+
+breakpoint *breakpoints;
+breakpoint *watchpoints;
+
+// temporary breakpoints live to the point one of them is hit. in that case all of them has to be removed
+temporary_breakpoint_t* temporary_breakpoints = NULL;
+
+breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type, 
+    int bk_size, int value, const char* text) {
+    breakpoint* elem = calloc(1, sizeof(breakpoint));
+    
+    elem->type = type;
+    elem->value = value;
+    elem->enabled = 1;
+    elem->text = NULL;
+    LL_APPEND(breakpoints, elem);
+    
+    bk.add_breakpoint(bk_type, value, bk_size);
+    return elem;
+}
+
+void delete_breakpoint(breakpoint* b) {
+    bk.remove_breakpoint(BK_BREAKPOINT_SOFTWARE, b->value, 1);
+    LL_DELETE(breakpoints, b);
+    if (b->text) {
+        free(b->text);
+        b->text = NULL;
+    }
+    free(b);
+}
+
+temporary_breakpoint_t* add_temporary_internal_breakpoint(uint32_t address, temporary_breakpoint_reason_t reason,
+    const char *source_filename, int source_lineno) {
+    temporary_breakpoint_t* tmp_step = malloc(sizeof(temporary_breakpoint_t));
+    tmp_step->at = address;
+    tmp_step->callee = NULL;
+    tmp_step->external = 0;
+    tmp_step->source_file = source_filename;
+    tmp_step->source_line = source_lineno;
+    tmp_step->reason = reason;
+    LL_APPEND(temporary_breakpoints, tmp_step);
+    return tmp_step;
+}
+
+void remove_temp_breakpoints() {
+    // regardless of the reason we've stopped, all temp breakpoints have to be removed
+    while (temporary_breakpoints) {
+        if (temporary_breakpoints->external) {
+            bk.remove_breakpoint(BK_BREAKPOINT_SOFTWARE, temporary_breakpoints->at, 1);
+        }
+        temporary_breakpoint_t* next = temporary_breakpoints->next;
+        free(temporary_breakpoints);
+        temporary_breakpoints = next;
+    }
+}
+
+uint8_t process_temp_breakpoints() {
+    uint8_t dodebug = 0;
+
+    temporary_breakpoint_t *temp_br;
+    LL_FOREACH(temporary_breakpoints, temp_br) {
+        if ((temp_br->at == 0xFFFFFFFF) || (bk.pc() == temp_br->at)) {
+            dodebug = 1;
+            temporary_breakpoint_reason_t reason = temp_br->reason;
+            switch (reason) {
+                case TMP_REASON_FIN: {
+                    struct debugger_regs_t regs;
+                    bk.get_regs(&regs);
+                    uint16_t hl = wrap_reg(regs.h, regs.l);
+                    uint16_t de = wrap_reg(regs.d, regs.e);
+                    uint32_t return_value = ((uint32_t)de << 16) | hl;
+                    if (temp_br->callee) {
+                        type_chain *ttt = temp_br->callee->type_record.first;
+                        if (ttt->type_ == TYPE_FUNCTION) {
+                            // skip DF
+                            ttt = ttt->next;
+                        }
+                        if (ttt == NULL) {
+                            printf("Warning: unknown callee return type, DEHL returned %08x.\n", return_value);
+                        } else {
+                            if (ttt->type_ != TYPE_VOID) {
+                                struct expression_result_t result = {0};
+                                debug_resolve_expression_element(&temp_br->callee->type_record, ttt,
+                                    RESOLVE_BY_VALUE, return_value, &result);
+                                if (is_expression_result_error(&result)) {
+                                    printf("function %s errored: %s\n", temp_br->callee->function_name, result.as_error);
+                                } else {
+                                    char resolved_result[128] = "<unknown>";
+                                    expression_result_value_to_string(&result, resolved_result, 128);
+                                    printf("function %s returned: %s\n", temp_br->callee->function_name, resolved_result);
+                                }
+                                expression_result_free(&result);
+                            }
+                        }
+                    } else {
+                        printf("Warning: returned from a function without frame pointer.\n");
+                    }
+                    break;
+                }
+                case TMP_REASON_STEP_SOURCE_LINE:
+                case TMP_REASON_NEXT_SOURCE_LINE: {
+                    const char *filename;
+                    int   lineno;
+                    const unsigned short pc = bk.pc();
+                    if (debug_find_source_location(pc, &filename, &lineno) < 0) {
+                        // don't know where we are, keep going
+                        if (reason == TMP_REASON_STEP_SOURCE_LINE) {
+                            bk.step();
+                        } else {
+                            bk.next();
+                        }
+                        return 0;
+                    }
+                    // we're still on the same source line
+                    if ((strcmp(filename, temp_br->source_file) == 0) && (lineno == temp_br->source_line)) {
+                        if (reason == TMP_REASON_STEP_SOURCE_LINE) {
+                            bk.step();
+                        } else {
+                            bk.next();
+                        }
+                        return 0;
+                    } else {
+                        dodebug = 1;
+                    }
+                    break;
+                }
+                default: {
+                    printf("Warning: unknown reason why we stopped on temporary breakpoint.\n");
+                    break;
+                }
+            }
+        }
+    }
+
+    if (dodebug) {
+        remove_temp_breakpoints();
+    }
+
+    return dodebug;
+}

--- a/src/ticks/breakpoints.h
+++ b/src/ticks/breakpoints.h
@@ -1,0 +1,65 @@
+#ifndef BREAKPOINTS_H
+#define BREAKPOINTS_H
+
+#include <stdint.h>
+#include "debug.h"
+
+enum bk_breakpoint_type
+{
+    BK_BREAKPOINT_SOFTWARE = 0,
+    BK_BREAKPOINT_HARDWARE = 1,
+    BK_BREAKPOINT_WATCHPOINT = 2,
+    BK_BREAKPOINT_REGISTER = 2,
+};
+
+typedef enum {
+    BREAK_PC,
+    BREAK_REGISTER,
+    BREAK_CHECK8,
+    BREAK_CHECK16,
+    BREAK_READ,
+    BREAK_WRITE,
+} breakpoint_type;
+
+typedef struct breakpoint {
+    breakpoint_type    type;
+    int                value;
+    unsigned char      lvalue;
+    uint16_t           lcheck_arg;
+    unsigned char      hvalue;
+    uint16_t           hcheck_arg;
+    char               enabled;
+    char               *text;
+    struct breakpoint  *next;
+} breakpoint;
+
+typedef enum {
+    TMP_REASON_UNKNOWN = 0,
+    TMP_REASON_FIN,
+    TMP_REASON_STEP_SOURCE_LINE,
+    TMP_REASON_NEXT_SOURCE_LINE,
+} temporary_breakpoint_reason_t;
+
+typedef struct temporary_breakpoint_t {
+    temporary_breakpoint_reason_t   reason;
+    uint32_t                        at;
+    debug_sym_function*             callee;
+    const char*                     source_file;
+    int                             source_line;
+    uint8_t                         external;
+    struct temporary_breakpoint_t*  next;
+} temporary_breakpoint_t;
+
+extern breakpoint *breakpoints;
+extern breakpoint *watchpoints;
+extern temporary_breakpoint_t* temporary_breakpoints;
+
+extern breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type, int bk_size, int value, const char* text);
+extern void delete_breakpoint(breakpoint* b);
+
+extern temporary_breakpoint_t* add_temporary_internal_breakpoint(uint32_t address, temporary_breakpoint_reason_t reason,
+    const char *source_filename, int source_lineno);
+extern void remove_temp_breakpoints();
+extern uint8_t process_temp_breakpoints();
+
+#endif

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -423,18 +423,14 @@ void debugger()
                         }
                         // we're still on the same source line
                         if ((strcmp(filename, temp_br->source_file) == 0) && (lineno == temp_br->source_line)) {
-                            remove_temp_breakpoints();
                             if (reason == TMP_REASON_STEP_SOURCE_LINE) {
-                                add_temporary_internal_breakpoint(0xFFFFFFFF, reason, filename, lineno);
                                 bk.step();
                             } else {
-                                char  b[100];
-                                int len = disassemble2(pc, b, sizeof(b), 0);
-                                add_temporary_internal_breakpoint(pc + len, reason, filename, lineno);
                                 bk.next();
                             }
                             return;
                         } else {
+                            remove_temp_breakpoints();
                             trace_source = 1;
                         }
                         break;
@@ -645,13 +641,7 @@ static int cmd_next_source(int argc, char **argv)
         printf("Warning: cannot obtain current source line.\n");
         return 0;
     }
-    uint16_t break_at;
-    {
-        char  buf[100];
-        int len = disassemble2(pc, buf, sizeof(buf), 0);
-        break_at = pc + len;
-    }
-    add_temporary_internal_breakpoint(break_at, TMP_REASON_NEXT_SOURCE_LINE, filename, lineno);
+    add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_NEXT_SOURCE_LINE, filename, lineno);
     bk.next();
     return 1;
 }

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -3,27 +3,6 @@
 
 #include <stdint.h>
 
-typedef enum {
-    BREAK_PC,
-    BREAK_REGISTER,
-    BREAK_CHECK8,
-    BREAK_CHECK16,
-    BREAK_READ,
-    BREAK_WRITE,
-} breakpoint_type;
-
-typedef struct breakpoint {
-    breakpoint_type    type;
-    int                value;
-    unsigned char      lvalue;
-    uint16_t           lcheck_arg;
-    unsigned char      hvalue;
-    uint16_t           hcheck_arg;
-    char               enabled;
-    char               *text;
-    struct breakpoint  *next;
-} breakpoint;
-
 extern int debugger_active;
 extern void      debugger_init();
 extern void      debugger();

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -480,7 +480,7 @@ void debugger_resume()
     send_request_no_response("c");
 }
 
-void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+void gdb_add_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
     switch (type)
     {
@@ -505,7 +505,7 @@ void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
     }
 }
 
-void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+void gdb_remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
     char req[64];
     sprintf(req, "z%zx,%zx,%zx", (size_t)type, (size_t)at, (size_t)sz);
@@ -520,12 +520,12 @@ void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
     }
 }
 
-void disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+void gdb_disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
     printf("Warning: not supported.\n");
 }
 
-void enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+void gdb_enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
     printf("Warning: not supported.\n");
 }
@@ -658,10 +658,10 @@ static backend_t gdb_backend = {
     .confirm_detach_w_breakpoints = 1,
     .detach = &debugger_detach,
     .restore = &debugger_restore,
-    .add_breakpoint = &add_breakpoint,
-    .remove_breakpoint = &remove_breakpoint,
-    .disable_breakpoint = &disable_breakpoint,
-    .enable_breakpoint = &enable_breakpoint,
+    .add_breakpoint = &gdb_add_breakpoint,
+    .remove_breakpoint = &gdb_remove_breakpoint,
+    .disable_breakpoint = &gdb_disable_breakpoint,
+    .enable_breakpoint = &gdb_enable_breakpoint,
     .breakpoints_check = &breakpoints_check,
     .is_verbose = is_verbose
 };

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -5,6 +5,7 @@
 #include "debug.h"
 #include "backend.h"
 #include "disassembler.h"
+#include "breakpoints.h"
 
 uint8_t verbose = 0;
 
@@ -92,9 +93,6 @@ void set_regs(struct debugger_regs_t* regs)
     yl = regs->yl;
 }
 
-extern breakpoint *breakpoints;
-extern breakpoint *watchpoints;
-
 void debugger_write_memory(int addr, uint8_t val)
 {
     breakpoint *elem;
@@ -138,10 +136,8 @@ uint8_t restore(const char* file_path, uint16_t at, uint8_t set_pc) {
     printf("Not supported.\n");
     return 1;
 }
-void add_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
-void remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
-void disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
-void enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz) {}
+
+static void do_nothing(uint8_t type, uint16_t at, uint8_t sz) {}
 
 void next()
 {
@@ -208,10 +204,10 @@ backend_t ticks_debugger_backend = {
     .confirm_detach_w_breakpoints = 0,
     .detach = &detach,
     .restore = &restore,
-    .add_breakpoint = &add_breakpoint,
-    .remove_breakpoint = &remove_breakpoint,
-    .disable_breakpoint = &disable_breakpoint,
-    .enable_breakpoint = &enable_breakpoint,
+    .add_breakpoint = &do_nothing,
+    .remove_breakpoint = &do_nothing,
+    .disable_breakpoint = &do_nothing,
+    .enable_breakpoint = &do_nothing,
     .breakpoints_check = &breakpoints_check,
     .is_verbose = is_verbose
 };


### PR DESCRIPTION
This fixes an essentially broken "next" instruction, often it would just fly off as "continue". Instead of placing breakpoint after "call" instruction, I now place a temp breakpoint "anywhere" and see where it lands us.

@suborb I'll keep this PR open for a day and if there's no concern, I'll merge it myself. Don't feel comfortable merging w/o a PR, want to keep you in the loop.