### PR TITLE
(+z80) Add a classic +z80 target to make it easier to get started

### DIFF
--- a/lib/config/z80.cfg
+++ b/lib/config/z80.cfg
@@ -11,6 +11,7 @@ OPTIONS		 -O2 -SO2 -iquote. -D__Z88DK -D__EMBEDDED_Z80 -D__Z80 -clib=sdcc_iy -su
 
 # Classic library configurations and CPU variants
 CLIB     classic -lz80_clib -lndos -Cc-standard-escape-chars -LDESTDIR/lib/clibs/z80
+CLIB     ixiy -lixiy_clib -startuplib=z80iy_crt0 -lndos -Cc-standard-escape-chars -LDESTDIR/lib/clibs/z80
 CLIB     8080 -m8080 -Cc-standard-escape-chars -l8080_clib -startuplib=8080_crt0 -D__8080__  -LDESTDIR/lib/clibs/8080
 CLIB     8085  -m8085 -Cc-standard-escape-chars -l8080_clib -startuplib=8080_crt0 -l8085_opt -D__8080__ -D__8085__ -LDESTDIR/lib/clibs/8085  -LDESTDIR/lib/clibs/8080
 CLIB     r2ka  -mr2ka -Cc-standard-escape-chars -lr2ka_clib  -DRCMX000 -D__RCMX000__ -startuplib=r2k_crt0  -LDESTDIR/lib/clibs/r2ka

--- a/lib/config/z80.cfg
+++ b/lib/config/z80.cfg
@@ -3,14 +3,20 @@
 #
 
 # Asm file which contains the startup code (without suffix)
-# Not supported in classic library
-CRT0		 DESTDIR/lib/z80_crt0
+CRT0		 DESTDIR/lib/target/z80/classic/z80_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
 OPTIONS		 -O2 -SO2 -iquote. -D__Z88DK -D__EMBEDDED_Z80 -D__Z80 -clib=sdcc_iy -subtype=default
 
-CLIB     default -lz80_clib -lndos -Cc-standard-escape-chars
+# Classic library configurations and CPU variants
+CLIB     classic -lz80_clib -lndos -Cc-standard-escape-chars -LDESTDIR/lib/clibs/z80
+CLIB     8080 -m8080 -Cc-standard-escape-chars -l8080_clib -startuplib=8080_crt0 -D__8080__  -LDESTDIR/lib/clibs/8080
+CLIB     8085  -m8085 -Cc-standard-escape-chars -l8080_clib -startuplib=8080_crt0 -l8085_opt -D__8080__ -D__8085__ -LDESTDIR/lib/clibs/8085  -LDESTDIR/lib/clibs/8080
+CLIB     r2ka  -mr2ka -Cc-standard-escape-chars -lr2ka_clib  -DRCMX000 -D__RCMX000__ -startuplib=r2k_crt0  -LDESTDIR/lib/clibs/r2ka
+
+
+# Newlib configurations below
 CLIB     new -Cc-standard-escape-chars -D__SCCZ80 -nostdlib -isystemDESTDIR/include/_DEVELOPMENT/sccz80 -Ca-IDESTDIR/libsrc/_DEVELOPMENT/target/z80 -lz80 -LDESTDIR/libsrc/_DEVELOPMENT/lib/sccz80 -Cl-IDESTDIR/libsrc/_DEVELOPMENT/target/z80 -crt0=DESTDIR/libsrc/_DEVELOPMENT/target/z80/z80_crt.asm.m4
 CLIB     sdcc_ix -compiler=sdcc -D__SDCC -D__SDCC_IX -Ca-D__SDCC_IX -Cl-D__SDCC_IX -nostdlib -isystemDESTDIR/include/_DEVELOPMENT/sdcc -Ca-IDESTDIR/libsrc/_DEVELOPMENT/target/z80 -lz80 -LDESTDIR/libsrc/_DEVELOPMENT/lib/sdcc_ix -Cl-IDESTDIR/libsrc/_DEVELOPMENT/target/z80 -crt0=DESTDIR/libsrc/_DEVELOPMENT/target/z80/z80_crt.asm.m4
 CLIB     sdcc_iy -compiler=sdcc --reserve-regs-iy -D__SDCC -D__SDCC_IY -Ca-D__SDCC_IY -Cl-D__SDCC_IY -nostdlib -isystemDESTDIR/include/_DEVELOPMENT/sdcc -Ca-IDESTDIR/libsrc/_DEVELOPMENT/target/z80 -lz80 -LDESTDIR/libsrc/_DEVELOPMENT/lib/sdcc_iy -Cl-IDESTDIR/libsrc/_DEVELOPMENT/target/z80 -crt0=DESTDIR/libsrc/_DEVELOPMENT/target/z80/z80_crt.asm.m4

--- a/lib/crt/classic/crt_defaults.inc
+++ b/lib/crt/classic/crt_defaults.inc
@@ -1,0 +1,18 @@
+;
+; Default value
+
+
+   defc DEF__register_sp               = 0       ;; initial value of sp (-1 = do not modify (some targets may redefine meaning), 0 = top of memory)
+
+   defc DEF__crt_enable_restart        = 0       ;; if non-zero, restart the program on exit (correct initialization of static variables with rom models only)
+   defc DEF__crt_on_exit               = 0x10001 ;; halt on exit (see documentation for other exit behaviours)
+   defc DEF__crt_enable_eidi           = 0       ;; bit flags: 0x01 = di on start, 0x02 = ei on start, 0x10 = di on exit, 0x20 = ei on exit
+
+   defc DEF__crt_enable_rst            = 0       ;; if non-zero and in some crts with code org = 0, set bits indicate which rst locations are implemented with user code
+   defc DEF__crt_enable_nmi            = 0       ;; if non-zero and in some crts with code org = 0, a jump to user code to service the nmi is inserted
+
+
+   ; clib defaults
+   defc DEF__clib_exit_stack_size      = 32      ;; max number of functions that can be registered with atexit()
+
+   defc DEF__clib_banking_stack_size   = 100	 ;; For each bank call we save 2 words on the temporary stack

--- a/lib/crt/classic/crt_exit_atexit.inc
+++ b/lib/crt/classic/crt_exit_atexit.inc
@@ -1,0 +1,11 @@
+
+; Unwind the atexit() stack
+
+    PUBLIC  __clib_exit_stack_size
+
+IF __clib_exit_stack_size > 0
+    ld      hl, +(__clib_exit_stack_size * 2)
+    add     hl,sp
+    ld      sp,hl
+ENDIF
+

--- a/lib/crt/classic/crt_exit_eidi.inc
+++ b/lib/crt/classic/crt_exit_eidi.inc
@@ -1,0 +1,9 @@
+; ei/di state at the end of the program 
+
+   IF (__crt_enable_eidi & 0x10)
+      di
+   ENDIF
+   IF (__crt_enable_eidi & 0x20)
+      ei
+   ENDIF
+

--- a/lib/crt/classic/crt_rules.inc
+++ b/lib/crt/classic/crt_rules.inc
@@ -65,6 +65,16 @@
   ENDIF
 
 
+   IFDEF CRT_ENABLE_EIDI
+      defc __crt_enable_eidi = CRT_ENABLE_EIDI
+   ELSE
+      IFDEF TAR__crt_enable_eidi
+         defc __crt_enable_eidi = TAR__crt_enable_eidi
+      ELSE
+         defc __crt_enable_eidi = DEF__crt_enable_eidi
+      ENDIF
+   ENDIF
+
 
    ; By default we want to have stdio working for us
    IFNDEF CRT_ENABLE_STDIO

--- a/lib/crt/classic/crt_rules.inc
+++ b/lib/crt/classic/crt_rules.inc
@@ -1,6 +1,7 @@
 
 ; Rules for setting up defaults for configuring the build
 
+   INCLUDE "crt/classic/crt_defaults.inc"
 
    IFNDEF CRT_INITIALIZE_BSS
       defc CRT_INITIALIZE_BSS = 1
@@ -21,7 +22,7 @@
    ENDIF
 
    IFNDEF TAR__crt_enable_rst
-       defc TAR__crt_enable_rst = 0x0000
+       defc TAR__crt_enable_rst = DEF__crt_enable_rst
    ENDIF
 
    IFDEF CRT_ENABLE_RST
@@ -38,6 +39,32 @@
      ENDIF
      defc __crt_enable_nmi = TAR__crt_enable_nmi
    ENDIF
+
+   IFDEF CRT_ENABLE_RESTART
+      defc __crt_enable_restart = CRT_ENABLE_RESTART
+   ELSE
+      IFDEF TAR__crt_enable_restart
+         defc __crt_enable_restart = TAR__crt_enable_restart
+      ELSE
+         defc __crt_enable_restart = DEF__crt_enable_restart
+      ENDIF
+   ENDIF
+
+  IF __crt_enable_restart
+      defc __crt_on_exit = 0x10008
+   ELSE
+      IFDEF CRT_ON_EXIT
+         defc __crt_on_exit = CRT_ON_EXIT
+      ELSE
+         IFDEF TAR__crt_on_exit
+            defc __crt_on_exit = TAR__crt_on_exit
+         ELSE
+            defc __crt_on_exit = DEF__crt_on_exit
+         ENDIF
+      ENDIF
+  ENDIF
+
+
 
    ; By default we want to have stdio working for us
    IFNDEF CRT_ENABLE_STDIO
@@ -61,7 +88,7 @@
       IFDEF TAR__clib_banking_stack_size
          defc CLIB_BANKING_STACK_SIZE = TAR__clib_banking_stack_size
       ELSE
-         defc CLIB_BANKING_STACK_SIZE = 100
+         defc CLIB_BANKING_STACK_SIZE = DEF__clib_banking_stack_size
       ENDIF
    ENDIF
 

--- a/lib/crt/classic/crt_start_eidi.inc
+++ b/lib/crt/classic/crt_start_eidi.inc
@@ -1,0 +1,9 @@
+; ei/di state at the start of the program 
+
+   IF (__crt_enable_eidi & 0x01)
+      di
+   ENDIF
+   IF (__crt_enable_eidi & 0x02)
+      ei
+   ENDIF
+

--- a/lib/crt/classic/crt_terminate.asm
+++ b/lib/crt/classic/crt_terminate.asm
@@ -1,0 +1,20 @@
+;
+; When a program terminates, what behaviour should we take?
+;
+
+
+IF __crt_on_exit < 0x10000
+	; Jump to an address
+        jp      __crt_on_exit
+ELIF __crt_on_exit = 0x10001
+	; Halt
+        halt
+	jr	ASMPC
+ELIF __crt_on_exit = 0x10002
+	; Return to caller
+        ret
+ELIF __crt_on_exit = 0x10008
+	; Restart
+        jp	start
+ENDIF
+

--- a/lib/crt/classic/crt_terminate.inc
+++ b/lib/crt/classic/crt_terminate.inc
@@ -2,6 +2,7 @@
 ; When a program terminates, what behaviour should we take?
 ;
 
+INCLUDE "crt/classic/crt_exit_eidi.inc"
 
 IF __crt_on_exit < 0x10000
 	; Jump to an address
@@ -11,7 +12,9 @@ ELIF __crt_on_exit = 0x10001
         halt
 	jr	ASMPC
 ELIF __crt_on_exit = 0x10002
-	; Return to caller
+	; Return to caller - unwind the atexit stack - we assume
+	; that we've not modified the entry stack
+	INCLUDE	"crt/classic/crt_exit_atexit.inc"
         ret
 ELIF __crt_on_exit = 0x10008
 	; Restart

--- a/lib/target/pc6001/classic/pc6001_crt0.asm
+++ b/lib/target/pc6001/classic/pc6001_crt0.asm
@@ -70,7 +70,7 @@ ENDIF
         defc    TAR__fputc_cons_generic = 1
 	defc	TAR__no_ansifont = 1
         defc    TAR__clib_exit_stack_size = 32
-	defc	DEF__register_sp = -1
+	defc	TAR__register_sp = -1
 	defc	__CPU_CLOCK = 3800000
 	INCLUDE	"crt/classic/crt_rules.inc"
 

--- a/lib/target/pc6001/classic/pc6001_crt0.asm
+++ b/lib/target/pc6001/classic/pc6001_crt0.asm
@@ -70,7 +70,9 @@ ENDIF
         defc    TAR__fputc_cons_generic = 1
 	defc	TAR__no_ansifont = 1
         defc    TAR__clib_exit_stack_size = 32
+IFNDEF TAR__register_sp
 	defc	TAR__register_sp = -1
+ENDIF
 	defc	__CPU_CLOCK = 3800000
 	INCLUDE	"crt/classic/crt_rules.inc"
 

--- a/lib/target/sc3000/classic/rom.asm
+++ b/lib/target/sc3000/classic/rom.asm
@@ -70,7 +70,7 @@ ENDIF
 
 
     ; Initialise mode 2 by default
-    ld      hl,2
+    ld      hl,1
     call    msx_set_mode
     im      1
     ;	ei

--- a/lib/target/sos/classic/sos_crt0.asm
+++ b/lib/target/sos/classic/sos_crt0.asm
@@ -24,7 +24,7 @@ ENDIF
 
     IF !DEFINED_CRT_COMMANDLINE_REDIRECTION
         define  DEFINED_CRT_COMMANDLINE_REDIRECTION
-        defc    DEF__CRT_COMMANDLINE_REDIRECTION = 0
+        defc    TAR__CRT_COMMANDLINE_REDIRECTION = 0
     ENDIF
     defc    TAR__clib_exit_stack_size = 32
     defc    TAR__register_sp = -0x1f6a	;;Upper limit of the user area

--- a/lib/target/z80/classic/z80_crt0.asm
+++ b/lib/target/z80/classic/z80_crt0.asm
@@ -1,0 +1,89 @@
+;
+; A configurable CRT for bare-metal
+;
+;
+
+	MODULE z80_crt0 
+
+;-------
+; Include zcc_opt.def to find out information about us
+;-------
+
+        defc    crt0 = 1
+	INCLUDE "zcc_opt.def"
+
+;-------
+; Some general scope declarations
+;-------
+
+        EXTERN    _main           ;main() is always external to crt0 code
+        PUBLIC    cleanup         ;jp'd to by exit()
+        PUBLIC    l_dcal          ;jp(hl)
+	EXTERN	  asm_im1_handler
+	EXTERN	  asm_nmi_handler
+
+IF DEFINED_CRT_ORG_BSS
+        defc    __crt_org_bss = CRT_ORG_BSS
+ENDIF
+
+IF      !CRT_ORG_CODE
+	defc	CRT_ORG_CODE = 0x0000
+ENDIF
+
+IF CRT_ORG_CODE = 0x0000
+        ; By default we don't have any rst handlers
+        defc    TAR__crt_enable_rst = $0000
+ENDIF
+	
+	; Default, don't change the stack pointer
+	defc	TAR__register_sp = -1
+        defc    TAR__clib_exit_stack_size = 32
+	; Default, halt loop
+	defc    TAR__crt_on_exit = 0x10001
+
+	defc	__CPU_CLOCK = 4000000
+	INCLUDE	"crt/classic/crt_rules.inc"
+
+
+	org    	CRT_ORG_CODE
+
+
+IF CRT_ORG_CODE = 0x0000
+	jp	start
+	INCLUDE	"crt/classic/crt_z80_rsts.asm"
+ENDIF
+
+start:
+	INCLUDE	"crt/classic/crt_init_sp.asm"
+	; Make room for the atexit() stack
+	INCLUDE	"crt/classic/crt_init_atexit.asm"
+	call	crt0_init_bss
+IF __CPU_INTEL__
+	ld	hl,0
+	add	hl,sp
+	ld	(exitsp),hl
+ELSE
+	ld      (exitsp),sp
+ENDIF
+
+	; Entry to the user code
+	call    _main
+	; Exit code is in hl
+cleanup:
+        call    crt0_exit
+
+        ; Include the restart behaviour
+	INCLUDE "crt/classic/crt_terminate.asm"
+
+l_dcal:
+	jp      (hl)
+
+        INCLUDE "crt/classic/crt_runtime_selection.asm"
+
+        ; If we were given a model then use it
+        IF DEFINED_CRT_MODEL
+            defc __crt_model = CRT_MODEL
+        ELSE
+            defc __crt_model = 1
+        ENDIF
+	INCLUDE	"crt/classic/crt_section.asm"

--- a/lib/target/z80/classic/z80_crt0.asm
+++ b/lib/target/z80/classic/z80_crt0.asm
@@ -54,6 +54,7 @@ IF CRT_ORG_CODE = 0x0000
 ENDIF
 
 start:
+	INCLUDE	"crt/classic/crt_start_eidi.inc"
 	INCLUDE	"crt/classic/crt_init_sp.asm"
 	; Make room for the atexit() stack
 	INCLUDE	"crt/classic/crt_init_atexit.asm"
@@ -72,8 +73,8 @@ ENDIF
 cleanup:
         call    crt0_exit
 
-        ; Include the restart behaviour
-	INCLUDE "crt/classic/crt_terminate.asm"
+	; How does the program end?
+	INCLUDE "crt/classic/crt_terminate.inc"
 
 l_dcal:
 	jp      (hl)

--- a/lib/target/zx/classic/spec_crt0.asm
+++ b/lib/target/zx/classic/spec_crt0.asm
@@ -33,7 +33,7 @@
             defc    CRT_ORG_CODE = $5CCB     ; repleaces BASIC program
             defc	DEFINED_CRT_ORG_CODE = 1
         ENDIF
-        defc TAR__register_sp = 0xff57	; below UDG, keep eye when using banks
+        defc REG__register_sp = 0xff57	; below UDG, keep eye when using banks
     ENDIF
 
 
@@ -87,7 +87,7 @@
     ; We use the generic driver by default
     defc    TAR__fputc_cons_generic = 1
 
-    defc    DEF__register_sp = -1
+    defc    TAR__register_sp = -1
     defc    TAR__clib_exit_stack_size = 32
     defc    CRT_KEY_DEL = 12
     defc    __CPU_CLOCK = 3500000

--- a/lib/target/zx/classic/spec_crt0.asm
+++ b/lib/target/zx/classic/spec_crt0.asm
@@ -87,7 +87,9 @@
     ; We use the generic driver by default
     defc    TAR__fputc_cons_generic = 1
 
+IFNDEF TAR__register_sp
     defc    TAR__register_sp = -1
+ENDIF
     defc    TAR__clib_exit_stack_size = 32
     defc    CRT_KEY_DEL = 12
     defc    __CPU_CLOCK = 3500000

--- a/lib/target/zxn/classic/ram_crt0.asm
+++ b/lib/target/zxn/classic/ram_crt0.asm
@@ -9,7 +9,7 @@
     ; We use the generic driver by default
     defc    TAR__fputc_cons_generic = 1
 
-    defc	DEF__register_sp = 65535
+    defc    TAR__register_sp = 65535
     defc    TAR__clib_exit_stack_size = 32
     INCLUDE	"crt/classic/crt_rules.inc"
 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -134,6 +134,7 @@ TOCREATE += $(call check_target,vz,vz_clib.lib)
 TOCREATE += $(call check_target,x07,x07_clib.lib)
 TOCREATE += $(call check_target,x1,x1_clib.lib x1_cpm.lib $(CPMLIBS))
 TOCREATE += $(call check_target,z1013,z1013_clib.lib)
+TOCREATE += $(call check_target,z80,z80_clib.lib 8080_clib.lib 8085_clib.lib r2ka_clib.lib)
 TOCREATE += $(call check_target,z80tvgame,z80tvgame_clib.lib)
 TOCREATE += $(call check_target,z88,z88_clib.lib z88_math.lib)
 TOCREATE += $(call check_target,z9001,z9001_clib.lib)
@@ -1098,6 +1099,38 @@ z9001_clib.lib:
 	$(MAKE) -C games TARGET=z9001
 	$(MAKE) -C video/krt TARGET=z9001
 	TARGET=z9001 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORz9001 -x$(OUTPUT_DIRECTORY)/z9001_clib @$(TARGET_DIRECTORY)/z9001/z9001.lst
+
+# Barebone z80 clib
+z80_clib.lib:
+	@echo ''
+	@echo '--- Building +z80 Library ---'
+	@echo ''
+	$(call buildgeneric,z80)
+	TARGET=z80 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/z80_clib @$(TARGET_DIRECTORY)/z80/z80.lst
+
+# Barebone z80/8080 clib
+8080_clib.lib:
+	@echo ''
+	@echo '--- Building +z80 (8080) Library ---'
+	@echo ''
+	$(call buildgeneric,z80)
+	TARGET=z80 TYPE=8080 $(LIBLINKER) -m8080 -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/8080_clib @$(TARGET_DIRECTORY)/z80/808x.lst
+
+# Barebone z80/8085 clib
+8085_clib.lib:
+	@echo ''
+	@echo '--- Building +z80 (8085) Library ---'
+	@echo ''
+	$(call buildgeneric,z80)
+	TARGET=z80 TYPE=8085 $(LIBLINKER) -m8085 -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/8085_clib @$(TARGET_DIRECTORY)/z80/808x.lst
+
+# Barebone z80/r2k clib
+r2k_clib.lib:
+	@echo ''
+	@echo '--- Building +z80 (r2ka) Library ---'
+	@echo ''
+	$(call buildgeneric,z80)
+	TARGET=z80 TYPE=r2k $(LIBLINKER) -mr2ka -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/r2ka_clib @$(TARGET_DIRECTORY)/z80/z80.lst
 
 # Robotron HC900, KC85/2..KC85/5 library - Stefano
 kc_clib.lib:

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -134,7 +134,7 @@ TOCREATE += $(call check_target,vz,vz_clib.lib)
 TOCREATE += $(call check_target,x07,x07_clib.lib)
 TOCREATE += $(call check_target,x1,x1_clib.lib x1_cpm.lib $(CPMLIBS))
 TOCREATE += $(call check_target,z1013,z1013_clib.lib)
-TOCREATE += $(call check_target,z80,z80_clib.lib 8080_clib.lib 8085_clib.lib r2ka_clib.lib)
+TOCREATE += $(call check_target,z80,z80_clib.lib ixiy_clib.lib 8080_clib.lib 8085_clib.lib r2ka_clib.lib)
 TOCREATE += $(call check_target,z80tvgame,z80tvgame_clib.lib)
 TOCREATE += $(call check_target,z88,z88_clib.lib z88_math.lib)
 TOCREATE += $(call check_target,z9001,z9001_clib.lib)
@@ -1108,6 +1108,14 @@ z80_clib.lib:
 	$(call buildgeneric,z80)
 	TARGET=z80 TYPE=z80 $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/z80_clib @$(TARGET_DIRECTORY)/z80/z80.lst
 
+# Barebone z80 (ixiy swapped)clib
+ixiy_clib.lib:
+	@echo ''
+	@echo '--- Building +z80 (ixiy) Library ---'
+	@echo ''
+	$(call buildgeneric,z80)
+	TARGET=z80 TYPE=ixiy $(LIBLINKER) -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/ixiy_clib @$(TARGET_DIRECTORY)/z80/z80.lst
+
 # Barebone z80/8080 clib
 8080_clib.lib:
 	@echo ''
@@ -1125,7 +1133,7 @@ z80_clib.lib:
 	TARGET=z80 TYPE=8085 $(LIBLINKER) -m8085 -DSTANDARDESCAPECHARS -DFORz80 -x$(OUTPUT_DIRECTORY)/8085_clib @$(TARGET_DIRECTORY)/z80/808x.lst
 
 # Barebone z80/r2k clib
-r2k_clib.lib:
+r2ka_clib.lib:
 	@echo ''
 	@echo '--- Building +z80 (r2ka) Library ---'
 	@echo ''

--- a/libsrc/target/z80/808x.lst
+++ b/libsrc/target/z80/808x.lst
@@ -1,0 +1,2 @@
+target/z80/stdio/fputc_cons_native
+@stdio/stdio_8080.lst

--- a/libsrc/target/z80/README.md
+++ b/libsrc/target/z80/README.md
@@ -1,0 +1,9 @@
+The +z80 target is bare bones, and doesn't have much in it.
+
+We have some library variants going on here:
+
+- z80
+- ixiy
+- 8080
+- 8085
+- r2k

--- a/libsrc/target/z80/stdio/fputc_cons_native.asm
+++ b/libsrc/target/z80/stdio/fputc_cons_native.asm
@@ -1,0 +1,13 @@
+;
+; Noop implementation of printing to console
+
+SECTION code_clib
+
+EXTERN l_ret
+PUBLIC fputc_cons_native
+PUBLIC _fputc_cons_native
+
+
+defc fputc_cons_native = l_ret
+defc _fputc_cons_native = fputc_cons_native
+

--- a/libsrc/target/z80/z80.lst
+++ b/libsrc/target/z80/z80.lst
@@ -1,0 +1,2 @@
+target/z80/stdio/fputc_cons_native
+@stdio/stdio.lst


### PR DESCRIPTION
This should massively simplify the effort needed to get running on a random piece of hardware - variants for 8080 & 8085 & r2k also supplied.

Add some more of the newlib pragmas/behaviour so it's comparable + need to add some more.

Need to create a wiki page to document all of this - that's now here: https://github.com/z88dk/z88dk/wiki/Classic--Homebrew

