### PR TITLE
Fix GDB TCP connection on Windows 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ win32/ipch/
 win32/z88dk.VC.VC.opendb
 win32/z88dk.VC.db
 zsdcc_*_src.tar.gz
+.ticks_history.txt

--- a/src/ticks/Makefile
+++ b/src/ticks/Makefile
@@ -24,7 +24,7 @@ endif
 all: z88dk-ticks$(EXESUFFIX) z88dk-dis$(EXESUFFIX) z88dk-gdb$(EXESUFFIX)
 
 z88dk-ticks$(EXESUFFIX):	$(OBJS) $(LEXOBJS)
-	$(CC) -o $@ $(CFLAGS) $(OBJS) $(LEXOBJS) $(LDFLAGS)
+	$(CC) -o $@ $(CFLAGS) $(OBJS) $(LEXOBJS) $(LDFLAGS) $(GDBLDFLAGS)
 
 z88dk-gdb$(EXESUFFIX):	$(GDBOBJS) $(LEXOBJS)
 	$(CC) -o $@ $(CFLAGS) $(GDBOBJS) $(LEXOBJS) $(LDFLAGS) $(GDBLDFLAGS)

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -13,6 +13,10 @@
 #include <stdarg.h>
 #endif
 
+#ifdef _MSC_VER
+#include <WinSock2.h>
+#endif
+
 #include "debugger.h"
 #include "utlist.h"
 
@@ -220,6 +224,14 @@ void ctrl_c_handler(int signum) {
 }
 
 void debugger_init() {
+#ifdef _WIN32
+			struct WSAData wsa;
+			int ret = WSAStartup(MAKEWORD(2, 2), &wsa);
+			if (ret) {
+				bk.debug("Socket initialization error: %d\n", ret);
+			}
+#endif
+
     signal(SIGINT, ctrl_c_handler);
     linenoiseSetCompletionCallback(completion, NULL);
     linenoiseHistoryLoad(HISTORY_FILE); /* Load the history at startup */

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -5,7 +5,7 @@
 #include <ctype.h>
 #include <signal.h>
 #ifdef WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #include <io.h>
 #define F_OK 0
 #define access _access

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -5,16 +5,13 @@
 #include <ctype.h>
 #include <signal.h>
 #ifdef WIN32
+#include <WinSock2.h>
 #include <io.h>
 #define F_OK 0
 #define access _access
 #else
 #include <unistd.h>                         // For declarations of isatty()
 #include <stdarg.h>
-#endif
-
-#ifdef _MSC_VER
-#include <WinSock2.h>
 #endif
 
 #include "debugger.h"
@@ -1101,7 +1098,7 @@ static int parse_number(char *str, char **end)
     if ( *str == '$' ) {
         base = 16;
         str++;
-    } 
+    }
     return strtol(str, end, base);
 }
 
@@ -1148,7 +1145,7 @@ static int cmd_stack(int argc, char **argv)
 }
 
 
-/* Parse an address operand. 
+/* Parse an address operand.
  *
  * It may be one of:
  * 1. A number address
@@ -1181,7 +1178,7 @@ const char *resolve_to_label(int addr)
 {
     static char tbuf[1024];
     const char *sym;
-    
+
     if ( (sym = find_symbol(addr, SYM_ADDRESS) ) != NULL ) {
         return sym;
     }
@@ -1248,7 +1245,7 @@ static int cmd_disassemble(int argc, char **argv)
 
 
 
-static int cmd_registers(int argc, char **argv) 
+static int cmd_registers(int argc, char **argv)
 {
     bk.invalidate();
     const unsigned short pc = bk.pc();
@@ -1331,7 +1328,7 @@ static int cmd_watch(int argc, char **argv)
                 bk.console("%d:\t(read) @$%04x (%s) %s\n",i, elem->value,resolve_to_label(elem->value), elem->enabled ? "" : " (disabled)");
             } else if ( elem->type == BREAK_WRITE) {
                 bk.console("%d:\t(write) @$%04x (%s) %s\n",i, elem->value,resolve_to_label(elem->value), elem->enabled ? "" : " (disabled)");
-            } 
+            }
             i++;
         }
 
@@ -1371,7 +1368,7 @@ static int cmd_watch(int argc, char **argv)
         } else {
             bk.console("Unknown watchpoint\n");
         }
-    } 
+    }
     return 0;
 }
 
@@ -1559,7 +1556,7 @@ static int cmd_examine(int argc, char **argv)
         uint8_t b = bk.get_memory(addr);
         abuf[i % 16] = isprint(b) ? ((char) b) : '.';   // Prepare end of dump in ASCII format
 
-        if ( i % 16 == 0 ) {                            // Handle line prefix 
+        if ( i % 16 == 0 ) {                            // Handle line prefix
             if (interact_with_tty) {
                 bk.console(FNT_CLR"%04X"FNT_RST":   ", addr);
             } else {
@@ -1844,7 +1841,7 @@ static int cmd_list(int argc, char **argv)
         return 0;
     }
     srcfile_display(filename, lineno - 5, 10, lineno);
-    
+
     return 0;
 }
 

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -937,6 +937,12 @@ static uint8_t is_gdbserver_connected()
 static uint8_t connect_to_gdbserver(const char* connect_host, int connect_port)
 {
     connection_socket = socket(AF_INET, SOCK_STREAM, 0);
+#ifdef _WIN32
+	if (connection_socket == SOCKET_ERROR) {
+		bk.debug("Socket error: %d\n", WSAGetLastError());
+		return 1;
+	}
+#endif
 
     struct sockaddr_in servaddr;
     memset(&servaddr, 0, sizeof(servaddr));

--- a/src/ticks/debugger_gdb_packets.c
+++ b/src/ticks/debugger_gdb_packets.c
@@ -70,7 +70,7 @@ int read_data_once(sock_t sockfd)
     ssize_t nread;
     uint8_t buf[4096];
 
-    nread = read(sockfd, buf, sizeof(buf));
+    nread = recv(sockfd, buf, sizeof(buf), 0);
     if (nread <= 0)
     {
         return -1;
@@ -86,7 +86,7 @@ void write_flush(sock_t sockfd)
     while (write_index < out.end)
     {
         ssize_t nwritten;
-        nwritten = write(sockfd, out.buf + write_index, out.end - write_index);
+        nwritten = send(sockfd, out.buf + write_index, out.end - write_index, 0);
         if (nwritten < 0)
         {
             printf("Write error\n");

--- a/win32/ticks/ticks.vcxproj
+++ b/win32/ticks/ticks.vcxproj
@@ -94,6 +94,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+	  <AdditionalDependencies>ws2_32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -108,6 +109,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+	  <AdditionalDependencies>ws2_32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -126,6 +128,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+	  <AdditionalDependencies>ws2_32.lib</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>copy /y $(OutDir)$(TargetName)$(TargetExt) ..\..\bin\$(TargetName)$(TargetExt)</Command>
@@ -153,6 +156,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+	  <AdditionalDependencies>ws2_32.lib</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>copy /y $(OutDir)$(TargetName)$(TargetExt) ..\..\bin\$(TargetName)$(TargetExt)</Command>


### PR DESCRIPTION
On Windows we need to initialize WinSock and use the correct send/recv functions instead of read/write