### PR TITLE
change the order of z1013 joysticks

### DIFF
--- a/libsrc/target/z1013/games/joystick.asm
+++ b/libsrc/target/z1013/games/joystick.asm
@@ -10,10 +10,10 @@ EXTERN getk
 joystick:
 _joystick:
     ld      a,l
-    ld      c,$20
+    ld      c,$40
     cp      1
     jr      z,read_stick
-    ld      c,$40
+    ld      c,$20
     cp      2
     jr      z,read_stick
     cp      3


### PR DESCRIPTION
This pull request changes the order of the joystick of target z1013. 

Please look at the picture:
![z1023Joystik-2](https://user-images.githubusercontent.com/9704038/197858738-cde1c2ce-59b4-4e90-8d42-4a51042ce24a.png)
The input of joystick 1 goes to joystick 2.


The code at http://z1013.mrboot.de/software-database/db/5591df18d0d6145646e91d54f4d0637a-joystick_demo/index.html says `0x20` is for joystick 2 and `0x40` is for joystick 1

>__asm__("ld a,#0x20"); //select JOYSTICK 2
> ...
> __asm__("ld a,#0x40"); //select JOYSTICK 1
