### PR TITLE
switch from FNKBDS to FNKBDZ

### DIFF
--- a/libsrc/target/kc/stdio/fgetc_cons.asm
+++ b/libsrc/target/kc/stdio/fgetc_cons.asm
@@ -18,7 +18,7 @@
 .fgetc_cons
 ._fgetc_cons
 .nokey  call    PV1
-        defb    FNKBDS
+        defb    FNKBDZ
         jr      NC,nokey
 IF STANDARDESCAPECHARS
 	cp	13

--- a/libsrc/target/kc/stdio/generic_console.asm
+++ b/libsrc/target/kc/stdio/generic_console.asm
@@ -348,7 +348,7 @@ not_udg:
 	ld	l,a
 	call	print_half
 
-	; And now colour (again only KC82/2)
+	; And now colour (again only KC85/2)
 	pop	bc
 
 	call	cxypos


### PR DESCRIPTION
Currently gets() returns many chars for one keypress. 

The function FNKBDZ acknowledges the the key and prevent duplicate chars.