### PR TITLE
Fix appmake for vg5k

### DIFF
--- a/src/appmake/vg5k.c
+++ b/src/appmake/vg5k.c
@@ -267,6 +267,11 @@ int vg5k_exec(char* target)
             writebyte(c, fpout);
         }
 
+        /* The ROM is expecting the file to have 10 zeroes at the end of the data payload */
+        for (i = 0; i < 10; i++) {
+            writebyte(0, fpout);
+        }
+
         fclose(fpin);
         fclose(fpout);
     }


### PR DESCRIPTION
The VG5000 ROM expects a trailing part of 10 zeroes to the payload of
the tape format.

Some emulators can accept them missing while others and the real
hardware are more strict about it.