### PR TITLE
Misc. fixes

### DIFF
--- a/src/appmake/msx.c
+++ b/src/appmake/msx.c
@@ -118,6 +118,7 @@ int msx_exec(char* target)
 {
     char filename[FILENAME_MAX + 1];
     char wavfile[FILENAME_MAX + 1];
+    char crtname[FILENAME_MAX + 1];
     FILE *fpin, *fpout;
     char name[11];
     int c;
@@ -128,14 +129,21 @@ int msx_exec(char* target)
     if (help)
         return -1;
 
-    if (binname == NULL || (!dumb && (crtfile == NULL && origin == -1))) {
+    if (binname == NULL) {
         return -1;
+    }
+
+    if (crtfile == NULL)
+    {
+        snprintf(crtname, sizeof(crtname) - 4, "%s", binname);
+        suffix_change(crtname, "");
+        crtfile = crtname;
     }
 
     if (origin != -1) {
         pos = origin;
     } else {
-        if ((pos = get_org_addr(crtfile)) == -1) {
+        if (!dumb && (pos = get_org_addr(crtfile)) == -1) {
             exit_log(1,"Could not find parameter ZORG (not z88dk compiled?)\n");
         }
     }
@@ -230,7 +238,7 @@ int msx_exec(char* target)
     }
 
     if ( disk ) {
-        return fat_write_file_to_image("msxbasic", "raw", NULL, filename, NULL, NULL);
+        return fat_write_file_to_image("msxbasic", "raw", NULL, filename, crtfile, NULL);
     }
 
     /* ***************************************** */

--- a/src/z80asm/asmstyle.pl
+++ b/src/z80asm/asmstyle.pl
@@ -20,12 +20,11 @@ my $OPCODE = 2*$TAB;
 my $ARGS = 4*$TAB;
 my $COMMENT = 10*$TAB;
 my $DEFVARS = 6*$TAB;
-my $LEVEL = 0;
+my $LEVEL = 1;
 my $DEFVARSLEVEL = 0;
 
 @ARGV or die "Usage: ",path($0)->basename," FILES...\n";
 for my $asm (@ARGV) {
-    $LEVEL = 0;
 	open(my $in, "<", $asm) or die "$asm: $!\n";
 	open(my $out, ">:raw", $asm.".new") or die "$asm.new: $!\n";
 	while (<$in>) {


### PR DESCRIPTION
This PR contains the following fixes:

1) appmake - Segmentation fault on MSX targets. NULL was being passed for the crtfile.
2) asmstyle.pl - Move conditional statements to first indentation level to be more compatible with simple assemblers. 

IH.