### PR TITLE
bdosh() function for CP/M

### DIFF
--- a/include/cpm.h
+++ b/include/cpm.h
@@ -157,6 +157,10 @@ extern struct dpb __LIB__  *get_dpb(int drive)  __z88dk_fastcall;
 extern int __LIB__ bdos(int func,int arg) __smallc;
 extern int __LIB__ bdos_callee(int func,int arg) __smallc __z88dk_callee;
 #define bdos(a,b)   bdos_callee(a,b)
+/* As above, but on exit it passes HW error code ob MSB and error code on LSB */
+extern int __LIB__ bdosh(int func,int arg) __smallc;
+extern int __LIB__ bdosh_callee(int func,int arg) __smallc __z88dk_callee;
+#define bdosh(a,b)   bdosh_callee(a,b)
 
 /* Executes the BIOS function passing BC and DE as arguments, error status in A on exit */
 extern int __LIB__ bios(int func,int arg,int arg2) __smallc;

--- a/libsrc/target/cpm/fcntl/Makefile
+++ b/libsrc/target/cpm/fcntl/Makefile
@@ -5,6 +5,8 @@ CFILES = \
 	bios.c \
 	bdos.c \
 	bdos_callee.c \
+	bdosh.c \
+	bdosh_callee.c \
 	cache.c \
 	close.c \
 	creat.c \

--- a/libsrc/target/cpm/fcntl/bdosh.c
+++ b/libsrc/target/cpm/fcntl/bdosh.c
@@ -1,0 +1,25 @@
+/*
+ *	Call a CPM BDOS routine
+ *
+ *	$Id: bdosh.c $
+ */
+
+#include <cpm.h>
+
+
+int bdosh(int func,int arg)
+{
+#asm
+	EXTERN __bdos
+
+	ld	hl,2
+	add	hl,sp
+	ld	e,(hl)	;arg
+	inc	hl
+	ld	d,(hl)
+	inc	hl
+	ld	c,(hl)	;func
+	call __bdos
+	ld	l,a
+#endasm
+}

--- a/libsrc/target/cpm/fcntl/bdosh_callee.c
+++ b/libsrc/target/cpm/fcntl/bdosh_callee.c
@@ -1,7 +1,7 @@
 /*
  *	Call a CPM BDOS routine
  *
- *	$Id: bdos_callee.c $
+ *	$Id: bdosh_callee.c $
  */
 
 #include <cpm.h>

--- a/libsrc/target/cpm/fcntl/bdosh_callee.c
+++ b/libsrc/target/cpm/fcntl/bdosh_callee.c
@@ -1,0 +1,30 @@
+/*
+ *	Call a CPM BDOS routine
+ *
+ *	$Id: bdos_callee.c $
+ */
+
+#include <cpm.h>
+
+
+int bdosh_callee(int func,int arg)
+{
+#asm
+	EXTERN __bdos
+;	ld	hl,2
+;	add	hl,sp
+;	ld	e,(hl)	;arg
+;	inc	hl
+;	ld	d,(hl)
+;	inc	hl
+;	ld	c,(hl)	;func
+	
+	pop	hl
+	pop de
+	pop bc
+	push hl
+	
+	call __bdos
+	ld	l,a
+#endasm
+}

--- a/libsrc/target/cpm/fcntl/fcntl.lst
+++ b/libsrc/target/cpm/fcntl/fcntl.lst
@@ -1,6 +1,8 @@
 target/cpm/fcntl/obj/${TYPE}/${DEVICE}/bios
 target/cpm/fcntl/obj/${TYPE}/${DEVICE}/bdos
 target/cpm/fcntl/obj/${TYPE}/${DEVICE}/bdos_callee
+target/cpm/fcntl/obj/${TYPE}/${DEVICE}/bdosh
+target/cpm/fcntl/obj/${TYPE}/${DEVICE}/bdosh_callee
 target/cpm/fcntl/obj/${TYPE}/${DEVICE}/cache
 target/cpm/fcntl/obj/${TYPE}/${DEVICE}/close
 target/cpm/fcntl/obj/${TYPE}/${DEVICE}/creat


### PR DESCRIPTION
A BDOS call variant providing a more detailed error code on output (HW error code on MSB as in "Portable CP/M").