### PR TITLE
zcc: +config at any place, support for -xc

### DIFF
--- a/include/sys/compiler.h
+++ b/include/sys/compiler.h
@@ -3,6 +3,26 @@
 #ifndef __SYS_COMPILER_H__
 #define __SYS_COMPILER_H__
 
+#if defined(__CLION_IDE__) | defined(__INTELLISENSE__)
+
+#define __LIB__
+#define __SAVEFRAME__
+#define __z88dk_fastcall
+#define __FASTCALL__
+#define __CALLEE__
+#define __SCCZ80
+#define __Z80
+#define __naked
+#define __z88dk_callee
+#define __stdc
+#define __smallc
+#define __preserves_regs
+#define __no_z88dk_declspec
+#define __at(x)
+#define __sfr
+#define __vasmallc
+
+#else
 
 /* Temporary fix to turn off features not supported by sdcc */
 #if __SDCC | __clang__
@@ -25,6 +45,8 @@
 #else
 #define __vasmallc __smallc
 #define __z88dk_deprecated
+#endif
+
 #endif
 
 #ifdef __8080__

--- a/src/common/option.c
+++ b/src/common/option.c
@@ -49,7 +49,9 @@ int option_parse(option *args, int argc, char **argv)
 
     for ( i = 1; i < argc; i++ ) {
         option *myarg;
-        if ( argv[i][0] == '-') {
+        if ( argv[i][0] == '+') {
+            // do nothing
+        } else if ( argv[i][0] == '-') {
             char   *argstart = argv[i] + 1;
             int     doubledash = 0;
 

--- a/src/zcc/Makefile
+++ b/src/zcc/Makefile
@@ -8,7 +8,7 @@ endif
 
 INSTALL ?= install
 
-INCLUDES += -I. -I../copt -I../common
+INCLUDES += -I. -I../copt -I../common -I../../ext/uthash/include
 
 CFLAGS += -DLOCAL_REGEXP -Wall -pedantic -g -MMD
 

--- a/win32/zcc/zcc.vcxproj
+++ b/win32/zcc/zcc.vcxproj
@@ -88,7 +88,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;LOCAL_REGEXP;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common;..\..\ext\uthash\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,7 +102,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;LOCAL_REGEXP;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common;..\..\ext\uthash\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,7 +118,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;LOCAL_REGEXP;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common;..\..\ext\uthash\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,7 +145,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;LOCAL_REGEXP;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\copt;..\..\src\common;..\..\ext\uthash\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
This change allows to do the following:

args.txt
```
-xc +zx -debug -fpch-preprocess -v -dD -E -D___CIDR_DEFINITIONS_END
```
test (NO extension)
```
int main() {}
```
then
```
zcc @args.txt test
```

As you can notice, the following changes:

1. `+zx` can be specified as not-first-argument
2. `-xc` is now supported, makes any file type to be treated as C files. Note that there is `-x <filename>` option to build a library, but those are different.
3. `@args.txt` can not only specify files to compile, but also any arguments
4. `-dD` argument tu dump all generated defines.

All this trickery been done to convince CLion that zcc is a real compiler. I am hoping, in consequent PRs, suggest a CMake toolchain file and make zcc to be supported by CLion out-of-the-box.