### PR TITLE
BIFROST*2 interface improvement

### DIFF
--- a/include/_DEVELOPMENT/clang/arch/zx/bifrost2.h
+++ b/include/_DEVELOPMENT/clang/arch/zx/bifrost2.h
@@ -194,7 +194,9 @@ extern void BIFROST2_resetAnim4Frames(void);
 #define COL2PY_RIGHT(col)       ((col)>>1)
 
 // ----------------------------------------------------------------
-// Instantly draw a multicolor tile at the specified screen position
+// Instantly draw a multicolor tile at the specified screen position.
+// Adding value BIFROST2STATIC (or not) to tile index won't make any
+// difference since it will be drawn only once.
 //
 // Parameters:
 //     lin: pixel line (0-192)

--- a/include/_DEVELOPMENT/proto/arch/zx/bifrost2.h
+++ b/include/_DEVELOPMENT/proto/arch/zx/bifrost2.h
@@ -174,7 +174,9 @@ __OPROTO(`b,c,d,e',`b,c,d,e',void,,BIFROST2_resetAnim4Frames,void)
 #define COL2PY_RIGHT(col)       ((col)>>1)
 
 // ----------------------------------------------------------------
-// Instantly draw a multicolor tile at the specified screen position
+// Instantly draw a multicolor tile at the specified screen position.
+// Adding value BIFROST2STATIC (or not) to tile index won't make any
+// difference since it will be drawn only once.
 //
 // Parameters:
 //     lin: pixel line (0-192)

--- a/include/_DEVELOPMENT/sccz80/arch/zx/bifrost2.h
+++ b/include/_DEVELOPMENT/sccz80/arch/zx/bifrost2.h
@@ -200,7 +200,9 @@ extern void __LIB__ BIFROST2_resetAnim4Frames(void) __smallc;
 #define COL2PY_RIGHT(col)       ((col)>>1)
 
 // ----------------------------------------------------------------
-// Instantly draw a multicolor tile at the specified screen position
+// Instantly draw a multicolor tile at the specified screen position.
+// Adding value BIFROST2STATIC (or not) to tile index won't make any
+// difference since it will be drawn only once.
 //
 // Parameters:
 //     lin: pixel line (0-192)

--- a/include/_DEVELOPMENT/sdcc/arch/zx/bifrost2.h
+++ b/include/_DEVELOPMENT/sdcc/arch/zx/bifrost2.h
@@ -197,7 +197,9 @@ extern void BIFROST2_resetAnim4Frames(void) __preserves_regs(b,c,d,e);
 #define COL2PY_RIGHT(col)       ((col)>>1)
 
 // ----------------------------------------------------------------
-// Instantly draw a multicolor tile at the specified screen position
+// Instantly draw a multicolor tile at the specified screen position.
+// Adding value BIFROST2STATIC (or not) to tile index won't make any
+// difference since it will be drawn only once.
 //
 // Parameters:
 //     lin: pixel line (0-192)

--- a/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sccz80/BIFROST2_drawTileH.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sccz80/BIFROST2_drawTileH.asm
@@ -18,6 +18,7 @@ BIFROST2_drawTileH:
    	ld hl,2
    	add hl,sp
    	ld a,(hl)       ; A=tile
+   	and 127         ; discard BIFROST2STATIC
    	inc hl
    	inc hl
    	ld e,(hl)       ; E=col
@@ -25,4 +26,4 @@ BIFROST2_drawTileH:
    	inc hl
    	ld d,(hl)       ; D=lin
 
-    jp asm_BIFROST2_drawTileH        ; execute 'draw_tile'
+   	jp asm_BIFROST2_drawTileH        ; execute 'draw_tile'

--- a/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sccz80/BIFROST2_drawTileH_callee.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sccz80/BIFROST2_drawTileH_callee.asm
@@ -22,5 +22,6 @@ BIFROST2_drawTileH_callee:
         ex (sp),hl      ; L=lin
         ld d,l          ; D=lin
         ld a,c          ; A=tile
-        
+       	and 127         ; discard BIFROST2STATIC
+
         jp asm_BIFROST2_drawTileH        ; execute 'draw_tile'

--- a/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sdcc/BIFROST2_drawTileH.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sdcc/BIFROST2_drawTileH.asm
@@ -15,12 +15,13 @@ EXTERN asm_BIFROST2_drawTileH
 
 _BIFROST2_drawTileH:
 
-   ld hl,2
+	ld hl,2
 	add hl,sp
 	ld d,(hl)       ; D = lin
 	inc hl
 	ld e,(hl)       ; E = col
 	inc hl
 	ld a,(hl)       ; A = tile
-	
+   	and 127         ; discard BIFROST2STATIC
+
 	jp asm_BIFROST2_drawTileH

--- a/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sdcc/BIFROST2_drawTileH_callee.asm
+++ b/libsrc/_DEVELOPMENT/arch/zx/bifrost2/c/sdcc/BIFROST2_drawTileH_callee.asm
@@ -16,11 +16,12 @@ EXTERN asm_BIFROST2_drawTileH
 
 _BIFROST2_drawTileH_callee:
 
-   pop hl
+	pop hl
 	dec sp
 	pop de          ; D = lin
 	ex (sp),hl
 	ld e,l          ; E = col
 	ld a,h          ; A = tile
+	and 127         ; discard BIFROST2STATIC
 
-   jp asm_BIFROST2_drawTileH
+	jp asm_BIFROST2_drawTileH


### PR DESCRIPTION
It was too confusing that certain functions must be called adding value BIFROST2STATIC to tile index but not others. Now BIFROST2drawTileH will ignore the BIFROST2STATIC flag so it won't matter anymore if value BIFROST2STATIC was added or not. For further details see:

https://spectrumcomputing.co.uk/forums/viewtopic.php?p=109323#p109323