### PR TITLE
mi/2: restore program upon connection

### DIFF
--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -8,8 +8,8 @@ endif
 
 include ../Make.common
 
-OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o breakpoints.o profiler.o exp_engine.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o $(UNIXem_OBJS)
-GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o breakpoints.o profiler.o debugger_gdb.o debugger_mi2.o debugger_gdb_packets.o linenoise.o srcfile.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
+OBJS = ticks.o cpu.o backend.o hook_cpm.o hook_console.o hook_io.o hook_misc.o hook.o debugger.o breakpoints.o profiler.o exp_engine.o debugger_ticks.o linenoise.o utf8.o syms.o disassembler_alg.o memory.o am9511.o acia.o hook_rc2014.o debug.o srcfile.o ../common/dirname.o $(UNIXem_OBJS)
+GDBOBJS = cpu.o backend.o syms.o disassembler_alg.o debug.o exp_engine.o debugger.o breakpoints.o profiler.o debugger_gdb.o debugger_mi2.o debugger_gdb_packets.o linenoise.o srcfile.o ../common/dirname.o sxmlc.o sxmlsearch.o $(UNIXem_OBJS)
 DISOBJS = disassembler_main.o syms.o disassembler_alg.o debug.o exp_engine.o backend.o
 LEXOBJS = lex.yy.o expressions.tab.o
 

--- a/src/ticks/debugger.h
+++ b/src/ticks/debugger.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <utstring.h>
 
 #ifndef va_copy
 #define va_copy(a,b) (a)=(b)
@@ -14,12 +15,15 @@ extern size_t current_frame;
 
 extern void debugger_init();
 extern void debugger();
+extern uint8_t debugger_read_symbol_file(char* symbol_file);
+extern void debugger_restore_pending_binary_file();
 int debugger_evaluate(char* line);
 extern void debugger_request_a_break();
 
 void stdout_log(const char *fmt, ...);
 
 extern const char *resolve_to_label(int addr);
+extern int get_restore_address(char* address_text);
 extern int parse_address(char *arg, const char** corrected_source);
 extern void unwrap_reg(uint16_t data, uint8_t* h, uint8_t* l);
 extern uint16_t wrap_reg(uint8_t h, uint8_t l);

--- a/src/ticks/debugger_gdb.h
+++ b/src/ticks/debugger_gdb.h
@@ -17,6 +17,8 @@ extern void execute_on_main_thread(trapped_action_t call, const void* data, void
 extern void execute_on_main_thread_no_response(trapped_action_t call, const void* data);
 extern char *mem2hex(const uint8_t *mem, char *buf, uint32_t count);
 
+extern void debugger_gdb_break(uint8_t temporary);
+
 extern uint8_t temporary_break;
 
 #endif


### PR DESCRIPTION
Tested on CLion/VSCode and [Fuse fork](https://github.com/speccytools/fuse-for-macosx).

Basically, when z88dk-gdb is fed with a debugging file `folder/<filename>.map`, it checks for neighbouring file `folder/<filename>.bin` or just `folder/<filename>`. If such file exists, upon connections, z88dk-gdb uploads (restores) the binary onto remote, so there is no need to upload such binary to remote in some other way now.