### PR TITLE
Add a manually selected failback to boost::filesystem

### DIFF
--- a/src/z80asm/Makefile
+++ b/src/z80asm/Makefile
@@ -31,6 +31,12 @@ LOCAL_CFLAGS += -std=gnu11 $(COMMON_FLAGS) \
 CXX_FLAGS	+= -std=gnu++17 $(COMMON_FLAGS) -Wextra -Werror -pedantic-errors \
 			-Isrc/cpp
 
+ifeq ($(USE_BOOST_FILESYSTEM),1)
+   CXX_FLAGS += -DUSE_BOOST_FILESYSTEM
+   LDFLAGS += -lboost_filesystem -lboost_system
+endif
+
+
 # so that we can use C++17 features on older systems
 ifeq ($(CROSS),1)
   ifeq ($(EXESUFFIX),.exe)

--- a/src/z80asm/src/cpp/utils.h
+++ b/src/z80asm/src/cpp/utils.h
@@ -14,7 +14,11 @@
 #include <vector>
 using namespace std;
 
-#if __has_include(<filesystem>)
+
+#ifdef USE_BOOST_FILESYSTEM
+	#include <boost/filesystem.hpp>
+	namespace fs = boost::filesystem;
+#elif __has_include(<filesystem>)
 	// std::filesystem from C++17
 	#include <filesystem>
 	namespace fs = std::filesystem;


### PR DESCRIPTION
macOS (Mojave? and earlier) don't have std::filesystem in any form and:

1. libstdc++ is no longer supported
2. libc++ can't be statically linked
3. I think boost::filesystem is compatible for what we use it for

So producing nightly builds with this flag for macOS will gain us a bit more backwards compatibility to support older hardware

