### PR TITLE
IDE debug (mi/2)

### DIFF
--- a/src/sccz80/main.c
+++ b/src/sccz80/main.c
@@ -500,9 +500,7 @@ static void dumpfns()
                 if ( storage != LSTATIC && storage != TYPDEF ) {
                     GlobalPrefix();                    
                     outname(ptr->name, dopref(ptr)); nl();
-                    if ( storage != STATIK ) {
-                        debug_write_symbol(ptr);
-                    }
+                    debug_write_symbol(ptr);
                 }
                 if ( ptr->flags & ASSIGNED_ADDR ) {
                     outfmt("\tdefc\t"); outname(ptr->name,1); outfmt("\t= %d\n", ptr->ctype->value);

--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -9,7 +9,7 @@ endif
 include ../Make.common
 
 OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o breakpoints.o exp_engine.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
-GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o breakpoints.o debugger_gdb.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
+GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o breakpoints.o debugger_gdb.o debugger_mi2.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
 DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o exp_engine.o backend.o
 LEXOBJS = lex.yy.o expressions.tab.o
 

--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -16,10 +16,22 @@ typedef void (*out_cb)(int port, int value);
 typedef void (*debugger_write_memory_cb)(int addr, uint8_t val);
 typedef void (*debugger_read_memory_cb)(int addr);
 typedef void (*get_regs_cb)(struct debugger_regs_t* regs);
+typedef void (*break_cb)(uint8_t temporary);
 typedef void (*void_cb)();
 typedef uint8_t (*uint8_t_cb)();
+typedef void (*log_cb)(const char *fmt, ...);
 typedef uint8_t (*breakpoints_check_cb)();
-typedef void (*breakpoint_cb)(uint8_t type, uint16_t at, uint8_t sz);
+
+typedef enum
+{
+    BREAKPOINT_ERROR_OK = 0,
+    BREAKPOINT_ERROR_NOT_CONNECTED,
+    BREAKPOINT_ERROR_RUNNING,
+    BREAKPOINT_ERROR_FAILURE,
+} breakpoint_ret_t;
+
+typedef breakpoint_ret_t (*breakpoint_cb)(uint8_t type, uint16_t at, uint8_t sz);
+typedef uint8_t (*connect_cb)(const char* hostname, int port);
 
 typedef struct {
     get_longlong_cb st;
@@ -37,7 +49,7 @@ typedef struct {
     debugger_read_memory_cb debugger_read_memory;
     void_cb invalidate;
     uint8_t breakable;
-    void_cb break_;
+    break_cb break_;
     void_cb resume;
     void_cb next;
     void_cb step;
@@ -50,6 +62,11 @@ typedef struct {
     breakpoint_cb enable_breakpoint;
     breakpoints_check_cb breakpoints_check;
     uint8_t_cb is_verbose;
+    log_cb console;
+    log_cb debug;
+    connect_cb remote_connect;
+    void_cb execution_stopped;
+    void_cb ctrl_c;
 } backend_t;
 
 extern backend_t bk;

--- a/src/ticks/backend.h
+++ b/src/ticks/backend.h
@@ -65,6 +65,7 @@ typedef struct {
     log_cb console;
     log_cb debug;
     connect_cb remote_connect;
+    uint8_t_cb is_remote_connected;
     void_cb execution_stopped;
     void_cb ctrl_c;
 } backend_t;

--- a/src/ticks/breakpoints.c
+++ b/src/ticks/breakpoints.c
@@ -16,6 +16,20 @@ temporary_breakpoint_t* temporary_breakpoints = NULL;
 int next_breakpoint_number = 1;
 int break_required = 0;
 
+breakpoint* add_watchpoint(breakpoint_type operation, int value) {
+    breakpoint* w = calloc(1, sizeof(breakpoint));
+
+    // TODO: tie up watchpoints to a backend (e.g. gdb)
+
+    w->number = next_breakpoint_number++;
+    w->type = operation;
+    w->value = value;
+    w->enabled = 1;
+    LL_APPEND(watchpoints, w);
+
+    return w;
+}
+
 breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type, 
     int bk_size, int value, const char* text) {
     breakpoint* elem = calloc(1, sizeof(breakpoint));
@@ -43,6 +57,16 @@ breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type
     }
 
     return elem;
+}
+
+void delete_watchpoint(breakpoint* w) {
+    LL_DELETE(watchpoints, w);
+
+    if (w->text) {
+        free(w->text);
+        w->text = NULL;
+    }
+    free(w);
 }
 
 void delete_breakpoint(breakpoint* b) {
@@ -88,6 +112,16 @@ void delete_all_breakpoints() {
 breakpoint* find_breakpoint(int number) {
     breakpoint *elem;
     LL_FOREACH(breakpoints, elem) {
+        if (elem->number == number) {
+            return elem;
+        }
+    }
+    return NULL;
+}
+
+breakpoint* find_watchpoint(int number) {
+    breakpoint *elem;
+    LL_FOREACH(watchpoints, elem) {
         if (elem->number == number) {
             return elem;
         }

--- a/src/ticks/breakpoints.c
+++ b/src/ticks/breakpoints.c
@@ -142,24 +142,26 @@ uint8_t process_temp_breakpoints() {
                             ttt = ttt->next;
                         }
                         if (ttt == NULL) {
-                            printf("Warning: unknown callee return type, DEHL returned %08x.\n", return_value);
+                            bk.debug("Warning: unknown callee return type, DEHL returned %08x.\n", return_value);
                         } else {
                             if (ttt->type_ != TYPE_VOID) {
                                 struct expression_result_t result = {0};
                                 debug_resolve_expression_element(&temp_br->callee->type_record, ttt,
                                     RESOLVE_BY_VALUE, return_value, &result);
                                 if (is_expression_result_error(&result)) {
-                                    printf("function %s errored: %s\n", temp_br->callee->function_name, result.as_error);
+                                    bk.debug("function %s errored: %s\n", temp_br->callee->function_name, result.as_error);
                                 } else {
-                                    char resolved_result[128] = "<unknown>";
-                                    expression_result_value_to_string(&result, resolved_result, 128);
-                                    printf("function %s returned: %s\n", temp_br->callee->function_name, resolved_result);
+                                    UT_string* resolved_result =
+                                        expression_result_value_to_string(&result);
+                                    bk.debug("function %s returned: %s\n", temp_br->callee->function_name,
+                                        utstring_body(resolved_result));
+                                    utstring_free(resolved_result);
                                 }
                                 expression_result_free(&result);
                             }
                         }
                     } else {
-                        printf("Warning: returned from a function without frame pointer.\n");
+                        bk.debug("Warning: returned from a function without frame pointer.\n");
                     }
                     break;
                 }
@@ -196,7 +198,7 @@ uint8_t process_temp_breakpoints() {
                     break;
                 }
                 default: {
-                    printf("Warning: unknown reason why we stopped on temporary breakpoint.\n");
+                    bk.debug("Warning: unknown reason why we stopped on temporary breakpoint.\n");
                     break;
                 }
             }

--- a/src/ticks/breakpoints.h
+++ b/src/ticks/breakpoints.h
@@ -43,7 +43,10 @@ typedef enum {
     TMP_REASON_FIN,
     TMP_REASON_STEP_SOURCE_LINE,
     TMP_REASON_NEXT_SOURCE_LINE,
+    TMP_REASON_ONE_INSTRUCTION,
 } temporary_breakpoint_reason_t;
+
+#define TEMP_BREAKPOINT_ANYWHERE (0xFFFFFFFF)
 
 typedef struct temporary_breakpoint_t {
     temporary_breakpoint_reason_t   reason;
@@ -58,7 +61,6 @@ typedef struct temporary_breakpoint_t {
 extern breakpoint *breakpoints;
 extern breakpoint *watchpoints;
 extern temporary_breakpoint_t* temporary_breakpoints;
-extern int break_required;
 extern int next_breakpoint_number;
 
 extern breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type, int bk_size, int value, const char* text);
@@ -69,8 +71,10 @@ extern void delete_all_breakpoints();
 extern breakpoint* find_breakpoint(int number);
 extern breakpoint* find_watchpoint(int number);
 
+extern temporary_breakpoint_t* add_temp_breakpoint_one_instruction();
 extern temporary_breakpoint_t* add_temporary_internal_breakpoint(uint32_t address, temporary_breakpoint_reason_t reason,
     const char *source_filename, int source_lineno);
+extern void remove_temp_breakpoint(temporary_breakpoint_t* b);
 extern void remove_temp_breakpoints();
 extern uint8_t process_temp_breakpoints();
 

--- a/src/ticks/breakpoints.h
+++ b/src/ticks/breakpoints.h
@@ -21,16 +21,25 @@ typedef enum {
     BREAK_WRITE,
 } breakpoint_type;
 
+typedef struct breakpoint breakpoint;
+
+typedef void (*breakpoint_deleted_cb)(breakpoint* b);
+
 typedef struct breakpoint {
-    breakpoint_type    type;
-    int                value;
-    unsigned char      lvalue;
-    uint16_t           lcheck_arg;
-    unsigned char      hvalue;
-    uint16_t           hcheck_arg;
-    char               enabled;
-    char               *text;
-    struct breakpoint  *next;
+    breakpoint_type         type;
+    int                     value;
+    unsigned char           lvalue;
+    uint16_t                lcheck_arg;
+    unsigned char           hvalue;
+    uint16_t                hcheck_arg;
+
+    uint8_t                 pending_add;
+    uint8_t                 pending_remove;
+
+    int                     number;
+    char                    enabled;
+    char                    *text;
+    struct breakpoint       *next;
 } breakpoint;
 
 typedef enum {
@@ -53,9 +62,13 @@ typedef struct temporary_breakpoint_t {
 extern breakpoint *breakpoints;
 extern breakpoint *watchpoints;
 extern temporary_breakpoint_t* temporary_breakpoints;
+extern int break_required;
+extern int next_breakpoint_number;
 
 extern breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type, int bk_size, int value, const char* text);
 extern void delete_breakpoint(breakpoint* b);
+extern void delete_all_breakpoints();
+extern breakpoint* find_breakpoint(int number);
 
 extern temporary_breakpoint_t* add_temporary_internal_breakpoint(uint32_t address, temporary_breakpoint_reason_t reason,
     const char *source_filename, int source_lineno);

--- a/src/ticks/breakpoints.h
+++ b/src/ticks/breakpoints.h
@@ -21,10 +21,6 @@ typedef enum {
     BREAK_WRITE,
 } breakpoint_type;
 
-typedef struct breakpoint breakpoint;
-
-typedef void (*breakpoint_deleted_cb)(breakpoint* b);
-
 typedef struct breakpoint {
     breakpoint_type         type;
     int                     value;
@@ -66,9 +62,12 @@ extern int break_required;
 extern int next_breakpoint_number;
 
 extern breakpoint* add_breakpoint(breakpoint_type type, enum bk_breakpoint_type bk_type, int bk_size, int value, const char* text);
+extern breakpoint* add_watchpoint(breakpoint_type operation, int value);
 extern void delete_breakpoint(breakpoint* b);
+extern void delete_watchpoint(breakpoint* w);
 extern void delete_all_breakpoints();
 extern breakpoint* find_breakpoint(int number);
+extern breakpoint* find_watchpoint(int number);
 
 extern temporary_breakpoint_t* add_temporary_internal_breakpoint(uint32_t address, temporary_breakpoint_reason_t reason,
     const char *source_filename, int source_lineno);

--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -177,7 +177,7 @@ static uint8_t parse_record_type(const char *rt, type_record *record)
                         break;
                     }
                     default: {
-                        printf("Warning: unknown type D%c.\n", c);
+                        bk.debug("Warning: unknown type D%c.\n", c);
                         goto err;
                     }
                 }
@@ -228,7 +228,7 @@ static uint8_t parse_record_type(const char *rt, type_record *record)
                         break;
                     }
                     default: {
-                        printf("Warning: unknown type F%c.\n", c);
+                        bk.debug("Warning: unknown type F%c.\n", c);
                         goto err;
                     }
                 }
@@ -280,7 +280,7 @@ static uint8_t parse_record_type(const char *rt, type_record *record)
                 break;
             }
             case RECORD_PARSING_MODE_DONE: {
-                printf("Warning: data after sign.\n");
+                bk.debug("Warning: data after sign.\n");
                 goto err;
             }
         }
@@ -353,7 +353,7 @@ static void debug_add_function_info(const char *encoded)
         }
         default:
         {
-            printf("Warning: unknown function scope: %c\n", function_scope);
+            bk.debug("Warning: unknown function scope: %c\n", function_scope);
             return;
         }
     }
@@ -378,12 +378,12 @@ static void debug_add_function_info(const char *encoded)
     }
 
     if (parse_record_type(type_record, &f->type_record)) {
-        printf("Warning cannot parse type record.\n");
+        bk.debug("Warning cannot parse type record.\n");
         goto err;
     }
 
     if (parse_address_space(encoded, &encoded, &f->address_space)) {
-        printf("Warning cannot parse address space.\n");
+        bk.debug("Warning cannot parse address space.\n");
         goto err;
     }
 
@@ -393,7 +393,7 @@ static void debug_add_function_info(const char *encoded)
 
 err:
     free(f);
-    printf("Warning: could not add debug info on function.\n");
+    bk.debug("Warning: could not add debug info on function.\n");
 }
 
 static debug_sym_symbol* debug_parse_symbol_info(const char* encoded, const char** result)
@@ -456,7 +456,7 @@ static debug_sym_symbol* debug_parse_symbol_info(const char* encoded, const char
         }
         default:
         {
-            printf("Warning: unknown symbol scope: %c\n", symbol_scope);
+            bk.debug("Warning: unknown symbol scope: %c\n", symbol_scope);
         }
     }
 
@@ -501,7 +501,7 @@ static debug_sym_symbol* debug_parse_symbol_info(const char* encoded, const char
                     arg->next = last;
                     s->belongs_to_function->arguments = arg;
                 } else {
-                    printf("Warning: could not find function %s.%s for argument %s.\n",
+                    bk.debug("Warning: could not find function %s.%s for argument %s.\n",
                         file_name, function_name, s->symbol_name);
                 }
 
@@ -512,12 +512,12 @@ static debug_sym_symbol* debug_parse_symbol_info(const char* encoded, const char
     }
 
     if (parse_record_type(type_record, &s->type_record)) {
-        printf("Warning cannot parse type record.\n");
+        bk.debug("Warning cannot parse type record.\n");
         goto err;
     }
 
     if (parse_address_space(encoded, &encoded, &s->address_space)) {
-        printf("Warning cannot parse address space.\n");
+        bk.debug("Warning cannot parse address space.\n");
         goto err;
     }
 
@@ -527,7 +527,7 @@ static debug_sym_symbol* debug_parse_symbol_info(const char* encoded, const char
 err:
     *result = NULL;
     free(s);
-    printf("Warning: could not add debug info on symbol.\n");
+    bk.debug("Warning: could not add debug info on symbol.\n");
     return NULL;
 }
 
@@ -578,7 +578,7 @@ static debug_sym_type* debug_parse_type_info(const char* encoded)
         }
         default:
         {
-            printf("Warning: unknown symbol scope: %c\n", symbol_scope);
+            bk.debug("Warning: unknown symbol scope: %c\n", symbol_scope);
             break;
         }
     }
@@ -630,7 +630,7 @@ err_type_info:
     free(type_info);
 err:
     free(t);
-    printf("Warning: could not add debug info on type.\n");
+    bk.debug("Warning: could not add debug info on type.\n");
     return NULL;
 }
 
@@ -695,13 +695,13 @@ void debug_add_info_encoded(char *encoded)
         }
         default:
         {
-            printf("Warning: unknown record type: %c\n", record_type);
+            bk.debug("Warning: unknown record type: %c\n", record_type);
             break;
         }
     }
 
     if (bk.is_verbose()) {
-        printf("Decoded cdb: <%s>\n",encoded);
+        bk.debug("Decoded cdb: <%s>\n",encoded);
     }
 }
 
@@ -1182,7 +1182,7 @@ uint8_t debug_symbol_valid(debug_sym_symbol *sym, uint16_t stack, debug_frame_po
 }
 
 debug_sym_symbol* cdb_find_symbol(const char* cname) {
-    debug_sym_symbol* result;
+    debug_sym_symbol* result = NULL;
     HASH_FIND_STR(cdb_csymbols, cname, result);
     return result;
 }

--- a/src/ticks/debug.h
+++ b/src/ticks/debug.h
@@ -12,6 +12,7 @@ typedef struct type_chain_s type_chain;
 typedef struct address_space_s address_space;
 typedef struct debug_sym_function_s debug_sym_function;
 typedef struct debug_sym_symbol_s debug_sym_symbol;
+typedef struct debug_sym_file_s debug_sym_file;
 typedef struct debug_sym_type_s debug_sym_type;
 typedef struct debug_sym_type_member_s debug_sym_type_member;
 typedef struct debug_sym_function_argument_s debug_sym_function_argument;
@@ -111,6 +112,12 @@ struct debug_sym_symbol_s {
     UT_hash_handle          hh;
 };
 
+struct debug_sym_file_s {
+    char                    name[128];
+    debug_sym_symbol*       file_local_symbols;
+    UT_hash_handle          hh;
+};
+
 struct debug_sym_type_member_s {
     uint16_t                    offset;
     debug_sym_symbol*           symbol;
@@ -171,8 +178,9 @@ extern debug_sym_function* debug_find_function(const char* function_name, const 
 extern void debug_resolve_expression_element(type_record* record, type_chain* chain, enum resolve_chain_value_kind resolve_by, uint32_t data, struct expression_result_t* into);
 extern void debug_get_symbol_value_expression(debug_sym_symbol* sym, debug_frame_pointer* frame_pointer, struct expression_result_t* into);
 extern uint8_t debug_symbol_valid(debug_sym_symbol* sym, uint16_t stack, debug_frame_pointer* frame_pointer);
-extern debug_sym_symbol* cdb_get_first_symbol();
-extern debug_sym_symbol* cdb_find_symbol(const char* cname);
+extern debug_sym_symbol* cdb_get_first_global_symbol();
+extern debug_sym_symbol* cdb_get_first_local_symbol(const char* filename);
+extern debug_sym_symbol* cdb_find_symbol(const char* cname, const char* filename);
 extern debug_sym_type* cdb_find_type(const char* tname);
 
 extern debug_frame_pointer* debug_stack_frames_construct(uint16_t pc, uint16_t sp, struct debugger_regs_t* regs, uint16_t limit);

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -1228,40 +1228,35 @@ static int cmd_watch(int argc, char **argv)
         int value = parse_address(argv[2], &corrected_source);
 
         if ( value != -1 ) {
-            elem = calloc(1, sizeof(*elem));
-            elem->number = next_breakpoint_number++;
-            elem->type = breakwrite ? BREAK_WRITE : BREAK_READ;
-            elem->value = value;
-            elem->enabled = 1;
-            LL_APPEND(watchpoints, elem);
-            bk.console("Adding %s watchpoint at '%s' $%04x (%s)\n",breakwrite ? "write" : "read", corrected_source, value,  resolve_to_label(value));
+            elem = add_watchpoint(breakwrite ? BREAK_WRITE : BREAK_READ, value);
+            bk.console("Adding %s watchpoint at '%s' $%04x (%s)\n",
+                breakwrite ? "write" : "read", corrected_source, value,  resolve_to_label(value));
         } else {
             bk.console("Cannot set watchpoint on '%s'\n", corrected_source);
         }
     } else if ( argc == 3 && strcmp(argv[1],"delete") == 0 ) {
-        int num = atoi(argv[2]);
-        delete_breakpoint_by_number_and_log(num);
+        breakpoint *elem = find_watchpoint(atoi(argv[2]));
+        if (elem) {
+            bk.console("Deleting watchpoint %d \n", atoi(argv[2]));
+            delete_watchpoint(elem);
+        } else {
+            bk.console("Unknown watchpoint\n");
+        }
     } else if ( argc == 3 && strcmp(argv[1],"disable") == 0 ) {
-        int num = atoi(argv[2]);
-        breakpoint *elem;
-        LL_FOREACH(watchpoints, elem) {
-            num--;
-            if ( num == 0 ) {
-                bk.console("Disabling watchpoint %d\n",atoi(argv[2]));
-                elem->enabled = 0;
-                break;
-            }
+        breakpoint *elem = find_watchpoint(atoi(argv[2]));
+        if (elem) {
+            bk.console("Disabling watchpoint %d\n", atoi(argv[2]));
+            elem->enabled = 0;
+        } else {
+            bk.console("Unknown watchpoint\n");
         }
     } else if ( argc == 3 && strcmp(argv[1],"enable") == 0 ) {
-        int num = atoi(argv[2]);
-        breakpoint *elem;
-        LL_FOREACH(watchpoints, elem) {
-            num--;
-            if ( num == 0 ) {
-                bk.console("Enabling watchpoint %d\n",atoi(argv[2]));
-                elem->enabled = 1;
-                break;
-            }
+        breakpoint *elem = find_watchpoint(atoi(argv[2]));
+        if (elem) {
+            bk.console("Enabling watchpoint %d\n",atoi(argv[2]));
+            elem->enabled = 1;
+        } else {
+            bk.console("Unknown watchpoint\n");
         }
     } 
     return 0;

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -1739,34 +1739,38 @@ static void print_hotspots()
 void stdout_log(const char *fmt, ...)
 {
     va_list args;
+    va_list args2;
     int len;
 
     /* Initialize a variable argument list */
     va_start(args, fmt);
+    va_copy(args2, args);
 
     /* Get length of format including arguments */
-    len = vsnprintf(NULL, 0, fmt, args);
+    len = vsnprintf(NULL, 0, fmt, args2);
 
     /* End using variable argument list */
-    va_end(args);
+    va_end(args2);
 
     if (len < 0) {
         /* vsnprintf failed */
         return;
     } else {
         /* Declare a character buffer for the formatted string */
-        char formatted[len + 1];
+        UT_string* formatted;
+        utstring_new(formatted);
 
         /* Initialize a variable argument list */
         va_start(args, fmt);
 
         /* Write the formatted output */
-        vsnprintf(formatted, sizeof(formatted), fmt, args);
+        utstring_printf_va(formatted, fmt, args);
 
         /* End using variable argument list */
         va_end(args);
 
         /* Call the wrapped function using the formatted output and return */
-        printf("%s", formatted);
+        printf("%s", utstring_body(formatted));
+        utstring_free(formatted);
     }
 }

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -2,12 +2,20 @@
 #define DEBUGGER_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 extern int debugger_active;
-extern void      debugger_init();
-extern void      debugger();
-extern void      debugger_process_signals();
+extern size_t current_frame;
 
+extern void debugger_init();
+extern void debugger();
+int debugger_evaluate(char* line);
+extern void debugger_process_signals();
+
+void stdout_log(const char *fmt, ...);
+
+extern const char *resolve_to_label(int addr);
+extern int parse_address(char *arg, const char** corrected_source);
 extern void unwrap_reg(uint16_t data, uint8_t* h, uint8_t* l);
 extern uint16_t wrap_reg(uint8_t h, uint8_t l);
 

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -14,7 +14,7 @@ extern size_t current_frame;
 extern void debugger_init();
 extern void debugger();
 int debugger_evaluate(char* line);
-extern void debugger_process_signals();
+extern void debugger_request_a_break();
 
 void stdout_log(const char *fmt, ...);
 

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifndef va_copy
+#define va_copy(a,b) (a)=(b)
+#endif
+
 extern int debugger_active;
 extern size_t current_frame;
 

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -9,6 +9,7 @@
 #endif
 
 extern int debugger_active;
+extern int debugger_break_requested;
 extern size_t current_frame;
 
 extern void debugger_init();

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -1,4 +1,6 @@
+#include "debugger_gdb.h"
 #include "debugger.h"
+#include "debugger_mi2.h"
 #include "backend.h"
 #include "debug.h"
 #include "disassembler.h"
@@ -8,37 +10,39 @@
 #include <stdio.h>
 
 #include <pthread.h>
-#include <sys/fcntl.h>
-#include <semaphore.h>
 #include "debugger_gdb_packets.h"
 #include "sxmlc.h"
 #include "sxmlsearch.h"
 
-typedef void (*trapped_action_t)(const void* data, void* response);
-typedef void (*network_op_cb)(void* arg);
-
-struct network_op
-{
-    network_op_cb callback;
-    void* arg;
-    struct network_op* prev;
-};
-
 static uint8_t verbose = 0;
 int c_autolabel = 0;
+uint8_t temporary_break = 0;
 static uint8_t registers_invalidated = 1;
-static sem_t* req_response_mutex = NULL;
-static sem_t* response_mutex = NULL;
-static sem_t* trap_mutex = NULL;
 static pthread_cond_t network_op_cond;
 static pthread_mutex_t network_op_mutex;
-static pthread_mutex_t trap_process_mutex;
+
+static pthread_cond_t main_thread_cond;
+static pthread_mutex_t main_thread_mutex;
 static int supported_packet_size = 1024;
-static trapped_action_t scheduled_action = NULL;
-static const void* scheduled_action_data = NULL;
-static void* scheduled_action_response = NULL;
+
+struct scheduled_action_t
+{
+    trapped_action_t scheduled_action;
+    const void* scheduled_action_data;
+    void* scheduled_action_response;
+    uint8_t* wait;
+
+    pthread_mutex_t* wait_mutex;
+    pthread_cond_t* wait_cond;
+
+    struct scheduled_action_t* next;
+};
+
+static struct scheduled_action_t* first_scheduled_action = NULL;
 static char request_response[1024];
 static uint8_t write_request = 0;
+static pthread_mutex_t req_response_mutex;
+static pthread_cond_t req_response_cond;
 static uint8_t waiting_for_response = 0;
 static const char hexchars[] = "0123456789abcdef";
 static struct debugger_regs_t registers;
@@ -134,17 +138,19 @@ void schedule_write_raw(const uint8_t* data, ssize_t length)
 
 static void send_request_no_response(const char* request)
 {
-    waiting_for_response = 0;
-
     schedule_write_packet(request);
 }
 
 static const char* send_request(const char* request)
 {
+    pthread_mutex_lock(&req_response_mutex);
     waiting_for_response = 1;
-
     schedule_write_packet(request);
-    sem_wait(req_response_mutex);
+
+    while (waiting_for_response) {
+        pthread_cond_wait(&req_response_cond, &req_response_mutex);
+    }
+    pthread_mutex_unlock(&req_response_mutex);
 
     return request_response;
 }
@@ -462,8 +468,19 @@ void port_out(int port, int value) {}
 void debugger_write_memory(int addr, uint8_t val) {}
 void debugger_read_memory(int addr) {}
 
-void debugger_break()
+void debugger_break(uint8_t temporary)
 {
+    if (temporary)
+    {
+        temporary_break = 1;
+    }
+
+    if (connection_socket == 0)
+    {
+        bk.debug("Nothing to break, as we're not connected.\n");
+        return;
+    }
+
     static uint8_t req[] = { 0x03 };
     schedule_write_raw(req, 1);
 }
@@ -472,6 +489,7 @@ void debugger_detach()
 {
     send_request("D");
     shutdown(connection_socket, 0);
+    connection_socket = 0;
 }
 
 void debugger_resume()
@@ -480,54 +498,63 @@ void debugger_resume()
     send_request_no_response("c");
 }
 
-void gdb_add_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+breakpoint_ret_t gdb_add_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
-    switch (type)
-    {
+    if (connection_socket == 0) {
+        return BREAKPOINT_ERROR_NOT_CONNECTED;
+    }
+
+    if (debugger_active == 0) {
+        return BREAKPOINT_ERROR_RUNNING;
+    }
+
+    switch (type) {
         case BK_BREAKPOINT_REGISTER:
         case BK_BREAKPOINT_HARDWARE:
         {
-            printf("Warning: not supported.\n");
-            return;
+            return BREAKPOINT_ERROR_FAILURE;
         }
     }
 
     char req[64];
     sprintf(req, "Z%zx,%zx,%zx", (size_t)type, (size_t)at, (size_t)sz);
     const char* resp = send_request(req);
-    if (strcmp(resp, "E01") == 0)
+    if (strcmp(resp, "OK") != 0)
     {
-        printf("Could not set breakpoint.\n");
+        return BREAKPOINT_ERROR_FAILURE;
     }
-    else if (strcmp(resp, "OK") != 0)
-    {
-        printf("Could not set breakpoint: %s\n", resp);
-    }
+
+    return BREAKPOINT_ERROR_OK;
 }
 
-void gdb_remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+breakpoint_ret_t gdb_remove_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
+    if (connection_socket == 0) {
+        return BREAKPOINT_ERROR_NOT_CONNECTED;
+    }
+    if (debugger_active == 0) {
+        return BREAKPOINT_ERROR_RUNNING;
+    }
+
     char req[64];
     sprintf(req, "z%zx,%zx,%zx", (size_t)type, (size_t)at, (size_t)sz);
     const char* resp = send_request(req);
-    if (strcmp(resp, "E01") == 0)
+    if (strcmp(resp, "OK") != 0)
     {
-        printf("Could not set breakpoint.\n");
+        return BREAKPOINT_ERROR_FAILURE;
     }
-    else if (strcmp(resp, "OK") != 0)
-    {
-        printf("Could not set breakpoint: %s\n", resp);
-    }
+
+    return BREAKPOINT_ERROR_OK;
 }
 
-void gdb_disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+breakpoint_ret_t gdb_disable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
-    printf("Warning: not supported.\n");
+    return BREAKPOINT_ERROR_FAILURE;
 }
 
-void gdb_enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
+breakpoint_ret_t gdb_enable_breakpoint(uint8_t type, uint16_t at, uint8_t sz)
 {
-    printf("Warning: not supported.\n");
+    return BREAKPOINT_ERROR_FAILURE;
 }
 
 uint8_t breakpoints_check()
@@ -635,67 +662,63 @@ uint8_t debugger_restore(const char* file_path, uint16_t at, uint8_t set_pc)
     return 0;
 }
 
-static backend_t gdb_backend = {
-    .st = &get_st,
-    .ff = &get_ff,
-    .pc = &get_pc,
-    .sp = &get_sp,
-    .get_memory = &get_memory,
-    .get_regs = &get_regs,
-    .set_regs = &set_regs,
-    .f = &f,
-    .f_ = &f_,
-    .memory_reset_paging = &memory_reset_paging,
-    .out = &port_out,
-    .debugger_write_memory = &debugger_write_memory,
-    .debugger_read_memory = &debugger_read_memory,
-    .invalidate = &invalidate,
-    .breakable = 1,
-    .break_ = &debugger_break,
-    .resume = &debugger_resume,
-    .next = &debugger_next,
-    .step = &debugger_step,
-    .confirm_detach_w_breakpoints = 1,
-    .detach = &debugger_detach,
-    .restore = &debugger_restore,
-    .add_breakpoint = &gdb_add_breakpoint,
-    .remove_breakpoint = &gdb_remove_breakpoint,
-    .disable_breakpoint = &gdb_disable_breakpoint,
-    .enable_breakpoint = &gdb_enable_breakpoint,
-    .breakpoints_check = &breakpoints_check,
-    .is_verbose = is_verbose
-};
-
-static void execute_on_main_thread(trapped_action_t call, const void* data, void* response)
+void execute_on_main_thread(trapped_action_t call, const void* data, void* response)
 {
+    pthread_mutex_t wait_mutex;
+    pthread_cond_t wait_cond;
+
+    pthread_mutex_init(&wait_mutex, NULL);
+    pthread_cond_init(&wait_cond, NULL);
+
+    uint8_t wait = 1;
+
     // prepare the action arguments
-    pthread_mutex_lock(&trap_process_mutex);
-    scheduled_action = call;
-    scheduled_action_data = data;
-    scheduled_action_response = response;
-    pthread_mutex_unlock(&trap_process_mutex);
+    pthread_mutex_lock(&main_thread_mutex);
+    struct scheduled_action_t* aa = calloc(1, sizeof(struct scheduled_action_t));
+    aa->scheduled_action = call;
+    aa->scheduled_action_data = data;
+    aa->scheduled_action_response = response;
+    aa->wait = &wait;
+    aa->wait_mutex = &wait_mutex;
+    aa->wait_cond = &wait_cond;
+    LL_APPEND(first_scheduled_action, aa);
 
     // notify the main thread
-    sem_post(trap_mutex);
+    pthread_cond_signal(&main_thread_cond);
+    pthread_mutex_unlock(&main_thread_mutex);
 
-    // wait for the response
-    sem_wait(response_mutex);
+    pthread_mutex_lock(&wait_mutex);
+
+    // wait for the response on the same cond
+    while (wait)
+    {
+        pthread_cond_wait(&wait_cond, &wait_mutex);
+    }
+
+    pthread_mutex_unlock(&wait_mutex);
+
+    pthread_mutex_destroy(&wait_mutex);
+    pthread_cond_destroy(&wait_cond);
 }
 
-static void execute_on_main_thread_no_response(trapped_action_t call, const void* data)
+void execute_on_main_thread_no_response(trapped_action_t call, const void* data)
 {
     // prepare the action arguments
-    pthread_mutex_lock(&trap_process_mutex);
-    scheduled_action = call;
-    scheduled_action_data = data;
-    scheduled_action_response = NULL;
-    pthread_mutex_unlock(&trap_process_mutex);
+    pthread_mutex_lock(&main_thread_mutex);
+    struct scheduled_action_t* aa = calloc(1, sizeof(struct scheduled_action_t));
+    aa->scheduled_action = call;
+    aa->scheduled_action_data = data;
+    aa->scheduled_action_response = NULL;
+    aa->wait = NULL;
+    LL_APPEND(first_scheduled_action, aa);
 
     // notify the main thread
-    sem_post(trap_mutex);
+    pthread_cond_signal(&main_thread_cond);
+
+    pthread_mutex_unlock(&main_thread_mutex);
 }
 
-void remote_execution_stopped(const void* data, void* response)
+static void gdb_execution_stopped()
 {
     if (debugger_active == 1)
     {
@@ -704,10 +727,15 @@ void remote_execution_stopped(const void* data, void* response)
 
     if (bk.is_verbose())
     {
-        printf("Execution stopped.\n");
+        bk.debug("Execution stopped\n");
     }
 
     debugger_active = 1;
+}
+
+void remote_execution_stopped(const void* data, void* response)
+{
+    bk.execution_stopped();
 }
 
 static uint8_t process_packet()
@@ -721,14 +749,14 @@ static uint8_t process_packet()
 
     if (inbuf_size > 0 && *inbuf == '+') {
         if (bk.is_verbose()) {
-            printf("ack.\n");
+            bk.debug("ack.\n");
         }
         inbuf_erase_head(1);
         return 1;
     }
 
     if (bk.is_verbose()) {
-        printf("r: %.*s\n", inbuf_size, inbuf);
+        bk.debug("r: %.*s\n", inbuf_size, inbuf);
     }
 
     uint8_t *packetend_ptr = (uint8_t *)memchr(inbuf, '#', inbuf_size);
@@ -747,7 +775,7 @@ static uint8_t process_packet()
     if (checksum != (hex(inbuf[packetend + 1]) << 4 | hex(inbuf[packetend + 2])))
     {
         if (bk.is_verbose()) {
-            printf("Warning: incorrect checksum, expected: %02x\n", checksum);
+            bk.debug("Warning: incorrect checksum, expected: %02x\n", checksum);
         }
         inbuf_erase_head(packetend + 3);
         return 1;
@@ -757,25 +785,29 @@ static uint8_t process_packet()
     strcpy(recv_data, (char*)&inbuf[1]);
     inbuf_erase_head(packetend + 3);
 
+    pthread_mutex_lock(&req_response_mutex);
+
     if (waiting_for_response)
     {
         waiting_for_response = 0;
         strcpy(request_response, recv_data);
-        sem_post(req_response_mutex);
+        pthread_cond_signal(&req_response_cond);
+        pthread_mutex_unlock(&req_response_mutex);
+        return 1;
     }
-    else
+
+    pthread_mutex_unlock(&req_response_mutex);
+
+    char request = recv_data[0];
+    char *payload = (char *)&recv_data[1];
+
+    switch (request)
     {
-        char request = recv_data[0];
-        char *payload = (char *)&recv_data[1];
-
-        switch (request)
+        case 'T':
         {
-            case 'T':
-            {
-                execute_on_main_thread_no_response(&remote_execution_stopped, NULL);
+            execute_on_main_thread_no_response(&remote_execution_stopped, NULL);
 
-                break;
-            }
+            break;
         }
     }
 
@@ -786,21 +818,16 @@ static void* network_read_thread(void* arg)
 {
     sock_t socket = *(sock_t*)arg;
 
-    while (1)
+    while (connection_socket)
     {
         int ret;
         if ((ret = read_packet(socket)))
         {
-            printf("A network error occured: %d\n", ret);
             break;
         }
 
         while (process_packet()) {};
     }
-
-    shutdown(socket, 0);
-    printf("Disconnected.\n");
-    exit(1);
 
     return NULL;
 }
@@ -809,7 +836,7 @@ static void* network_write_thread(void* arg)
 {
     sock_t socket = *(sock_t*)arg;
 
-    while (1)
+    while (connection_socket)
     {
         pthread_mutex_lock(&network_op_mutex);
         while (last_network_op == NULL) {
@@ -829,47 +856,20 @@ static void* network_write_thread(void* arg)
     return NULL;
 }
 
+static void init_mutexes()
+{
+    pthread_mutex_init(&main_thread_mutex, NULL);
+    pthread_cond_init(&main_thread_cond, NULL);
 
-int main(int argc, char **argv) {
-    char* connect_host = NULL;
-    int connect_port = 0;
+    pthread_mutex_init(&req_response_mutex, NULL);
+    pthread_cond_init(&req_response_cond, NULL);
 
-    printf("----------------------------------\n"
-           "z88dk-gdb, a gdb client for z88dk.\n"
-           "----------------------------------\n"
-           "\n"
-           "See the following for a list of compatible gdb servers: "
-           "https://github.com/z88dk/z88dk/wiki/Tool-z88dk-gdb\n"
-           "\n");
+    pthread_mutex_init(&network_op_mutex, NULL);
+    pthread_cond_init(&network_op_cond, NULL);
+}
 
-    set_backend(gdb_backend);
-
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-p") == 0) {
-            connect_port = atoi(argv[++i]);
-        } else if (strcmp(argv[i], "-h") == 0) {
-            connect_host = argv[++i];
-        } else if (strcmp(argv[i], "-x") == 0) {
-            char* debug_symbols = argv[++i];
-            if (bk.is_verbose()) {
-                printf("Reading debug symbols...");
-            }
-            read_symbol_file(debug_symbols);
-            if (bk.is_verbose()) {
-                printf("OK\n");
-            }
-        } else if (strcmp(argv[i], "-v") == 0) {
-            verbose = 1;
-        }
-    }
-
-    if (connect_port == 0 || connect_host == NULL) {
-        printf("Usage: z88dk-gdb -h <connect host> -p <connect port> -x <debug symbols> [-x <debug symbols>] [-v]\n");
-        return 1;
-    }
-
-    debugger_init();
-
+static uint8_t connect_to_gdbserver(const char* connect_host, int connect_port)
+{
     connection_socket = socket(AF_INET, SOCK_STREAM, 0);
 
     struct sockaddr_in servaddr;
@@ -883,22 +883,8 @@ int main(int argc, char **argv) {
     // connect the client socket to server socket
     int ret = connect(connection_socket, (struct sockaddr*)&servaddr, sizeof(servaddr));
     if (ret) {
-        printf("Could not connect to the server: %d\n", ret);
         return 1;
-    } else {
-        printf("Connected to the server.\n");
     }
-
-    sem_unlink("req_response_mutex");
-    req_response_mutex = sem_open("req_response_mutex", O_CREAT|O_EXCL, 0600, 0);
-    sem_unlink("response_mutex");
-    response_mutex = sem_open("response_mutex", O_CREAT|O_EXCL, 0600, 0);
-    sem_unlink("trap_mutex");
-    trap_mutex = sem_open("trap_mutex", O_CREAT|O_EXCL, 0600, 0);
-
-    pthread_cond_init(&network_op_cond, NULL);
-    pthread_mutex_init(&network_op_mutex, NULL);
-    pthread_mutex_init(&trap_process_mutex, NULL);
 
     {
         pthread_t id;
@@ -1026,38 +1012,175 @@ int main(int argc, char **argv) {
     // this should break us
     send_request_no_response("?");
 
-    while (1)
-    {
-        registers_invalidated = 1;
-
-        debugger_process_signals();
-
-        if (debugger_active)
-        {
-            debugger();
-        }
-        else
-        {
-            sem_wait(trap_mutex);
-
-            pthread_mutex_lock(&trap_process_mutex);
-            if (scheduled_action != NULL)
-            {
-                scheduled_action(scheduled_action_data, scheduled_action_response);
-                scheduled_action = NULL;
-
-                if (scheduled_action_response != NULL)
-                {
-                    // notify the waiter that we're done
-                    sem_post(response_mutex);
-                }
-            }
-            pthread_mutex_unlock(&trap_process_mutex);
-        }
-    }
+    return 0;
 
 shutdown:
     shutdown(connection_socket, 0);
+    return 1;
+}
+
+static void ctrl_c()
+{
+    break_required = 1;
+}
+
+static backend_t gdb_backend = {
+    .st = &get_st,
+    .ff = &get_ff,
+    .pc = &get_pc,
+    .sp = &get_sp,
+    .get_memory = &get_memory,
+    .get_regs = &get_regs,
+    .set_regs = &set_regs,
+    .f = &f,
+    .f_ = &f_,
+    .memory_reset_paging = &memory_reset_paging,
+    .out = &port_out,
+    .debugger_write_memory = &debugger_write_memory,
+    .debugger_read_memory = &debugger_read_memory,
+    .invalidate = &invalidate,
+    .breakable = 1,
+    .break_ = &debugger_break,
+    .resume = &debugger_resume,
+    .next = &debugger_next,
+    .step = &debugger_step,
+    .confirm_detach_w_breakpoints = 1,
+    .detach = &debugger_detach,
+    .restore = &debugger_restore,
+    .add_breakpoint = &gdb_add_breakpoint,
+    .remove_breakpoint = &gdb_remove_breakpoint,
+    .disable_breakpoint = &gdb_disable_breakpoint,
+    .enable_breakpoint = &gdb_enable_breakpoint,
+    .breakpoints_check = &breakpoints_check,
+    .is_verbose = is_verbose,
+    .remote_connect = connect_to_gdbserver,
+    .console = stdout_log,
+    .debug = stdout_log,
+    .execution_stopped = gdb_execution_stopped,
+    .ctrl_c = ctrl_c
+};
+
+static void process_scheduled_actions()
+{
+    pthread_mutex_lock(&main_thread_mutex);
+
+    // wait until we have a job
+    while (first_scheduled_action == NULL)
+    {
+        pthread_cond_wait(&main_thread_cond, &main_thread_mutex);
+    }
+
+    // we need to unblock the queue for new jobs. jobs scheduled on main thread may want to
+    // schedule new jobs. to mitigate that deadlock, the queue is blocked on its own
+    struct scheduled_action_t* first_to_process = first_scheduled_action;
+    first_scheduled_action = NULL;
+
+    pthread_mutex_unlock(&main_thread_mutex);
+
+    struct scheduled_action_t* entry;
+    struct scheduled_action_t* tmp;
+
+    LL_FOREACH_SAFE(first_to_process, entry, tmp)
+    {
+        entry->scheduled_action(entry->scheduled_action_data, entry->scheduled_action_response);
+
+        if (entry->wait)
+        {
+            pthread_mutex_lock(entry->wait_mutex);
+            // notify the waiter that we're done
+            *entry->wait = 0;
+            pthread_cond_signal(entry->wait_cond);
+            pthread_mutex_unlock(entry->wait_mutex);
+        }
+
+        LL_DELETE(first_to_process, entry);
+        free(entry);
+    }
+}
+
+int main(int argc, char **argv) {
+    char* connect_host = NULL;
+    int connect_port = 0;
+
+    set_backend(gdb_backend);
+
+    uint8_t debugger_mi2_mode = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-p") == 0) {
+            connect_port = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "-h") == 0) {
+            connect_host = argv[++i];
+        } else if (strcmp(argv[i], "-x") == 0) {
+            char* debug_symbols = argv[++i];
+            if (bk.is_verbose()) {
+                printf("Reading debug symbols...");
+            }
+            read_symbol_file(debug_symbols);
+            if (bk.is_verbose()) {
+                printf("OK\n");
+            }
+        } else if (strcmp(argv[i], "-v") == 0) {
+            verbose = 1;
+        } else if (strcmp(argv[i], "--version") == 0) {
+            printf("GNU gdb (GDB) 11.0\n");
+            printf("The line above is fake, we're pretending to be a gdb here.\n");
+            exit(0);
+        } else if (strstr(argv[i], "--interpreter=")) {
+            const char* interpreter = argv[i] + 14;
+            if (strcmp(interpreter, "mi2") == 0) {
+                debugger_mi2_mode = 1;
+            }
+        }
+    }
+
+    debugger_init();
+    init_mutexes();
+
+    if (debugger_mi2_mode) {
+        debugger_mi2_init();
+
+        mi2_printf_thread("thread-group-added,id=\"i1\"");
+        bk.console("z88dk-gdb, a gdb client for z88dk\n");
+
+        while (1) {
+            registers_invalidated = 1;
+            process_scheduled_actions();
+        }
+
+    } else {
+        printf("----------------------------------\n"
+               "z88dk-gdb, a gdb client for z88dk.\n"
+               "----------------------------------\n"
+               "\n"
+               "See the following for a list of compatible gdb servers: "
+               "https://github.com/z88dk/z88dk/wiki/Tool-z88dk-gdb\n"
+               "\n");
+
+        if (connect_port == 0 || connect_host == NULL) {
+            printf("Usage: z88dk-gdb -h <connect host> -p <connect port> -x <debug symbols> [-x <debug symbols>] [-v]\n");
+            return 1;
+        } else {
+            if (connect_to_gdbserver(connect_host, connect_port)) {
+                printf("Could not connect to the server\n");
+                return 1;
+            }
+
+            printf("Connected to the server.\n");
+
+            while (1) {
+                registers_invalidated = 1;
+
+                debugger_process_signals();
+
+                if (debugger_active) {
+                    debugger();
+                } else {
+                    process_scheduled_actions();
+                }
+            }
+        }
+    }
 
     return 0;
 }

--- a/src/ticks/debugger_gdb.h
+++ b/src/ticks/debugger_gdb.h
@@ -1,0 +1,22 @@
+#ifndef DEBUGGER_GDB_H
+#define DEBUGGER_GDB_H
+
+#include <stdint.h>
+
+typedef void (*trapped_action_t)(const void* data, void* response);
+typedef void (*network_op_cb)(void* arg);
+
+struct network_op
+{
+    network_op_cb callback;
+    void* arg;
+    struct network_op* prev;
+};
+
+extern void execute_on_main_thread(trapped_action_t call, const void* data, void* response);
+extern void execute_on_main_thread_no_response(trapped_action_t call, const void* data);
+extern char *mem2hex(const uint8_t *mem, char *buf, uint32_t count);
+
+uint8_t temporary_break;
+
+#endif

--- a/src/ticks/debugger_mi2.c
+++ b/src/ticks/debugger_mi2.c
@@ -618,7 +618,7 @@ static void cmd_evaluate_expression(const char* flow, int argc, char **argv) {
     struct expression_result_t* result = get_expression_result();
     if (is_expression_result_error(result))
     {
-        mi2_printf_error(flow, "%s", result->as_error);
+        mi2_printf_response(flow, "done,value=\"<%s>\"", result->as_error);
         utstring_free(expression);
         return;
     }
@@ -993,7 +993,7 @@ static void cmd_fin(const char* flow, int argc, char **argv) {
     } else {
         debug_stack_frames_free(first_frame_pointer);
 
-        add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_FIN, NULL, 0);
+        add_temporary_internal_breakpoint(TEMP_BREAKPOINT_ANYWHERE, TMP_REASON_FIN, NULL, 0);
         bk.step();
     }
 
@@ -1006,14 +1006,14 @@ static void cmd_next(const char* flow, int argc, char **argv) {
     int   lineno;
     const unsigned short pc = bk.pc();
     if (debug_find_source_location(pc, &filename, &lineno) < 0) {
-        add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_NEXT_SOURCE_LINE, NULL, 0);
+        add_temporary_internal_breakpoint(TEMP_BREAKPOINT_ANYWHERE, TMP_REASON_NEXT_SOURCE_LINE, NULL, 0);
         bk.next();
         report_continue();
         mi2_printf_response(flow, "done");
         return;
     }
 
-    add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_NEXT_SOURCE_LINE, filename, lineno);
+    add_temporary_internal_breakpoint(TEMP_BREAKPOINT_ANYWHERE, TMP_REASON_NEXT_SOURCE_LINE, filename, lineno);
     bk.next();
     report_continue();
     mi2_printf_response(flow, "done");
@@ -1025,14 +1025,14 @@ static void cmd_step(const char* flow, int argc, char **argv) {
     int   lineno;
     const unsigned short pc = bk.pc();
     if (debug_find_source_location(pc, &filename, &lineno) < 0) {
-        add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_STEP_SOURCE_LINE, NULL, 0);
+        add_temporary_internal_breakpoint(TEMP_BREAKPOINT_ANYWHERE, TMP_REASON_STEP_SOURCE_LINE, NULL, 0);
         bk.step();
         report_continue();
         mi2_printf_response(flow, "done");
         return;
     }
 
-    add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_STEP_SOURCE_LINE, filename, lineno);
+    add_temporary_internal_breakpoint(TEMP_BREAKPOINT_ANYWHERE, TMP_REASON_STEP_SOURCE_LINE, filename, lineno);
     bk.step();
     report_continue();
     mi2_printf_response(flow, "done");

--- a/src/ticks/debugger_mi2.c
+++ b/src/ticks/debugger_mi2.c
@@ -1269,17 +1269,6 @@ void execute_prompt(const void* data, void* response) {
     mi2_printf_prompt();
 }
 
-
-void execute_ctrl_c(const void* data, void* response) {
-    bk.console("Caught ctrl-c.");
-    bk.break_(0);
-    mi2_printf_prompt();
-}
-
-static void ctrl_c() {
-    execute_on_main_thread_no_response(execute_ctrl_c, NULL);
-}
-
 static void* debugger_mi2_console_loop(void* arg) {
     char *debugger_line = malloc(1024);
     size_t debugger_line_size = 1024;
@@ -1481,7 +1470,6 @@ void debugger_mi2_init()
     bk.console = mi2_console_printf;
     bk.debug = mi2_internal_printf;
     bk.execution_stopped = mi2_execution_stopped;
-    bk.ctrl_c = ctrl_c;
 
     {
         pthread_t id;

--- a/src/ticks/debugger_mi2.c
+++ b/src/ticks/debugger_mi2.c
@@ -1,0 +1,1359 @@
+
+#include "debugger_mi2.h"
+#include "backend.h"
+#include "syms.h"
+#include "debug.h"
+#include "debugger.h"
+#include "debugger_gdb.h"
+#include "disassembler.h"
+#include "exp_engine.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <ctype.h>
+#include <stdarg.h>
+
+typedef struct {
+    char name[128];
+    int frame;
+    char expression[128];
+    UT_hash_handle hh;
+} mi2_var;
+
+static mi2_var* mi2_vars = NULL;
+
+typedef struct {
+    char   *cmd;
+    void   (*func)(int argc, char **argv);
+} command;
+
+static void cmd_exit(int argc, char **argv);
+static void cmd_do_nothing(int argc, char **argv);
+static void cmd_target_select(int argc, char **argv);
+static void cmd_target_detach(int argc, char **argv);
+static void cmd_show(int argc, char **argv);
+static void cmd_info(int argc, char **argv);
+static void cmd_maintenance(int argc, char **argv);
+static void cmd_continue(int argc, char **argv);
+static void cmd_file_exec_and_symbols(int argc, char **argv);
+static void cmd_break(int argc, char **argv);
+static void cmd_next(int argc, char **argv);
+static void cmd_next_instruction(int argc, char **argv);
+static void cmd_step(int argc, char **argv);
+static void cmd_fin(int argc, char **argv);
+static void cmd_break_insert(int argc, char **argv);
+static void cmd_break_delete(int argc, char **argv);
+static void cmd_thread_info(int argc, char **argv);
+static void cmd_data_disassemble(int argc, char **argv);
+static void cmd_plain_disassemble(int argc, char **argv);
+static void cmd_stack_list_frames(int argc, char **argv);
+static void cmd_stack_list_variables(int argc, char **argv);
+static void cmd_interpreter_exec(int argc, char **argv);
+static void cmd_evaluate_expression(int argc, char **argv);
+static void cmd_var_create(int argc, char **argv);
+static void cmd_var_delete(int argc, char **argv);
+static void cmd_var_evaluate_expression(int argc, char **argv);
+static void cmd_var_list_children(int argc, char **argv);
+
+static command mi2_commands[] = {
+    {"-gdb-exit",                   cmd_exit},
+    {"q",                           cmd_exit},
+    {"-gdb-set",                    cmd_do_nothing},
+    {"-gdb-show",                   cmd_show},
+    {"-enable-pretty-printing",     cmd_do_nothing},
+    {"info",                        cmd_info},
+    {"maintenance",                 cmd_maintenance},
+    {"-exec-continue",              cmd_continue},
+    {"-exec-interrupt",             cmd_break},
+    {"-exec-next",                  cmd_next},
+    {"-exec-step",                  cmd_step},
+    {"-exec-next-instruction",      cmd_next_instruction},
+    {"-exec-finish",                cmd_fin},
+    {"-target-select",              cmd_target_select},
+    {"-target-detach",              cmd_target_detach},
+    {"-file-exec-and-symbols",      cmd_file_exec_and_symbols},
+    {"-break-insert",               cmd_break_insert},
+    {"-break-delete",               cmd_break_delete},
+    {"-thread-info",                cmd_thread_info},
+    {"-data-disassemble",           cmd_data_disassemble},
+    {"disassemble",                 cmd_plain_disassemble},
+    {"-stack-list-frames",          cmd_stack_list_frames},
+    {"-stack-list-variables",       cmd_stack_list_variables},
+    {"-interpreter-exec",           cmd_interpreter_exec},
+    {"0-interpreter-exec",          cmd_interpreter_exec},
+    {"-data-evaluate-expression",   cmd_evaluate_expression},
+    {"-var-create",                 cmd_var_create},
+    {"-var-delete",                 cmd_var_delete},
+    {"-var-evaluate-expression",    cmd_var_evaluate_expression},
+    {"-var-list-children",          cmd_var_list_children},
+    { NULL, NULL }
+};
+
+static void report_continue() {
+    debugger_active = 0;
+    mi2_printf_async("running,thread-id=\"all\"")
+}
+
+static void cmd_exit(int argc, char **argv) {
+    mi2_printf_response("exit");
+    exit(0);
+}
+
+static void cmd_file_exec_and_symbols(int argc, char **argv) {
+    if (argc < 2) {
+        mi2_printf_error("No file specified");
+        return;
+    }
+    read_symbol_file(argv[1]);
+    mi2_printf_response("done");
+}
+
+static void cmd_info(int argc, char **argv) {
+    if (argc < 2) {
+        mi2_printf_error("please specify section");
+        return;
+    }
+
+    const char* section = argv[1];
+    if (strcmp(section, "pretty-printer") == 0) {
+        bk.debug("pretty-printing is not supported\n");
+    } else {
+        bk.debug("unknown info section: %s\n", section);
+    }
+
+    mi2_printf_response("done");
+}
+
+static void cmd_maintenance(int argc, char **argv) {
+    if (argc < 3) {
+        mi2_printf_error("please specify section");
+        return;
+    }
+
+    const char* section = argv[2];
+    if (strcmp(section, "sections") == 0) {
+        bk.console("Exec file:");
+        bk.console("    `program', file type z80.");
+        bk.console(" [0]      0x000000000->0x00000FFFF at 0x00000000: .text ALLOC LOAD CODE HAS_CONTENTS");
+    } else {
+        bk.debug("unknown info section: %s\n", section);
+    }
+
+    mi2_printf_response("done");
+}
+
+static void cmd_thread_info(int argc, char **argv) {
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    debug_frame_pointer* fp = debug_stack_frames_construct(regs.pc, regs.sp, &regs, 1);
+
+    if (fp) {
+        if (fp->symbol && fp->filename && fp->function) {
+            mi2_printf_response(
+                "done,threads=[{id=\"1\",target-id=\"Thread\","
+                "frame={level=\"0\",addr=\"0x%08x\",func=\"%s\","
+                "args=[],file=\"%s\","
+                "fullname=\"%s\",line=\"%d\"},"
+                "state=\"stopped\"}],current-thread-id=\"1\"",
+                regs.pc, fp->function->name, fp->filename, fp->filename, fp->lineno);
+            debug_stack_frames_free(fp);
+            return;
+        }
+
+        debug_stack_frames_free(fp);
+    }
+
+    uint16_t offset = 0;
+    symbol* s = symbol_find_lower(regs.pc, SYM_ADDRESS, &offset);
+
+    const char* filename;
+    int lineno;
+    if (s == NULL || debug_find_source_location(regs.pc, &filename, &lineno)) {
+        mi2_printf_response(
+            "done,threads=[{id=\"1\",target-id=\"Thread\","
+            "frame={level=\"0\",addr=\"0x%08x\","
+            "args=[]},"
+            "state=\"stopped\"}],current-thread-id=\"1\"",
+            regs.pc);
+    } else {
+        mi2_printf_response(
+            "done,threads=[{id=\"1\",target-id=\"Thread\","
+            "frame={level=\"0\",addr=\"0x%08x\",func=\"%s\","
+            "args=[],file=\"%s\","
+            "fullname=\"%s\",line=\"%d\"},"
+            "state=\"stopped\"}],current-thread-id=\"1\"",
+            regs.pc, s->name, filename, filename, lineno);
+    }
+}
+
+static void cmd_stack_list_variables(int argc, char **argv) {
+    uint8_t no_values = 0;
+
+    for (int i = 1; i < argc; i++) {
+        const char* arg = argv[i];
+        if (strcmp(arg, "--frame") == 0) {
+            current_frame = atoi(argv[++i]);
+        } else if (strcmp(arg, "--no-values") == 0) {
+            no_values = 1;
+        }
+    }
+
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint16_t stack = regs.sp;
+    uint16_t initial_stack = stack;
+    uint16_t at = bk.pc();
+
+    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 0);
+    debug_frame_pointer* fp = debug_stack_frames_at(first_frame_pointer, current_frame);
+
+    char* response = malloc(4096);
+    *response = '\0';
+    char* ptr = response;
+    uint8_t first = 1;
+
+    debug_sym_function* fn = fp->function;
+    if (fn != NULL) {
+        char function_args[255] = {0};
+        debug_sym_function_argument* arg = fn->arguments;
+        while (arg) {
+            if (!first) {
+                ptr += sprintf(ptr, ",");
+            }
+            debug_sym_symbol* s = arg->symbol;
+            if (no_values) {
+                ptr += sprintf(ptr, "{name=\"%s\"}", s->symbol_name);
+            } else {
+                if (debug_symbol_valid(s, initial_stack, fp)) {
+                    struct expression_result_t exp = {0};
+                    debug_get_symbol_value_expression(s, fp, &exp);
+                    if (is_expression_result_error(&exp)) {
+                        ptr += sprintf(ptr, "{name=\"%s\",value=\"<error>\"}", s->symbol_name);
+                    } else {
+                        char exp_type[128] = "unknown";
+                        char* exp_value = malloc(2048);
+                        strcpy(exp_value, "???");
+                        expression_result_type_to_string(&exp.type, exp.type.first, exp_type);
+                        expression_result_value_to_string(&exp, exp_value, 2048);
+                        ptr += sprintf(ptr, "{name=\"%s\",type=\"%s\",value=\"%s\"}", s->symbol_name, exp_type, exp_value);
+                        free(exp_value);
+                    }
+                    expression_result_free(&exp);
+                } else {
+                    ptr += sprintf(ptr, "{name=\"%s\",value=\"<invalid>\"}", s->symbol_name);
+                }
+            }
+            first = 0;
+            arg = arg->next;
+        }
+    }
+
+    debug_stack_frames_free(first_frame_pointer);
+    mi2_printf_response("done,variables=[%s]", response);
+    free(response);
+}
+
+static void cmd_interpreter_exec(int argc_, char **argv_) {
+    char* interpreter = NULL;
+    char* exec = NULL;
+
+    for (int i = 1; i < argc_; i++) {
+        char* arg = argv_[i];
+        if (strcmp(arg, "--frame") == 0) {
+            current_frame = atoi(argv_[++i]);
+        } else if (strcmp(arg, "--thread") == 0) {
+            // ignore next option
+            i++;
+        } else {
+            if (interpreter == NULL) {
+                interpreter = arg;
+            } else if (exec == NULL) {
+                exec = arg;
+            }
+        }
+    }
+
+    if (interpreter == NULL || exec == NULL) {
+        mi2_printf_error("Interpreter or exec are not specified.");
+        return;
+    }
+
+    if (strcmp(interpreter, "console") == 0) {
+        debugger_evaluate(exec);
+        mi2_printf_response("done");
+    } else if (strcmp(interpreter, "mi2") == 0) {
+        int argc;
+        char **argv = parse_words(exec, &argc);
+
+        if ( argc > 0 ) {
+            const char* command_name = argv[0];
+            command *cmd = &mi2_commands[0];
+            uint8_t command_found = 0;
+
+            while ( cmd->cmd ) {
+                if ( strcmp(command_name, cmd->cmd) == 0 ) {
+                    command_found = 1;
+                    cmd->func(argc, argv);
+                    break;
+                }
+                cmd++;
+            }
+
+            free(argv);
+
+            if (command_found == 0) {
+                mi2_printf_error("Cannot evaluate command: %s", exec);
+            }
+        }
+    } else {
+        mi2_printf_error("Unsupported interpreter");
+    }
+
+}
+
+static void cmd_var_create(int argc, char **argv)
+{
+    int frame = 0;
+    char* name = NULL;
+    char* kind = NULL;
+    char* expr = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        char* arg = argv[i];
+        if (strcmp(arg, "--frame") == 0) {
+            frame = atoi(argv[++i]);
+        } else if (strcmp(arg, "--thread") == 0) {
+            // ignore next option
+            i++;
+        }
+        if (name == NULL) {
+            name = arg;
+        } else if (kind == NULL) {
+            kind = arg;
+        } else if (expr == NULL) {
+            expr = arg;
+        }
+    }
+
+    if (expr == NULL) {
+        mi2_printf_error("expression is not specified");
+        return;
+    }
+
+    mi2_var* var = calloc(1, sizeof(mi2_var));
+
+    strcpy(var->name, name);
+    var->frame = frame;
+    strcpy(var->expression, expr);
+
+    current_frame = frame;
+    evaluate_expression_string(expr);
+
+    struct expression_result_t* result = get_expression_result();
+    if (is_expression_result_error(result))
+    {
+        mi2_printf_response("done,name=\"%s\",numchild=\"0\",thread-id=\"1\"", name);
+        return;
+    }
+
+    char type[128] = {};
+    char value[255] = {};
+
+    expression_result_value_to_string(result, value, sizeof(value));
+    expression_result_type_to_string(&result->type, result->type.first, type);
+
+    int num_members = expression_count_members(result);
+
+    HASH_ADD_STR(mi2_vars, name, var);
+    mi2_printf_response("done,name=\"%s\",numchild=\"%d\",type=\"%s\",value=\"%s\",thread-id=\"1\"",
+        name, num_members, type, value);
+}
+
+static void cmd_var_delete(int argc, char **argv)
+{
+    if (argc < 2) {
+        mi2_printf_error("Not enough arguments");
+        return;
+    }
+
+    mi2_var* var = NULL;
+    HASH_FIND_STR(mi2_vars, argv[1], var);
+
+    if (var == NULL) {
+        mi2_printf_error("Unknown variable");
+        return;
+    }
+
+    HASH_DEL(mi2_vars, var);
+    free(var);
+    mi2_printf_response("done");
+}
+
+static void cmd_var_evaluate_expression(int argc, char **argv)
+{
+    if (argc < 2) {
+        mi2_printf_error("Not enough arguments");
+        return;
+    }
+
+    mi2_var* var = NULL;
+    HASH_FIND_STR(mi2_vars, argv[1], var);
+
+    if (var == NULL) {
+        mi2_printf_error("Unknown variable");
+        return;
+    }
+
+    current_frame = var->frame;
+    evaluate_expression_string(var->expression);
+
+    struct expression_result_t* result = get_expression_result();
+    if (is_expression_result_error(result))
+    {
+        mi2_printf_response("done,value=\"%s\"", result->as_error);
+        return;
+    }
+
+    char value[255] = {};
+    expression_result_value_to_string(result, value, sizeof(value));
+    mi2_printf_response("done,value=\"%s\"", value);
+}
+
+static void resolve_expression_result_to_child(
+    const char* member, struct expression_result_t* result, char* ptr, int all_values)
+{
+    if (is_expression_result_error(result)) {
+        sprintf(ptr, "child={exp=\"%s\",type=\"<error>\",value=\"%s\"}", member, result->as_error);
+    } else {
+        char type[255] = {};
+
+        expression_result_type_to_string(&result->type, result->type.first, type);
+
+        if (all_values) {
+            char value[255] = {};
+            expression_result_value_to_string(result, value, sizeof(value));
+            sprintf(ptr, "child={exp=\"%s\",value=\"%s\",type=\"%s\"}", member, value, type);
+        } else {
+            sprintf(ptr, "child={exp=\"%s\",type=\"%s\"}", member, type);
+        }
+    }
+}
+
+static void cmd_var_list_children(int argc, char **argv)
+{
+    int all_values = 0;
+    char* name = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        char* arg = argv[i];
+        if (strcmp(arg, "--all-values") == 0) {
+            all_values = 1;
+        } else {
+            if (name == NULL) {
+                name = arg;
+            }
+        }
+    }
+
+    if (name == NULL) {
+        mi2_printf_error("variable name is not specified");
+        return;
+    }
+
+    mi2_var* var = NULL;
+    HASH_FIND_STR(mi2_vars, name, var);
+
+    if (var == NULL) {
+        mi2_printf_error("Unknown variable %s", name);
+        return;
+    }
+
+    current_frame = var->frame;
+    evaluate_expression_string(var->expression);
+
+    struct expression_result_t* result = get_expression_result();
+
+    if (is_expression_result_error(result))
+    {
+        mi2_printf_error("%s", result->as_error);
+        return;
+    }
+
+    char* members[64] = {};
+    int num_child = 0;
+
+    struct expression_result_t* struct_ = NULL;
+    struct expression_result_t* dereferenced = NULL;
+
+    switch (result->type.first->type_)
+    {
+        case TYPE_CODE_POINTER:
+        case TYPE_GENERIC_POINTER:
+        {
+            dereferenced = calloc(1, sizeof(struct expression_result_t));
+            expression_dereference_pointer(result, dereferenced);
+            struct_ = dereferenced;
+            break;
+        }
+        case TYPE_STRUCTURE:
+        {
+            struct_ = result;
+            break;
+        }
+        default:
+        {
+            mi2_printf_error("Do not know how to process this");
+            break;
+        }
+    }
+
+    expression_get_struct_members(struct_, &num_child, (char**)&members);
+
+    char* child_buffer = malloc(8192);
+    *child_buffer = '\0';
+    char* ptr = child_buffer;
+
+    for (int i = 0; i < num_child; i++) {
+        if (i) {
+            ptr += sprintf(ptr, ",");
+        }
+
+        char* member = members[i];
+
+        struct expression_result_t member_result = {};
+        expression_resolve_struct_member(struct_, member, &member_result);
+
+        char* child_resolved = malloc(4096);
+        resolve_expression_result_to_child(member, &member_result, child_resolved, all_values);
+        ptr += sprintf(ptr, "%s", child_resolved);
+
+        free(child_resolved);
+        expression_result_free(&member_result);
+    }
+
+    mi2_printf_response("done,children=[%s]", child_buffer);
+    free(child_buffer);
+
+    if (dereferenced)
+    {
+        expression_result_free(dereferenced);
+    }
+}
+
+static void cmd_evaluate_expression(int argc, char **argv) {
+    char* expression = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        char* arg = argv[i];
+        if (strcmp(arg, "--frame") == 0) {
+            current_frame = atoi(argv[++i]);
+        } else if (strcmp(arg, "--thread") == 0) {
+            // ignore next option
+            i++;
+        } else {
+            if (expression == NULL) {
+                expression = strdup(arg);
+            } else {
+                char spaced[256];
+                sprintf(spaced, "%s %s", expression, arg);
+                free(expression);
+                expression = strdup(spaced);
+            }
+        }
+    }
+
+    if (expression == NULL) {
+        mi2_printf_error("expression is not specified");
+        return;
+    }
+
+    bk.debug("evaluating expression %s\n", expression);
+    evaluate_expression_string(expression);
+
+    struct expression_result_t* result = get_expression_result();
+    if (is_expression_result_error(result))
+    {
+        mi2_printf_error("%s", result->as_error);
+        free(expression);
+        return;
+    }
+
+    char evaluated_value[128] = "<unknown>";
+    expression_result_value_to_string(result, evaluated_value, sizeof(evaluated_value));
+
+    mi2_printf_response("done,value=\"%s\"", evaluated_value);
+    free(expression);
+}
+
+static char* sprintf_frame0(char* ptr) {
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    debug_frame_pointer* fp = debug_stack_frames_construct(regs.pc, regs.sp, &regs, 1);
+
+    if (fp) {
+        if (fp->symbol && fp->filename && fp->function) {
+            ptr += sprintf(ptr,
+                "level=\"0\",addr=\"0x%08x\",func=\"%s\","
+                "args=[],file=\"%s\","
+                "fullname=\"%s\",line=\"%d\"",
+                regs.pc, fp->function->name, fp->filename, fp->filename, fp->lineno);
+            goto done;
+        }
+    } else {
+        uint16_t offset;
+        symbol* sym = symbol_find_lower(regs.pc, SYM_ADDRESS, &offset);
+        if (sym != NULL) {
+            const char *filename;
+            int lineno;
+            if (debug_find_source_location(regs.pc, &filename, &lineno)) {
+                ptr += sprintf(ptr, "level=\"0\",addr=\"0x%08x\",func=\"%s\","
+                                    "file=\"%s\","
+                                    "fullname=\"%s\",line=\"%d\","
+                                    "arch=\"z80\"", regs.pc, sym->name, sym->file, filename, lineno);
+            } else {
+                ptr += sprintf(ptr, "level=\"0\",addr=\"0x%08x\",func=\"%s\","
+                                    "file=\"%s\","
+                                    "fullname=\"%s\","
+                                    "arch=\"z80\"", regs.pc, sym->name, sym->file, sym->file);
+            }
+        } else {
+            ptr += sprintf(ptr, "level=\"0\",addr=\"0x%08x\"", regs.pc);
+        }
+    }
+
+done:
+    debug_stack_frames_free(fp);
+    return ptr;
+}
+
+static void cmd_stack_list_frames(int argc, char **argv) {
+
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint16_t stack = regs.sp;
+    uint16_t initial_stack = stack;
+    uint16_t at = bk.pc();
+
+    char* dump_buffer = malloc(65536);
+    char* ptr = dump_buffer;
+    *ptr = 0;
+
+    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(regs.pc, regs.sp, &regs, 0);
+    if (first_frame_pointer == NULL) {
+        uint16_t offset;
+        symbol* sym = symbol_find_lower(regs.pc, SYM_ADDRESS, &offset);
+        if (sym != NULL) {
+
+            const char *filename;
+            int lineno;
+            if (debug_find_source_location(regs.pc, &filename, &lineno)) {
+                ptr += sprintf(ptr, "frame={level=\"0\",addr=\"0x%08x\",func=\"%s\","
+                                    "file=\"%s\","
+                                    "fullname=\"%s\",line=\"%d\","
+                                    "arch=\"z80\"}", regs.pc, sym->name, sym->file, filename, lineno);
+            } else {
+                ptr += sprintf(ptr, "frame={level=\"0\",addr=\"0x%08x\",func=\"%s\","
+                                    "file=\"%s\","
+                                    "fullname=\"%s\","
+                                    "arch=\"z80\"}", regs.pc, sym->name, sym->file, sym->file);
+            }
+        } else {
+            ptr += sprintf(ptr, "frame={level=\"0\",addr=\"0x%08x\"}", regs.pc);
+        }
+    } else {
+        debug_frame_pointer* fp = first_frame_pointer;
+        int level = 0;
+
+        while (fp) {
+            if (level != 0) {
+                ptr += sprintf(ptr, ",");
+            }
+
+            if (fp->symbol && fp->filename && fp->function) {
+                ptr += sprintf(ptr, "frame={level=\"%d\",addr=\"0x%08x\",func=\"%s\","
+                                    "file=\"%s\","
+                                    "fullname=\"%s\",line=\"%d\","
+                                    "arch=\"z80\"}", level, fp->address, fp->function->name,
+                    fp->filename, fp->filename, fp->lineno);
+            } else {
+                ptr += sprintf(ptr, "frame={level=\"%d\",addr=\"0x%08x\"}",
+                    level, fp->address);
+            }
+
+            fp = fp->next;
+            level++;
+        }
+
+        debug_stack_frames_free(first_frame_pointer);
+    }
+
+    mi2_printf_response("done,stack=[%s]", dump_buffer);
+    free(dump_buffer);
+}
+
+static void cmd_data_disassemble(int argc, char **argv) {
+    const char* from = NULL;
+    const char* to = NULL;
+    const char* mode = NULL;
+
+    for (int i = 0; i < argc; i++) {
+        const char* arg = argv[i];
+        if (strcmp(arg, "-s") == 0) {
+            from = argv[++i];
+        } else if (strcmp(arg, "-e") == 0) {
+            to = argv[++i];
+        } else if (strcmp(arg, "--") == 0) {
+            mode = argv[++i];
+        }
+    }
+
+    if (from == NULL || to == NULL) {
+        mi2_printf_error("Range is not properly specified");
+        return;
+    }
+
+    int mode_d;
+
+    if (mode != NULL) {
+        mode_d = atoi(mode);
+        if (mode_d != 0 && mode_d != 2) {
+            mi2_printf_error("Mode is not properly specified");
+            return;
+        }
+    } else {
+        mode_d = 2;
+    }
+
+    int from_d = 0;
+    int to_d = 0;
+
+    from += 2; // skip 0x
+    if (sscanf(from, "%x", &from_d) != 1) {
+        mi2_printf_error("Range 'from' is not properly specified");
+        return;
+    }
+
+    to += 2; // skip 0x
+    if (sscanf(to, "%x", &to_d) != 1) {
+        mi2_printf_error("Range 'to' is not properly specified");
+        return;
+    }
+
+    if (to_d <= from_d) {
+        mi2_printf_error("Incorrect range");
+        return;
+    }
+
+    int pc = from_d;
+
+    uint16_t offset = 0;
+    symbol* sym = symbol_find_lower(pc, SYM_ADDRESS, &offset);
+    uint8_t first = 1;
+
+    char* dump_buffer = malloc(65536);
+    char* ptr = dump_buffer;
+    *ptr = 0;
+
+    while (pc <= to_d) {
+        char db[256] = {};
+        int len = disassemble2(pc, db, sizeof(db), 2);
+
+        if (!first) {
+            ptr += sprintf(ptr, ",");
+        }
+
+        if (mode_d == 2) {
+            char* opcodes = strchr(db, ';');
+            *opcodes = 0;
+            opcodes++;
+            if (sym) {
+                ptr += sprintf(ptr, "{address=\"0x%08x\",func-name=\"%s\",offset=\"%d\",inst=\"%s\",opcodes=\"%s\"}",
+                    pc, sym->name, offset, db, opcodes);
+            } else {
+                ptr += sprintf(ptr, "{address=\"0x%08x\",inst=\"%s\",opcodes=\"%s\"}", pc, db, opcodes);
+            }
+        } else {
+            if (sym) {
+                ptr += sprintf(ptr, "{address=\"0x%08x\",func-name=\"%s\",offset=\"%d\",inst=\"%s\"}",
+                    pc, sym->name, offset, db);
+            } else {
+                ptr += sprintf(ptr, "{address=\"0x%08x\",inst=\"%s\"}", pc, db);
+            }
+        }
+
+        offset += len;
+        pc += len;
+        first = 0;
+    }
+
+    mi2_printf_response("done,asm_insns=[%s]", dump_buffer);
+    free(dump_buffer);
+}
+
+static void cmd_plain_disassemble(int argc, char **argv) {
+    const char* address = NULL;
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint8_t raw_bytes = 0;
+
+    for (int i = 1; i < argc; i++) {
+        const char* arg = argv[i];
+        if (strcmp(arg, "/r") == 0) {
+            raw_bytes = 1;
+        } else {
+            address = argv[i];
+            break;
+        }
+    }
+
+    int from_d = 0;
+    int to_d = 0;
+    int len_d = 0;
+
+    address += 2;
+    if (sscanf(address, "%x,+%d", &from_d, &len_d) != 2) {
+        if (sscanf(address, "%x", &from_d) != 1) {
+            mi2_printf_error("Range is not properly specified");
+            return;
+        } else {
+            to_d = regs.pc + 256;
+        }
+    } else {
+        to_d = from_d + len_d;
+    }
+
+    if (to_d > 0xFFFF) {
+        to_d = 0xFFFF;
+    }
+
+    int pc = from_d;
+
+    bk.console("Dump of assembler code from 0x%08x to 0x%08x:\n", from_d, to_d);
+
+    while (pc <= to_d) {
+        char db[256] = {};
+        int len = disassemble2(pc, db, sizeof(db), 2);
+
+        const char* ppp = (pc == regs.pc) ? "=> " : "   ";
+
+        if (raw_bytes) {
+            char* opcodes = strchr(db, ';');
+            if (opcodes) {
+                *opcodes = 0;
+                opcodes++;
+                bk.console("%s0x%08x:\\t%s\\t%s\n", ppp, pc, opcodes, db);
+            } else {
+                bk.console("%s0x%08x:\\t%s\n", ppp, pc, db);
+            }
+        } else {
+            bk.console("%s0x%08x:\\t%s\n", ppp, pc, db);
+        }
+
+        pc += len;
+    }
+
+    bk.console("End of assembler dump.\n");
+    mi2_printf_response("done");
+}
+
+static void cmd_show(int argc, char **argv) {
+    if (argc < 2) {
+        mi2_printf_error("please specify variable");
+        return;
+    }
+
+    const char* variable = argv[1];
+
+    if (strcmp(variable, "mi-async") == 0) {
+        mi2_printf_response("done,value=\"on\"");
+        return;
+    }
+
+    mi2_printf_response("done,value=\"unknown\"");
+}
+
+static void cmd_continue(int argc, char **argv) {
+    bk.console("Resuming execution\n");
+    bk.resume();
+    mi2_printf_response("running");
+    report_continue();
+}
+
+static void cmd_break(int argc, char **argv) {
+    bk.break_(0);
+    mi2_printf_response("done");
+}
+
+static void cmd_next_instruction(int argc, char **argv) {
+    bk.next();
+    mi2_printf_response("done");
+    report_continue();
+}
+
+static void cmd_fin(int argc, char **argv) {
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    uint16_t stack = regs.sp;
+    uint16_t initial_stack = stack;
+    uint16_t at = bk.pc();
+
+    debug_frame_pointer* first_frame_pointer = debug_stack_frames_construct(at, stack, &regs, 1);
+
+    if (first_frame_pointer && first_frame_pointer->return_address) {
+        temporary_breakpoint_t* tmp = add_temporary_internal_breakpoint(first_frame_pointer->return_address,
+            TMP_REASON_FIN, NULL, 0);
+        tmp->callee = first_frame_pointer->function;
+        tmp->external = 1;
+        bk.add_breakpoint(BK_BREAKPOINT_SOFTWARE, first_frame_pointer->return_address, 1);
+
+        debug_stack_frames_free(first_frame_pointer);
+        debugger_active = 0;
+        bk.resume();
+    } else {
+        debug_stack_frames_free(first_frame_pointer);
+
+        add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_FIN, NULL, 0);
+        bk.step();
+    }
+
+    mi2_printf_response("done");
+}
+
+static void cmd_next(int argc, char **argv) {
+
+    const char *filename;
+    int   lineno;
+    const unsigned short pc = bk.pc();
+    if (debug_find_source_location(pc, &filename, &lineno) < 0) {
+        add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_NEXT_SOURCE_LINE, NULL, 0);
+        bk.next();
+        report_continue();
+        mi2_printf_response("done");
+        return;
+    }
+
+    add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_NEXT_SOURCE_LINE, filename, lineno);
+    bk.next();
+    report_continue();
+    mi2_printf_response("done");
+}
+
+static void cmd_step(int argc, char **argv) {
+
+    const char *filename;
+    int   lineno;
+    const unsigned short pc = bk.pc();
+    if (debug_find_source_location(pc, &filename, &lineno) < 0) {
+        add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_STEP_SOURCE_LINE, NULL, 0);
+        bk.step();
+        report_continue();
+        mi2_printf_response("done");
+        return;
+    }
+
+    add_temporary_internal_breakpoint(0xFFFFFFFF, TMP_REASON_STEP_SOURCE_LINE, filename, lineno);
+    bk.step();
+    report_continue();
+    mi2_printf_response("done");
+}
+
+static void cmd_do_nothing(int argc, char **argv) {
+    // we don't set anything
+    mi2_printf_response("done");
+}
+
+static uint8_t report_connected = 0;
+
+static void cmd_target_select(int argc, char **argv) {
+    if (argc < 3) {
+        mi2_printf_error("target-select: requires 2 arguments");
+        return;
+    }
+
+    if (strcmp(argv[1], "remote") != 0) {
+        mi2_printf_error("target-select: unsupported %s", argv[1]);
+        return;
+    }
+
+    char hostname[128];
+    int port;
+
+    {
+        int scanf_res = sscanf(argv[2], "tcp:%[^:]:%d", hostname, &port);
+        if (scanf_res != 2) {
+            mi2_printf_error("target-select: cannot process target address: %s", argv[2]);
+            return;
+        }
+    }
+
+    if (bk.remote_connect(hostname, port) ) {
+        mi2_printf_error("target-select: cannot connect hostname %s port %d", hostname, port);
+        return;
+    }
+
+    report_connected = 1;
+}
+
+static void cmd_target_detach(int argc, char **argv)
+{
+    delete_all_breakpoints();
+    bk.detach();
+    mi2_printf_response("done");
+}
+
+static void cmd_break_insert(int argc, char **argv) {
+    char* insert_path = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        const char* arg = argv[i];
+
+        if (strcmp(arg, "-f") == 0) {
+            insert_path = argv[++i];
+        }
+    }
+
+    if (insert_path) {
+        const char *sym;
+        breakpoint *elem;
+        const char* corrected_source = insert_path;
+        int value = parse_address(insert_path, &corrected_source);
+
+        if ( value != -1 ) {
+            elem = add_breakpoint(BREAK_PC, BK_BREAKPOINT_SOFTWARE, 1, value, NULL);
+
+            uint16_t offset = 0;
+            symbol* s = symbol_find_lower(value, SYM_ADDRESS, &offset);
+
+            const char* filename;
+            int lineno;
+            if (debug_find_source_location(value, &filename, &lineno)) {
+                mi2_printf_response(
+                    "done,bkpt={number=\"%d\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\","
+                    "addr=\"0x%08x\",func=\"%s\",file=\"%s\","
+                    "fullname=\"%s\",thread-groups=[\"i1\"],"
+                    "times=\"0\"}", elem->number, value, s->name, s->file, s->file);
+            } else {
+                mi2_printf_response(
+                    "done,bkpt={number=\"%d\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\","
+                    "addr=\"0x%08x\",func=\"%s\",file=\"%s\","
+                    "fullname=\"%s\",line=\"%d\",thread-groups=[\"i1\"],"
+                    "times=\"0\"}", elem->number, value, s->name, s->file, s->file, lineno);
+            }
+        } else {
+            mi2_printf_error("Cannot break on '%s'", corrected_source);
+        }
+    } else {
+        mi2_printf_error("Cannot understand this");
+    }
+}
+
+static void cmd_break_delete(int argc, char **argv) {
+    char* insert_path = NULL;
+
+    if (argc < 2) {
+        mi2_printf_error("Specify breakpoint number");
+        return;
+    }
+
+    breakpoint* b = find_breakpoint(atoi(argv[1]));
+
+    if (b == NULL) {
+        mi2_printf_error("unknown breakpoint");
+        return;
+    }
+
+    delete_breakpoint(b);
+    mi2_printf_response("done");
+}
+
+typedef struct mi2_command_execution {
+    command *cmd;
+    char **argv;
+    int argc;
+} mi2_command_execution;
+
+static void mi2_execution_stopped() {
+    debugger_active = 1;
+
+    struct debugger_regs_t regs;
+    bk.get_regs(&regs);
+
+    {
+        breakpoint* elem;
+        breakpoint* tmp;
+        LL_FOREACH_SAFE(breakpoints, elem, tmp) {
+            if (elem->pending_add) {
+                elem->pending_add = 0;
+                bk.add_breakpoint(BK_BREAKPOINT_SOFTWARE, elem->value, 1);
+            }
+            if (elem->pending_remove) {
+                elem->pending_remove = 0;
+                bk.remove_breakpoint(BK_BREAKPOINT_SOFTWARE, elem->value, 1);
+
+                LL_DELETE(breakpoints, elem);
+                if (elem->text) {
+                    free(elem->text);
+                    elem->text = NULL;
+                }
+                free(elem);
+            }
+        }
+    }
+
+    if (temporary_break)
+    {
+        temporary_break = 0;
+        bk.resume();
+        return;
+    }
+
+    static uint8_t report_thread = 1;
+
+    if (report_thread) {
+        report_thread = 0;
+        mi2_printf_thread("thread-created,id=\"1\",group-id=\"i1\"");
+    }
+
+    breakpoint *breakpoint_hit = NULL;
+
+    {
+        breakpoint *elem;
+        LL_FOREACH(breakpoints, elem) {
+            if ( elem->enabled == 0 ) {
+                continue;
+            }
+            switch (elem->type) {
+                case BREAK_PC: {
+                    if (elem->value == regs.pc) {
+                        breakpoint_hit = elem;
+                    }
+                    break;
+                }
+                default:
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    char frame[512] = {};
+    sprintf_frame0(frame);
+
+    if (breakpoint_hit) {
+        bk.console("Hit a breakpoint\n");
+        mi2_printf_async(
+            "stopped,reason=\"breakpoint-hit\",disp=\"keep\",bkptno=\"%d\","
+            "frame={%s},thread-id=\"1\",stopped-threads=\"all\"",
+            breakpoint_hit->number, frame);
+    } else {
+        if (process_temp_breakpoints()) {
+            mi2_printf_async(
+                "stopped,reason=\"end-stepping-range\",frame={%s},thread-id=\"1\",stopped-threads=\"all\"", frame);
+            return;
+        }
+    }
+
+    if (report_connected) {
+        report_connected = 0;
+        mi2_printf_async(
+            "stopped,reason=\"first-break\",frame={%s},thread-id=\"1\",stopped-threads=\"all\"", frame);
+        mi2_printf_response("connected");
+        mi2_printf_prompt();
+    }
+}
+
+void execute_mi2_command_on_main_thread(const void* data, void* response) {
+    const mi2_command_execution* exec = (const mi2_command_execution*)data;
+    exec->cmd->func(exec->argc, exec->argv);
+}
+
+void execute_unknown_command(const void* data, void* response) {
+    bk.debug("warning: unknown command: %s\n", (char*)data);
+    mi2_printf_response("done");
+}
+
+void execute_prompt(const void* data, void* response) {
+    mi2_printf_prompt();
+}
+
+
+void execute_ctrl_c(const void* data, void* response) {
+    bk.console("Caught ctrl-c.");
+    bk.break_(0);
+    mi2_printf_prompt();
+}
+
+static void ctrl_c() {
+    execute_on_main_thread_no_response(execute_ctrl_c, NULL);
+}
+
+static void* debugger_mi2_console_loop(void* arg) {
+    char *debugger_line = malloc(1024);
+    size_t debugger_line_size = 1024;
+
+    while (1) {
+        execute_on_main_thread(execute_prompt, NULL, NULL);
+
+        while (getline(&debugger_line, &debugger_line_size, stdin) == 0) ;
+
+        int argc;
+        char **argv = parse_words(debugger_line, &argc);
+
+        if ( argc > 0 ) {
+            const char* command_name = argv[0];
+            command *cmd = &mi2_commands[0];
+            uint8_t command_found = 0;
+
+            while ( cmd->cmd ) {
+                if ( strcmp(command_name, cmd->cmd) == 0 ) {
+                    command_found = 1;
+
+                    mi2_command_execution exec;
+                    exec.cmd = cmd;
+                    exec.argv = argv;
+                    exec.argc = argc;
+
+                    execute_on_main_thread(execute_mi2_command_on_main_thread, &exec, NULL);
+
+                    break;
+                }
+                cmd++;
+            }
+
+            if (command_found == 0) {
+                execute_on_main_thread(execute_unknown_command, argv[0], NULL);
+            }
+        }
+
+        free(argv);
+    }
+
+    free(debugger_line);
+
+    return NULL;
+}
+
+static void slash(char* formatted)
+{
+    char* newline;
+    while ((newline = strchr(formatted, '\n')))
+    {
+        *newline = '\\';
+        newline++;
+
+        // make way for '\n'
+        memmove(newline + 1, newline, strlen(newline) + 1);
+
+        *newline = 'n';
+    }
+
+    char* tab;
+    while ((tab = strchr(formatted, '\t')))
+    {
+        *tab = '\\';
+        tab++;
+
+        // make way for '\n'
+        memmove(tab + 1, tab, strlen(tab) + 1);
+
+        *tab = 't';
+    }
+}
+
+static void mi2_console_printf(const char *fmt, ...) {
+    va_list args;
+    int len;
+
+    /* Initialize a variable argument list */
+    va_start(args, fmt);
+
+    /* Get length of format including arguments */
+    len = vsnprintf(NULL, 0, fmt, args);
+
+    /* End using variable argument list */
+    va_end(args);
+
+    if (len < 0) {
+        return;
+    } else {
+        /* Declare a character buffer for the formatted string */
+        char formatted[len + 64];
+
+        /* Initialize a variable argument list */
+        va_start(args, fmt);
+
+        /* Write the formatted output */
+        vsnprintf(formatted, sizeof(formatted), fmt, args);
+
+        /* End using variable argument list */
+        va_end(args);
+
+        slash(formatted);
+
+        /* Call the wrapped function using the formatted output and return */
+        printf("~\"%s\"\n", formatted);
+    }
+}
+
+static void mi2_internal_printf(const char *fmt, ...) {
+    va_list args;
+    int len;
+
+    /* Initialize a variable argument list */
+    va_start(args, fmt);
+
+    /* Get length of format including arguments */
+    len = vsnprintf(NULL, 0, fmt, args);
+
+    /* End using variable argument list */
+    va_end(args);
+
+    if (len < 0) {
+        /* vsnprintf failed */
+        return;
+    } else {
+        /* Declare a character buffer for the formatted string */
+        char formatted[len + 64];
+
+        /* Initialize a variable argument list */
+        va_start(args, fmt);
+
+        /* Write the formatted output */
+        vsnprintf(formatted, sizeof(formatted), fmt, args);
+
+        /* End using variable argument list */
+        va_end(args);
+
+        slash(formatted);
+
+        /* Call the wrapped function using the formatted output and return */
+        printf("&\"%s\"\n", formatted);
+    }
+}
+
+
+void debugger_mi2_init()
+{
+    // we need to disable buffering or the client won't be happy
+    setbuf(stdout, NULL);
+
+    bk.console = mi2_console_printf;
+    bk.debug = mi2_internal_printf;
+    bk.execution_stopped = mi2_execution_stopped;
+    bk.ctrl_c = ctrl_c;
+
+    {
+        pthread_t id;
+        pthread_create(&id, NULL, debugger_mi2_console_loop, NULL);
+        pthread_detach(id);
+    }
+}

--- a/src/ticks/debugger_mi2.c
+++ b/src/ticks/debugger_mi2.c
@@ -429,12 +429,11 @@ static void resolve_expression_result_to_child(
     if (is_expression_result_error(result)) {
         sprintf(ptr, "child={exp=\"%s\",type=\"<error>\",value=\"%s\"}", member, result->as_error);
     } else {
-        char type[255] = {};
-
+        char type[255] = "<unknown>";
         expression_result_type_to_string(&result->type, result->type.first, type);
 
         if (all_values) {
-            char value[255] = {};
+            char value[255] = "<undefined>";
             expression_result_value_to_string(result, value, sizeof(value));
             sprintf(ptr, "child={exp=\"%s\",value=\"%s\",type=\"%s\"}", member, value, type);
         } else {
@@ -761,7 +760,7 @@ static void cmd_data_disassemble(int argc, char **argv) {
     *ptr = 0;
 
     while (pc <= to_d) {
-        char db[256] = {};
+        char db[256] = "";
         int len = disassemble2(pc, db, sizeof(db), 2);
 
         if (!first) {
@@ -838,7 +837,7 @@ static void cmd_plain_disassemble(int argc, char **argv) {
     bk.console("Dump of assembler code from 0x%08x to 0x%08x:\n", from_d, to_d);
 
     while (pc <= to_d) {
-        char db[256] = {};
+        char db[256] = "";
         int len = disassemble2(pc, db, sizeof(db), 2);
 
         const char* ppp = (pc == regs.pc) ? "=> " : "   ";
@@ -1145,7 +1144,7 @@ static void mi2_execution_stopped() {
         }
     }
 
-    char frame[512] = {};
+    char frame[512] = "";
     sprintf_frame0(frame);
 
     if (breakpoint_hit) {

--- a/src/ticks/debugger_mi2.h
+++ b/src/ticks/debugger_mi2.h
@@ -4,8 +4,8 @@
 #define mi2_printf_prompt() printf("(gdb)\n")
 #define mi2_printf_async(format, ...) printf("*" format "\n" __VA_OPT__(,) __VA_ARGS__);
 #define mi2_printf_thread(format, ...) printf("=" format "\n" __VA_OPT__(,) __VA_ARGS__);
-#define mi2_printf_error(format, ...) printf("^error,msg=\"" format "\\n\"\n" __VA_OPT__(,) __VA_ARGS__);
-#define mi2_printf_response(format, ...) printf("^" format "\n" __VA_OPT__(,) __VA_ARGS__);
+#define mi2_printf_error(flow, format, ...) printf("%s^error,msg=\"" format "\\n\"\n", flow __VA_OPT__(,) __VA_ARGS__);
+#define mi2_printf_response(flow, format, ...) printf("%s^" format "\n", flow __VA_OPT__(,) __VA_ARGS__);
 
 void debugger_mi2_init();
 

--- a/src/ticks/debugger_mi2.h
+++ b/src/ticks/debugger_mi2.h
@@ -1,0 +1,12 @@
+#ifndef DEBUGGER_MI2_H
+#define DEBUGGER_MI2_H
+
+#define mi2_printf_prompt() printf("(gdb)\n")
+#define mi2_printf_async(format, ...) printf("*" format "\n" __VA_OPT__(,) __VA_ARGS__);
+#define mi2_printf_thread(format, ...) printf("=" format "\n" __VA_OPT__(,) __VA_ARGS__);
+#define mi2_printf_error(format, ...) printf("^error,msg=\"" format "\\n\"\n" __VA_OPT__(,) __VA_ARGS__);
+#define mi2_printf_response(format, ...) printf("^" format "\n" __VA_OPT__(,) __VA_ARGS__);
+
+void debugger_mi2_init();
+
+#endif

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -217,6 +217,7 @@ backend_t ticks_debugger_backend = {
     .breakpoints_check = &breakpoints_check,
     .is_verbose = is_verbose,
     .remote_connect = NULL,
+    .is_remote_connected = NULL,
     .console = stdout_log,
     .debug = stdout_log,
     .execution_stopped = NULL,

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -142,7 +142,6 @@ static breakpoint_ret_t do_nothing(uint8_t type, uint16_t at, uint8_t sz) { retu
 
 void next()
 {
-    extern int next_address;
     char  buf[100];
     int   len;
     const unsigned short pc = bk.pc();
@@ -163,18 +162,22 @@ void next()
         case 0xe4:
         case 0xec:
         case 0xf4:
+        {
             // It's a call
+            add_temporary_internal_breakpoint(pc + len, TMP_REASON_ONE_INSTRUCTION, NULL, 0);
             debugger_active = 0;
-            next_address = pc + len;
-        return;
+            return;
+        }
     }
 
-    debugger_active = 1;
+    add_temp_breakpoint_one_instruction();
+    debugger_active = 0;
 }
 
 void step()
 {
-    debugger_active = 1;
+    add_temp_breakpoint_one_instruction();
+    debugger_active = 0;
 }
 
 static void ctrl_c()

--- a/src/ticks/debugger_ticks.c
+++ b/src/ticks/debugger_ticks.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "debugger.h"
 #include "ticks.h"
@@ -129,7 +130,7 @@ void debugger_read_memory(int addr)
 }
 
 void invalidate() {}
-void break_() {debugger_active=1; }
+void break_(uint8_t temporary) {debugger_active=1; }
 void resume() {}
 void detach() {}
 uint8_t restore(const char* file_path, uint16_t at, uint8_t set_pc) {
@@ -137,7 +138,7 @@ uint8_t restore(const char* file_path, uint16_t at, uint8_t set_pc) {
     return 1;
 }
 
-static void do_nothing(uint8_t type, uint16_t at, uint8_t sz) {}
+static breakpoint_ret_t do_nothing(uint8_t type, uint16_t at, uint8_t sz) { return BREAKPOINT_ERROR_OK; }
 
 void next()
 {
@@ -176,6 +177,11 @@ void step()
     debugger_active = 1;
 }
 
+static void ctrl_c()
+{
+    break_required = 1;
+}
+
 uint8_t breakpoints_check()
 {
     return debugger_active == 0;
@@ -209,5 +215,10 @@ backend_t ticks_debugger_backend = {
     .disable_breakpoint = &do_nothing,
     .enable_breakpoint = &do_nothing,
     .breakpoints_check = &breakpoints_check,
-    .is_verbose = is_verbose
+    .is_verbose = is_verbose,
+    .remote_connect = NULL,
+    .console = stdout_log,
+    .debug = stdout_log,
+    .execution_stopped = NULL,
+    .ctrl_c = ctrl_c
 };

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -262,13 +262,15 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
     state->pc = pc;
     
     label = find_symbol(pc, SYM_ADDRESS);
-    if (label ) {
+    if (label && (compact <= 1)) {
         offs += snprintf(bufstart + offs, buflen - offs, "%s:%s",label, compact ? "" : "\n");
     }
     buf = bufstart + offs;
     buflen -= offs;
 
-    offs = snprintf(buf, buflen, "%-20s", "");
+    if (compact <= 1) {
+        offs = snprintf(buf, buflen, "%-20s", "");
+    }
 
     if ( address_is_code(state->pc) == 0 ) {
         READ_BYTE(state, b);
@@ -683,16 +685,24 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
         } while (1);
     }
 
-    while ( offs < 60 ) {
-        buf[offs++] = ' ';
-        buf[offs] = 0;
+    if (compact <= 1) {
+        while ( offs < 60 ) {
+            buf[offs++] = ' ';
+            buf[offs] = 0;
+        }
+
+        offs += snprintf(buf + offs, buflen - offs, ";[%04x] ", start_pc & 0xffff);
+    } else {
+        offs += snprintf(buf + offs, buflen - offs, ";");
     }
-    offs += snprintf(buf + offs, buflen - offs, ";[%04x] ", start_pc & 0xffff);
+
     for ( i = state->skip; i < state->len; i++ ) {
         offs += snprintf(buf + offs, buflen - offs,"%s%02x", i ? " " : "", state->instr_bytes[i]);
     }
-    if ( dolf ) {
-        offs += snprintf(buf + offs, buflen - offs,"\n");
+    if (compact <= 1) {
+        if ( dolf ) {
+            offs += snprintf(buf + offs, buflen - offs,"\n");
+        }
     }
 
     return state->len;

--- a/src/ticks/disassembler_main.c
+++ b/src/ticks/disassembler_main.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         if( argv[1][0] == '-' && argv[2] ) {
             switch (argc--, argv++[1][1]){
             case 'o':
-                symbol_addr = symbol_resolve(argv[1]);
+                symbol_addr = symbol_resolve(argv[1], NULL);
                 org = (-1 == symbol_addr) ? strtol(argv[1], &endp, 0) : symbol_addr;
                 if ( start == -1 ) {
                     start = org;
@@ -78,12 +78,12 @@ int main(int argc, char **argv)
                 argc--; argv++;
                 break;
             case 's':
-                symbol_addr = symbol_resolve(argv[1]);
+                symbol_addr = symbol_resolve(argv[1], NULL);
                 start = (-1 == symbol_addr) ? strtol(argv[1], &endp, 0) : symbol_addr;
                 argc--; argv++;
                 break;
             case 'e':
-                symbol_addr = symbol_resolve(argv[1]);
+                symbol_addr = symbol_resolve(argv[1], NULL);
                 end = (-1 == symbol_addr) ? strtol(argv[1], &endp, 0) : symbol_addr;
                 argc--; argv++;
                 break;

--- a/src/ticks/exp_engine.h
+++ b/src/ticks/exp_engine.h
@@ -2,6 +2,7 @@
 #define EXPRESSION_H
 
 #include <inttypes.h>
+#include <utstring.h>
 #include "debug.h"
 
 enum expression_flags_t {
@@ -42,7 +43,7 @@ extern void set_expression_result_error_str(struct expression_result_t* result, 
 
 extern void expression_result_free(struct expression_result_t* result);
 extern void convert_expression(struct expression_result_t* from, struct expression_result_t* to, type_record* type);
-extern void expression_result_type_to_string(type_record* root, type_chain* type, char* buffer);
+extern UT_string* expression_result_type_to_string(type_record* root, type_chain* type);
 extern void expression_dereference_pointer(struct expression_result_t *from, struct expression_result_t *to);
 extern void expression_resolve_struct_member(struct expression_result_t *struct_, const char *member, struct expression_result_t* result);
 extern void expression_resolve_struct_member_ptr(struct expression_result_t *struct_ptr, const char *member, struct expression_result_t* result);
@@ -54,7 +55,7 @@ extern void expression_math_div(struct expression_result_t* a, struct expression
 extern void expression_string_get_type(const char* str, type_record* type);
 extern void expression_get_struct_members(struct expression_result_t* result, int* count, char** members);
 extern int expression_count_members(struct expression_result_t* result);
-extern int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len);
+extern UT_string* expression_result_value_to_string(struct expression_result_t* result);
 extern void zero_expression_result(struct expression_result_t* result);
 extern struct expression_result_t* get_expression_result();
 

--- a/src/ticks/exp_engine.h
+++ b/src/ticks/exp_engine.h
@@ -34,6 +34,7 @@ struct history_expression_t {
 
 extern struct history_expression_t* history_expressions;
 
+extern void exp_engine_init();
 extern void evaluate_expression_string(const char* expr);
 extern uint8_t is_expression_result_error(struct expression_result_t* result);
 extern void set_expression_result_error(struct expression_result_t* result);
@@ -51,6 +52,8 @@ extern void expression_math_sub(struct expression_result_t* a, struct expression
 extern void expression_math_mul(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_math_div(struct expression_result_t* a, struct expression_result_t* b, struct expression_result_t* result);
 extern void expression_string_get_type(const char* str, type_record* type);
+extern void expression_get_struct_members(struct expression_result_t* result, int* count, char** members);
+extern int expression_count_members(struct expression_result_t* result);
 extern int expression_result_value_to_string(struct expression_result_t* result, char* buffer, int buffer_len);
 extern void zero_expression_result(struct expression_result_t* result);
 extern struct expression_result_t* get_expression_result();

--- a/src/ticks/expressions.l
+++ b/src/ticks/expressions.l
@@ -16,7 +16,7 @@ int lookup_word();
 
 %}
 
-history_expr $[0-9]+
+history_expr $[a-zA-Z0-9_]+
 word [a-zA-Z_][a-zA-Z0-9_]*
 struct_word "struct "[a-zA-Z_][a-zA-Z0-9_]*
 multiple_words "unsigned char"|"unsigned short"|"unsigned int"|"unsigned long"

--- a/src/ticks/srcfile.c
+++ b/src/ticks/srcfile.c
@@ -1,6 +1,7 @@
 // Routines for displaying source files
 
 #include "ticks.h"
+#include "backend.h"
 #include <stdio.h>
 
 typedef struct srcfile_s srcfile;
@@ -70,9 +71,9 @@ void srcfile_display(const char *filename, int start_line, int count, int highli
 
     for ( i = start_line; i <= end_line; i++ ) {
         if ( count > 1 ) {
-            printf("%s% 5d: %s\n", i == highlight ? ">" : " ", i, file->lines[i-1]);
+            bk.console("%s% 5d: %s\n", i == highlight ? ">" : " ", i, file->lines[i-1]);
         } else {
-            printf("        %s\n", file->lines[i-1]);
+            bk.console("        %s\n", file->lines[i-1]);
         }
     }
 }

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -226,6 +226,19 @@ int symbol_resolve(char *name, const char *filename)
         return sym->address;
     }
 
+    if (filename == NULL) {
+        // well, try and find something
+        symbol_file* f;
+        symbol_file* tmp;
+        HASH_ITER(hh, symbol_files, f, tmp)
+        {
+            HASH_FIND_STR(f->symbols, name, sym);
+            if (sym) {
+                return sym->address;
+            }
+        }
+    }
+
     return -1;
 }
 

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -65,7 +65,7 @@ static int symbol_compare(const void *p1, const void *p2)
     return s2->address - s1->address;
 }
 
-static char read_symbol_buf[2048];
+static char read_symbol_buf[8192];
 
 void read_symbol_file(char *filename)
 {

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -5,8 +5,9 @@
 #include "ticks.h"
 #include "debug.h"
 
-static symbol  *symbols[SYM_TAB_SIZE] = {0};
-static symbol  *symbols_byname = NULL;
+static symbol*          symbols[SYM_TAB_SIZE] = {0};
+static symbol*          global_symbols = NULL;
+static symbol_file*     symbol_files = NULL;
 
 typedef struct section_s section;
 
@@ -92,7 +93,7 @@ void read_symbol_file(char *filename)
                             symbol *sym;
                             int     start;
                             strcpy(argv[0]+len - 5, "_head");
-                            if ((start = symbol_resolve(argv[0])) != -1 ) { // Looking for __head
+                            if ((start = symbol_resolve(argv[0], NULL)) != -1 ) { // Looking for __head
                                 section *sect = calloc(1,sizeof(*sect));
                                 sect->start = start;
                                 sect->end = start + size;
@@ -122,7 +123,7 @@ void read_symbol_file(char *filename)
                             LL_APPEND(symbols[sym->address % SYM_TAB_SIZE], sym);
                         }
                     }
-                    HASH_ADD_KEYPTR(hh, symbols_byname, sym->name, strlen(sym->name), sym);
+                    HASH_ADD_KEYPTR(hh, global_symbols, sym->name, strlen(sym->name), sym);
                 }
                 free(argv);
                 continue;
@@ -145,16 +146,28 @@ void read_symbol_file(char *filename)
 
                 sym->section = strdup(argv[8]); // TODO, comma
                 sym->islocal = 0;
-                if ( strcmp(argv[5], "local,")) {
+                if (strcmp(argv[5], "local,") == 0) {
                     sym->islocal = 1;
                 }
                 sym->symtype = SYM_ADDRESS;
-                if ( strcmp(argv[4],"const,") == 0 ) {
+                if (strcmp(argv[4],"const,") == 0 ) {
                     sym->symtype = SYM_CONST;
                 }
                 sym->address = strtol(argv[2] + 1, NULL, 16);
                 LL_APPEND(symbols[sym->address % SYM_TAB_SIZE], sym);
-                HASH_ADD_KEYPTR(hh, symbols_byname, sym->name, strlen(sym->name), sym);
+
+                if (sym->islocal) {
+                    symbol_file* f = NULL;
+                    HASH_FIND_STR(symbol_files, sym->file, f);
+                    if (f == NULL) {
+                        f = calloc(1, sizeof(symbol_file));
+                        f->name = strdup(sym->file);
+                        HASH_ADD_STR(symbol_files, name, f);
+                    }
+                    HASH_ADD_KEYPTR(hh, f->symbols, sym->name, strlen(sym->name), sym);
+                } else {
+                    HASH_ADD_KEYPTR(hh, global_symbols, sym->name, strlen(sym->name), sym);
+                }
             } else if ( argc > 9 ) {
                 /* It's a cline/asmline symbol */
                 char   filename[FILENAME_MAX+1];
@@ -172,21 +185,43 @@ void read_symbol_file(char *filename)
     }
 }
 
-symbol *find_symbol_byname(const char *name)
+symbol *find_symbol_byname(const char *name, const char *filename)
 {
-    symbol *sym;
+    if (filename) {
+        symbol_file* f = NULL;
+        HASH_FIND_STR(symbol_files, filename, f);
+        if (f) {
+            symbol *sym = NULL;
+            HASH_FIND_STR(f->symbols, name, sym);
+            if (sym) {
+                return sym;
+            }
+        }
+    }
 
-    HASH_FIND_STR(symbols_byname, name, sym);
-
+    symbol *sym = NULL;
+    HASH_FIND_STR(global_symbols, name, sym);
     return sym;
 }
 
-int symbol_resolve(char *name)
+int symbol_resolve(char *name, const char *filename)
 {
+    if (filename) {
+        symbol_file* f = NULL;
+        HASH_FIND_STR(symbol_files, filename, f);
+        if (f) {
+            symbol *sym = NULL;
+            HASH_FIND_STR(f->symbols, name, sym);
+            if (sym) {
+                return sym->address;
+            }
+        }
+    }
+
     symbol *sym;
     char   *ptr;
 
-    HASH_FIND_STR(symbols_byname, name, sym);
+    HASH_FIND_STR(global_symbols, name, sym);
     if ( sym != NULL ) {
         return sym->address;
     }
@@ -352,7 +387,7 @@ void symbol_add_autolabel(int address, char *label)
     sym->address = address;
     sym->symtype = SYM_ADDRESS;
     LL_APPEND(symbols[sym->address % SYM_TAB_SIZE], sym);
-    HASH_ADD_KEYPTR(hh, symbols_byname, sym->name, strlen(sym->name), sym);
+    HASH_ADD_KEYPTR(hh, global_symbols, sym->name, strlen(sym->name), sym);
 
 }
 

--- a/src/ticks/syms.h
+++ b/src/ticks/syms.h
@@ -10,6 +10,7 @@ typedef enum {
     SYM_ADDRESS = 2,
 } symboltype;
 
+typedef struct symbol_file_s symbol_file;
 typedef struct symbol_s symbol;
 
 struct symbol_s {
@@ -24,11 +25,17 @@ struct symbol_s {
     UT_hash_handle hh;
 };
 
+struct symbol_file_s {
+    const char    *name;
+    symbol        *symbols;
+    UT_hash_handle hh;
+};
+
 extern symbol* symbol_find_lower(int addr, symboltype preferred_type, uint16_t* offset);
 extern void      read_symbol_file(char *filename);
 extern const char     *find_symbol(int addr, symboltype preferred_symtype);
-extern symbol   *find_symbol_byname(const char *name);
-extern int symbol_resolve(char *name);
+extern symbol   *find_symbol_byname(const char *name, const char *filename);
+extern int symbol_resolve(char *name, const char *filename);
 extern char **parse_words(char *line, int *argc);
 extern void symbol_add_autolabel(int addr, char *label);
 extern int address_is_code(int addr);

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -582,6 +582,7 @@ int    ioport = -1;
 int    rom_size = 0;
 int    rc2014_mode = 0;
 int    c_autolabel = 0;
+int    break_required = 0;
 
 static const uint8_t mirror_table[] = {
     0x0, 0x8, 0x4, 0xC,  /*  0-3  */
@@ -1042,7 +1043,10 @@ int main (int argc, char **argv){
   do{
     char buf[256];
     if ( ih ) {
-        debugger_process_signals();
+        if (break_required) {
+            break_required = 0;
+            debugger_request_a_break();
+        }
         debugger();
     }
     if( pc==start )

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -759,15 +759,15 @@ int main (int argc, char **argv){
           memory_model = argv[1];
           break;
         case 'p':
-          symbol_addr= symbol_resolve(argv[1]);
+          symbol_addr= symbol_resolve(argv[1], NULL);
           pc= (-1 == symbol_addr) ? strtol(argv[1], NULL, 16) : symbol_addr;
           break;
         case 's':
-          symbol_addr= symbol_resolve(argv[1]);
+          symbol_addr= symbol_resolve(argv[1], NULL);
           start= (-1 == symbol_addr) ? strtol(argv[1], NULL, 16) : symbol_addr;
           break;
         case 'e':
-          symbol_addr= symbol_resolve(argv[1]);
+          symbol_addr= symbol_resolve(argv[1], NULL);
           end= (-1 == symbol_addr) ? strtol(argv[1], NULL, 16) : symbol_addr;
           break;
         case 'r':

--- a/src/ticks/ticks.h
+++ b/src/ticks/ticks.h
@@ -38,6 +38,7 @@ extern int trace;
 extern int rom_size;		/* amount of memory in low addresses that is read-only */
 extern int ioport;
 extern int rc2014_mode;
+extern int break_required;
 
 extern uint8_t verbose;
 

--- a/win32/ticks/ticks.vcxproj
+++ b/win32/ticks/ticks.vcxproj
@@ -168,9 +168,11 @@
     <ClCompile Include="..\..\src\ticks\acia.c" />
     <ClCompile Include="..\..\src\ticks\am9511.c" />
     <ClCompile Include="..\..\src\ticks\backend.c" />
+    <ClCompile Include="..\..\src\ticks\breakpoints.c" />
     <ClCompile Include="..\..\src\ticks\cpu.c" />
     <ClCompile Include="..\..\src\ticks\debug.c" />
     <ClCompile Include="..\..\src\ticks\debugger.c" />
+    <ClCompile Include="..\..\src\ticks\debugger_mi2.c" />
     <ClCompile Include="..\..\src\ticks\debugger_ticks.c" />
     <ClCompile Include="..\..\src\ticks\disassembler_alg.c" />
     <ClCompile Include="..\..\src\ticks\expressions.tab.c" />


### PR DESCRIPTION
This PR is a home for ongoing development for `mi/2` protocol implementation for z88dk-gdb, aka visual debugging with IDEs

Standard document: https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI.html

This is being only tested with CLion, but will eventually test with Visual Studio Code.

For VSCode, have this `launch.json`:
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "gdb",
            "request": "attach",
            "name": "Attach to gdbserver",
            "executable": "${workspaceRoot}/build/client.map", // or appropriate .map of your project (-m -debug needed!)
            "target": "127.0.0.1:1337",
            "remote": true,
            "cwd": "${workspaceRoot}", 
            "gdbpath": "/usr/local/bin/z88dk-gdb",
            "autorun": [
            ]
        }
    ]
}
```

CLion configuration:
<img src="https://user-images.githubusercontent.com/1666014/171963193-b76093ff-0c50-4a8d-ad1e-6e50c6336948.png" width="400"/>

- [x] Placing, removing breakpoints both before connecting and under run
- [x] Backtrace
- [x] Local variables
- [x] Step Over, Step Into, Finish
- [x] Disassembly view
- [x] Expression evaluation
- [x] Fix global variables not showing up
- ~~Implement recursive view of a variables (only upmost root members are currently shown)~~ Too lazy to do it now
- [x] Test I didn't break command line z88dk-gdb
- [x] Test I didn't break ticks
- [x] Test on Visual Studio Code

Would appreciate any eyes ahead of time.