### PR TITLE
sccz80: l_gcharX, l_gintX, l_gintXsp optimisations

### DIFF
--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -6837,3 +6837,87 @@ $notcpu 8085
 	ld	hl,%1
 	%3c	(hl)
 	ld	hl,%2
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+	inc	hl
+	inc	hl
+	inc	hl
+	call	l_gint	;
+=
+	call	l_gint3	;
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+	inc	hl
+	inc	hl
+	call	l_gint	;
+=
+	call	l_gint2	;
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+	inc	hl
+	call	l_gint	;
+=
+	call	l_gint1	;
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+%check 4 <= %1 <= 8
+	ld	bc,%1
+	add	hl,bc
+	call	l_gint	;
+=
+	call	l_gint%1	;
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+%check 1 <= %1 <= 8
+	ld	hl,%1	;const
+	add	hl,sp
+	call	l_gint	;
+=
+	call	l_gint%1sp	;
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+	inc	hl
+	inc	hl
+	inc	hl
+	call	l_gchar
+=
+	call	l_gchar3
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+	inc	hl
+	inc	hl
+	call	l_gchar
+=
+	call	l_gchar2
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+	inc	hl
+	call	l_gchar
+=
+	call	l_gchar1
+
+%notcpu 8085
+%notcpu r2ka
+%notcpu r3k
+%check 4 <= %1 <= 8
+	ld	bc,%1
+	add	hl,bc
+	call	l_gchar
+=
+	call	l_gchar%1

--- a/src/z80asm/t/issue_0341.t
+++ b/src/z80asm/t/issue_0341.t
@@ -39,17 +39,17 @@ spew("${test}1.map", @map);
 check_text_file("${test}1.map", <<END);
 __C_LINE_0_${test_expanded}_2ec = \$0000 ; addr, local, , ${test}_c, , ${test}.c:0
 __C_LINE_1_${test_expanded}_2ec = \$0000 ; addr, local, , ${test}_c, , ${test}.c:1
-__C_LINE_2_${test_expanded}_2ec_3a_3aadd_3a_3a0_3a_3a0 = \$016E ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::0::0:2
-__C_LINE_3_${test_expanded}_2ec_3a_3aadd_3a_3a1_3a_3a1 = \$016E ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::1::1:3
-__C_LINE_6_${test_expanded}_2ec_3a_3aadd_3a_3a0_3a_3a1 = \$017B ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::0::1:6
-__C_LINE_7_${test_expanded}_2ec_3a_3amain_3a_3a0_3a_3a2 = \$017B ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::0::2:7
-__C_LINE_8_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$017B ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:8
-__C_LINE_9_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$017F ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:9
-__C_LINE_10_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0183 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:10
-__C_LINE_11_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0183 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:11
+__C_LINE_2_${test_expanded}_2ec_3a_3aadd_3a_3a0_3a_3a0 = \$0180 ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::0::0:2
+__C_LINE_3_${test_expanded}_2ec_3a_3aadd_3a_3a1_3a_3a1 = \$0180 ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::1::1:3
+__C_LINE_6_${test_expanded}_2ec_3a_3aadd_3a_3a0_3a_3a1 = \$018C ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::0::1:6
+__C_LINE_7_${test_expanded}_2ec_3a_3amain_3a_3a0_3a_3a2 = \$018C ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::0::2:7
+__C_LINE_8_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$018C ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:8
+__C_LINE_9_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0190 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:9
+__C_LINE_10_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0194 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:10
+__C_LINE_11_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0194 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:11
 __ASM_LINE_2_${test_expanded}1_2easm = \$0000 ; addr, local, , ${test}1_asm, , ${test}1.asm:2
-_add                            = \$016E ; addr, public, , ${test}_c, code_compiler, ${test}.c::add::0::0:2
-_main                           = \$017B ; addr, public, , ${test}_c, code_compiler, ${test}.c::main::0::2:7
+_add                            = \$0180 ; addr, public, , ${test}_c, code_compiler, ${test}.c::add::0::0:2
+_main                           = \$018C ; addr, public, , ${test}_c, code_compiler, ${test}.c::main::0::2:7
 func                            = \$0000 ; addr, public, , ${test}1_asm, , ${test}1.asm:2
 END
 

--- a/testsuite/l_gint_const.c
+++ b/testsuite/l_gint_const.c
@@ -1,0 +1,34 @@
+struct v
+{
+    char a;
+    char b;
+    char c;
+    char d;
+    char e;
+    char f;
+};
+
+struct v2
+{
+    int a;
+    int b;
+    int c;
+    int d;
+    int e;
+    int f;
+};
+
+void check1(int a, int b, int c, int d)
+{
+    return a * 2 + b * 3 + c * 4 + d * 5;
+}
+
+void check_gchar(struct v* vv)
+{
+    int a = vv->a + vv->b + vv->c + vv->d + vv->e + vv->f;
+}
+
+void check_gint(struct v2* vv)
+{
+    int a = vv->a + vv->b + vv->c + vv->d + vv->e + vv->f;
+}

--- a/testsuite/results/Issue_1015_break_with_loop_variable.opt
+++ b/testsuite/results/Issue_1015_break_with_loop_variable.opt
@@ -29,12 +29,9 @@
 	jp	nc,i_3	;
 	push	bc
 	push	bc
-	ld	hl,4	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,5
+	call	l_gint4sp	;
+	ld	de,5
+	ex	de,hl
 	call	l_ge
 	jp	nc,i_5	;
 	pop	bc
@@ -43,9 +40,7 @@
 .i_5
 	ld	hl,i_1+0
 	push	hl
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	ld	a,2
 	call	printf

--- a/testsuite/results/Issue_1015_break_without_loop_variable.opt
+++ b/testsuite/results/Issue_1015_break_without_loop_variable.opt
@@ -29,12 +29,9 @@
 	jp	nc,i_3	;
 	push	bc
 	push	bc
-	ld	hl,4	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,5
+	call	l_gint4sp	;
+	ld	de,5
+	ex	de,hl
 	call	l_ge
 	jp	nc,i_5	;
 	pop	bc
@@ -43,9 +40,7 @@
 .i_5
 	ld	hl,i_1+0
 	push	hl
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	ld	a,2
 	call	printf

--- a/testsuite/results/Issue_1105_function_pointer_calls.opt
+++ b/testsuite/results/Issue_1105_function_pointer_calls.opt
@@ -13,9 +13,7 @@
 	push	hl
 	ld	hl,6	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	ld	a,3
 	call	printf
@@ -64,9 +62,7 @@
 ._s_regular
 	ld	hl,65535	;const
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	call	_placeholder
 	pop	bc
@@ -97,9 +93,7 @@
 ._is_regular
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	call	_placeholder
 	pop	bc

--- a/testsuite/results/Issue_1167_choosing_which_function.opt
+++ b/testsuite/results/Issue_1167_choosing_which_function.opt
@@ -22,9 +22,7 @@
 	ld	hl,_func2
 .i_3
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	ex	(sp),hl
 	call	l_jphl
 	pop	bc

--- a/testsuite/results/Issue_1178_kr_main_stdc.opt
+++ b/testsuite/results/Issue_1178_kr_main_stdc.opt
@@ -16,12 +16,8 @@
 	push	hl
 	call	_func
 	pop	bc
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
-	inc	hl
-	inc	hl
-	call	l_gint	;
+	call	l_gint4sp	;
+	call	l_gint2	;
 	push	hl
 	call	_func2
 	pop	bc
@@ -30,9 +26,7 @@
 
 
 ._func3
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	call	_func
 	pop	bc
@@ -40,9 +34,7 @@
 	pop	hl
 	push	hl
 	push	bc
-	inc	hl
-	inc	hl
-	call	l_gint	;
+	call	l_gint2	;
 	push	hl
 	call	_func2
 	pop	bc

--- a/testsuite/results/Issue_1212_double_promotion.opt
+++ b/testsuite/results/Issue_1212_double_promotion.opt
@@ -68,9 +68,7 @@
 	push	hl
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	ld	a,3
 	call	printf
@@ -140,9 +138,7 @@
 	push	hl
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	ld	a,3
 	call	printf

--- a/testsuite/results/Issue_1260_com.opt
+++ b/testsuite/results/Issue_1260_com.opt
@@ -11,12 +11,9 @@
 ._func
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,16
+	call	l_gint4sp	;
+	ld	de,16
+	ex	de,hl
 	and	a
 	sbc	hl,de
 	ld	de,65535

--- a/testsuite/results/Issue_1466_float16.opt
+++ b/testsuite/results/Issue_1466_float16.opt
@@ -11,9 +11,7 @@
 ._func1
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	l_f16_add
 	ret
 
@@ -152,9 +150,7 @@
 	ld	hl,4	;const
 	add	hl,sp
 	call	dldpsh
-	ld	hl,8	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint8sp	;
 	call	l_f48_f16tof
 	call	dmul
 	call	l_f48_ftof16
@@ -209,9 +205,7 @@
 ._func5e
 	ld	hl,2	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	call	l_f16_sint2f
 	call	l_f16_mul
 	ret
@@ -221,9 +215,7 @@
 ._func5f
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	ex	(sp),hl
 	call	l_f16_sint2f
 	call	l_f16_mul
@@ -235,9 +227,7 @@
 	ld	hl,4	;const
 	add	hl,sp
 	call	dldpsh
-	ld	hl,8	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint8sp	;
 	call	l_f48_f16tof
 	call	dadd
 	call	l_f48_ftof16
@@ -292,9 +282,7 @@
 ._func6e
 	ld	hl,2	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	call	l_f16_sint2f
 	call	l_f16_add
 	ret
@@ -304,9 +292,7 @@
 ._func6f
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	ex	(sp),hl
 	call	l_f16_sint2f
 	call	l_f16_add
@@ -330,9 +316,7 @@
 	ld	hl,4	;const
 	add	hl,sp
 	call	l_glong2sp
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	pop	de
 	ex	(sp),hl
 	ex	de,hl
@@ -358,9 +342,7 @@
 	ld	hl,4	;const
 	add	hl,sp
 	call	l_glong2sp
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	pop	de
 	ex	(sp),hl
 	ex	de,hl

--- a/testsuite/results/Issue_1466_float16_callee.opt
+++ b/testsuite/results/Issue_1466_float16_callee.opt
@@ -50,9 +50,7 @@
 	ld	a,h
 	or	l
 	jp	z,i_4	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	pop	bc
 	pop	af
 	pop	af
@@ -61,14 +59,10 @@
 
 
 .i_4
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	logf16
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	l_f16_mul
 	call	expf16
 	pop	bc

--- a/testsuite/results/Issue_1466_float16_compare.opt
+++ b/testsuite/results/Issue_1466_float16_compare.opt
@@ -157,9 +157,7 @@
 ._eq_int
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	l_f16_sint2f
 	call	l_f16_eq
 	ld	a,h
@@ -219,9 +217,7 @@
 ._eq_float16
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	l_f16_eq
 	ld	a,h
 	or	l
@@ -238,9 +234,7 @@
 ._eq_int_r
 	ld	hl,2	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	ex	(sp),hl
 	call	l_f16_sint2f
 	call	l_f16_eq
@@ -304,9 +298,7 @@
 ._eq_float16_r
 	ld	hl,2	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	call	l_f16_eq
 	ld	a,h
 	or	l
@@ -467,9 +459,7 @@
 ._lt_int
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	l_f16_sint2f
 	call	l_f16_lt
 	ld	a,h
@@ -530,9 +520,7 @@
 ._lt_float16
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	call	l_f16_lt
 	ld	a,h
 	or	l
@@ -549,9 +537,7 @@
 ._lt_int_r
 	ld	hl,2	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	ex	(sp),hl
 	call	l_f16_sint2f
 	ex	(sp),hl
@@ -617,9 +603,7 @@
 ._lt_float16_r
 	ld	hl,2	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	call	l_f16_lt
 	ld	a,h
 	or	l

--- a/testsuite/results/Issue_1623_stdcbench_issues.opt
+++ b/testsuite/results/Issue_1623_stdcbench_issues.opt
@@ -26,9 +26,7 @@
 ._func0b
 	ld	hl,_y_endpositions
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	add	hl,hl
 	add	hl,hl
 	add	hl,hl
@@ -36,9 +34,7 @@
 	add	hl,hl
 	pop	de
 	add	hl,de
-	ld	bc,4
-	add	hl,bc
-	call	l_gint	;
+	call	l_gint4	;
 	ret
 
 
@@ -46,9 +42,7 @@
 ._func1b
 	ld	hl,(_y_endpos)
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	add	hl,hl
 	add	hl,hl
 	add	hl,hl
@@ -56,18 +50,14 @@
 	add	hl,hl
 	pop	de
 	add	hl,de
-	ld	bc,4
-	add	hl,bc
-	call	l_gint	;
+	call	l_gint4	;
 	ret
 
 
 
 ._func2
 	ld	hl,(_x_endpos+20)
-	ld	bc,4
-	add	hl,bc
-	call	l_gint	;
+	call	l_gint4	;
 	ret
 
 

--- a/testsuite/results/Issue_1662_static_ptrs.opt
+++ b/testsuite/results/Issue_1662_static_ptrs.opt
@@ -65,9 +65,7 @@
 	dec	hl
 	dec	hl
 	ld	(_pint),hl
-	inc	hl
-	inc	hl
-	call	l_gint	;
+	call	l_gint2	;
 	ret
 
 

--- a/testsuite/results/Issue_188_builtins.opt
+++ b/testsuite/results/Issue_188_builtins.opt
@@ -11,9 +11,7 @@
 ._strchr1
 	ld	hl,4	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	ex	de,hl
 	pop	hl
 .i_2
@@ -31,9 +29,7 @@
 
 
 ._strchr2
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	ld	e,97
 .i_4
 	ld	a,(hl)
@@ -50,9 +46,7 @@
 
 
 ._memset1
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	ld	e,0
 	ld	b,13
@@ -68,9 +62,7 @@
 ._memset2
 	ld	hl,6	;const
 	call	l_gintspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	ex	de,hl
 	pop	hl
 	push	hl
@@ -87,9 +79,7 @@
 ._memset3
 	ld	hl,6	;const
 	call	l_g2intspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	call	memset_callee
 	ret
@@ -97,9 +87,7 @@
 
 
 ._memset4
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	ld	e,0
 	ld	b,0
@@ -113,11 +101,8 @@
 
 
 ._strcpy1
-	ld	hl,4	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
+	call	l_gint4sp	;
+	ex	de,hl
 	ld	hl,i_1+0
 	push	de
 	xor	a
@@ -132,14 +117,9 @@
 
 ._strcpy2
 	ld	hl,4	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	pop	bc
-	pop	hl
-	push	hl
-	push	bc
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	push	de
 	xor	a
 .i_10
@@ -152,9 +132,7 @@
 
 
 ._memcpy1
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	ex	de,hl
 	ld	hl,1000
@@ -167,14 +145,9 @@
 
 ._memcpy2
 	ld	hl,4	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	pop	bc
-	pop	hl
-	push	hl
-	push	bc
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	push	de
 	ld	bc,10
 	ldir
@@ -186,9 +159,7 @@
 ._memcpy3
 	ld	hl,6	;const
 	call	l_g2intspsp	;
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	push	hl
 	call	memcpy_callee
 	ret

--- a/testsuite/results/Issue_26_casting.opt
+++ b/testsuite/results/Issue_26_casting.opt
@@ -16,9 +16,7 @@
 	ld	hl,0	;const
 	add	hl,sp
 	push	hl
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	ld	de,0
 	call	lp_glong
 	pop	bc
@@ -38,9 +36,7 @@
 	ld	hl,0	;const
 	add	hl,sp
 	push	hl
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	ld	de,0
 	call	lp_gint
 	call	l_int2long_s

--- a/testsuite/results/Issue_452_arrays.opt
+++ b/testsuite/results/Issue_452_arrays.opt
@@ -11,7 +11,7 @@
 ._func
 	ld	hl,0	;const
 	push	hl
-	ld	l,4	
+	ld	l,4
 	call	l_gintspsp	;
 	pop	bc
 	pop	hl
@@ -32,7 +32,7 @@
 	ld	sp,hl
 	ld	hl,0	;const
 	push	hl
-	ld	l,2	
+	ld	l,2
 	add	hl,sp
 	pop	de
 	push	de
@@ -75,9 +75,7 @@
 	ld	hl,65516	;const
 	add	hl,sp
 	ld	sp,hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	exx
 	ld	hl,20	;const
 	add	hl,sp

--- a/testsuite/results/Issue_452_pointers.opt
+++ b/testsuite/results/Issue_452_pointers.opt
@@ -18,6 +18,10 @@
 	pop	bc
 	push	hl
 	push	de
+	ld	hl,0	;const
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -37,6 +41,10 @@
 	pop	bc
 	push	hl
 	push	de
+	ld	hl,0	;const
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -58,6 +66,10 @@
 	pop	bc
 	push	hl
 	push	de
+	ld	hl,0	;const
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -81,6 +93,10 @@
 	pop	bc
 	push	hl
 	push	de
+	ld	hl,0	;const
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -103,6 +119,10 @@
 	pop	bc
 	push	hl
 	push	de
+	ld	hl,0	;const
+	call	l_gintspsp	;
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de

--- a/testsuite/results/Issue_482_optrule.opt
+++ b/testsuite/results/Issue_482_optrule.opt
@@ -41,9 +41,7 @@
 	sbc	hl,de
 	pop	de
 	call	l_pint
-	ld	hl,7	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint7sp	;
 	inc	sp
 	ret
 
@@ -68,17 +66,15 @@
 	ld	e,(hl)
 	inc	hl
 	ld	d,(hl)
-	ld	hl,2	;const
-	add	hl,sp
-	call	l_gint
+	push	de
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
 	pop	de
 	call	l_pint
-	ld	hl,8	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint8sp	;
 	pop	bc
 	ret
 

--- a/testsuite/results/Issue_491_enums.opt
+++ b/testsuite/results/Issue_491_enums.opt
@@ -20,9 +20,7 @@
 	pop	bc
 	push	hl
 	ld	hl,(_editedNoteStep)
-	ld	bc,5
-	add	hl,bc
-	call	l_gint	;
+	call	l_gint5	;
 	pop	bc
 	push	hl
 	ld	hl,1	;const

--- a/testsuite/results/Issue_564_casting.opt
+++ b/testsuite/results/Issue_564_casting.opt
@@ -24,9 +24,7 @@
 	pop	hl
 	push	hl
 	push	bc
-	inc	hl
-	inc	hl
-	call	l_gint	;
+	call	l_gint2	;
 	push	hl
 	call	_value
 	pop	bc
@@ -39,9 +37,7 @@
 	pop	hl
 	push	hl
 	push	bc
-	inc	hl
-	inc	hl
-	call	l_gint	;
+	call	l_gint2	;
 	push	hl
 	call	_value
 	pop	bc

--- a/testsuite/results/Issue_600_fastcall.opt
+++ b/testsuite/results/Issue_600_fastcall.opt
@@ -15,9 +15,7 @@
 	ld	e,l
 	push	de
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	call	_func
 	pop	bc
@@ -33,9 +31,7 @@
 	ld	hl,4	;const
 	add	hl,sp
 	call	l_glong2sp
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	call	_func
 	pop	bc
@@ -53,9 +49,7 @@
 	ld	e,l
 	push	de
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	call	_func
 	pop	bc

--- a/testsuite/results/Issue_608_Arrays.opt
+++ b/testsuite/results/Issue_608_Arrays.opt
@@ -35,11 +35,10 @@
 	SECTION	code_compiler
 
 ._func
-	ld	de,_carray
-	pop	bc
-	pop	hl
+	ld	hl,_carray
 	push	hl
-	push	bc
+	call	l_gint4sp	;
+	pop	de
 	add	hl,de
 	call	l_gchar
 	ret
@@ -49,9 +48,7 @@
 ._func2
 	ld	hl,_larray
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	add	hl,hl
 	add	hl,hl
 	pop	de
@@ -64,9 +61,7 @@
 ._func2_b
 	ld	hl,_larrays
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	add	hl,hl
 	add	hl,hl
 	pop	de
@@ -79,9 +74,7 @@
 ._func3
 	ld	hl,_narray
 	push	hl
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	ld	b,h
 	ld	c,l
 	add	hl,bc
@@ -89,9 +82,7 @@
 	add	hl,hl
 	pop	de
 	add	hl,de
-	inc	hl
-	inc	hl
-	call	l_gint	;
+	call	l_gint2	;
 	ret
 
 

--- a/testsuite/results/Issue_98_Stack_offset.opt
+++ b/testsuite/results/Issue_98_Stack_offset.opt
@@ -27,9 +27,7 @@
 	call	l_declong
 	push	de
 	push	hl
-	ld	hl,6	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint6sp	;
 	dec	hl
 	push	hl
 	call	_BottomUpTree
@@ -45,9 +43,7 @@
 	rl	d
 	push	de
 	push	hl
-	ld	hl,8	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint8sp	;
 	dec	hl
 	push	hl
 	call	_BottomUpTree

--- a/testsuite/results/Issue_98_check_int.opt
+++ b/testsuite/results/Issue_98_check_int.opt
@@ -29,11 +29,10 @@
 
 
 ._mul3
-	ld	de,(_g)
-	pop	bc
-	pop	hl
+	ld	hl,(_g)
 	push	hl
-	push	bc
+	call	l_gint4sp	;
+	pop	de
 	call	l_mult
 	ret
 
@@ -78,11 +77,10 @@
 
 
 ._div3
-	ld	de,(_g)
-	pop	bc
-	pop	hl
+	ld	hl,(_g)
 	push	hl
-	push	bc
+	call	l_gint4sp	;
+	pop	de
 	call	l_div
 	ret
 
@@ -164,11 +162,10 @@
 
 
 ._sub3
-	ld	de,(_g)
-	pop	bc
-	pop	hl
+	ld	hl,(_g)
 	push	hl
-	push	bc
+	call	l_gint4sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de

--- a/testsuite/results/fastcall.opt
+++ b/testsuite/results/fastcall.opt
@@ -30,9 +30,7 @@
 	push	hl
 	ld	hl,6	;const
 	call	l_gintspsp	;
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gint4sp	;
 	push	hl
 	ld	a,3
 	call	printf

--- a/testsuite/results/l_gint_const.opt
+++ b/testsuite/results/l_gint_const.opt
@@ -1,0 +1,128 @@
+
+
+
+
+
+	INCLUDE "z80_crt0.hdr"
+
+
+	SECTION	code_compiler
+
+._check1
+	call	l_gint8sp	;
+	add	hl,hl
+	push	hl
+	call	l_gint8sp	;
+	ld	b,h
+	ld	c,l
+	add	hl,bc
+	add	hl,bc
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint6sp	;
+	add	hl,hl
+	add	hl,hl
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	ld	b,h
+	ld	c,l
+	add	hl,hl
+	add	hl,hl
+	add	hl,bc
+	pop	de
+	add	hl,de
+	ret
+
+
+
+._check_gchar
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	call	l_gchar
+	push	hl
+	call	l_gint4sp	;
+	call	l_gchar1
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gchar2
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gchar3
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gchar4
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gchar5
+	pop	de
+	add	hl,de
+	ret
+
+
+
+._check_gint
+	pop	bc
+	pop	hl
+	push	hl
+	push	bc
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+	push	de
+	call	l_gint4sp	;
+	call	l_gint2	;
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gint4	;
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gint6	;
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	call	l_gint8	;
+	pop	de
+	add	hl,de
+	push	hl
+	call	l_gint4sp	;
+	ld	bc,10
+	add	hl,bc
+	call	l_gint	;
+	pop	de
+	add	hl,de
+	ret
+
+
+
+
+
+	SECTION	bss_compiler
+	SECTION	code_compiler
+
+
+
+	GLOBAL	_check1
+	GLOBAL	_check_gchar
+	GLOBAL	_check_gint
+
+
+
+

--- a/testsuite/results/pointer_arith.opt
+++ b/testsuite/results/pointer_arith.opt
@@ -32,13 +32,9 @@
 
 ._func1c
 	ld	hl,2	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gintspsp	;
+	call	l_gint6sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -95,13 +91,9 @@
 
 ._func2c
 	ld	hl,2	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gintspsp	;
+	call	l_gint6sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -166,13 +158,9 @@
 
 ._func3c
 	ld	hl,2	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gintspsp	;
+	call	l_gint6sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -237,13 +225,9 @@
 
 ._func4c
 	ld	hl,2	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gintspsp	;
+	call	l_gint6sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de
@@ -313,13 +297,9 @@
 
 ._func5c
 	ld	hl,2	;const
-	add	hl,sp
-	ld	e,(hl)
-	inc	hl
-	ld	d,(hl)
-	ld	hl,4	;const
-	add	hl,sp
-	call	l_gint	;
+	call	l_gintspsp	;
+	call	l_gint6sp	;
+	pop	de
 	ex	de,hl
 	and	a
 	sbc	hl,de

--- a/testsuite/results/rabbit/rabbit_optimisations.opt
+++ b/testsuite/results/rabbit/rabbit_optimisations.opt
@@ -176,7 +176,7 @@
 ._pushinstr
 	ld	hl,1	;const
 	push	hl
-	ld	l,2	
+	ld	l,2
 	push	hl
 	ld	hl,3	;const
 	push	hl

--- a/testsuite/results/sizeof_w_str_concat.opt
+++ b/testsuite/results/sizeof_w_str_concat.opt
@@ -11,11 +11,11 @@
 ._main
 	ld	hl,14	;const
 	push	hl
-	ld	l,8	
+	ld	l,8
 	push	hl
 	ld	hl,7	;const
 	push	hl
-	ld	l,0	
+	ld	l,0
 	pop	bc
 	pop	bc
 	pop	bc

--- a/testsuite/results/z80n/Issue_312_z80n_optimisations.opt
+++ b/testsuite/results/z80n/Issue_312_z80n_optimisations.opt
@@ -140,7 +140,7 @@
 ._pushinstr
 	ld	hl,1	;const
 	push	hl
-	ld	l,2	
+	ld	l,2
 	push	hl
 	ld	hl,3	;const
 	push	hl


### PR DESCRIPTION
These optimisations shave off 2K of code on my project.

`l_gint_const.opt` showcases the change.

- `inc hl by X`, then call `l_gint` is replaced by `l_gintX`
- `inc hl by X`, then call `l_gchar` is replaced by `l_gcharX`
- `set hl to sp + X`, then call `l_gint` is replaced by `l_gintXsp`

Example of optimisation:

```
	ld	hl,4	;const
	add	hl,sp
	call	l_gint	;
	ld	bc,8
	add	hl,bc
	call	l_gint	;
```
is replaced with
```
	call	l_gint4sp	;
	call	l_gint8	;
```