### PR TITLE
MI2 backslashes

### DIFF
--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -42,16 +42,35 @@ static int demangle_filename(const char *input, char *filename, char *funcname, 
     *funcname = 0;
 
     // Full packed format
+#ifdef WIN32
+	// Match path with drive letter in it
+    if ( sscanf(input,"%c:%[^:]::%[^:]::%d::%d:%d",filename,&filename[2], funcname, level, scope, lineno) == 6) {
+		filename[1] = ':';
+        return 0;
+    }
+#endif
     if ( sscanf(input,"%[^:]::%[^:]::%d::%d:%d",filename,funcname, level, scope, lineno) == 5 ) {
         return 0;
     }
 
     // Classic in function format: adv_a.c::CHKAWAY:2206
+#ifdef WIN32
+    if ( sscanf(input,"%c:%[^:]::%[^:]:%d",filename,&filename[2],funcname, lineno) == 4 ) {
+		filename[1] = ':';
+        return 0;
+    }
+#endif
     if ( sscanf(input,"%[^:]::%[^:]:%d",filename,funcname, lineno) == 3 ) {
         return 0;
     }
 
     // Just a waypoint file:line
+#ifdef WIN32
+    if ( sscanf(input,"%c:%[^:]:%d",filename,&filename[2], lineno) == 3) {
+		filename[1] = ':';
+        return 0;
+    }
+#endif
     if ( sscanf(input,"%[^:]:%d",filename,lineno) == 2 ) {
         return 0;
     }

--- a/src/ticks/syms.c
+++ b/src/ticks/syms.c
@@ -180,7 +180,13 @@ void read_symbol_file(char *filename)
 
                 {
                     char fname[FILENAME_MAX];
-                    if (sscanf(argv[9], "%[^:]", fname) == 1) {
+#ifdef WIN32
+					if (sscanf(argv[9], "%c:%[^:]", fname, &fname[2]) == 2) {
+						fname[1] = ':';
+						sym->file = strdup(fname);
+					} else
+#endif
+					if (sscanf(argv[9], "%[^:]", fname) == 1) {
                         sym->file = strdup(fname);
                     } else {
                         sym->file = NULL;


### PR DESCRIPTION
The MI2 interpreter doesn't escape backslashes in the response which, you guessed it, causes problems with Windows. Now all filenames are escaped. Also fixed another colon scan problem in the symbols.

This PR is based on #2153 because I needed the fixes in there to debug further.