### PR TITLE
add usraddr option to appmake

### DIFF
--- a/src/appmake/zx-util.c
+++ b/src/appmake/zx-util.c
@@ -280,6 +280,10 @@ int zx_tape(struct zx_common *zxc, struct zx_tape *zxt, struct banked_memory *me
                 exit_log(1,"Could not find parameter ZORG (not z88dk compiled?)\n");
             }
         }
+        if (zxt->usr_address == -1 )
+        {
+          zxt->usr_address = pos;
+        }
 
         if ((fpin = fopen_bin(zxc->binname, zxc->crtfile)) == NULL) {
             exit_log(1, "Can't open input file %s\n", zxc->binname);
@@ -350,7 +354,7 @@ int zx_tape(struct zx_common *zxc, struct zx_tape *zxt, struct banked_memory *me
             writebyte_p(0xf9, fpout, &zxt->parity);       /* RANDOMIZE */
             writebyte_p(0xc0, fpout, &zxt->parity);       /* USR */
             writebyte_p(0xb0, fpout, &zxt->parity);       /* VAL */
-            sprintf(mybuf, "\"%i\"", (int)pos);      /* Location for USR */
+            sprintf(mybuf, "\"%i\"", zxt->usr_address);      /* Location for USR */
             writestring_p(mybuf, fpout, &zxt->parity);
             writebyte_p(0x0d, fpout, &zxt->parity);       /* ENTER (end of BASIC line) */
             writebyte_p(zxt->parity, fpout, &zxt->parity);
@@ -515,7 +519,7 @@ int zx_tape(struct zx_common *zxc, struct zx_tape *zxt, struct banked_memory *me
                     writebyte_p(0xf9, fpout, &zxt->parity);       /* RANDOMIZE */
                     writebyte_p(0xc0, fpout, &zxt->parity);       /* USR */
                     writebyte_p(0xb0, fpout, &zxt->parity);       /* VAL */
-                    sprintf(mybuf, "\"%i\"", (int)pos);           /* Location for USR */
+                    sprintf(mybuf, "\"%i\"", zxt->usr_address);           /* Location for USR */
                     writestring_p(mybuf, fpout, &zxt->parity);
                     writebyte_p(0x0d, fpout, &zxt->parity);       /* ENTER (end of BASIC line) */
                     writebyte_p(zxt->parity, fpout, &zxt->parity);
@@ -2200,6 +2204,10 @@ int zx_plus3(struct zx_common *zxc, struct zx_tape *zxt, struct banked_memory *m
             exit_log(1,"Could not find parameter ZORG (not z88dk compiled?)\n");
         }
     }
+    if (zxt->usr_address == -1 )
+    {
+      zxt->usr_address = (int)origin;
+    }
 
     if ((fpin = fopen_bin(zxc->binname, zxc->crtfile)) == NULL) {
         exit_log(1,"Can't open input file %s\n", zxc->binname);
@@ -2254,7 +2262,7 @@ int zx_plus3(struct zx_common *zxc, struct zx_tape *zxt, struct banked_memory *m
     writebyte_b(0xf9, &ptr);	/* RANDOMIZE */
     writebyte_b(0xc0, &ptr);	/* USR */
     writebyte_b(0xb0, &ptr);	/* VAL */
-    snprintf(tbuf,sizeof(tbuf), "\"%i\"", (int)origin);           /* Location for USR */
+    snprintf(tbuf,sizeof(tbuf), "\"%i\"", zxt->usr_address);           /* Location for USR */
     writestring_b(tbuf, &ptr);
     writebyte_b(':', &ptr);
     writebyte_b(234, &ptr);      /* REM */

--- a/src/appmake/zx-util.h
+++ b/src/appmake/zx-util.h
@@ -23,6 +23,7 @@ struct zx_tape
     char          *merge;
     int            patchpos;
     int            clear_address;
+    int            usr_address;
     char          *patchdata;
     char          *screen;
     char           audio;

--- a/src/appmake/zx.c
+++ b/src/appmake/zx.c
@@ -69,6 +69,7 @@ static struct zx_tape zxt = {
     NULL,       // merge
     -1,         // patchpos
     -1,         // clear_address
+    -1,         // usr_address
     NULL,       // patchdata
     NULL,       // screen
     0,          // audio
@@ -155,6 +156,7 @@ option_t zx_options[] = {
     { 0 , "merge",     "Merge a custom loader from external TAP file", OPT_STR, &zxt.merge },
     { 0 , "blockname", "Name of the code block in tap file", OPT_STR, &zxt.blockname },
     { 0,  "clearaddr", "Address to CLEAR at",       OPT_INT,   &zxt.clear_address },
+    { 0,  "usraddr",   "USR address to run from",   OPT_INT,   &zxt.usr_address },
     { 0 ,  NULL,       NULL,                        OPT_NONE,  NULL }
 };
 


### PR DESCRIPTION
As per my [request](https://www.z88dk.org/forum/viewtopic.php?p=20631#p20631) on the forum, this adds an option to appmake for ZX to set the RANDOMISE USR address in the BASIC loader. This is useful if the code start point isn't the same address it loads into.

It's a simple addition, adding usr_address to the zx_tape structure and (optionally) populating it from the command line. If the value is not at the -1 default in the save-loader code then it's picked up and used. Otherwise the loader code just does what it did before.

Tested on a 48K loader, the turbo loader and the +3 loader.

I'm not too familiar with the code, so if I've missed something let me know. :)