### PR TITLE
(tms9918) Place __tms9918_map_colour into the correct code section

### DIFF
--- a/libsrc/video/tms9918/stdio/generic_console/conio_map_colour.asm
+++ b/libsrc/video/tms9918/stdio/generic_console/conio_map_colour.asm
@@ -5,7 +5,9 @@
 ; Used:  hl,bc,f
 ;
 
-	MODULE	code_clib
+	MODULE __tms9918_map_colour
+	SECTION	code_clib
+
 	PUBLIC	__tms9918_map_colour
 
 	EXTERN	__CLIB_CONIO_NATIVE_COLOUR


### PR DESCRIPTION
The  __tms9918_map_colour function was not being placed in the correct section during compilation. This makes sure it is placed into the code_clib section like the other tms9918 functions.