### PR TITLE
fix zx_pxy2saddr prototype and macro declaration in spectrum.h

### DIFF
--- a/include/arch/zx/spectrum.h
+++ b/include/arch/zx/spectrum.h
@@ -467,7 +467,7 @@ extern int __LIB__ zx_printf(char *fmt, ...);
 extern uchar __LIB__              *zx_cxy2saddr(uchar row, uchar col) __smallc;
 extern uchar __LIB__  *zx_cy2saddr(uchar row) __z88dk_fastcall;           // cx assumed 0
 
-extern uchar __LIB__              *zx_pxy2saddr(uchar xcoord, uchar ycoord, uchar *mask) __smallc;
+extern uchar __LIB__              *zx_pxy2saddr(uchar xcoord, uchar ycoord) __smallc;
 extern uchar __LIB__  *zx_py2saddr(uchar ycoord) __z88dk_fastcall;        // px assumed 0
 
 extern uint  __LIB__   zx_saddr2cx(void *pixeladdr) __z88dk_fastcall;
@@ -489,7 +489,7 @@ extern uchar __LIB__              *zx_saddrpright(void *pixeladdr, uchar *mask) 
 extern uchar __LIB__  *zx_saddrpup(void *pixeladdr) __z88dk_fastcall;
 
 extern uchar __LIB__    *zx_cxy2saddr_callee(uchar row, uchar col) __smallc __z88dk_callee;
-extern uchar __LIB__    *zx_pxy2saddr_callee(uchar xcoord, uchar ycoord, uchar *mask) __smallc __z88dk_callee;
+extern uchar __LIB__    *zx_pxy2saddr_callee(uchar xcoord, uchar ycoord) __smallc __z88dk_callee;
 extern uint  __LIB__     zx_saddr2px_callee(void *pixeladdr, uchar mask) __smallc __z88dk_callee;
 extern uchar __LIB__    *zx_saddrpleft_callee(void *pixeladdr, uchar *mask) __smallc __z88dk_callee;
 extern uchar __LIB__    *zx_saddrpright_callee(void *pixeladdr, uchar *mask) __smallc __z88dk_callee;
@@ -497,7 +497,7 @@ extern uchar __LIB__    *zx_saddrpright_callee(void *pixeladdr, uchar *mask) __s
 #define zx_cyx2saddr(a,b)          zx_cxy2saddr_callee(b,a)
 #define zx_cxy2saddr(a,b)          zx_cxy2saddr_callee(a,b)
 
-#define zx_pxy2saddr(a,b,c)        zx_pxy2saddr_callee(a,b,c)
+#define zx_pxy2saddr(a,b)        zx_pxy2saddr_callee(a,b)
 #define zx_saddr2px(a,b)           zx_saddr2px_callee(a,b)
 #define zx_saddrpleft(a,b)         zx_saddrpleft_callee(a,b)
 #define zx_saddrpright(a,b)        zx_saddrpright_callee(a,b)

--- a/include/arch/zx/spectrum.h
+++ b/include/arch/zx/spectrum.h
@@ -497,7 +497,7 @@ extern uchar __LIB__    *zx_saddrpright_callee(void *pixeladdr, uchar *mask) __s
 #define zx_cyx2saddr(a,b)          zx_cxy2saddr_callee(b,a)
 #define zx_cxy2saddr(a,b)          zx_cxy2saddr_callee(a,b)
 
-#define zx_pxy2saddr(a,b)        zx_pxy2saddr_callee(a,b)
+#define zx_pxy2saddr(a,b)          zx_pxy2saddr_callee(a,b)
 #define zx_saddr2px(a,b)           zx_saddr2px_callee(a,b)
 #define zx_saddrpleft(a,b)         zx_saddrpleft_callee(a,b)
 #define zx_saddrpright(a,b)        zx_saddrpright_callee(a,b)


### PR DESCRIPTION
fix: remove spurious *mask parameter from zx_pxy2saddr prototype and macro in spectrum.h.

The following code does not compile with `master`:

```
// zcc +zx test1.c -lndos -o test1 -create-app

#include <stdio.h>
#include <spectrum.h>

void main( void ) {
    printf( "Hello world\n\n\n" );
    printf( "pxy2saddr( 128,64 ) = %d\n", zx_pxy2saddr( 128, 64 ) );
}
```
The prototype and macro declarations for `zx_pxy2saddr` are wrong in `spectrum.h`

I have checked the ASM implementations, and indeed they do _not_ expect the `*mask` parameter