### PR TITLE
updates to getting started guide to match changed executable filenames

### DIFF
--- a/doc/ZXSpectrumZSDCCnewlib_01_GettingStarted.md
+++ b/doc/ZXSpectrumZSDCCnewlib_01_GettingStarted.md
@@ -70,16 +70,16 @@ these commands should produce something similar to the output given:
   <pages and pages of help and options snipped>
 ```
 ```
-  >zsdcc -v
+  >z88dk-zsdcc -v
   ZSDCC IS A MODIFICATION OF SDCC FOR Z88DK
-  Build: 3.6.6 #9921 (Linux) Jun  2 2017
+  Build: 4.2.0 #13131 (Linux) Jan  5 2023
 ```
 ```
   >z80asm
   Z80 Module Assembler 2.8.5, (c) InterLogic 1993-2009, Paulo Custodio 2011-2017
 ```
 ```
-  >appmake 
+  >z88dk-appmake 
   appmake [+target] [options]
   
   The z88dk application generator
@@ -248,9 +248,9 @@ which together make up the entire sdcc_iy library. Any of those files can supply
 code for a zsdcc compiled program. The important one for Spectrum programmers is
 zx.lib. That library file is full of optimised Z80 machine code routines which
 provide the sorts of features Spectrum programs need. If you're interested you
-can inspect the contents of the library with the z80nm command:
+can inspect the contents of the library with the z88dk-z80nm command:
 ```
->z80nm zx.lib | less
+>z88dk-z80nm zx.lib | less
 ```
 Do a search and you'll find the zx_border() function listed in there.
 

--- a/doc/ZXSpectrumZSDCCnewlib_07_BiFrost.md
+++ b/doc/ZXSpectrumZSDCCnewlib_07_BiFrost.md
@@ -9,7 +9,7 @@ This document covers the BiFrost library which provides multicolour graphics
 support for Spectrum programs. Although this might be considered a rather niche
 topic, the discussion also covers other aspects of Z88DK which will be referred
 to in future installments. We introduce separately loaded libraries and the
-BASIC loader required to load them, more advanced appmake usage, and a
+BASIC loader required to load them, more advanced z88dk-appmake usage, and a
 makefile. The reader is encouraged to read the document even if they have no
 particular interest in BiFrost.
 
@@ -299,33 +299,33 @@ created. In previous examples we've used zcc's -create-app option to do this
 step, but since we're now working with multiple code files which are beyond
 zcc's remit we need to do it manually.
 
-The command to convert a binary machine code file to a .TAP file is _appmake_
+The command to convert a binary machine code file to a .TAP file is _z88dk-appmake_
 and for our piece of code we build a command as follows.
 
 Our target machine, as ever, will be a ZX Spectrum:
 
 ```
-appmake +zx ...
+z88dk-appmake +zx ...
 ```
 
 Our binary input file is bifrost_01_CODE.bin:
 
 ```
-appmake +zx -b bifrost_01_CODE.bin ...
+z88dk-appmake +zx -b bifrost_01_CODE.bin ...
 ```
 
 and the output file will be bifrost_01_code.tap:
 
 ```
-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap ...
+z88dk-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap ...
 ```
 
-By default the appmake utility produces a little BASIC loader program to load
+By default the z88dk-appmake utility produces a little BASIC loader program to load
 machine code. In this case we've already written our own, so we need to suppress
 that:
 
 ```
-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader ...
+z88dk-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader ...
 ```
 
 Next we need to specify where the piece of code will be LOADed. This value goes
@@ -335,13 +335,13 @@ the code. By default Z88DK compiled code expects to load and run from address
 32768, so:
 
 ```
-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 ...
+z88dk-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 ...
 ```
 
 Finally we need to provide a name for the block of CODE on the tape:
 
 ```
-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 --blockname bifrost_01_code
+z88dk-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 --blockname bifrost_01_code
 ```
 
 We have to create two pieces of tape loadable code for our BiFrost project, the
@@ -349,8 +349,8 @@ second containing the BiFrost code which expects to load and run from address
 58625. So the two commands to create the .TAP files are:
 
 ```
-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 --blockname bifrost_01_code
-appmake +zx -b bifrost_01_BIFROSTL.bin -o bifrostl.tap --noloader --org 58625 --blockname bifrostl
+z88dk-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 --blockname bifrost_01_code
+z88dk-appmake +zx -b bifrost_01_BIFROSTL.bin -o bifrostl.tap --noloader --org 58625 --blockname bifrostl
 ```
 
 Finally, we need to merge our 3 tape files into a single one. The .TAP format is
@@ -370,8 +370,8 @@ bifrost_01_CODE.bin: bifrost_01.c ctile.asm coloured_ball.ctile
 	zcc +zx -vn -startup=31 -clib=sdcc_iy bifrost_01.c ctile.asm -o bifrost_01
 
 bifrost_01_code.tap: bifrost_01_CODE.bin
-	appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 --blockname bifrost_01_code
-	appmake +zx -b bifrost_01_BIFROSTL.bin -o bifrostl.tap --noloader --org 58625 --blockname bifrostl
+	z88dk-appmake +zx -b bifrost_01_CODE.bin -o bifrost_01_code.tap --noloader --org 32768 --blockname bifrost_01_code
+	z88dk-appmake +zx -b bifrost_01_BIFROSTL.bin -o bifrostl.tap --noloader --org 58625 --blockname bifrostl
 
 bifrost_01.tap: bifrost_01_code.tap
 	cat bifrost_loader.tap bifrost_01_code.tap bifrostl.tap > bifrost_01.tap
@@ -547,8 +547,8 @@ bifrost_02_CODE.bin: bifrost_02.c ctile.asm coloured_ball.ctile
 	zcc +zx -vn -startup=31 -clib=sdcc_iy bifrost_02.c ctile.asm -o bifrost_02
 
 bifrost_02_code.tap: bifrost_02_CODE.bin
-	appmake +zx -b bifrost_02_CODE.bin -o bifrost_02_code.tap --noloader --org 32768 --blockname bifrost_02_code
-	appmake +zx -b bifrost_02_BIFROSTH.bin -o bifrosth.tap --noloader --org 57047 --blockname bifrosth
+	z88dk-appmake +zx -b bifrost_02_CODE.bin -o bifrost_02_code.tap --noloader --org 32768 --blockname bifrost_02_code
+	z88dk-appmake +zx -b bifrost_02_BIFROSTH.bin -o bifrosth.tap --noloader --org 57047 --blockname bifrosth
 
 bifrost_02.tap: bifrost_02_code.tap
 	cat bifrost_loader.tap bifrost_02_code.tap bifrosth.tap > bifrost_02.tap
@@ -683,20 +683,20 @@ different approach for building. Use these commands to build the example:
 
 ```
 zcc +zx -vn -m -startup=31 -clib=sdcc_iy bifrost_03.c ctile.asm -o bifrost_03
-appmake +glue -b bifrost_03 --filler 0 --clean
-appmake +zx -b bifrost_03__.bin --org 32768 --blockname bifrost_03 -o bifrost_03.tap
+z88dk-appmake +glue -b bifrost_03 --filler 0 --clean
+z88dk-appmake +zx -b bifrost_03__.bin --org 32768 --blockname bifrost_03 -o bifrost_03.tap
 ```
 
 The -m option to zcc causes it to output a _map_ file. The map is a text file
 containing the addresses of all the symbols the compiler encountered in generating its
 output. You can use it to find the location of main(), BiFrost, the tile
 buffers, etc., which can be useful when working with a disassembler, debugger or
-memory monitor. In this build, the first run of appmake uses the +glue target
+memory monitor. In this build, the first run of z88dk-appmake uses the +glue target
 and (by implication) the map file to generate a single binary file containing the C
 program and the BiFrost*2 library. It _glues_ the two binary pieces together,
 filling the hole between them with zeroes. This negates the need for the BASIC
 loader we've used throughout the examples, which loads two pieces of CODE. The
-second call to appmake takes this one large binary file and wraps a standard
+second call to z88dk-appmake takes this one large binary file and wraps a standard
 BASIC loader around it.
 
 The +glue approach is much less fussy than building the two separate binary

--- a/doc/ZXSpectrumZSDCCnewlib_08_Interrupts.md
+++ b/doc/ZXSpectrumZSDCCnewlib_08_Interrupts.md
@@ -497,7 +497,7 @@ why this guide has focused so heavily on understanding the memory layout.
 
 If you find yourself uncertain as to how to proceed with a particular scenario,
 or are getting occasional or strange, sudden crashes, consider raising the
-issue on the Z88DK [ZX support forum](https://www.z88dk.org/forum/viewforum.php?id=2).
+issue on the Z88DK [ZX support forum](https://www.z88dk.org/forum/viewforum.php?f=2).
 
 ### Conclusion
 

--- a/doc/ZXSpectrumZSDCCnewlib_GettingStartedGuide.md
+++ b/doc/ZXSpectrumZSDCCnewlib_GettingStartedGuide.md
@@ -33,16 +33,17 @@ an excellent basis for Spectrum games written with Z88DK:
 
 
 These documents are a work in progress. Comments and suggestions are welcome in
-the [Z88DK Sinclair ZX forum](https://www.z88dk.org/forum/viewforum.php?id=2).
+the [Z88DK Sinclair ZX forum](https://www.z88dk.org/forum/viewforum.php?f=2).
 
 
 | Further Reading | Covers        |
 | --------------- | ------------- |
 | [The author's Github project](https://github.com/derekfountain/z88dk-zxspectrum-examples) | Example code from this guide with pre-compiled TAP files and occasionally some further work and extensions. |
-| [Wonky One Key](https://github.com/derekfountain/zxwonkyonekey) | A game written by the author of this guide, uses lots of the techniques covered. |
+| [Wonky One Key](https://github.com/derekfountain/zxwonkyonekey) | An SP1-based game written by the author of this guide, uses lots of the techniques covered. |
+| [The Virus](https://github.com/derekfountain/the-virus) | Another game written by the author of this guide. |
 | [Jordi Sesmero's SP1 Tutorial](https://github.com/jsmolina/z88dk-tutorial-sp1) | Another tutorial on using the SP1 library, covers more topics than this guide albeit in less detail. Contains a nice [Pacman](https://spectrumcomputing.co.uk/forums/viewtopic.php?p=30569) example. |
 | [Antonio Mateus's SP1 Examples](https://github.com/antoniocmateus) | A selection of SP1 examples, including a nice [Breakout clone](https://github.com/antoniocmateus/z88dk_sp1_breakout) which uses tiles. |
 
 And of course, the [Programming Forum](https://spectrumcomputing.co.uk/forums/viewforum.php?f=6) at [Spectrum Computing](https://spectrumcomputing.co.uk/), where many of the best Spectrum developers are always ready to discuss everything to do with programming the ZX Spectrum.
 
-[Derek Fountain](http://www.derekfountain.org/), March, 2021
+[Derek Fountain](http://www.derekfountain.org/), January, 2023

--- a/doc/ZXSpectrumZSDCCnewlib_SP1_01_GettingStarted.md
+++ b/doc/ZXSpectrumZSDCCnewlib_SP1_01_GettingStarted.md
@@ -194,7 +194,7 @@ standard C library, as described
 On Linux you can confirm this with a command such as:
 
 ```
->z80nm $ZCCCFG/../../libsrc/_DEVELOPMENT/lib/sdcc_iy/zx.lib | less
+>z88dk-z80nm $ZCCCFG/../../libsrc/_DEVELOPMENT/lib/sdcc_iy/zx.lib | less
 ```
 
 and search for 'sp1' in the output.


### PR DESCRIPTION
Simple updates to the ZX getting started guide to reflect the changes in filenames of various tools and executables.