### PR TITLE
classic - lib3d add homogeneous coordinate matrix operations

### DIFF
--- a/examples/msx/ex1.c
+++ b/examples/msx/ex1.c
@@ -40,13 +40,13 @@ void star_randomize(star_t* st) {
 void star_move(star_t* st) {
 	int x, y, z;
 	z = (st->z -= 2);
-	x = f2i(divfx(st->x, z)) + 128;
-	y = f2i(divfx(st->y, z)) + 96;
+	x = st->x / z + 128;
+	y = st->y / z + 96;
 	if (z < 1 || x < 0 || x >= MODE2_WIDTH || y < 0 || y >= MODE2_HEIGHT) {
 		star_randomize(st);
 		z = st->z;
-		x = f2i(divfx(st->x, z)) + 128;
-		y = f2i(divfx(st->y, z)) + 96;
+		x = st->x / z + 128;
+		y = st->y / z + 96;
 	}
 	st->last = st->addr;
 	st->addr = map_pixel(x, y);

--- a/examples/msx/ex9.c
+++ b/examples/msx/ex9.c
@@ -43,13 +43,13 @@ void star_randomize(star_t* st) {
 void star_move(star_t* st) {
 	int x, y, z;
 	z = (st->z -= 2);
-	x = f2i(divfx(st->x, z)) + 128;
-	y = f2i(divfx(st->y, z)) + 96;
+	x = st->x / z + 128;
+	y = st->y / z + 96;
 	if (z < 1 || x < 0 || x >= MODE2_WIDTH || y < 0 || y >= MODE2_HEIGHT) {
 		star_randomize(st);
 		z = st->z;
-		x = f2i(divfx(st->x, z)) + 128;
-		y = f2i(divfx(st->y, z)) + 96;
+		x = st->x / z + 128;
+		y = st->y / z + 96;
 	}
 	st->sx = x;
 	st->sy = y;

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -87,13 +87,13 @@ extern int __LIB__ f2i (long v);
 /// weighted average (w=0.0 -> x, w=0.5->average, w=1.0 ->y)
 //#define wgavgfx(x, y, w)	(mulfx(i2f(1) - w, x) + mulfx(w, y))
 
-// ELEMENTing point arithmetic
+// Floating point arithmetic
 
 #define MATRIX_ORDER    4           // order for 3D homogeneous coordinate graphics
 
 #ifdef __MATH_AM9511
 
-    #define ELEMENT     ELEMENT_t
+    #define ELEMENT     float_t
 
     #define INV(x)      1/(x)
     #define SQR(x)      sqr(x)
@@ -106,7 +106,7 @@ extern int __LIB__ f2i (long v);
 
 #elif __MATH_MATH32
 
-    #define ELEMENT     ELEMENT_t
+    #define ELEMENT     float_t
 
     #define INV(x)      inv(x)
     #define SQR(x)      sqr(x)
@@ -119,7 +119,7 @@ extern int __LIB__ f2i (long v);
 
 #elif __MATH_MATH16
 
-    #define ELEMENT     _ELEMENT16
+    #define ELEMENT     _Float16
 
     #define INV(x)      invf16(x)
     #define SQR(x)      ((x)*(x))

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -137,7 +137,7 @@ extern int __LIB__ f2i (long v);
     #define INV(x)      (i2f(1)/(long)x)
     #define SQR(x)      sqrfx(x)
     #define SQRT(x)     sqrtfx(x)
-    #define INVSQRT(x)  (f2i(i2f(1)/sqrtfx(x))
+    #define INVSQRT(x)  (f2i(i2f(1)/sqrtfx(x)))
 
     #define COS(x)      icos(x)
     #define SIN(x)      isin(x)

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -73,13 +73,13 @@ extern long __LIB__  i2f (int v) __z88dk_fastcall;
 extern int __LIB__ f2i (long v);
 
 /// fixed-point multiplication
-#define mulfx(x,y)	f2i((long)y * (long)x)
+#define mulfx(x,y)	(f2i((long)(x * y)))
 
 /// fixed-point division
-#define divfx(x,y)	(i2f(x)/(long)y)
+#define divfx(x,y)	(f2i(i2f(x)/y))
 
 /// fixed-point square
-#define sqrfx(x)	(f2i((long)x * (long)x))
+#define sqrfx(x)	(f2i((long)(x * x)))
 
 /// fixed-point square root
 #define sqrtfx(x)	(((long)(sqrt(x)))*8)

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -288,6 +288,7 @@ extern void __LIB__ stencil_add_ellipse(int cx, int cy, int sa, int ea, int xrad
 
 
 /* Turtle Graphics */
+
 #define T_NORTH 270
 #define T_SOUTH 90
 #define T_WEST 180
@@ -296,6 +297,7 @@ extern int __LIB__  set_direction(int degrees) __z88dk_fastcall; /* input must b
 extern int __LIB__  fwd(int length) __z88dk_fastcall;
 extern int __LIB__  turn_left(int degrees) __z88dk_fastcall; /* input must be between 0 and 360 */
 extern int __LIB__  turn_right(int degrees) __z88dk_fastcall; /* input must be between 0 and 360 */
+
 
 /* Homogenous Coordinate 3D Graphics */
 
@@ -308,7 +310,7 @@ extern void __LIB__ scale_v(vector_t * vect, ELEMENT scale) __smallc;
 /* Produce a dot product between vectors */
 ELEMENT __LIB__ dot_v(vector_t * vect1, vector_t * vect2) __smallc;
 
-/* Vector Matrix Multiplication */
+/* Vector Matrix Multiplication [vect] = [vect]*[multiplier] */
 extern void __LIB__ mult_v(vector_t * vect, matrix_t * multiplier) __smallc;
 
 /* Produce an identity matrix */
@@ -338,7 +340,7 @@ extern void __LIB__ projection_opengl_m(matrix_t * matrix, ELEMENT fov, ELEMENT 
 /* Set up projection W3Woody */
 extern void __LIB__ projection_w3woody_m(matrix_t * matrix, ELEMENT fov, ELEMENT aspect_ratio, ELEMENT near, ELEMENT far) __smallc;
 
-/* Matrix Multiplication */
+/* Matrix Multiplication [multiplicand] = [multiplicand]*[multiplier] */
 extern void __LIB__ mult_m(matrix_t * multiplicand, matrix_t * multiplier) __smallc;
 
 

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -60,30 +60,31 @@ extern "C" {
 
 #include <sys/compiler.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <math.h>
 
 // fixed point arithmetic
 
-/// integer to fixed-point
+/// integer to fixed-point 26.6
 extern long __LIB__  i2f (int v) __z88dk_fastcall;
 
-/// fixed-point to integer
-extern int __LIB__ f2i (long v);
+/// fixed-point 26.6 to integer
+extern int __LIB__ f2i (long v) __z88dk_fastcall;
 
 /// fixed-point multiplication
-#define mulfx(x,y)	(f2i((long)(x * y)))
+//#define mulfx(x,y)    (f2i(i2f(x)*y))
 
 /// fixed-point division
-#define divfx(x,y)	(f2i(i2f(x)/y))
+//#define divfx(x,y)    (f2i(i2f(x)/y))
 
 /// fixed-point square
-#define sqrfx(x)	(f2i((long)(x * x)))
+//#define sqrfx(x)      (f2i(i2f(x)*x))
 
 /// fixed-point square root
-#define sqrtfx(x)	(f2i(((long)(sqrt(x)))*8))
+//#define sqrtfx(x)     (((long)(sqrt(x)))*8)
 
 /// weighted average (w=0.0 -> x, w=0.5->average, w=1.0 ->y)
-//#define wgavgfx(x, y, w)	(mulfx(i2f(1) - w, x) + mulfx(w, y))
+//#define wgavgfx(x, y, w)  (mulfx(i2f(1) - w, x) + mulfx(w, y))
 
 // Floating point arithmetic
 
@@ -96,7 +97,6 @@ extern int __LIB__ f2i (long v);
     #define INV(x)      1/(x)
     #define SQR(x)      sqr(x)
     #define SQRT(x)     sqrt(x)
-    #define INVSQRT(x)  1/SQRT(x)
 
     #define COS(x)      cos(x)
     #define SIN(x)      sin(x)
@@ -109,7 +109,6 @@ extern int __LIB__ f2i (long v);
     #define INV(x)      inv(x)
     #define SQR(x)      sqr(x)
     #define SQRT(x)     sqrt(x)
-    #define INVSQRT(x)  invsqrt(x)
 
     #define COS(x)      cos(x)
     #define SIN(x)      sin(x)
@@ -122,7 +121,6 @@ extern int __LIB__ f2i (long v);
     #define INV(x)      invf16(x)
     #define SQR(x)      ((x)*(x))
     #define SQRT(x)     sqrtf16(x)
-    #define INVSQRT(x)  invsqrtf16(x)
 
     #define COS(x)      cosf16(x)
     #define SIN(x)      sinf16(x)
@@ -132,10 +130,9 @@ extern int __LIB__ f2i (long v);
 
     #define ELEMENT     int
 
-    #define INV(x)      (i2f(1)/(x))
-    #define SQR(x)      sqrfx(x)
-    #define SQRT(x)     sqrtfx(x)
-    #define INVSQRT(x)  (f2i(i2f(1)/sqrtfx(x)))
+    #define INV(x)      1
+    #define SQR(x)      ((x)*(x))
+    #define SQRT(x)     isqrt(x)
 
     #define COS(x)      icos(x)
     #define SIN(x)      isin(x)
@@ -152,46 +149,46 @@ extern int __LIB__ f2i (long v);
 /// represents a vector in 4 dimensions
 typedef struct Vector_s
 {
-    ELEMENT x;          // x dimension
-    ELEMENT y;          // y dimension
-    ELEMENT z;          // z dimension
-    ELEMENT w;          // w dimension
+    ELEMENT x;              /// x dimension
+    ELEMENT y;              /// y dimension
+    ELEMENT z;              /// z dimension
+    ELEMENT w;              /// w dimension
 } Vector_t;
 
 #define vector_t Vector_t
 
 /// a triangle made of 3 vertexes
 typedef struct {
-	vector_t* vertexes[3];	///< 3 vertexes
+    vector_t* vertexes[3];  ///< 3 vertexes
 } triangle_t;
 
 /// mesh: a set of points (vectors) refered by a set of triangles
 typedef struct {
-	int pcount;	///< number of points
-	int tcount;	///< number of triangles
+    int pcount;             ///< number of points
+    int tcount;             ///< number of triangles
 
-	vector_t* points;	///< points
-	triangle_t* triangles;	///< triangles
+    vector_t* points;       ///< points
+    triangle_t* triangles;  ///< triangles
 } mesh_t;
 
 /// an object is a solid in a scene, with translation, rotation and the solid's mesh
 typedef struct {
-	mesh_t* mesh;	///< mesh
-	unsigned char rot_x;	///< angle of rotation X-axis
-	unsigned char rot_y;	///< angle of rotation Y-axis
-	unsigned char rot_z;	///< angle of rotation Z-axis
-	int trans_x;	///< translation on X-axis
-	int trans_y;	///< translation on Y-axis
-	int trans_z;	///< translation on Z-axis
+    mesh_t* mesh;           ///< mesh
+    unsigned char rot_x;    ///< angle of rotation X-axis
+    unsigned char rot_y;    ///< angle of rotation Y-axis
+    unsigned char rot_z;    ///< angle of rotation Z-axis
+    int trans_x;            ///< translation on X-axis
+    int trans_y;            ///< translation on Y-axis
+    int trans_z;            ///< translation on Z-axis
 } object_t;
 
 typedef struct {
-	int x, y;
+    int x, y;
 } Point_t;
 
 typedef struct {
-	int pitch, roll, yaw;
-	int x, y, z;
+    int pitch, roll, yaw;
+    int x, y, z;
 } Cam_t;
 
 typedef struct matrix_s // homogeneous coordinate system
@@ -257,15 +254,15 @@ extern void __LIB__ mesh_delete(mesh_t* mesh) __smallc;
 extern void __LIB__ object_apply_transformations(object_t* obj, vector_t* pbuffer, int x, int y) __smallc;
 
 /*
-	Integer sin functions taken from the lib3d library, OZ7xx DK
-	by Hamilton, Green and Pruss
-	isin and icos return a value between -254 and +255
-	(changed by Stefano, originally it was +/- 16384)
+    Integer sin functions taken from the lib3d library, OZ7xx DK
+    by Hamilton, Green and Pruss
+    isin and icos return a value between -254 and +255
+    (changed by Stefano, originally it was +/- 16384)
 */
 
-extern int __LIB__  isin(unsigned int degrees) __z88dk_fastcall; /* input must be between 0 and 360 */
-extern int __LIB__  icos(unsigned int degrees) __z88dk_fastcall; /* input must be between 0 and 360 */
-extern int __LIB__  div256(long value); /* divide by 255 */
+extern int __LIB__  isin(unsigned int degrees) __z88dk_fastcall;    /* input must be between 0 and 360 */
+extern int __LIB__  icos(unsigned int degrees) __z88dk_fastcall;    /* input must be between 0 and 360 */
+extern int __LIB__  div256(long value) __z88dk_fastcall;            /* divide by 255 */
 
 
 /* Monochrome graphics functions depending on lib3d portions */

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -132,7 +132,7 @@ extern int __LIB__ f2i (long v);
 
     #define ELEMENT     int
 
-    #define INV(x)      (i2f(1)/(long)x)
+    #define INV(x)      (i2f(1)/(x))
     #define SQR(x)      sqrfx(x)
     #define SQRT(x)     sqrtfx(x)
     #define INVSQRT(x)  (f2i(i2f(1)/sqrtfx(x)))

--- a/include/lib3d.h
+++ b/include/lib3d.h
@@ -1,15 +1,13 @@
 /*
-lib3d.h
-
-Structs for standard Wizard 3d and 4d math functions
-
-Copyright 2002, Mark Hamilton
-
-*/
+ * lib3d.h
+ *
+ * Structs for standard Wizard 3d and 4d math functions
+ *
+ * Copyright 2002, Mark Hamilton
+ *
+ */
 
 /*
- * 3d.h
- *
  * Copyright (c) 2022 Phillip Stevens
  * Create Time: October 2022
  *
@@ -82,7 +80,7 @@ extern int __LIB__ f2i (long v);
 #define sqrfx(x)	(f2i((long)(x * x)))
 
 /// fixed-point square root
-#define sqrtfx(x)	(((long)(sqrt(x)))*8)
+#define sqrtfx(x)	(f2i(((long)(sqrt(x)))*8))
 
 /// weighted average (w=0.0 -> x, w=0.5->average, w=1.0 ->y)
 //#define wgavgfx(x, y, w)	(mulfx(i2f(1) - w, x) + mulfx(w, y))
@@ -141,7 +139,7 @@ extern int __LIB__ f2i (long v);
 
     #define COS(x)      icos(x)
     #define SIN(x)      isin(x)
-    #define TAN(x)      (f2i(i2f(icos(x))/(long)isin(x)))
+    #define TAN(x)      (f2i(i2f(icos(x))/isin(x)))
 
 #endif
 

--- a/libsrc/lib3d/div256.asm
+++ b/libsrc/lib3d/div256.asm
@@ -1,30 +1,27 @@
 ;
-;	OZ-7xx DK emulation layer for Z88DK
-;	by Stefano Bodrato - Oct. 2003
+;    OZ-7xx DK emulation layer for Z88DK
+;    by Stefano Bodrato - Oct. 2003
 ;
-;	int div256(long value);
-;	divide by 256
-;
-; ------
-; $Id: div256.asm,v 1.3 2016-06-28 19:31:42 dom Exp $
+;    int div256(long value);
+;    divide by 256
 ;
 
-	SECTION code_clib
-	PUBLIC	div256
-	PUBLIC	_div256
+    SECTION code_clib
+    PUBLIC  div256
+    PUBLIC  _div256
 
 div256:
 _div256:
-        pop     bc
-        pop     hl
-        pop     de
-        push    de
-        push    hl
-        push    bc
-	
-	; DEHL holds value
-	
-	ld	l,h
-	ld	h,e
+    pop     bc
+    pop     hl
+    pop     de
+    push    de
+    push    hl
+    push    bc
 
-        ret
+    ; DEHL holds value
+
+    ld      l,h
+    ld      h,e
+
+    ret

--- a/libsrc/lib3d/div256.asm
+++ b/libsrc/lib3d/div256.asm
@@ -2,7 +2,7 @@
 ;    OZ-7xx DK emulation layer for Z88DK
 ;    by Stefano Bodrato - Oct. 2003
 ;
-;    int div256(long value);
+;    int div256(long value) __z88dk_fastcall;
 ;    divide by 256
 ;
 
@@ -12,12 +12,12 @@
 
 div256:
 _div256:
-    pop     bc
-    pop     hl
-    pop     de
-    push    de
-    push    hl
-    push    bc
+    ;pop     bc
+    ;pop     hl
+    ;pop     de
+    ;push    de
+    ;push    hl
+    ;push    bc
 
     ; DEHL holds value
 

--- a/libsrc/lib3d/dot_v.c
+++ b/libsrc/lib3d/dot_v.c
@@ -55,5 +55,5 @@
 /* Produce a dot product between vectors */
 ELEMENT dot_v(vector_t * vect1,vector_t * vect2)
 {
-    return vect1->x * vect2->x + vect1->y * vect2->y + vect1->z * vect2->z;
+    return (vect1->x * vect2->x) + (vect1->y * vect2->y) + (vect1->z * vect2->z);
 }

--- a/libsrc/lib3d/dot_v.c
+++ b/libsrc/lib3d/dot_v.c
@@ -1,0 +1,59 @@
+/*
+ * dot_v.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Produce a dot product between vectors */
+ELEMENT dot_v(vector_t * vect1,vector_t * vect2)
+{
+    return vect1->x * vect2->x + vect1->y * vect2->y + vect1->z * vect2->z;
+}

--- a/libsrc/lib3d/ellipse.c
+++ b/libsrc/lib3d/ellipse.c
@@ -1,14 +1,13 @@
 /*
 
-	Graphics functions requiring some of the LIB3D Extensions
+    Graphics functions requiring some of the LIB3D Extensions
 
-	ellipse( cx,  cy,  startangle,  endangle,  xradius,  yradius)
-	
-	Draw an ellipse arc delimited by 'startangle' and 'endangle',
-	specified in degrees.
-	
-	
-	$Id: ellipse.c,v 1.3 2013-10-09 06:10:33 stefano Exp $
+    ellipse( cx,  cy,  startangle,  endangle,  xradius,  yradius)
+    
+    Draw an ellipse arc delimited by 'startangle' and 'endangle',
+    specified in degrees.
+
+    $Id: ellipse.c,v 1.3 2013-10-09 06:10:33 stefano Exp $
 */
 
 
@@ -21,12 +20,12 @@ void ellipse(int cx, int cy, int sa, int ea, int xradius, int yradius)
 
 int i,k;
 
-	plot(cx+icos(sa)*xradius/256,cy+isin(sa)*yradius/256);
-	
-	if (ea==0) k=360; else k=ea;
+    plot(cx+icos(sa)*xradius/256,cy+isin(sa)*yradius/256);
 
-	for (i=sa;i!=k;i++) {
-		if (i==360) i=0;
-		drawto(cx+icos(i)*xradius/256,cy+isin(i)*yradius/256);
-	}
+    if (ea==0) k=360; else k=ea;
+
+    for (i=sa;i!=k;i++) {
+        if (i==360) i=0;
+        drawto(cx+icos(i)*xradius/256,cy+isin(i)*yradius/256);
+    }
 }

--- a/libsrc/lib3d/f2i.asm
+++ b/libsrc/lib3d/f2i.asm
@@ -1,8 +1,8 @@
 ;
 ;    Fixed Point functions
 ;
-;    int f2i (long v)
-;    fixed point to integer
+;    int f2i (long v) __z88dk_fastcall;
+;    fixed point 26.6 to integer
 ;
 
     SECTION code_clib
@@ -12,12 +12,12 @@
 
 .f2i
 ._f2i
-    pop     bc    ; RET addr.
-    pop     hl
-    pop     de
-    push    de
-    push    hl
-    push    bc
+    ;pop     bc    ; RET addr.
+    ;pop     hl
+    ;pop     de
+    ;push    de
+    ;push    hl
+    ;push    bc
 
 ;; DEHL holds value
 

--- a/libsrc/lib3d/f2i.asm
+++ b/libsrc/lib3d/f2i.asm
@@ -1,50 +1,46 @@
 ;
-;	Fixed Point functions
+;    Fixed Point functions
 ;
-;	int f2i (long v)
-;	fixed point to integer
-;
-; ------
-; $Id: f2i.asm,v 1.3 2016-06-28 19:31:42 dom Exp $
+;    int f2i (long v)
+;    fixed point to integer
 ;
 
-        SECTION code_clib
-	PUBLIC	f2i
-	PUBLIC	_f2i
+    SECTION code_clib
+    PUBLIC  f2i
+    PUBLIC  _f2i
 
 
 .f2i
 ._f2i
-        pop     bc	; RET addr.
-        pop     hl
-        pop     de
-        push    de
-        push    hl
-        push    bc
+    pop     bc    ; RET addr.
+    pop     hl
+    pop     de
+    push    de
+    push    hl
+    push    bc
 
 ;; DEHL holds value
 
-	;rr	d
-	;rr	e
-	;rr	h
-	;rr	l
-	;rr	d
-	;rr	e
-	;rr	h
-	;rr	l
+    ;rr    d
+    ;rr    e
+    ;rr    h
+    ;rr    l
+    ;rr    d
+    ;rr    e
+    ;rr    h
+    ;rr    l
 
-	ld	d,l
+    ld      d,l
 
-	ld	l,h
-	ld	h,e
-	
-	rl	d
-	rl	l
-	rl	h
+    ld      l,h
+    ld      h,e
+    
+    rl      d
+    rl      l
+    rl      h
 
-	rl	d
-	rl	l
-	rl	h
-	
-	ret
-	
+    rl      d
+    rl      l
+    rl      h
+
+    ret

--- a/libsrc/lib3d/fwd.asm
+++ b/libsrc/lib3d/fwd.asm
@@ -2,49 +2,48 @@
 ;       Turtle graphics library
 ;       Stefano - 11/2017
 ;
-;       $Id: fwd.asm $
-;
 
-        SECTION   code_clib
-        PUBLIC    fwd
-        PUBLIC    _fwd
-		
-		EXTERN	l_mult
-		EXTERN	l_div
-		EXTERN	icos
-		EXTERN	isin
-		EXTERN	move
-        EXTERN __direction
+    SECTION code_clib
+    PUBLIC  fwd
+    PUBLIC  _fwd
+
+    EXTERN  l_mult
+    EXTERN  l_div
+    EXTERN  icos
+    EXTERN  isin
+    EXTERN  move
+
+    EXTERN  __direction
 
 .fwd
 ._fwd
-		; __FASTCALL
-		
-		push	hl
-		ld		hl,(__direction)
-    	call	icos
-		pop		de
-		push	de
-		call	l_mult
-		ld		de,256
-		ex		de,hl
-		call	l_div
+    ; __FASTCALL
 
-		pop		de
-		push	hl
-		push	de
+    push    hl
+    ld      hl,(__direction)
+    call    icos
+    pop     de
+    push    de
+    call    l_mult
+    ld      de,256
+    ex      de,hl
+    call    l_div
 
-		ld		hl,(__direction)
-    	call	isin
-		pop		de
-		call	l_mult
-		ld		de,256
-		ex		de,hl
-		call	l_div
-		
-		push	hl
-		
-		call	move
-		pop		hl
-		pop		hl
-		ret
+    pop     de
+    push    hl
+    push    de
+
+    ld      hl,(__direction)
+    call    isin
+    pop     de
+    call    l_mult
+    ld      de,256
+    ex      de,hl
+    call    l_div
+
+    push    hl
+
+    call    move
+    pop     hl
+    pop     hl
+    ret

--- a/libsrc/lib3d/get_direction.asm
+++ b/libsrc/lib3d/get_direction.asm
@@ -2,17 +2,15 @@
 ;       Turtle graphics library
 ;       Stefano - 11/2017
 ;
-;       $Id: get_direction.asm $
-;
 
-        SECTION   code_clib
-        PUBLIC    get_direction
-        PUBLIC    _get_direction
-        
-        EXTERN __direction
+    SECTION code_clib
+    PUBLIC  get_direction
+    PUBLIC  _get_direction
+
+    EXTERN  __direction
 
 
 .get_direction
 ._get_direction
-	ld	hl,(__direction)
-	ret
+    ld      hl,(__direction)
+    ret

--- a/libsrc/lib3d/i2f.asm
+++ b/libsrc/lib3d/i2f.asm
@@ -2,7 +2,7 @@
 ;    Fixed Point functions
 ;
 ;    long i2f (int v) __z88dk_fastcall;
-;    integer to float;
+;    integer to fixed point 26.6;
 ;
 
     SECTION code_clib

--- a/libsrc/lib3d/i2f.asm
+++ b/libsrc/lib3d/i2f.asm
@@ -1,45 +1,42 @@
 ;
-;	Fixed Point functions
+;    Fixed Point functions
 ;
-;	long __FASTCALL__ i2f (int v)
-;	integer to float;
-;
-; ------
-; $Id: i2f.asm,v 1.3 2016-06-28 19:31:42 dom Exp $
+;    long i2f (int v) __z88dk_fastcall;
+;    integer to float;
 ;
 
-        SECTION code_clib
-	PUBLIC	i2f
-	PUBLIC	_i2f
-	
+    SECTION code_clib
+    PUBLIC  i2f
+    PUBLIC  _i2f
+    
 
 .i2f
 ._i2f
-        ;pop     bc
-        ;pop     hl
-        ;push    hl
-        ;push    bc
+    ;pop     bc
+    ;pop     hl
+    ;push    hl
+    ;push    bc
 
 ;; put long result in DEHL
-	ld	e,h
-	ld	h,l
-	ld	l,0
-	ld	d,l
-        bit     7,e
-        jr	z,noneg
-        dec     d
-        inc	l	; when rotated it will become bit 31
-        scf		; when rotated it will become bit 30
-.noneg	
-	rr	d
-	rr	e
-	rr	h
-	rr	l
-	
-	rr	d
-	rr	e
-	rr	h
-	rr	l
+    ld      e,h
+    ld      h,l
+    ld      l,0
+    ld      d,l
+    bit     7,e
+    jr      Z,noneg
+    dec     d
+    inc     l   ; when rotated it will become bit 31
+    scf         ; when rotated it will become bit 30
 
-        ret
+.noneg
+    rr      d
+    rr      e
+    rr      h
+    rr      l
 
+    rr      d
+    rr      e
+    rr      h
+    rr      l
+
+    ret

--- a/libsrc/lib3d/icos.asm
+++ b/libsrc/lib3d/icos.asm
@@ -1,31 +1,29 @@
 ;
-;	OZ-7xx DK emulation layer for Z88DK
-;	by Stefano Bodrato - Oct. 2003
+;    OZ-7xx DK emulation layer for Z88DK
+;    by Stefano Bodrato - Oct. 2003
 ;
-;	int icos(unsigned degrees);
-;	input must be between 0 and 360
-;
-; ------
-; $Id: icos.asm,v 1.3 2016-06-28 19:31:42 dom Exp $
+;    int icos(unsigned degrees) __z88dk_fastcall;
+;    input must be between 0 and 360
 ;
 
-        SECTION code_clib
-	PUBLIC	icos
-	PUBLIC	_icos
 
-	EXTERN	isin
+    SECTION code_clib
+    PUBLIC  icos
+    PUBLIC  _icos
+
+    EXTERN  isin
 
 icos:
 _icos:
-	; __FASTCALL__
-	ld	b,h
-	ld	c,l
+    ; __FASTCALL__
+    ld      b,h
+    ld      c,l
 
-        ld      hl,90
-        or      a
-        sbc     hl,bc
-        jp      nc,isin
-        ld      bc,360
-        add     hl,bc
-        jp      isin
+    ld      hl,90
+    or      a
+    sbc     hl,bc
+    jp      nc,isin
+    ld      bc,360
+    add     hl,bc
+    jp      isin
 

--- a/libsrc/lib3d/identity_m.c
+++ b/libsrc/lib3d/identity_m.c
@@ -1,0 +1,65 @@
+/*
+ * identity_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Produce an identity matrix */
+void identity_m(matrix_t * matrix)
+{
+    memset(matrix, 0, sizeof(ELEMENT)*MATRIX_ORDER*MATRIX_ORDER);
+
+    uint8_t i = 0;
+    do{
+        matrix->e[i] = 1.0;
+    }while( (i += (MATRIX_ORDER+1)) < (MATRIX_ORDER*MATRIX_ORDER) );
+}

--- a/libsrc/lib3d/identity_m.c
+++ b/libsrc/lib3d/identity_m.c
@@ -60,6 +60,6 @@ void identity_m(matrix_t * matrix)
 
     uint8_t i = 0;
     do{
-        matrix->e[i] = 1.0;
+        matrix->e[i] = (ELEMENT)1;
     }while( (i += (MATRIX_ORDER+1)) < (MATRIX_ORDER*MATRIX_ORDER) );
 }

--- a/libsrc/lib3d/isin.asm
+++ b/libsrc/lib3d/isin.asm
@@ -1,72 +1,73 @@
 ;
-;	OZ-7xx DK emulation layer for Z88DK
-;	by Stefano Bodrato - Oct. 2003
+;    OZ-7xx DK emulation layer for Z88DK
+;    by Stefano Bodrato - Oct. 2003
 ;
-;	int isin(unsigned degrees);
-;	input must be between 0 and 360
-;	returns value from -255 to +255
-;
-; ------
-; $Id: isin.asm,v 1.3 2016-06-28 19:31:43 dom Exp $
+;    int isin(unsigned degrees) __z88dk_fastcall;
+;    input must be between 0 and 360
+;    returns value from -255 to +255
 ;
 
-        SECTION code_clib
-	PUBLIC	isin
-	PUBLIC	_isin
+
+    SECTION code_clib
+    PUBLIC  isin
+    PUBLIC  _isin
 
 
 isin:
 _isin:
-	; __FASTCALL__
-        ld      c,l
-        ld      b,h ;; save input
-        ld      de,181
-        or      a
-        sbc     hl,de
-        jr      c,DontFlip
-        ld      hl,360
-        sbc     hl,bc  ;; no carry here
-        ld      c,l
-        ld      b,h
-        ld      a,1
-        jr      Norm_0_180
+    ; __FASTCALL__
+    ld      c,l
+    ld      b,h ;; save input
+    ld      de,181
+    or      a
+    sbc     hl,de
+    jr      c,DontFlip
+    ld      hl,360
+    sbc     hl,bc  ;; no carry here
+    ld      c,l
+    ld      b,h
+    ld      a,1
+    jr      Norm_0_180
+
 DontFlip:
-        ld      l,c
-        ld      h,b
-        xor     a
+    ld      l,c
+    ld      h,b
+    xor     a
 Norm_0_180:
 ;; degrees normalized between 0 and 180 in hl and in bc
 ;; sign of output in a
-        ld      de,90
-        or      a
-        sbc     hl,de
-        jr      c,DontFlip2
-        ld      hl,180
-        sbc     hl,bc   ;; carry is 0 here
-        jr      Norm_0_90
+    ld      de,90
+    or      a
+    sbc     hl,de
+    jr      c,DontFlip2
+    ld      hl,180
+    sbc     hl,bc   ;; carry is 0 here
+    jr      Norm_0_90
+
 DontFlip2:
-        ld      l,c
-        ld      h,b
+    ld      l,c
+    ld      h,b
 Norm_0_90:
 ;; degrees normalized between 0 and 90 in hl and sign of answer is in a
-        ;add     hl,hl
-        ld      de,sin_table
-        add     hl,de
-        ld      e,(hl)
-        ;inc     hl
-        ;ld      d,(hl)
-        ld	d,0
+   ;add     hl,hl
+    ld      de,sin_table
+    add     hl,de
+    ld      e,(hl)
+   ;inc     hl
+   ;ld      d,(hl)
+    ld      d,0
 ;; de=answer
-        or      a
-        jr      z,DontNegate
-        ld      hl,0
-        sbc     hl,de   ;; carry is 0 here
-        ret
-DontNegate:
-        ex      de,hl
-        ret
+    or      a
+    jr      z,DontNegate
+    ld      hl,0
+    sbc     hl,de   ;; carry is 0 here
+    ret
 
-	SECTION rodata_clib
+DontNegate:
+    ex      de,hl
+    ret
+
+    SECTION rodata_clib
 sin_table:
 
 ;; Smaller table, generated with Excel; formula (Italian language):  =INT(SEN(RADIANTI(A1))*255,4)

--- a/libsrc/lib3d/lib3d.lst
+++ b/libsrc/lib3d/lib3d.lst
@@ -33,3 +33,17 @@ get_direction
 fwd
 turn_left
 turn_right
+dot_v
+mult_v
+scale_v
+unit_v
+identity_m
+mult_m
+rotx_m
+roty_m
+rotz_m
+scale_m
+shear_m
+translate_m
+projection_opengl_m
+projection_w3woody_m

--- a/libsrc/lib3d/mesh_delete.c
+++ b/libsrc/lib3d/mesh_delete.c
@@ -1,13 +1,13 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Create new mesh
-	
-	$Id: mesh_delete.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Create new mesh
+
+    $Id: mesh_delete.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
@@ -15,9 +15,9 @@
 #include <malloc.h>
 
 void mesh_delete(mesh_t* mesh) {
-	free(mesh->points);
-	free(mesh->triangles);
-	free(mesh);
+    free(mesh->points);
+    free(mesh->triangles);
+    free(mesh);
 }
 
 

--- a/libsrc/lib3d/mesh_new.c
+++ b/libsrc/lib3d/mesh_new.c
@@ -1,13 +1,13 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Create new mesh
-	
-	$Id: mesh_new.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Create new mesh
+
+    $Id: mesh_new.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
@@ -16,18 +16,18 @@
 
 
 /// allocates space for  c elements of type x
-#define newa(x, c)	((x*)malloc(sizeof(x) * c))
+#define newa(x, c)  ((x*)malloc(sizeof(x) * c))
 
 
 mesh_t* mesh_new(int pcount, int tcount) {
-	//mesh_t* r = new(mesh_t);
-	mesh_t* r;
-	
-	r = (mesh_t*)malloc(sizeof(mesh_t));
-	r->pcount = pcount;
-	r->tcount = tcount;
-	r->points = newa(vector_t, pcount);
-	r->triangles = newa(triangle_t, tcount);
-	return r;
+    //mesh_t* r = new(mesh_t);
+    mesh_t* r;
+    
+    r = (mesh_t*)malloc(sizeof(mesh_t));
+    r->pcount = pcount;
+    r->tcount = tcount;
+    r->points = newa(vector_t, pcount);
+    r->triangles = newa(triangle_t, tcount);
+    return r;
 }
 

--- a/libsrc/lib3d/mult_m.c
+++ b/libsrc/lib3d/mult_m.c
@@ -1,0 +1,74 @@
+/*
+ * mult_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Matrix Multiplication */
+void mult_m(matrix_t * multiplicand, matrix_t * multiplier)
+{
+    matrix_t result;
+
+    memset(&result, 0, sizeof(ELEMENT)*MATRIX_ORDER*MATRIX_ORDER);
+
+    for(uint8_t y = 0; y < MATRIX_ORDER; ++y) {
+        uint8_t col = y * MATRIX_ORDER;
+        for(uint8_t x = 0; x < MATRIX_ORDER; ++x) {
+            for(uint8_t i = 0; i < MATRIX_ORDER; ++i) {
+                result.e[col + x] += multiplicand->e[col + i] * multiplier->e[i * MATRIX_ORDER + x];
+            }
+        }
+    }
+
+    *multiplicand = result;
+}

--- a/libsrc/lib3d/mult_v.c
+++ b/libsrc/lib3d/mult_v.c
@@ -1,0 +1,67 @@
+/*
+ * mult_v.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Vector Matrix Multiplication */
+void mult_v(vector_t * vect, matrix_t * multiplier)
+{
+    vector_t result;
+
+    result.x = vect->x*multiplier->e[0] + vect->y*multiplier->e[4] + vect->z*multiplier->e[8 ] + vect->w*multiplier->e[12];
+    result.y = vect->x*multiplier->e[1] + vect->y*multiplier->e[5] + vect->z*multiplier->e[9 ] + vect->w*multiplier->e[13];
+    result.z = vect->x*multiplier->e[2] + vect->y*multiplier->e[6] + vect->z*multiplier->e[10] + vect->w*multiplier->e[14];
+    result.w = vect->x*multiplier->e[3] + vect->y*multiplier->e[7] + vect->z*multiplier->e[11] + vect->w*multiplier->e[15];
+
+    *vect = result;
+}

--- a/libsrc/lib3d/object_apply_transformations.c
+++ b/libsrc/lib3d/object_apply_transformations.c
@@ -6,7 +6,7 @@
 	Copyright (C) 2004  Rafael de Oliveira Jannone
 
 	Apply perspective transformations on object obj, centering the points around x and y
-	
+
 	$Id: object_apply_transformations.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 

--- a/libsrc/lib3d/object_render_flatshading.c
+++ b/libsrc/lib3d/object_render_flatshading.c
@@ -6,7 +6,7 @@
 	Copyright (C) 2004  Rafael de Oliveira Jannone
 
 	Render an object with flat-shading, requires a normalized source of light
-	
+
 	$Id: object_render_flatshading.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 

--- a/libsrc/lib3d/object_render_wireframe.c
+++ b/libsrc/lib3d/object_render_wireframe.c
@@ -6,7 +6,7 @@
 	Copyright (C) 2004  Rafael de Oliveira Jannone
 
 	Render an object with wireframes
-	
+
 	$Id: object_render_wireframe.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 

--- a/libsrc/lib3d/ozplotpoint.c
+++ b/libsrc/lib3d/ozplotpoint.c
@@ -11,13 +11,13 @@ Copyright© 2002, Mark Hamilton
 
 void ozplotpoint(Vector_t *v, Point_t *p)
 {
-	Vector_t temp;
+    Vector_t temp;
 
-	/* flip x and y to rotate points 90° */
-	temp.x = v->y;
-	temp.y = v->x;
-	temp.z = v->z + 256; /* add a large number so it doesn't look too big */
-	/* add perspective */
-	p->x = temp.x * 256 / temp.z;
-	p->y = temp.y * 256 / temp.z;
+    /* flip x and y to rotate points 90° */
+    temp.x = v->y;
+    temp.y = v->x;
+    temp.z = v->z + 256; /* add a large number so it doesn't look too big */
+    /* add perspective */
+    p->x = temp.x * 256 / temp.z;
+    p->y = temp.y * 256 / temp.z;
 }

--- a/libsrc/lib3d/ozplotpointcam.c
+++ b/libsrc/lib3d/ozplotpointcam.c
@@ -13,20 +13,20 @@ void ozplotpointcam(Vector_t *v, Cam_t *c, Point_t *p)
 {
     static Vector_t temp;
     static Vector_t offset;
-	temp.x = v->y;
-	temp.y = v->x;
-	temp.z = v->z + 256;
-	offset.x = -c->x;
-	offset.y = -c->y;
-	offset.z = -c->z;
-	ozrotatepointx(&temp, -c->pitch);
-	ozrotatepointy(&temp, -c->roll);
-	ozrotatepointz(&temp, -c->yaw);
-	oztranslatevector(&temp, &offset);
-	oztranslatevector(&temp, &offset);
-	oztranslatevector(&temp, &offset);
-	p->x = temp.x * 256 / temp.z;
-	p->y = temp.y * 256 / temp.z;
+    temp.x = v->y;
+    temp.y = v->x;
+    temp.z = v->z + 256;
+    offset.x = -c->x;
+    offset.y = -c->y;
+    offset.z = -c->z;
+    ozrotatepointx(&temp, -c->pitch);
+    ozrotatepointy(&temp, -c->roll);
+    ozrotatepointz(&temp, -c->yaw);
+    oztranslatevector(&temp, &offset);
+    oztranslatevector(&temp, &offset);
+    oztranslatevector(&temp, &offset);
+    p->x = temp.x * 256 / temp.z;
+    p->y = temp.y * 256 / temp.z;
 }
 
 

--- a/libsrc/lib3d/ozrotatepointx.c
+++ b/libsrc/lib3d/ozrotatepointx.c
@@ -12,8 +12,8 @@ Copyright© 2002, Mark Hamilton
 void ozrotatepointx(Vector_t *v, int rot)
 {
     static long y, z;
-	y = v->y;
-	z = v->z;
+    y = v->y;
+    z = v->z;
     v->y = div256(y * icos(rot) - z * isin(rot));
     v->z = div256(y * isin(rot) + z * icos(rot));
 }

--- a/libsrc/lib3d/ozrotatepointy.c
+++ b/libsrc/lib3d/ozrotatepointy.c
@@ -12,8 +12,8 @@ Copyright© 2002, Mark Hamilton
 void ozrotatepointy(Vector_t *v, int rot)
 {
     static long x, z;
-	x = v->x;
-	z = v->z;
+    x = v->x;
+    z = v->z;
     v->x = div256(x * icos(rot) - z * isin(rot));
     v->z = div256(x * isin(rot) + z * icos(rot));
 }

--- a/libsrc/lib3d/ozrotatepointz.c
+++ b/libsrc/lib3d/ozrotatepointz.c
@@ -12,8 +12,8 @@ Copyright© 2002, Mark Hamilton
 void ozrotatepointz(Vector_t *v, int rot)
 {
     static long x, y;
-	x = v->x;
-	y = v->y;
+    x = v->x;
+    y = v->y;
     v->x = div256(x * icos(rot) - y * isin(rot));
     v->y = div256(x * isin(rot) + y * icos(rot));
 }

--- a/libsrc/lib3d/oztranslatevector.c
+++ b/libsrc/lib3d/oztranslatevector.c
@@ -11,7 +11,7 @@ Copyright© 2002, Mark Hamilton
 
 void oztranslatevector(Vector_t *v, Vector_t *offset)
 {
-	v->x += offset->x;
-	v->y += offset->y;
-	v->z += offset->z;
+    v->x += offset->x;
+    v->y += offset->y;
+    v->z += offset->z;
 }

--- a/libsrc/lib3d/polygon.c
+++ b/libsrc/lib3d/polygon.c
@@ -3,10 +3,9 @@
 	Graphics functions requiring some of the LIB3D Extensions
 
 	polygon(cx, cy, corners, radius, startangle)
-	
+
 	Draw a polygon of a given no. of corners and a corner at a given angle (0..360).
-	
-	
+
 	$Id: polygon.c,v 1.1 2013-05-08 16:41:36 stefano Exp $
 */
 

--- a/libsrc/lib3d/projection_opengl_m.c
+++ b/libsrc/lib3d/projection_opengl_m.c
@@ -63,7 +63,7 @@ void projection_opengl_m(matrix_t * matrix, ELEMENT fov, ELEMENT aspect_ratio, E
     matrix->e[0]  =  aspect_ratio / f;
     matrix->e[5]  =  INV(f);
     matrix->e[10] = -(far + near) / (far - near);
-    matrix->e[11] = -1;
+    matrix->e[11] =  (ELEMENT)-1;
     matrix->e[14] = -(far * near) / ((far - near) * 2);
     matrix->e[15] =  0;
 }

--- a/libsrc/lib3d/projection_opengl_m.c
+++ b/libsrc/lib3d/projection_opengl_m.c
@@ -1,0 +1,69 @@
+/*
+ * projection_opengl_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Set up projection OpenGL */
+void projection_opengl_m(matrix_t * matrix, ELEMENT fov, ELEMENT aspect_ratio, ELEMENT near, ELEMENT far)
+{
+    ELEMENT f = TAN(fov / 2);
+
+    identity_m( matrix );
+
+    matrix->e[0]  =  aspect_ratio / f;
+    matrix->e[5]  =  INV(f);
+    matrix->e[10] = -(far + near) / (far - near);
+    matrix->e[11] = -1;
+    matrix->e[14] = -(far * near) / ((far - near) * 2);
+    matrix->e[15] =  0;
+}

--- a/libsrc/lib3d/projection_opengl_m.c
+++ b/libsrc/lib3d/projection_opengl_m.c
@@ -64,6 +64,6 @@ void projection_opengl_m(matrix_t * matrix, ELEMENT fov, ELEMENT aspect_ratio, E
     matrix->e[5]  =  INV(f);
     matrix->e[10] = -(far + near) / (far - near);
     matrix->e[11] =  (ELEMENT)-1;
-    matrix->e[14] = -(far * near) / ((far - near) * 2);
+    matrix->e[14] = -(far * near * (ELEMENT)2) / ((far - near));
     matrix->e[15] =  0;
 }

--- a/libsrc/lib3d/projection_w3woody_m.c
+++ b/libsrc/lib3d/projection_w3woody_m.c
@@ -68,7 +68,7 @@ void projection_w3woody_m(matrix_t * matrix, ELEMENT fov, ELEMENT aspect_ratio, 
     matrix->e[0]  =  aspect_ratio / f;
     matrix->e[5]  =  INV(f);
     matrix->e[10] =  0;
-    matrix->e[11] = -1;
+    matrix->e[11] =  (ELEMENT)-1;
     matrix->e[14] = -near;
     matrix->e[15] =  0;
 }

--- a/libsrc/lib3d/projection_w3woody_m.c
+++ b/libsrc/lib3d/projection_w3woody_m.c
@@ -1,0 +1,74 @@
+/*
+ * projection_w3woody_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * Goodbye Far Clipping Plane.
+ * https://chaosinmotion.com/2010/09/06/goodbye-far-clipping-plane/
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Set up Projection W3Woody */
+void projection_w3woody_m(matrix_t * matrix, ELEMENT fov, ELEMENT aspect_ratio, ELEMENT near, ELEMENT far)
+{
+    (void)far;      // unused here, so avoid compiler warning
+
+    ELEMENT f = TAN(fov / 2);
+
+    identity_m( matrix );
+
+    matrix->e[0]  =  aspect_ratio / f;
+    matrix->e[5]  =  INV(f);
+    matrix->e[10] =  0;
+    matrix->e[11] = -1;
+    matrix->e[14] = -near;
+    matrix->e[15] =  0;
+}

--- a/libsrc/lib3d/rotx_m.c
+++ b/libsrc/lib3d/rotx_m.c
@@ -1,0 +1,72 @@
+/*
+ * rotx_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Rotation in x dimension */
+void rotx_m(matrix_t * matrix, ELEMENT angle)
+{
+    matrix_t rotx;
+
+    ELEMENT cos_angle = COS(angle);
+    ELEMENT sin_angle = SIN(angle);
+
+    identity_m( &rotx );
+
+    rotx.e[5]  =  cos_angle;
+    rotx.e[6]  = -sin_angle;
+    rotx.e[9]  =  sin_angle;
+    rotx.e[10] =  cos_angle;
+
+    mult_m( matrix, &rotx );
+}

--- a/libsrc/lib3d/roty_m.c
+++ b/libsrc/lib3d/roty_m.c
@@ -1,0 +1,72 @@
+/*
+ * roty_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Rotation in y dimension */
+void roty_m(matrix_t * matrix, ELEMENT angle)
+{
+    matrix_t roty;
+
+    ELEMENT cos_angle = COS(angle);
+    ELEMENT sin_angle = SIN(angle);
+
+    identity_m( &roty );
+
+    roty.e[0]  =  cos_angle;
+    roty.e[2]  =  sin_angle;
+    roty.e[8]  = -sin_angle;
+    roty.e[10] =  cos_angle;
+
+    mult_m( matrix, &roty );
+}

--- a/libsrc/lib3d/rotz_m.c
+++ b/libsrc/lib3d/rotz_m.c
@@ -1,0 +1,72 @@
+/*
+ * rotz_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Rotation in z dimension */
+void rotz_m(matrix_t * matrix, ELEMENT angle)
+{
+    matrix_t rotz;
+
+    ELEMENT cos_angle = COS(angle);
+    ELEMENT sin_angle = SIN(angle);
+
+    identity_m( &rotz );
+
+    rotz.e[0]  =  cos_angle;
+    rotz.e[1]  = -sin_angle;
+    rotz.e[4]  =  sin_angle;
+    rotz.e[5]  =  cos_angle;
+
+    mult_m( matrix, &rotz );
+}

--- a/libsrc/lib3d/scale_m.c
+++ b/libsrc/lib3d/scale_m.c
@@ -1,0 +1,67 @@
+/*
+ * scale_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Produce a transformation (scale) matrix */
+void scale_m(matrix_t * matrix, ELEMENT x, ELEMENT y, ELEMENT z)
+{
+    matrix_t scale;
+
+    identity_m( &scale );
+
+    scale.e[0] = x;
+    scale.e[5] = y;
+    scale.e[10] = z;
+
+    mult_m( matrix, &scale );
+}

--- a/libsrc/lib3d/scale_v.c
+++ b/libsrc/lib3d/scale_v.c
@@ -1,0 +1,61 @@
+/*
+ * scale_v.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Scale a vector, but don't touch w dimension */
+void scale_v(vector_t * vect, ELEMENT scale)
+{
+    vect->x *= scale;
+    vect->y *= scale;
+    vect->z *= scale;
+}

--- a/libsrc/lib3d/set_direction.asm
+++ b/libsrc/lib3d/set_direction.asm
@@ -2,22 +2,21 @@
 ;       Turtle graphics library
 ;       Stefano - 11/2017
 ;
-;       $Id: set_direction.asm $
-;
 
-        SECTION   code_clib
-        PUBLIC    set_direction
-        PUBLIC    _set_direction
+    SECTION code_clib
+    PUBLIC  set_direction
+    PUBLIC  _set_direction
 
 .set_direction
 ._set_direction
-	; __FASTCALL
-	ld	(__direction),hl
-	ret
+    ; __FASTCALL
+    ld      (__direction),hl
+    ret
 
-	
-		SECTION		bss_clib
-		PUBLIC		__direction
 
-__direction:	defw		0
+    SECTION bss_clib
+    PUBLIC  __direction
+
+.__direction
+    defw        0
 

--- a/libsrc/lib3d/shear_m.c
+++ b/libsrc/lib3d/shear_m.c
@@ -1,0 +1,75 @@
+/*
+ * shear_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Produce a transformation (shear) matrix */
+void shear_m(matrix_t * matrix, ELEMENT x, ELEMENT y, ELEMENT z)
+{
+    matrix_t shear;
+
+    ELEMENT invx = INV(x);
+    ELEMENT invy = INV(y);
+    ELEMENT invz = INV(z);
+
+    identity_m( &shear );
+
+    shear.e[1] = y*invx;
+    shear.e[2] = z*invx;
+    shear.e[4] = x*invy;
+    shear.e[6] = z*invy;
+    shear.e[8] = x*invz;
+    shear.e[9] = y*invz;
+
+    mult_m( matrix, &shear );
+}

--- a/libsrc/lib3d/stencil_add_ellipse.c
+++ b/libsrc/lib3d/stencil_add_ellipse.c
@@ -4,11 +4,10 @@
 	* stencil version
 
 	stencil_add_ellipse( cx,  cy,  startangle,  endangle,  xradius,  yradius, stencil)
-	
+
 	Draw an ellipse arc delimited by 'startangle' and 'endangle',
 	specified in degrees.
-	
-	
+
 	$Id: stencil_add_ellipse.c,v 1.2 2013-10-09 06:10:34 stefano Exp $
 */
 

--- a/libsrc/lib3d/stencil_add_polygon.c
+++ b/libsrc/lib3d/stencil_add_polygon.c
@@ -4,10 +4,9 @@
 	* stencil version
 
 	stencil_add_polygon(cx, cy, corners, radius, startangle,stencil)
-	
+
 	Add a regular polygon of a given no. of corners and a corner at a given angle (0..360).
-	
-	
+
 	$Id: stencil_add_polygon.c,v 1.1 2013-05-15 06:45:47 stefano Exp $
 */
 

--- a/libsrc/lib3d/translate_m.c
+++ b/libsrc/lib3d/translate_m.c
@@ -1,0 +1,67 @@
+/*
+ * translate_m.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Produce a transformation (translation) */
+void translate_m(matrix_t * matrix, ELEMENT x, ELEMENT y, ELEMENT z)
+{
+    matrix_t translation;
+
+    identity_m( &translation );
+
+    translation.e[12] = x;
+    translation.e[13] = y;
+    translation.e[14] = z;
+
+    mult_m( matrix, &translation );
+}

--- a/libsrc/lib3d/turn_left.asm
+++ b/libsrc/lib3d/turn_left.asm
@@ -2,24 +2,24 @@
 ;       Turtle graphics library
 ;       Stefano - 11/2017
 ;
-;       $Id: turn_left.asm $
-;
 
-        SECTION   code_clib
-        PUBLIC    turn_left
-        PUBLIC    _turn_left
-        EXTERN __direction
+    SECTION code_clib
+    PUBLIC  turn_left
+    PUBLIC  _turn_left
+
+    EXTERN  __direction
 
 .turn_left
 ._turn_left
-	; __FASTCALL
-	ld	de,(__direction)
-	ex	de,hl
-	and	a
-	sbc	hl,de
-	ld	(__direction),hl
-	ret	nc
-	ld	de,360
-	add	hl,de
-	ld	(__direction),hl
-	ret
+    ; __FASTCALL
+    ld      de,(__direction)
+    ex      de,hl
+    and     a
+    sbc     hl,de
+    ld      (__direction),hl
+    ret     nc
+
+    ld      de,360
+    add     hl,de
+    ld      (__direction),hl
+    ret

--- a/libsrc/lib3d/turn_right.asm
+++ b/libsrc/lib3d/turn_right.asm
@@ -2,25 +2,24 @@
 ;       Turtle graphics library
 ;       Stefano - 11/2017
 ;
-;       $Id: turn_right.asm $
-;
 
-        SECTION   code_clib
-        PUBLIC    turn_right
-        PUBLIC    _turn_right
-        EXTERN __direction
+    SECTION code_clib
+    PUBLIC  turn_right
+    PUBLIC  _turn_right
+
+    EXTERN  __direction
 
 .turn_right
 ._turn_right
-	; __FASTCALL
-	ld	de,(__direction)
-	ex	de,hl
-	add	hl,de
-	ld	(__direction),hl
-	and	a
-	ld	de,360
-	sbc	hl,de
-	ret	c
-	
-	ld	(__direction),hl
-	ret
+    ; __FASTCALL
+    ld      de,(__direction)
+    ex      de,hl
+    add     hl,de
+    ld      (__direction),hl
+    and     a
+    ld      de,360
+    sbc     hl,de
+    ret     c
+
+    ld      (__direction),hl
+    ret

--- a/libsrc/lib3d/unit_v.c
+++ b/libsrc/lib3d/unit_v.c
@@ -1,0 +1,65 @@
+/*
+ * unit_v.c
+ *
+ * Copyright (c) 2022 Phillip Stevens
+ * Create Time: October 2022
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted,free of charge,to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),to deal
+ * in the Software without restriction,including without limitation the rights
+ * to use,copy,modify,merge,publish,distribute,sublicense,and/or sell
+ * copies of the Software,and to permit persons to whom the Software is
+ * furnished to do so,subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS",WITHOUT WARRANTY OF ANY KIND,EXPRESS OR
+ * IMPLIED,INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,DAMAGES OR OTHER
+ * LIABILITY,WHETHER IN AN ACTION OF CONTRACT,TORT OR OTHERWISE,ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 3D homogeneous coordinate definition
+ * https://en.wikipedia.org/wiki/Homogeneous_coordinates
+ *
+ * project 3D coords onto 2D screen:
+ * https://stackoverflow.com/questions/724219/how-to-convert-a-3d-point-into-2d-perspective-projection
+ *
+ * transformation matrix:
+ * https://www.tutorialspoint.com/computer_graphics/3d_transformation.htm
+ *
+ */
+
+/****************************************************************************/
+/***        Include files                                                 ***/
+/****************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <lib3d.h>
+
+
+/****************************************************************************/
+/***       Function                                                       ***/
+/****************************************************************************/
+
+
+/* Produce a unit vector */
+void unit_v(vector_t * vect)
+{
+    ELEMENT inv_magnitude = INVSQRT( SQR(vect->x) + SQR(vect->y) + SQR(vect->z) );
+
+    vect->x *= inv_magnitude;
+    vect->y *= inv_magnitude;
+    vect->z *= inv_magnitude;
+    vect->w  = (ELEMENT)1;
+}

--- a/libsrc/lib3d/unit_v.c
+++ b/libsrc/lib3d/unit_v.c
@@ -56,10 +56,10 @@
 /* Produce a unit vector */
 void unit_v(vector_t * vect)
 {
-    ELEMENT inv_magnitude = INVSQRT( SQR(vect->x) + SQR(vect->y) + SQR(vect->z) );
+    ELEMENT magnitude = SQRT( SQR(vect->x) + SQR(vect->y) + SQR(vect->z) );
 
-    vect->x *= inv_magnitude;
-    vect->y *= inv_magnitude;
-    vect->z *= inv_magnitude;
+    vect->x /= magnitude;
+    vect->y /= magnitude;
+    vect->z /= magnitude;
     vect->w  = (ELEMENT)1;
 }

--- a/libsrc/lib3d/vector_add.c
+++ b/libsrc/lib3d/vector_add.c
@@ -1,13 +1,13 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	add vector v1 with v2, result in r
-	
-	$Id: vector_add.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    add vector v1 with v2, result in r
+
+    $Id: vector_add.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
@@ -15,7 +15,7 @@
 
 
 void vector_add(vector_t *v1, vector_t *v2, vector_t *r) {
-	r->x = v1->x + v2->x;
-	r->y = v1->y + v2->y;
-	r->z = v1->z + v2->z;
+    r->x = v1->x + v2->x;
+    r->y = v1->y + v2->y;
+    r->z = v1->z + v2->z;
 }

--- a/libsrc/lib3d/vector_cross_product.c
+++ b/libsrc/lib3d/vector_cross_product.c
@@ -1,26 +1,23 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Cross product of v1 by v2, result into r
-	
-	$Id: vector_cross_product.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Cross product of v1 by v2, result into r
+
+    $Id: vector_cross_product.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
 
 void vector_cross_product (vector_t* v1, vector_t* v2, vector_t* r) {
-	int x, y, z;
-	x = mulfx(v1->y, v2->z) - mulfx(v1->z, v2->y);
-	y = mulfx(v1->z, v2->x) - mulfx(v1->x, v2->z);
-	z = mulfx(v1->x, v2->y) - mulfx(v1->y, v2->x);
-	//x = (v1->y * v2->z) - (v1->z * v2->y);
-	//y = (v1->z * v2->x) - (v1->x * v2->z);
-	//z = (v1->x * v2->y) - (v1->y * v2->x);
-	r->x = x; r->y = y; r->z = z;
+    ELEMENT x, y, z;
+    x = (v1->y * v2->z) - (v1->z * v2->y);
+    y = (v1->z * v2->x) - (v1->x * v2->z);
+    z = (v1->x * v2->y) - (v1->y * v2->x);
+    r->x = x; r->y = y; r->z = z;
 }
 

--- a/libsrc/lib3d/vector_cross_product_z.c
+++ b/libsrc/lib3d/vector_cross_product_z.c
@@ -1,19 +1,18 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Cross product of the z axis of v1 by v2
-	
-	$Id: vector_cross_product_z.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Cross product of the z axis of v1 by v2
+
+    $Id: vector_cross_product_z.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
 
 int vector_cross_product_z (vector_t* v1, vector_t* v2) {
-	//return ((v1->x * v2->y) - (v1->y * v2->x));
-	return mulfx(v1->x, v2->y) - mulfx(v1->y, v2->x);
+    return ((v1->x * v2->y) - (v1->y * v2->x));
 }

--- a/libsrc/lib3d/vector_distance.c
+++ b/libsrc/lib3d/vector_distance.c
@@ -1,20 +1,20 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	distance between vectors v1 and v2
-	
-	$Id: vector_distance.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    distance between vectors v1 and v2
+
+    $Id: vector_distance.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
 
 int vector_distance (vector_t *v1, vector_t *v2) {
-	vector_t r;
-	vector_subtract(v1, v2, &r);
-	return vector_length(&r);
+    vector_t r;
+    vector_subtract(v1, v2, &r);
+    return vector_length(&r);
 }

--- a/libsrc/lib3d/vector_dot_product.c
+++ b/libsrc/lib3d/vector_dot_product.c
@@ -1,13 +1,13 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Dot product of v1 by v2
-	
-	$Id: vector_dot_product.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Dot product of v1 by v2
+
+    $Id: vector_dot_product.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
@@ -15,6 +15,5 @@
 
 
 int vector_dot_product (vector_t* v1, vector_t* v2) {
-	//return (v1->x * v2->x + v1->y * v2->y + v1->z * v2->z);
-	return mulfx(v1->x, v2->x) + mulfx(v1->y, v2->y) + mulfx(v1->z, v2->z);
+    return (v1->x * v2->x + v1->y * v2->y + v1->z * v2->z);
 }

--- a/libsrc/lib3d/vector_length.c
+++ b/libsrc/lib3d/vector_length.c
@@ -1,19 +1,18 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Create new mesh
-	
-	$Id: vector_length.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Length of vector v, result in r
+
+    $Id: vector_length.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
-#include <math.h>
 
 int vector_length(vector_t *v) {
-	return sqrtfx(sqrfx(v->x) + sqrfx(v->y) + sqrfx(v->z));
+    return isqrt((v->x * v->x) + (v->y * v->y) + (v->z * v->z));
 }

--- a/libsrc/lib3d/vector_normalize.c
+++ b/libsrc/lib3d/vector_normalize.c
@@ -1,26 +1,23 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Normalize vector p, result in r
-	
-	$Id: vector_normalize.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Normalize vector p, result in r
+
+    $Id: vector_normalize.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
 
 void vector_normalize(vector_t *p, vector_t *r) {
-	int d = vector_length(p);
-	if (d != 0) {
-		//r->x = p->x / d;
-		//r->y = p->y / d;
-		//r->z = p->z / d;
-		r->x = divfx(p->x, d);
-		r->y = divfx(p->y, d);
-		r->z = divfx(p->z, d);
-	}
+    int d = vector_length(p);
+    if (d != 0) {
+        r->x = p->x / d;
+        r->y = p->y / d;
+        r->z = p->z / d;
+    }
 }

--- a/libsrc/lib3d/vector_rotate.c
+++ b/libsrc/lib3d/vector_rotate.c
@@ -1,23 +1,21 @@
 /*
 
-	Lib3D Extension, based on the OZ DK and:
+    Lib3D Extension, based on the OZ DK and:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Rotate vector p by the given angles, result in r
-	
-	$Id: vector_rotate.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Rotate vector p by the given angles, result in r
+
+    $Id: vector_rotate.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
 
 void vector_rotate(vector_t* p, int angle_x, int angle_y, int angle_z, vector_t* r) {
-
-ozcopyvector (r,p);
-ozrotatepointz (r,angle_z);
-ozrotatepointy (r,angle_y);
-ozrotatepointx (r,angle_x);
-
+    ozcopyvector (r,p);
+    ozrotatepointz (r,angle_z);
+    ozrotatepointy (r,angle_y);
+    ozrotatepointx (r,angle_x);
 }

--- a/libsrc/lib3d/vector_scalar.c
+++ b/libsrc/lib3d/vector_scalar.c
@@ -1,20 +1,20 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	/// scale vector v by s, result in r
-	
-	$Id: vector_scalar.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Scale vector v by s, result in r
+
+    $Id: vector_scalar.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
 #include <lib3d.h>
 
 void vector_scalar(vector_t *v, int s, vector_t* r) {
-	r->x = mulfx(v->x, s);
-	r->y = mulfx(v->y, s);
-	r->z = mulfx(v->z, s);
+    r->x = v->x * s;
+    r->y = v->y * s;
+    r->z = v->z * s;
 }

--- a/libsrc/lib3d/vector_subtract.c
+++ b/libsrc/lib3d/vector_subtract.c
@@ -1,13 +1,13 @@
 /*
 
-	Lib3D Extension, imported from:
+    Lib3D Extension, imported from:
 
-	GFX - a small graphics library 
-	Copyright (C) 2004  Rafael de Oliveira Jannone
+    GFX - a small graphics library 
+    Copyright (C) 2004  Rafael de Oliveira Jannone
 
-	Subtract vector v1 by v2, result in r
-	
-	$Id: vector_subtract.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
+    Subtract vector v1 by v2, result in r
+
+    $Id: vector_subtract.c,v 1.1 2009-04-10 12:47:42 stefano Exp $
 */
 
 
@@ -15,7 +15,7 @@
 
 
 void vector_subtract(vector_t *v1, vector_t *v2, vector_t *r) {
-	r->x = v1->x - v2->x;
-	r->y = v1->y - v2->y;
-	r->z = v1->z - v2->z;
+    r->x = v1->x - v2->x;
+    r->y = v1->y - v2->y;
+    r->z = v1->z - v2->z;
 }


### PR DESCRIPTION
Add homogeneous coordinate matrix operations.
For #2099

Still need to update the Makefile to build the library with floating maths point at some stage.

The new vector and matrix operations won't work properly with fixed point maths, but this won't affect the previous functions' performance.

### Vector 4d functions

- unit_v
- dot_v
- mult_v
- scale_v

### Matrix 4d functions

- identity_m
- mult_m
- rotx_m
- roty_m
- rotz_m
- scale_m
- shear_m
- translate_m
- projection_opengl_m
- projection_w3woody_m
