### PR TITLE
build.sh: Use gmake on Darwin

### DIFF
--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -18,7 +18,7 @@ jobs:
         submodules: 'true'
     - name: Install homebrew dependencies
       run: |
-        brew install perl dos2unix boost ragel re2c
+        brew install perl dos2unix boost ragel re2c make
     - name: Install perl prerequisites
       run: |
         export PATH=/usr/local/bin:$PATH

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ case `uname -s` in                      # Insert default values for MAKE and INS
     INSTALL="ginstall"
     export INSTALL
     ;;
-  OpenBSD|NetBSD|FreeBSD)
+  OpenBSD|NetBSD|FreeBSD|Darwin)
     MAKE="gmake"
     INSTALL="install"
     export INSTALL


### PR DESCRIPTION
On Darwin, /usr/bin/make is GNU make 3.x that can not build z88dk reliably.

I'm suggesting here to use gmake 4.x from homebrew (or other 3rd party package manager).