### PR TITLE
Fix #2260: output dir prepended twice

### DIFF
--- a/src/z80asm/src/cpp/args.cpp
+++ b/src/z80asm/src/cpp/args.cpp
@@ -115,6 +115,10 @@ void Args::parse_args(const vector<string>& args) {
 string Args::prepend_output_dir(const string& filename) {
 	if (m_output_dir.empty())
 		return filename;
+	else if (filename.substr(0, m_output_dir.size() + 1) == m_output_dir + "/") {
+		// #2260: may be called with an object file already with the path prepended; do not add it twice
+		return filename;
+	}
 	else {
 		// NOTE: concatenation (/) of a relative fs::path and an
 		// absolute fs::path discards the first one! Do our magic

--- a/src/z80asm/t/issue_2260.t
+++ b/src/z80asm/t/issue_2260.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+
+# Test https://github.com/z88dk/z88dk/issues/2260
+# z80asm: -O with -x fails
+
+my $test_dir = "${test}_dir";
+path("${test}_dir/lib/sccz80")->mkpath;
+path("${test}_dir/adt/b_array/c/sccz80")->mkpath;
+spew("${test}_dir/adt/b_array/c/sccz80/b_array_append.asm", "nop");
+
+# make .o
+run_ok("z88dk-z80asm -v -d -O${test}_dir/target/rc2014/obj/sccz80 ".
+	   "-x${test}_dir/lib/sccz80/rc2014 ".
+	   "${test}_dir/adt/b_array/c/sccz80/b_array_append");
+
+# use .o
+run_ok("z88dk-z80asm -v -d -O${test}_dir/target/rc2014/obj/sccz80 ".
+	   "-x${test}_dir/lib/sccz80/rc2014 ".
+	   "${test}_dir/adt/b_array/c/sccz80/b_array_append");
+
+path($test_dir)->remove_tree if Test::More->builder->is_passing;
+unlink_testfiles;
+done_testing;


### PR DESCRIPTION
When a library is being created (-x), and an output directory is being created (-O), and a file without extension is passed, and the option -d is used, and the object file is up-to-date in respect to the asm file, the full object file name with the output dir prepended is returned from the argument parsing function; this object file is then fed into the library creating function, who prepends the output dir again.

If an asm file was passed as an argument, then the library creating funciton did the right thing, prepending the output dir.