### PR TITLE
switch from FNKBD to FNKBDS to prevent a visible cursor

### DIFF
--- a/libsrc/target/kc/stdio/fgetc_cons.asm
+++ b/libsrc/target/kc/stdio/fgetc_cons.asm
@@ -17,12 +17,9 @@
 
 .fgetc_cons
 ._fgetc_cons
-	push	iy
-	ld	iy,$1f0
-
-    call PV1
-    defb FNKBD
-	pop	iy
+.nokey  call    PV1
+        defb    FNKBDS
+        jr      NC,nokey
 IF STANDARDESCAPECHARS
 	cp	13
 	jr	nz,not_return


### PR DESCRIPTION
the documentation of function KBD says:

> Name: . . . KBD . . . . . . . . . . . . . UP-Nr. 04H
> FKT.: Tasteneingabe mit Einblendung des Cursors, wartet, bis Taste
> gedrückt bzw. liefert die Codefolge von vorher betätigter FTaste
> PE: -
> PA: Register A = Zeichencode (ASCII)
> VR: AF, HL
> Hinweis: vgl. auch UP-Nr. 16H

This means something like: keyboard input with **enabled cursor**, waits until a key is pressed. ...

In the past there were some problems with visible cursors. I think it's better to switch from function KBD to KBDS. This function doesn't activate a cursor, but it returns immediate. I add a small loop to wait until a key is pressed.

I tested with https://github.com/Hojoe42/KC-z88dk-Demos/tree/main/Farbpalette and https://sourceforge.net/projects/h-tron/ 

I compiled both projects with sccz80 and sdcc. It runs on JKCEMU with KC85/3 and /4.