### PR TITLE
8085: Some more low hanging fruit

### DIFF
--- a/lib/arch/8085/8085_rules.1
+++ b/lib/arch/8085/8085_rules.1
@@ -113,3 +113,24 @@
 	ld	b,d
 	ld	de,sp+%2
 	ld	hl,(de)
+
+%check 0 <= %1 <= 255
+	ld	hl,%1	;const
+	add	hl,sp
+	call	l_glong%2
+=
+	ld	de,sp+%1
+	ex	de,hl
+	call	l_glong%2
+
+
+%check 0 <= %1 <= 255
+	ld	hl,%1	;const
+	add	hl,sp
+	push	hl
+	call	l_glong%2
+=
+	ld	de,sp+%1
+	ex	de,hl
+	push	hl
+	call	l_glong%2

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -6980,3 +6980,36 @@ $notcpu 8085
 	call	l_gchar
 =
 	call	l_gchar%1
+
+%title Clear up a misoptimisation
+%cpu 8085
+	push	de
+	ld	hl,(de)	;l_gint
+	%2c	hl
+	pop	de
+	ld	(de),hl	;l_pint
+=
+	ld	hl,(de)	;l_gint
+	%2c	hl
+	ld	(de),hl	;l_pint
+
+%cpu 8085
+%check 0 <= %1 <= 255
+	ld	hl,%1	;const
+	add	hl,sp
+	ex	de,hl
+	ld	hl,%2	;const
+=
+	ld	de,sp+%1
+	ld	hl,%2	;const
+
+%cpu 8085
+%check 0 <= %2 <= 255
+	ld	de,sp+%1
+	ld	hl,%2	;const
+	add	hl,sp
+	ex	de,hl
+=
+	ld	de,sp+%1
+	ex	de,hl
+	ld	de,sp+%2


### PR DESCRIPTION
Few more rules for 8085 - cleanup some odd looking generated code + be more aggressive using ld de,sp+NN where we know we're going to reload de.

This saves around about 5% or so on the md5sum testcase and reduces program size quite a lot:

This branch: 13215 bytes, 47555113 ticks
Master: 13905 bytes, 49315247 ticks