### PR TITLE
z88dk-dis: fix undefined behavior dealing with large dumps

### DIFF
--- a/src/ticks/debug.c
+++ b/src/ticks/debug.c
@@ -717,7 +717,7 @@ void debug_add_info_encoded(char *encoded)
         }
     }
 
-    if (bk.is_verbose()) {
+    if (bk.is_verbose && bk.is_verbose()) {
         bk.debug("Decoded cdb: <%s>\n",encoded);
     }
 }

--- a/src/ticks/disassembler_main.c
+++ b/src/ticks/disassembler_main.c
@@ -126,12 +126,16 @@ int main(int argc, char **argv)
             FILE *fp = fopen(argv[1],"rb");
 
             if ( fp != NULL ) {
-                size_t r = fread(mem + (org % BUFF_SIZE), sizeof(char), BUFF_SIZE - (start % BUFF_SIZE), fp);
+                size_t amount = end - start;
+                fseek(fp, start - org, SEEK_SET);
+                size_t r = fread(mem + (start % BUFF_SIZE), sizeof(char), (amount % BUFF_SIZE), fp);
                 loaded = 1;
                 fclose(fp);
-                if ( r < end - org ) {
-                    end = org + r;
+                if (r < amount)
+                {
+                    amount = r;
                 }
+                end = start + amount;
             } else {
                 fprintf(stderr, "Cannot load file '%s'\n",argv[1]);
             }


### PR DESCRIPTION
1. Currently, dis crashing when `-x` for a map is provided
2. dis loads the whole file into memory regardless of start and end, instead I am doing seek
3. rearrange ranges a bit for more readability