### PR TITLE
Add inp/outp for the 8080

### DIFF
--- a/libsrc/Make.config
+++ b/libsrc/Make.config
@@ -16,9 +16,9 @@ OUTPUT_DIRECTORY :=  $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 NEWLIB_DIRECTORY := $(subst //,/,$(OUTPUT_DIRECTORY)/_DEVELOPMENT/)
 
 LIBLINKER = z88dk-z80asm -d -I$(ZCCCFG)/../
-ASSEMBLER = z88dk-z80asm 
+ASSEMBLER = z88dk-z80asm
 CFLAGS = -O2 -vn -c
-AFLAGS = 
+AFLAGS =
 
 Q ?= @
 ZCC := $(Q)zcc

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -1830,6 +1830,8 @@ rc2014-8085_clib.lib:
 	m4 -DCFG_ASM_DEF _DEVELOPMENT/target/rc2014/config_8085.m4 > _DEVELOPMENT/target/rc2014/config_rc2014-8085_private.inc
 	m4 -DCFG_ASM_PUB _DEVELOPMENT/target/rc2014/config_8085.m4 > _DEVELOPMENT/target/rc2014/config_rc2014-8085_public.inc
 	m4 -DCFG_C_DEF _DEVELOPMENT/target/rc2014/config_8085.m4 > _DEVELOPMENT/target/rc2014/config_rc2014-8085.h
+	$(RM) _DEVELOPMENT/target/rc2014/driver/ide/asm/*.o
+	$(RM) _DEVELOPMENT/target/rc2014/driver/diskio/8085/*.o
 	$(call buildgeneric,rc2014,portable)
 	TARGET=rc2014 TYPE=8085 $(LIBLINKER) -DSTANDARDESCAPECHARS -m8085 -DFORrc2014 -x$(OUTPUT_DIRECTORY)/rc2014-8085_clib @$(TARGET_DIRECTORY)/rc2014/rc2014-8085.lst
 

--- a/libsrc/stdlib/8080/inp.asm
+++ b/libsrc/stdlib/8080/inp.asm
@@ -1,0 +1,28 @@
+; uchar __FASTCALL__ inp(uint port)
+;
+; 8080 version originally written in 1982 by William C. Colley III
+
+IF __CPU_INTEL__
+
+SECTION code_clib
+PUBLIC inp
+PUBLIC _inp
+
+EXTERN iotmp
+
+.inp
+._inp
+
+   ; port in l
+   ld h,l         ; port
+   ld l,0xdb      ; in
+   shld iotmp
+   lxi h,iotmp + 2
+   ld (hl),0xc9   ; ret
+   call iotmp
+   ld h,0
+   ld l,a         ; return byte in hl
+   ret
+
+ENDIF
+

--- a/libsrc/stdlib/8080/inp.asm
+++ b/libsrc/stdlib/8080/inp.asm
@@ -16,8 +16,8 @@ EXTERN iotmp
    ; port in l
    ld h,l         ; port
    ld l,0xdb      ; in
-   shld iotmp
-   lxi h,iotmp + 2
+   ld (iotmp),hl
+   ld hl,iotmp+2
    ld (hl),0xc9   ; ret
    call iotmp
    ld h,0

--- a/libsrc/stdlib/8080/iotmp.asm
+++ b/libsrc/stdlib/8080/iotmp.asm
@@ -1,0 +1,11 @@
+; Allocates space for inp/outp
+
+IF __CPU_INTEL__
+
+SECTION bss_clib
+
+PUBLIC iotmp
+.iotmp   defs  3
+
+ENDIF
+

--- a/libsrc/stdlib/8080/outp.asm
+++ b/libsrc/stdlib/8080/outp.asm
@@ -1,0 +1,23 @@
+; CALLER linkage for function pointers
+
+IF __CPU_INTEL__
+
+SECTION code_clib
+PUBLIC outp
+PUBLIC _outp
+EXTERN asm_outp
+
+.outp
+._outp
+
+   pop af
+   pop de
+   pop bc
+   push bc
+   push de
+   push af
+   
+   jp asm_outp
+
+ENDIF
+

--- a/libsrc/stdlib/8080/outp.asm
+++ b/libsrc/stdlib/8080/outp.asm
@@ -10,12 +10,12 @@ EXTERN asm_outp
 .outp
 ._outp
 
-   pop af
+   pop hl
    pop de
    pop bc
    push bc
    push de
-   push af
+   push hl
    
    jp asm_outp
 

--- a/libsrc/stdlib/8080/outp_callee.asm
+++ b/libsrc/stdlib/8080/outp_callee.asm
@@ -1,0 +1,38 @@
+; void outp_callee(uint port, uchar byte)
+;
+; 8080 version originally written in 1982 by William C. Colley III
+
+IF __CPU_INTEL__
+
+SECTION code_clib
+PUBLIC outp_callee
+PUBLIC _outp_callee
+PUBLIC asm_outp
+
+EXTERN iotmp
+
+.outp_callee
+._outp_callee
+
+   pop hl
+   pop de
+   pop bc
+   push hl
+
+.asm_outp
+
+   ; bc = port
+   ; e = byte
+
+
+   ld l,0xd3  ; out
+   ld h,c     ; port
+   ld (iotmp),hl
+   ld hl,iotmp + 2
+   ld (hl),0xc9  ;ret
+   ld a,e        ; byte
+   jp iotmp
+   ret
+
+ENDIF
+

--- a/libsrc/stdlib/Makefile
+++ b/libsrc/stdlib/Makefile
@@ -10,7 +10,7 @@ include ../Make.config
 
 GENOBJECTS = unbcd.o wcmatch.o getopt.o
 ASMFILES = $(wildcard *.asm)
-ASMFILES_8080 = $(filter-out $(wildcard *sqrt*.asm *inp*.asm *outp*.asm *extract*.asm *sort_s*.asm) , $(wildcard *.asm)) $(wildcard 8080/*.asm)
+ASMFILES_8080 = $(filter-out $(wildcard *sqrt*.asm *extract*.asm *sort_s*.asm) , $(wildcard *.asm)) $(wildcard 8080/*.asm)
 ASMFILES_GBZ80 = $(filter-out $(wildcard *sqrt*.asm *inp*.asm *outp*.asm *extract*.asm *sort_s*.asm) , $(wildcard *.asm)) $(wildcard 8080/*.asm)
 
 

--- a/libsrc/stdlib/Makefile
+++ b/libsrc/stdlib/Makefile
@@ -10,7 +10,7 @@ include ../Make.config
 
 GENOBJECTS = unbcd.o wcmatch.o getopt.o
 ASMFILES = $(wildcard *.asm)
-ASMFILES_8080 = $(filter-out $(wildcard *sqrt*.asm *extract*.asm *sort_s*.asm) , $(wildcard *.asm)) $(wildcard 8080/*.asm)
+ASMFILES_8080 = $(filter-out $(wildcard *sqrt*.asm *inp*.asm *outp*.asm *extract*.asm *sort_s*.asm) , $(wildcard *.asm)) $(wildcard 8080/*.asm)
 ASMFILES_GBZ80 = $(filter-out $(wildcard *sqrt*.asm *inp*.asm *outp*.asm *extract*.asm *sort_s*.asm) , $(wildcard *.asm)) $(wildcard 8080/*.asm)
 
 
@@ -77,7 +77,7 @@ obj/zxn/%.o: %.c
 
 
 dirs:
-	@mkdir -p obj/z80 obj/z80n obj/ixiy obj/r2k obj/gbz80 -p obj/$(TARGET) obj/newlib-8080 obj/8080 obj/8080/8080 obj/gbz80 obj/gbz80/8080
+	@mkdir -p obj/z80 obj/z80n obj/ixiy obj/r2k obj/gbz80 obj/$(TARGET) obj/newlib-8080 obj/8080 obj/8080/8080 obj/gbz80 obj/gbz80/8080
 
 
 clean:

--- a/libsrc/stdlib/bpoke.asm
+++ b/libsrc/stdlib/bpoke.asm
@@ -8,12 +8,12 @@ EXTERN asm_bpoke
 .bpoke
 ._bpoke
 
-   pop af
+   pop bc
    pop de
    pop hl
    push hl
    push de
-   push af
+   push bc
    
    jp asm_bpoke
 

--- a/libsrc/stdlib/inp.asm
+++ b/libsrc/stdlib/inp.asm
@@ -1,7 +1,5 @@
 ; uchar __FASTCALL__ inp(uint port)
 ; 09.2005 aralbrec
-;
-; 8080 version originally written in 1982 by William C. Colley III
 
 SECTION code_clib
 PUBLIC inp
@@ -17,18 +15,6 @@ IF __CPU_R2KA__|__CPU_R3K__
    ld h,0
    ld l,a
 
-ELIF __CPU_INTEL__
-
-   ; port in l
-   ld h,l         ; port
-   ld l,0xdb      ; in
-   shld _iotmp
-   lxi h,_iotmp + 2
-   ld (hl),0xc9   ; ret
-   call _iotmp
-   ld h,0
-   ld l,a         ; return byte in hl
-
 ELSE
 
    ld c,l
@@ -39,7 +25,3 @@ ELSE
 ENDIF
 
    ret
-
-SECTION bss_clib
-
-._iotmp   defs  3

--- a/libsrc/stdlib/inp.asm
+++ b/libsrc/stdlib/inp.asm
@@ -1,5 +1,7 @@
 ; uchar __FASTCALL__ inp(uint port)
 ; 09.2005 aralbrec
+;
+; 8080 version originally written in 1982 by William C. Colley III
 
 SECTION code_clib
 PUBLIC inp
@@ -15,6 +17,18 @@ IF __CPU_R2KA__|__CPU_R3K__
    ld h,0
    ld l,a
 
+ELIF __CPU_8080__
+
+   ; port in l
+   ld h,l         ; port
+   ld l,0xdb      ; in
+   shld _iotmp
+   lxi h,_iotmp + 2
+   ld (hl),0xc9   ; ret
+   call _iotmp
+   ld h,0
+   ld l,a         ; return byte in hl
+
 ELSE
 
    ld c,l
@@ -25,3 +39,7 @@ ELSE
 ENDIF
 
    ret
+
+SECTION bss_clib
+
+._iotmp   defs  3

--- a/libsrc/stdlib/inp.asm
+++ b/libsrc/stdlib/inp.asm
@@ -17,7 +17,7 @@ IF __CPU_R2KA__|__CPU_R3K__
    ld h,0
    ld l,a
 
-ELIF __CPU_8080__
+ELIF __CPU_INTEL__
 
    ; port in l
    ld h,l         ; port

--- a/libsrc/stdlib/outp.asm
+++ b/libsrc/stdlib/outp.asm
@@ -8,11 +8,12 @@ EXTERN asm_outp
 .outp
 ._outp
 
-   pop af
+   pop bc
    pop de
    pop bc
    push bc
    push de
-   push af
+   push bc
    
    jp asm_outp
+

--- a/libsrc/stdlib/outp.asm
+++ b/libsrc/stdlib/outp.asm
@@ -8,12 +8,12 @@ EXTERN asm_outp
 .outp
 ._outp
 
-   pop bc
+   pop hl
    pop de
    pop bc
    push bc
    push de
-   push bc
+   push hl
    
    jp asm_outp
 

--- a/libsrc/stdlib/outp_callee.asm
+++ b/libsrc/stdlib/outp_callee.asm
@@ -1,5 +1,7 @@
 ; void outp_callee(uint port, uchar byte)
 ; 09.2005 aralbrec
+;
+; 8080 version originally written in 1982 by William C. Colley III
 
 SECTION code_clib
 PUBLIC outp_callee
@@ -9,10 +11,10 @@ PUBLIC asm_outp
 .outp_callee
 ._outp_callee
 
-   pop af
+   pop hl
    pop de
    pop bc
-   push af
+   push hl
 
 .asm_outp
 
@@ -27,6 +29,16 @@ IF __CPU_R2KA__|__CPU_R3K__
    defb 0d3h ; ioi
    ld (hl),a
 
+ELIF __CPU_8080__
+
+   ld l,0xd3  ; out
+   ld h,c     ; port
+   shld _iotmp
+   lxi h,_iotmp + 2
+   ld (hl),0xc9  ;ret
+   ld a,e        ; byte
+   jp _iotmp
+
 ELSE
 
    out (c),e
@@ -34,3 +46,7 @@ ELSE
 ENDIF
 
    ret
+
+SECTION bss_clib
+
+._iotmp   defs  3

--- a/libsrc/stdlib/outp_callee.asm
+++ b/libsrc/stdlib/outp_callee.asm
@@ -1,7 +1,5 @@
 ; void outp_callee(uint port, uchar byte)
 ; 09.2005 aralbrec
-;
-; 8080 version originally written in 1982 by William C. Colley III
 
 SECTION code_clib
 PUBLIC outp_callee
@@ -29,16 +27,6 @@ IF __CPU_R2KA__|__CPU_R3K__
    defb 0d3h ; ioi
    ld (hl),a
 
-ELIF __CPU_INTEL__
-
-   ld l,0xd3  ; out
-   ld h,c     ; port
-   shld _iotmp
-   lxi h,_iotmp + 2
-   ld (hl),0xc9  ;ret
-   ld a,e        ; byte
-   jp _iotmp
-
 ELSE
 
    out (c),e
@@ -47,6 +35,3 @@ ENDIF
 
    ret
 
-SECTION bss_clib
-
-._iotmp   defs  3

--- a/libsrc/stdlib/outp_callee.asm
+++ b/libsrc/stdlib/outp_callee.asm
@@ -29,7 +29,7 @@ IF __CPU_R2KA__|__CPU_R3K__
    defb 0d3h ; ioi
    ld (hl),a
 
-ELIF __CPU_8080__
+ELIF __CPU_INTEL__
 
    ld l,0xd3  ; out
    ld h,c     ; port

--- a/libsrc/stdlib/wpoke.asm
+++ b/libsrc/stdlib/wpoke.asm
@@ -8,12 +8,12 @@ EXTERN asm_wpoke
 .wpoke
 ._wpoke
 
-   pop af
+   pop bc
    pop de
    pop hl
    push hl
    push de
-   push af
+   push bc
    
    jp asm_wpoke
 


### PR DESCRIPTION
Uses the same technique as AZTEC C which is to dynamically write the subroutine into reserved data memory and call/jump to it.  This should allow the code to remain ROMable.

While here, change outp_callee to use hl instead of af for stack juggling. af was sending the program off into lala land.