### PR TITLE
cleanup clg(), crt_init und crt_exit for KC85/2..

### DIFF
--- a/lib/target/kc/classic/kc_crt0.asm
+++ b/lib/target/kc/classic/kc_crt0.asm
@@ -4,9 +4,6 @@
 ;       Stefano Bodrato October 2016
 ;		few hints were found on the sdcc lib by Andreas Ziermann and Bert Lange
 ;
-;		OPTIMIZATIONS:
-;		#pragma output nosound   - Save few bytes not preserving IX on tape and sound interrupts
-;
 ; - - - - - - -
 ;
 ;       $Id: kc_crt0.asm,v 1.2 2016-10-10 07:09:14 stefano Exp $
@@ -45,36 +42,6 @@ ENDIF
 
 
 start:
-    ; Keyboard
-    ld      hl,($01EE)
-    ld      (INT01EE+7),hl
-    ld      hl,INT01EE
-    ld      ($01EE),hl
-
-    ld      hl,($01E6)
-    ld      (INT01E6+7),hl
-    ld      hl,INT01E6
-    ld      ($01E6),hl
-
-IF !DEFINED_nosound
-    ; Sound
-    ld      hl,($01EC)
-    ld      (INT01EC+7),hl
-    ld      hl,INT01EC
-    ld      ($01EC),hl
-
-    ; Cassette
-    ld      hl,($01E4)
-    ld      (INT01E4+7),hl
-    ld      hl,INT01E4
-    ld      ($01E4),hl
-
-    ld      hl,($01EA)
-    ld      (INT01EA+7),hl
-    ld      hl,INT01EA
-    ld      ($01EA),hl
-ENDIF
-
     ld      (__restore_sp_onexit+1),sp	;Save entry stack
     INCLUDE "crt/classic/crt_init_sp.asm"	
     INCLUDE "crt/classic/crt_init_atexit.asm"	
@@ -105,58 +72,6 @@ __restore_sp_onexit:
 
 
 l_dcal:	jp	(hl)		;Used for function pointer calls
-
-;	Interrupt table
-;	01D4..01E1	free for user
-;	01E2	SIO channel B (if V24 module installed)
-;	01E4	PIO channel A (cassette input)
-;	01E6 	PIO channel B (keyboard input)
-;	01E8 	CTC channel 0 (free)
-;	01EA 	CTC channel 1 (cassette output)
-;	01EC 	CTC channel 2 (sound duration)
-;	01EE 	CTC channel 3 (keyboard input)
-
-; CTC channel 3 (keyboard input)
-INT01EE:
-    push    iy
-    ld      iy,$01f0
-    call    0
-    pop     iy
-    ret
-
-; PIO channel B (keyboard input)
-INT01E6:
-    push    iy
-    ld      iy,$01f0
-    call    0
-    pop     iy
-    ret
-
-IF !DEFINED_nosound
-; CTC channel 2 (sound duration)
-INT01EC:
-    push    iy
-    ld      iy,$01f0
-    call    0
-    pop     iy
-    ret
-
-; CTC channel 1 (cassette input)
-INT01E4:
-    push    iy
-    ld      iy,$01f0
-    call    0
-    pop     iy
-    ret
-
-; CTC channel 1 (cassette output)
-INT01EA:
-    push    iy
-    ld      iy,$01f0
-    call    0
-    pop     iy
-    ret
-ENDIF
 
     INCLUDE "crt/classic/crt_runtime_selection.asm"
     INCLUDE "crt/classic/crt_section.asm"

--- a/lib/target/kc/def/caos.def
+++ b/lib/target/kc/def/caos.def
@@ -23,18 +23,22 @@ lstoff
     defc	ARG2      = 0xb784 ; argument 2
     defc	ARG3      = 0xb786 ; argument 3
     defc	ARG4      = 0xb788 ; argument 4
-	defc	ARG5      = 0xb78a ; argument 5
-	defc	ARG6      = 0xb78c ; argument 6
-	defc	ARG7      = 0xb78e ; argument 7
-	defc	ARG8      = 0xb790 ; argument 8
-	defc	ARG9      = 0xb792 ; argument 9
+    defc	ARG5      = 0xb78a ; argument 5
+    defc	ARG6      = 0xb78c ; argument 6
+    defc	ARG7      = 0xb78e ; argument 7
+    defc	ARG8      = 0xb790 ; argument 8
+    defc	ARG9      = 0xb792 ; argument 9
     defc	ARG10     = 0xb794 ; argument 10
+
+    defc	WINNR     = 0xb79b ; window number
+    defc	WINON     = 0xb79c ; window start
+    defc	WINLG     = 0xb79e ; window size
 
     defc	CURSO_COL = 0xb7a0 ; cursor position x
     defc	CURSO_ROW = 0xb7a1 ; cursor position y
     defc	STBT      = 0xb7a2 ; control byte for screen
     defc	COLOR     = 0xb7a3 ; color byte
-          
+
     defc	HOR       = 0xb7d3 ; horizontal graphic position
     defc	VERT      = 0xb7d5 ; vertical graphic position
     defc	FARB      = 0xb7d6 ; graphic color
@@ -61,7 +65,7 @@ lstoff
     defc	FNLARG    = 0x15
     defc	FNINTB    = 0x16
     defc	FNINLIN   = 0x17
-	defc	FNRHEX    = 0x18
+    defc	FNRHEX    = 0x18
     defc	FNERRM    = 0x19
     defc	FNHLHX    = 0x1a
     defc	FNHLDE    = 0x1b

--- a/libsrc/target/kc/graphics/clg.asm
+++ b/libsrc/target/kc/graphics/clg.asm
@@ -1,5 +1,5 @@
 ;
-;       Fast CLS for the VEB MPM KC85/2..5
+;       CLS for the VEB MPM KC85/2..5
 ;       Stefano - Sept 2016
 ;
 ;
@@ -7,33 +7,37 @@
 ;
 
 		SECTION code_clib
-                PUBLIC    clg
-                PUBLIC    _clg
-				
-			EXTERN w_pixeladdress
+                PUBLIC  clg
+                PUBLIC  _clg
 
-;		INCLUDE  "target/kc/def/caos.def"
+                EXTERN  kc_type
+                EXTERN  kc_attr
+
+                INCLUDE "target/kc/def/caos.def"
 
 .clg
 ._clg
 
-	ld	de,0
-	ld h,d
-	ld l,e
-	
-	call	w_pixeladdress
-	ld h,d
-	ld l,e
-	inc	de
-        ld      (hl),0	
-	ld	bc,10239
-	ldir
-	
-;	ld      a,7
-;	ld      (COLOR),a
-;	
-;    ld  a,$0c ; clear screen    
-;    call PV1
-;    defb FNCRT
-	
-    ret
+        ld      a,(kc_type)
+        and     a
+        jr      z,clg_not_kc85_4
+        ; 85/4 needs to switch back to pixel memory  
+        ld      a,(iy+1)
+        res     1,a     ;access pixel memory
+        ld      (iy+1),a
+        out     ($84),a
+clg_not_kc85_4:
+        ; set window 0 to max size
+        ld      a,0
+        ld      (WINNR),a
+        ld      hl,0
+        ld      (WINON),hl
+        ld      hl,$2028
+        ld      (WINLG),hl
+        ; set color
+        ld      a,(kc_attr)
+        ld      (COLOR),a
+        ld      a,$0c ; clear screen
+        call    PV1
+        defb    FNCRT
+        ret

--- a/libsrc/target/kc/stdio/generic_console.asm
+++ b/libsrc/target/kc/stdio/generic_console.asm
@@ -523,18 +523,17 @@ not_odd_lhs:
         ret
 
 	SECTION	code_crt_init
-
-	; Remove the cursor
-	ld	hl,0xffff
-	ld	(CURSO_COL),hl
-
+        ; initialize the kc_attr
+        ld      a,@01111000    ; white on black
+        ld      (kc_attr),a
+        ; check for <= 85/3 oder >= 85/4
 	ld	hl,$0001
 	call	PV1
 	defb	FNPADR
 	ld	l,0
 	ld	a,h
 	cp	$81
-	jr	nz,not_kc85_4
+	jr	nz,crt_init_not_kc85_4
 	inc	l
 	ld	a,(iy+1)
 	res	0,a	;display image 0
@@ -542,14 +541,27 @@ not_odd_lhs:
 	set	3,a	;disable hicolor
 	ld	(iy+1),a
 	out	($84),a
-not_kc85_4:
+crt_init_not_kc85_4:
 	ld	a,l
 	ld	(kc_type),a
 
 
+        SECTION code_crt_exit
+        ld      a,(kc_type)
+        and     a
+        jr      z,crt_exit_not_kc85_4
+        ; 85/4 needs to switch back to pixel memory  
+        ld      a,(iy+1)
+        res     1,a     ;access to pixel memory
+        ld      (iy+1),a
+        out     ($84),a
+crt_exit_not_kc85_4:
+        ld      a,$39   ; CAOS default color: white on blue
+        ld      (COLOR),a
+
 		SECTION bss_clib
 
-.kc_type	defb	0		;holds 1 for KC85/4
+.kc_type	defb	0		;holds 1 for >= KC85/4
 
 		SECTION	data_clib
 .kc_attr	defb @01111000


### PR DESCRIPTION
This is for issue #683. There were some changes at clg.asm, but they didn't help. The KC 85/2-5 uses the IX register for interrupts, keyboard access and switching graphics memory.
The clg() implementation clears only the pixel memory, but not the color memory. As a result the cursor position was changed to a invalid value. (the cursor uses a different color)

I change clg() back to the CAOS implementation and add some more initialization stuff. For KC85/2-3 set the default window to max size and for KC85/4 switch to the pixel memory. The os expects the pixel memory is active.

After the changes for the IX register the setup code for the interrupts aren't needed any more. I have removed this code.

I tested with dstar and some other programs for KC85/2-5. 

One question: do you have some code styles for tabs and spaces? I am not sure what I have to use.