### PR TITLE
fixed a bug for -iochar in ticks

### DIFF
--- a/src/ticks/hook_console.c
+++ b/src/ticks/hook_console.c
@@ -73,7 +73,7 @@ int getch()
 int hook_console_out(int port, int value)
 {
     if (ioport !=-1 && (port&0xff) == ioport) {
-        fputc(c,stdout);
+        fputc(value,stdout);
         return 0;
     }
 


### PR DESCRIPTION
wrong variable in output for -iochar.