### PR TITLE
sccz80: save a byte on each debug call

### DIFF
--- a/lib/z80_crt0.hdr
+++ b/lib/z80_crt0.hdr
@@ -422,3 +422,4 @@
 
 	EXTERN	l_debug_push_frame
 	EXTERN	l_debug_pop_frame
+	EXTERN	l_debug_pop_frame_bc

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -7013,3 +7013,14 @@ $notcpu 8085
 	ld	de,sp+%1
 	ex	de,hl
 	ld	de,sp+%2
+
+	pop	bc
+	call	l_debug_pop_frame
+	ret
+=
+	jp	l_debug_pop_frame_bc
+
+	call	l_debug_pop_frame
+	ret
+=
+	jp	l_debug_pop_frame

--- a/libsrc/_DEVELOPMENT/l/sccz80/8-8080/l_debug_pop_frame.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/8-8080/l_debug_pop_frame.asm
@@ -3,7 +3,11 @@ SECTION code_clib
 SECTION code_l_sccz80
 
 PUBLIC l_debug_pop_frame
+PUBLIC l_debug_pop_frame_bc
 EXTERN __debug_framepointer
+
+l_debug_pop_frame_bc:
+    pop     bc
 
 l_debug_pop_frame:
     pop     bc      ;return code


### PR DESCRIPTION
Saves a ret and/or pop bc before it