### PR TITLE
complete make <target>-clean convention

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,15 +1,15 @@
 SUBDIRS = console ace cpm embedded msx osca rex sam sms sos spectrum vz z88 zxvgs pacman rcmx000 g800 gb c128
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
-     
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS)
-     
+
 subdirs: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
 clean: $(CLEANDIRS)
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/_DEVELOPMENT/Makefile
+++ b/libsrc/_DEVELOPMENT/Makefile
@@ -1,6 +1,6 @@
 #
-# make [target]       - Build libraries for target, (eg make zx)
-# make clean-[target] - Clean the target (eg make clean-zx)
+# make [target]       - Build libraries for target (eg make zx)
+# make [target]-clean - Clean the target libraries (eg make zx-clean)
 #
 
 
@@ -17,7 +17,7 @@ NEWLIB_ROOT = ./
 .PHONY: all clean install-clean
 all: $(TARGET)
 
-clean: $(addprefix clean-,$(TARGET))
+clean: $(addsuffix -clean,$(TARGET))
 	@find . -name '*.err' | xargs $(RM)
 	$(RM) config_private.inc
 
@@ -25,9 +25,8 @@ install-clean:
 	$(RM) -fr target/*/obj
 
 
-
 define config
-.PHONY: clean-$(1)
+.PHONY: $(1)-clean
 
 # +zx/+zxn use +z80 as part of the config stage so add the dependency
 target/zx/obj/config_private.inc: lib/sccz80/z80.lib
@@ -105,9 +104,9 @@ lib/sdcc_iy/$(1).lib: target/$(1)/obj/config_private.inc
 endef
 
 define make_clean
-.PHONY: clean-$(1)
+.PHONY: $(1)-clean
 
-clean-$(1):
+$(1)-clean:
 	@$(RM) -r target/$(1)/obj
 	@$(RM) lib/sccz80/$(1).lib
 	@$(RM) lib/sdcc_ix/$(1).lib

--- a/libsrc/adt/Makefile
+++ b/libsrc/adt/Makefile
@@ -2,7 +2,7 @@ include ../Make.config
 
 
 SUBDIRS = heap linkedlist queue stack
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all
 
@@ -20,9 +20,8 @@ subdirs-clean: $(CLEANDIRS)
 .PHONY:	subdirs-all $(SUBDIRS) $(SUBDIRS_CLEAN)
 
 
-
 $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/algorithm/Makefile
+++ b/libsrc/algorithm/Makefile
@@ -2,7 +2,7 @@ include ../Make.config
 
 
 SUBDIRS = AStarSearch
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all
 
@@ -25,4 +25,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/arch/Makefile
+++ b/libsrc/arch/Makefile
@@ -3,7 +3,7 @@ include ../Make.config
 
 SUBDIRS = z80 
 # Directories that need a target passed down
-CLEANDIRS = $(SUBDIRS:%=clean-%) $(TARGETDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean) $(TARGETDIRS:%=%-clean)
 
 all: $(SUBDIRS)
 
@@ -25,4 +25,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/compress/Makefile
+++ b/libsrc/compress/Makefile
@@ -3,10 +3,9 @@ include ../Make.config
 
 SUBDIRS = aplib zx7 zx0 zx1 zx2
 
-CLEANDIRS = $(SUBDIRS:%=clean-%) 
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: $(SUBDIRS)
-
 
 
 subdirs-all: $(SUBDIRS) $(TARGETDIRS)
@@ -25,4 +24,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/fcntl/Makefile
+++ b/libsrc/fcntl/Makefile
@@ -1,13 +1,13 @@
 SUBDIRS = dummy gen_rnd 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 include ../Make.config
 
-     
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS)
-     
+
 subdirs: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
@@ -17,4 +17,4 @@ clean: $(CLEANDIRS)
 	$(RM) */*/zcc_opt.def
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/font/Makefile
+++ b/libsrc/font/Makefile
@@ -2,7 +2,7 @@ include ../Make.config
 
 
 SUBDIRS = fzx font_4x8 font_8x8 font_8x10
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all
 
@@ -20,11 +20,10 @@ subdirs-clean: $(CLEANDIRS)
 .PHONY:	subdirs-all $(SUBDIRS) $(SUBDIRS_CLEAN)
 
 
-
 $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 
 clean-kludge:

--- a/libsrc/gfx/Makefile
+++ b/libsrc/gfx/Makefile
@@ -10,10 +10,9 @@ FLAVOUR ?= narrow
 
 SUBDIRS += $(FLAVOUR)
 
-CLEANDIRS = $(ALLSUBDIRS:%=clean-%) $(TARGETDIRS:%=clean-%)
+CLEANDIRS = $(ALLSUBDIRS:%=%-clean) $(TARGETDIRS:%=%-clean)
 
 all: $(SUBDIRS)
-
 
 
 subdirs-all: $(SUBDIRS) $(TARGETDIRS)
@@ -37,4 +36,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/interrupts/Makefile
+++ b/libsrc/interrupts/Makefile
@@ -4,7 +4,7 @@ TARGET ?= test
 
 SUBDIRS = common im1 im2 nmi
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -33,5 +33,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/math/Makefile
+++ b/libsrc/math/Makefile
@@ -1,12 +1,13 @@
-SUBDIRS = genmath z88math zxmath math48 cpcmath fastmath mbf32 mbf64 math16 math32 am9511 daimath32
-CLEANDIRS = $(SUBDIRS:%=clean-%)
-
 include ../Make.config
-     
+
+SUBDIRS = fastmath genmath math48 math32 math16 mbf32 daimath32 am9511 cpcmath mbf64 z88math zxmath
+CLEANDIRS = $(SUBDIRS:%=%-clean)
+
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS)
-     
+
 subdirs: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
@@ -14,4 +15,4 @@ clean: $(CLEANDIRS)
 	$(RM) */*.o
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/psg/Makefile
+++ b/libsrc/psg/Makefile
@@ -3,13 +3,13 @@ include ../Make.config
 
 SUBDIRS = ay sn76489 saa1099
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
-     
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS) clean
-     
+
 subdirs: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
@@ -17,4 +17,4 @@ clean: $(CLEANDIRS)
 	$(RM) */*.o
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/psg/ay/Makefile
+++ b/libsrc/psg/ay/Makefile
@@ -1,12 +1,12 @@
 #
-# Build the PSG lib componente
+# Build the PSG lib components
 #
 
 include ../../Make.config
 
 SUBDIRS = wyz vt2
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 CFILES = \
 	psg_channels.c \
@@ -21,7 +21,6 @@ OBJECTS = $(CFILES:.c=.o)
 
 
 all:    dirs $(SUBDIRS) $(addprefix obj/z80/, $(OBJECTS)) $(addprefix obj/ixiy/, $(OBJECTS))  $(addprefix obj/8080/, $(OBJECTS)) $(addprefix obj/z80n/,$(OBJECTS))
-
 
 
 dirs:
@@ -42,4 +41,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/target/Makefile
+++ b/libsrc/target/Makefile
@@ -1,15 +1,15 @@
 include ../Make.config
 
 
-SUBDIRS = c128 z88 x1 msx svi nc100 rex zx gb s1mp3 cpc sos ace pps tvc trs80 ticalc mtx oz enterprise cpm osca zx81 zxn zx-common ts2068 newbrain lm80c zx80
+SUBDIRS = ace c128 cpc cpm enterprise gb lm80c msx mtx nc100 newbrain osca oz pps rex s1mp3 sos svi ticalc trs80 ts2068 tvc x1 z88 zx-common zx zx80 zx81 zxn
 
-CLEANDIRS = $(addprefix clean-,$(SUBDIRS))
+CLEANDIRS = $(addsuffix -clean,$(SUBDIRS))
 
-     
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS)
-     
+
 subdirs: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
@@ -19,4 +19,4 @@ clean: $(CLEANDIRS)
 	$(RM) */*/*/*.o 
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/target/ace/Makefile
+++ b/libsrc/target/ace/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = ace
 
 SUBDIRS = ace
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,6 +35,6 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o
 	$(RM) */*/*.o

--- a/libsrc/target/c128/Makefile
+++ b/libsrc/target/c128/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = c128
 
 SUBDIRS = psg c128 graphics graphics_64k
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 CFILES = $(wildcard *.c)
 ASMFILES = $(wildcard *.asm)
@@ -39,5 +39,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/c128/c128/Makefile
+++ b/libsrc/target/c128/c128/Makefile
@@ -3,7 +3,7 @@ include ../../../Make.config
 TARGET = c128
 
 SUBDIRS = 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 CFILES = $(wildcard *.c)
 ASMFILES = $(wildcard *.asm)
@@ -39,5 +39,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/c128/psg/Makefile
+++ b/libsrc/target/c128/psg/Makefile
@@ -3,7 +3,7 @@ include ../../../Make.config
 TARGET = c128
 
 SUBDIRS = 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 CFILES = $(wildcard *.c)
 ASMFILES = $(wildcard *.asm)
@@ -39,5 +39,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/cpc/Makefile
+++ b/libsrc/target/cpc/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = cpc
 
 SUBDIRS = fcntl rs232
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/cpc/rs232/Makefile
+++ b/libsrc/target/cpc/rs232/Makefile
@@ -2,7 +2,7 @@ include ../../../Make.config
 
 
 SUBDIRS = booster sti
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all
 
@@ -25,4 +25,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/target/cpm/Makefile
+++ b/libsrc/target/cpm/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = cpm 
 
 SUBDIRS = graphics fcntl stdio time cpm
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -37,5 +37,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/enterprise/Makefile
+++ b/libsrc/target/enterprise/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = enterprise
 
 SUBDIRS = enterprise graphics graphics_hr
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/gb/Makefile
+++ b/libsrc/target/gb/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = gb
 
 SUBDIRS = 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/lm80c/Makefile
+++ b/libsrc/target/lm80c/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = lm80c
 
 SUBDIRS = rs232
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/msx/Makefile
+++ b/libsrc/target/msx/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = msx
 
 SUBDIRS = asmlib msxbios fcntl
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/msx/fcntl/Makefile
+++ b/libsrc/target/msx/fcntl/Makefile
@@ -3,7 +3,7 @@ include ../../../Make.config
 TARGET = msx
 
 SUBDIRS = msxdos2
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/mtx/Makefile
+++ b/libsrc/target/mtx/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = mtx
 
 SUBDIRS = rs232
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/newbrain/Makefile
+++ b/libsrc/target/newbrain/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = newbrain
 
 SUBDIRS = fcntl
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = 
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,7 +35,7 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o
 	$(RM) -r obj
 	$(RM) zcc_opt.def

--- a/libsrc/target/osca/Makefile
+++ b/libsrc/target/osca/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = osca
 
 SUBDIRS = fcntl
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/osca/fcntl/Makefile
+++ b/libsrc/target/osca/fcntl/Makefile
@@ -1,5 +1,5 @@
 SUBDIRS = flos flosmulti
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 include ../../../Make.config
      
@@ -13,4 +13,4 @@ $(SUBDIRS):
 clean: $(CLEANDIRS)
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/target/oz/Makefile
+++ b/libsrc/target/oz/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = oz
 
 SUBDIRS = oz
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/oz/oz/Makefile
+++ b/libsrc/target/oz/oz/Makefile
@@ -3,7 +3,7 @@ include ../../../Make.config
 TARGET = oz
 
 SUBDIRS = oztime ozinput
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/pps/Makefile
+++ b/libsrc/target/pps/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = pps
 
 SUBDIRS = fcntl time
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/sos/Makefile
+++ b/libsrc/target/sos/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = sos
 
 SUBDIRS = sos
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/sos/sos/Makefile
+++ b/libsrc/target/sos/sos/Makefile
@@ -3,7 +3,7 @@ include ../../../Make.config
 TARGET = sos
 
 SUBDIRS = tape
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/svi/Makefile
+++ b/libsrc/target/svi/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = svi
 
 SUBDIRS = svibios rs232
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o) 
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/ticalc/Makefile
+++ b/libsrc/target/ticalc/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET ?= ti82
 
 SUBDIRS = 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -37,5 +37,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/trs80/Makefile
+++ b/libsrc/target/trs80/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = trs80
 
 SUBDIRS = fcntl
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -35,5 +35,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/trs80/fcntl/Makefile
+++ b/libsrc/target/trs80/fcntl/Makefile
@@ -1,4 +1,3 @@
-# $Id: Makefile $
 
 include ../../../Make.config
 
@@ -22,11 +21,8 @@ OFILES = $(CFILES:.c=.o)
 OBJECTS = $(addprefix obj/,$(OFILES))
 
 all: dirs $(OBJECTS)
-	@echo ''
-	@echo '---> Building TRSDOS library <---'
-	@echo ''
 	$(LIBLINKER) -x$(OUTPUT_DIRECTORY)/trsdos @trsdos.lst
-	
+
 
 obj/%.o: %.c
 	$(ZCC) +trs80 $(CFLAGS) $^ -o $@

--- a/libsrc/target/ts2068/Makefile
+++ b/libsrc/target/ts2068/Makefile
@@ -8,7 +8,7 @@ ifeq ($(TARGET),zx)
   SUBDIRS += fzx fcntl rs232
 endif
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -41,5 +41,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/x1/Makefile
+++ b/libsrc/target/x1/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = x1
 
 SUBDIRS = x1 time 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all 
 
@@ -24,5 +24,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/z88/Makefile
+++ b/libsrc/target/z88/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = z88
 
 SUBDIRS = z88 net time fcntl rs232
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all 
 
@@ -24,5 +24,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx-common/Makefile
+++ b/libsrc/target/zx-common/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zx
 
 SUBDIRS = graphics fcntl
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -37,5 +37,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx-common/fcntl/Makefile
+++ b/libsrc/target/zx-common/fcntl/Makefile
@@ -1,16 +1,24 @@
-SUBDIRS = esxdos
-CLEANDIRS = $(SUBDIRS:%=clean-%)
-
 include ../../../Make.config
-     
+
+SUBDIRS = esxdos
+
+CLEANDIRS = $(SUBDIRS:%=%-clean)
+
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS)
-     
+
 all: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
-clean: $(CLEANDIRS)
+clean: subdirs-clean
+	$(RM) -r obj
+	$(RM) zcc_opt.def *.err *.o
+	$(RM) */*.o */*/*.o
+
+subdirs-clean: $(CLEANDIRS)
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
+	$(RM) */*.o

--- a/libsrc/target/zx-common/graphics/Makefile
+++ b/libsrc/target/zx-common/graphics/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zxn
 
 SUBDIRS = 
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm) $(wildcard ansi/*.asm)
 CFILES = $(wildcard *.c)
@@ -46,5 +46,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx/Makefile
+++ b/libsrc/target/zx/Makefile
@@ -12,7 +12,7 @@ ifeq ($(TARGET),zxn)
   SUBDIRS += fzx fcntl 
 endif
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -33,7 +33,7 @@ clean: subdirs-clean
 subdirs-clean: $(CLEANDIRS)
 
 obj/$(TARGET)/%.o: %.asm
-	$(Q)$(ASSEMBLER) -DFOR$(TARGET) -I../.. -I../../../lib/ $^
+	$(Q)$(ASSEMBLER) -DFOR$(TARGET) -I../.. -I../../../lib/  $^
 	@mv $(^:.asm=.o) $@
 
 dirs:
@@ -45,5 +45,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx/fcntl/Makefile
+++ b/libsrc/target/zx/fcntl/Makefile
@@ -1,16 +1,24 @@
-SUBDIRS = microdrive plus3 zxbasdrv 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
-
 include ../../../Make.config
-     
+
+
+SUBDIRS = microdrive plus3 zxbasdrv
+
+CLEANDIRS = $(SUBDIRS:%=%-clean)
+
+
 .PHONY: subdirs $(SUBDIRS) $(CLEANDIRS)
-     
+
 all: $(SUBDIRS)
-     
+
 $(SUBDIRS):
 	$(MAKE) -C $@
 
-clean: $(CLEANDIRS)
+clean: subdirs-clean
+	$(RM) zcc_opt.def *.err *.o
+
+subdirs-clean: $(CLEANDIRS)
 
 $(CLEANDIRS): 
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
+	$(RM) */*.o
+	$(RM) -r obj

--- a/libsrc/target/zx/games/Makefile
+++ b/libsrc/target/zx/games/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zx
 
 SUBDIRS = 
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 CFILES = $(wildcard *.c)
@@ -41,5 +41,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx/rs232/Makefile
+++ b/libsrc/target/zx/rs232/Makefile
@@ -2,7 +2,7 @@ include ../../../Make.config
 
 
 SUBDIRS = if1 plus3
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: subdirs-all
 
@@ -25,4 +25,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/target/zx/stdio/Makefile
+++ b/libsrc/target/zx/stdio/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zx
 
 SUBDIRS = 
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm) $(wildcard ansi/*.asm)
 CFILES = $(wildcard *.c)
@@ -46,5 +46,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx/tape/Makefile
+++ b/libsrc/target/zx/tape/Makefile
@@ -10,7 +10,7 @@ SUBDIRS =
 
 CFLAGS += -I$(Z88DK_INCLUDE)/arch/zx
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 CFILES = $(wildcard *.c)
@@ -47,5 +47,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx80/Makefile
+++ b/libsrc/target/zx80/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zx80
 
 SUBDIRS = stdlib
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -25,7 +25,7 @@ clean: subdirs-clean
 subdirs-clean: $(CLEANDIRS)
 
 obj/$(TARGET)/%.o: %.asm
-	$(Q)$(ASSEMBLER) -DFOR$(TARGET) -I../.. -I../../../lib/ $^
+	$(Q)$(ASSEMBLER) -DFOR$(TARGET) -I../.. -I../../../lib/  $^
 	@mv $(^:.asm=.o) $@
 
 dirs:
@@ -37,5 +37,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx80/stdlib/Makefile
+++ b/libsrc/target/zx80/stdlib/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zx81
 
 SUBDIRS = 
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 CFILES = $(wildcard *.c)
@@ -41,5 +41,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zx81/Makefile
+++ b/libsrc/target/zx81/Makefile
@@ -3,7 +3,7 @@ include ../../Make.config
 TARGET = zx81
 
 SUBDIRS = 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -36,5 +36,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/target/zxn/Makefile
+++ b/libsrc/target/zxn/Makefile
@@ -4,7 +4,7 @@ TARGET ?= zxn
 
 SUBDIRS = newlib 
 
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
@@ -37,5 +37,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/video/Makefile
+++ b/libsrc/video/Makefile
@@ -3,7 +3,7 @@ include ../Make.config
 
 SUBDIRS = tms9918 upd7220 krt
 # Directories that need a target passed down
-CLEANDIRS = $(SUBDIRS:%=clean-%) $(TARGETDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean) $(TARGETDIRS:%=%-clean)
 
 all: $(SUBDIRS)
 
@@ -25,4 +25,4 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean

--- a/libsrc/video/tms9918/Makefile
+++ b/libsrc/video/tms9918/Makefile
@@ -1,8 +1,7 @@
-
 include ../../Make.config
 
 SUBDIRS = stdio graphics
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 TARGET ?= test
 
@@ -44,5 +43,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/video/tms9918/stdio/Makefile
+++ b/libsrc/video/tms9918/stdio/Makefile
@@ -2,7 +2,7 @@ include ../../../Make.config
 
 
 SUBDIRS = ansi generic_console
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 all: $(SUBDIRS)
 
@@ -23,5 +23,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/libsrc/video/upd7220/Makefile
+++ b/libsrc/video/upd7220/Makefile
@@ -1,8 +1,7 @@
-
 include ../../Make.config
 
 SUBDIRS = gencon
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 
 TARGET ?= test
 
@@ -44,5 +43,5 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all TARGET=$(TARGET)
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 	$(RM) */*.o

--- a/support/Makefile
+++ b/support/Makefile
@@ -2,7 +2,7 @@ include
 
 
 SUBDIRS = basck debugger graphics pv1000 rcmx000
-CLEANDIRS = $(SUBDIRS:%=clean-%)
+CLEANDIRS = $(SUBDIRS:%=%-clean)
 INSTALLDIRS = $(SUBDIRS:%=install-%)
 
 all: subdirs-all
@@ -31,7 +31,7 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 $(CLEANDIRS):
-	$(MAKE) -C $(@:clean-%=%) clean
+	$(MAKE) -C $(@:%-clean=%) clean
 
 $(INSTALLDIRS):
 	$(MAKE) -C $(@:install-%=%) PREFIX=$(PREFIX) install

--- a/support/Makefile
+++ b/support/Makefile
@@ -3,7 +3,7 @@ include
 
 SUBDIRS = basck debugger graphics pv1000 rcmx000
 CLEANDIRS = $(SUBDIRS:%=%-clean)
-INSTALLDIRS = $(SUBDIRS:%=install-%)
+INSTALLDIRS = $(SUBDIRS:%=%-install)
 
 all: subdirs-all
 
@@ -34,4 +34,4 @@ $(CLEANDIRS):
 	$(MAKE) -C $(@:%-clean=%) clean
 
 $(INSTALLDIRS):
-	$(MAKE) -C $(@:install-%=%) PREFIX=$(PREFIX) install
+	$(MAKE) -C $(@:%-install=%) PREFIX=$(PREFIX) install


### PR DESCRIPTION
Different parts of z88dk have a different convention for clean syntax.
This PR tries (naively) to ensure that the `make <target>` and `make <target>-clean` convention is used throughout.

I'm not sure whether reversing the syntax will trigger issues with make on other platforms.
So, let's see if it builds.