### PR TITLE
ticks: profiler accuracy fixed

### DIFF
--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -1342,6 +1342,13 @@ static int cmd_registers(int argc, char **argv)
 
             pc, bk.get_memory(pc), sp, (bk.get_memory(sp+1) << 8 | bk.get_memory(sp))
             );
+
+        if (regs.clockh || regs.clockl)
+        {
+            bk.console(FNT_CLR "CLOCKH " FNT_RST "$" FNT_BLD "%04X" FNT_RST "   "
+                       FNT_CLR "CLOCKL " FNT_RST "$" FNT_BLD "%04X" FNT_RST "\n",
+                       regs.clockh, regs.clockl);
+        }
     } else {  // Original output for non-active tty
         bk.console("pc=%04X, [pc]=%02X,    bc=%04X,  de=%04X,  hl=%04X,  af=%04X, ix=%04X, iy=%04X\n"
                "sp=%04X, [sp]=%04X, bc'=%04X, de'=%04X, hl'=%04X, af'=%04X\n"
@@ -1349,6 +1356,11 @@ static int cmd_registers(int argc, char **argv)
                pc, bk.get_memory(pc), regs.c | regs.b << 8, regs.e | regs.d << 8, regs.l | regs.h << 8, bk.f() | regs.a << 8, regs.xl | regs.xh << 8, regs.yl | regs.yh << 8,
                sp, (bk.get_memory(sp+1) << 8 | bk.get_memory(sp)), regs.c_ | regs.b_ << 8, regs.e_ | regs.d_ << 8, regs.l_ | regs.h_ << 8, bk.f_() | regs.a_ << 8,
                (bk.f() & 0x80) ? 1 : 0, (bk.f() & 0x40) ? 1 : 0, (bk.f() & 0x10) ? 1 : 0, (bk.f() & 0x04) ? 1 : 0, (bk.f() & 0x02) ? 1 : 0, (bk.f() & 0x01) ? 1 : 0);
+
+        if (regs.clockh || regs.clockl)
+        {
+            bk.console("clockh=%04X, clockhl=%04X\n", regs.clockh, regs.clockl);
+        }
     }
 
     return 0;

--- a/src/ticks/debugger_gdb.c
+++ b/src/ticks/debugger_gdb.c
@@ -109,8 +109,8 @@ static const char* register_mapping_names[] = {
      * Some emulators would report this 16bit register pair, which could be used
      * to track ticks for profiling purposes
      */
-    "clockl_",
-    "clockh_",
+    "clockl",
+    "clockh",
 };
 
 static enum register_mapping_t register_mappings[32] = {0};
@@ -1045,7 +1045,7 @@ static uint8_t connect_to_gdbserver(const char* connect_host, int connect_port)
                 uint8_t found_mapping = 0;
 
                 for (int i = 0; i < REGISTER_MAPPING_MAX; i++) {
-                    if (strcmp(reg_name, register_mapping_names[i]) == 0) {
+                    if (strstr(reg_name, register_mapping_names[i]) == reg_name) {
                         register_mappings[register_mappings_count++] = i;
                         found_mapping = 1;
                         break;

--- a/src/ticks/profiler.c
+++ b/src/ticks/profiler.c
@@ -24,6 +24,7 @@ struct profile_function_t
     debug_sym_function* function;
     struct profile_function_call_t* calls;
     uint64_t total_time;
+    uint32_t total_calls;
 
     UT_hash_handle hh;
 };
@@ -107,6 +108,7 @@ uint8_t profiler_check(uint16_t pc) {
             if (head) {
                 uint32_t spent = bk.time() - head->time;
                 f->total_time += spent;
+                f->total_calls++;
                 DL_DELETE(f->calls, head);
                 free(head);
             }
@@ -199,15 +201,16 @@ void profiler_stop() {
     HASH_SORT(profiling_functions, sort_functions);
 
     bk.console("Profiling results:\n");
-    bk.console("----------------------------------\n");
-    bk.console("    Time     Share    Function\n");
-    bk.console("----------------------------------\n");
+    bk.console("-----------------------------------------\n");
+    bk.console("   Calls   Time     Share    Function\n");
+    bk.console("-----------------------------------------\n");
 
     struct profile_function_t* f = profiling_functions;
     while (f) {
         double time_percent = (double)f->total_time / (double)total_total_time;
         int time_percent_int = (int)(time_percent * 100.0f);
-        bk.console("%*d %*d%%    %s\n", 8, f->total_time, 8, time_percent_int, f->function->function_name);
+        bk.console("%*d %*d %*d%%    %s\n", 6, f->total_calls, 8, f->total_time,
+                   8, time_percent_int, f->function->function_name);
 
         f = f->hh.next;
     }
@@ -226,9 +229,9 @@ void profiler_stop() {
         free(f);
     }
 
-    bk.console("----------------------------------\n"
+    bk.console("-----------------------------------------\n"
                "Total time: %d\n"
-               "----------------------------------\n", total_total_time);
+               "-----------------------------------------\n", total_total_time);
 
     profiler_enabled = 0;
 }

--- a/src/ticks/profiler.c
+++ b/src/ticks/profiler.c
@@ -9,6 +9,9 @@ static struct profile_function_t* profiling_functions = NULL;
 static int stack_level = 0;
 const char* within_function_only = NULL;
 static int profiling_iterations_limit = 0;
+static uint32_t loop_start_time = 0;
+static uint32_t loop_end_time = 0;
+static uint64_t total_total_time = 0;
 
 struct profile_function_call_t {
     uint32_t time;
@@ -71,6 +74,12 @@ uint8_t profiler_check(uint16_t pc) {
 
         struct profile_function_call_t* call = calloc(1, sizeof(struct profile_function_call_t));
         call->time = bk.time();
+
+        if (stack_level == 0)
+        {
+            loop_start_time = call->time;
+        }
+
         DL_PREPEND(f->calls, call);
 
         debug_stack_frames_free(fp);
@@ -78,25 +87,6 @@ uint8_t profiler_check(uint16_t pc) {
 
         return 1;
     } else if (breakpoint_pop_frame->value == pc) {
-
-        if (stack_level) {
-            if (--stack_level == 0) {
-                // we've just reached an end of iteration
-                if (profiling_iterations_limit) {
-                    // we have a limit
-                    if (--profiling_iterations_limit == 0) {
-                        // it just completed
-                        debugger_active = 1;
-                        profiler_stop();
-                        return 0;
-                    }
-                }
-            }
-        } else {
-            // stack discrepancy, we don't care
-            return 1;
-        }
-
         uint16_t stack = bk.sp();
         struct debugger_regs_t regs;
         bk.get_regs(&regs);
@@ -122,6 +112,28 @@ uint8_t profiler_check(uint16_t pc) {
             }
         }
 
+        if (stack_level) {
+            if (--stack_level == 0) {
+
+                loop_end_time = bk.time();
+                total_total_time += (loop_end_time - loop_start_time);
+
+                // we've just reached an end of iteration
+                if (profiling_iterations_limit) {
+                    // we have a limit
+                    if (--profiling_iterations_limit == 0) {
+                        // it just completed
+                        debugger_active = 1;
+                        profiler_stop();
+                        return 0;
+                    }
+                }
+            }
+        } else {
+            // stack discrepancy, we don't care
+            return 1;
+        }
+
         return 1;
     }
 
@@ -134,6 +146,9 @@ void profiler_start(const char* function, int iterations_limit) {
         return;
     }
 
+    total_total_time = 0;
+    loop_start_time = 0;
+    loop_end_time = 0;
     stack_level = 0;
     within_function_only = function;
     profiling_iterations_limit = iterations_limit;
@@ -183,20 +198,12 @@ void profiler_stop() {
 
     HASH_SORT(profiling_functions, sort_functions);
 
-    uint64_t total_total_time = 0;
-
-    struct profile_function_t* f = profiling_functions;
-    while (f) {
-        total_total_time += f->total_time;
-        f = f->hh.next;
-    }
-
     bk.console("Profiling results:\n");
     bk.console("----------------------------------\n");
     bk.console("    Time     Share    Function\n");
     bk.console("----------------------------------\n");
 
-    f = profiling_functions;
+    struct profile_function_t* f = profiling_functions;
     while (f) {
         double time_percent = (double)f->total_time / (double)total_total_time;
         int time_percent_int = (int)(time_percent * 100.0f);
@@ -219,7 +226,9 @@ void profiler_stop() {
         free(f);
     }
 
-    bk.console("----------------------------------\n");
+    bk.console("----------------------------------\n"
+               "Total time: %d\n"
+               "----------------------------------\n", total_total_time);
 
     profiler_enabled = 0;
 }


### PR DESCRIPTION
Previosly profiler would basically ignore precise counter [FuseX](https://github.com/speccytools/fuse-for-macosx/releases) can provide

```
    $e8f6    (l_debug_pop_frame+0)> profiler -f update_game_state -i 100
Profiler enabled.
 (limited to function update_game_state)
 (limited to 100 iterations)

    $e8f6    (l_debug_pop_frame+0)> c
Profiling results:
-----------------------------------------
   Calls   Time     Share    Function
-----------------------------------------
   100    94092      100%    update_game_state
   100    30942       32%    client_map_update
   100    30800       32%    update_game_input
   100    21650       23%    client_map_render
   100    18800       19%    update_move_controls
    44    16913       17%    update_object
   100     4800        5%    update_other_controls
    22     3872        4%    update_object_boundaries
    88     2200        2%    render_effect_sprite
     4     1792        1%    client_map_redraw_objects
    24     1176        1%    update_chunk_animated_blocks
    32      768        0%    get_objects_a
     4       92        0%    client_map_object_hide
     2       48        0%    switch_sprite_data_a
-----------------------------------------
Total time: 94092
-----------------------------------------
```

Also share % calculation wasn't accurate either. This change allows to do perf testing outside of simple programs with ticks, using debugger, by not measuring time, but by measuring ticks an emulator can provide.
