### PR TITLE
Issue #2296: Sort out classic maths linking

### DIFF
--- a/lib/config/alias.inc
+++ b/lib/config/alias.inc
@@ -11,17 +11,13 @@ ALIAS   --hardware-keyboard -pragma-redirect:fgetc_cons=fgetc_cons_inkey -pragma
 #
 # Math library aliases (classic)
 #
-ALIAS   --math-mbf32            -Cc-fp-mode=mbf32   -lmbf32 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MBF32 -Ca-D__MATH_MBF32 -D__MATH_MBF32
-ALIAS   --math-mbf32_8080       -Cc-fp-mode=mbf32   -lmbf32_8080 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MBF32 -Ca-D__MATH_MBF32 -D__MATH_MBF32
-ALIAS   --math-mbf32_8085       -Cc-fp-mode=mbf32   -lmbf32_8085 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MBF32 -Ca-D__MATH_MBF32 -D__MATH_MBF32
-ALIAS   --math-mbf32_gbz80      -Cc-fp-mode=mbf32   -lmbf32_gbz80 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MBF32 -Ca-D__MATH_MBF32 -D__MATH_MBF32
+ALIAS   --math-mbf32            -Cc-fp-mode=mbf32   -lmbf32@{ZCC_LIBCPU} -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MBF32 -Ca-D__MATH_MBF32 -D__MATH_MBF32
 ALIAS   --math-mbf64            -Cc-fp-mode=mbf64 -pragma-define:CLIB_64BIT_FLOATS=1   -lmbf64
-ALIAS   --math-bbc              -Cc-fp-mode=z88     -lbbc_math
-ALIAS   --math-dai32            -Cc-fp-mode=am9511  -ldaimath32 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_DAI32 -Ca-D__MATH_DAI32 -D__MATH_DAI32
-ALIAS   --math-dai32_8080       -Cc-fp-mode=am9511  -ldaimath32_8080 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_DAI32 -Ca-D__MATH_DAI32 -D__MATH_DAI32
-ALIAS   --math-am9511           -Cc-fp-mode=ieee    -lam9511 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_AM9511 -Ca-D__MATH_AM9511 -D__MATH_AM9511
-ALIAS   --math-am9511_8085      -Cc-fp-mode=ieee    -lam9511_8085 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_AM9511 -Ca-D__MATH_AM9511 -D__MATH_AM9511
+ALIAS   --math-bbc              -Cc-fp-mode=z88     -lbbc_math@{ZCC_LIBCPU}
+ALIAS   --math-dai32            -Cc-fp-mode=am9511  -ldaimath32@{ZCC_LIBCPU} -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_DAI32 -Ca-D__MATH_DAI32 -D__MATH_DAI32
+ALIAS   --math-am9511           -Cc-fp-mode=ieee    -lam9511@{ZCC_LIBCPU} -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_AM9511 -Ca-D__MATH_AM9511 -D__MATH_AM9511
 ALIAS	--math-cpc		-Cc-fp-exponent-bias=128 -Cc-fp-mantissa-size=5     -lcpcz80_math -D__MATH_CPC
+ALIAS	--fastmath		-lfastmath@{ZCC_LIBCPU}
 
 
 
@@ -29,6 +25,6 @@ ALIAS	--math-cpc		-Cc-fp-exponent-bias=128 -Cc-fp-mantissa-size=5     -lcpcz80_m
 # Math library aliases (classic + newlib)
 #
 ALIAS   --math16                                    -lmath16 --opt-code-speed=inlineints -Cc-D__MATH_MATH16 -Ca-D__MATH_MATH16 -D__MATH_MATH16
-ALIAS   --math32                -Cc-fp-mode=ieee    -lmath32 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MATH32 -Ca-D__MATH_MATH32 -D__MATH_MATH32
-ALIAS   --am9511                -Cc-fp-mode=ieee    -lam9511 -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_AM9511 -Ca-D__MATH_AM9511 -D__MATH_AM9511
+ALIAS   --math32                -Cc-fp-mode=ieee    -lmath32@{ZCC_LIBCPU} -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_MATH32 -Ca-D__MATH_MATH32 -D__MATH_MATH32
+ALIAS   --am9511                -Cc-fp-mode=ieee    -lam9511@{ZCC_LIBCPU} -pragma-define:CLIB_32BIT_FLOATS=1 -Cc-D__MATH_AM9511 -Ca-D__MATH_AM9511 -D__MATH_AM9511
 

--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -40,7 +40,7 @@ SUBTYPE		alphatro  -Cz+cpmdisk -Cz-f -Czalphatro -Cz--container=imd -lalphatro_c
 SUBTYPE		ampro     -Cz+cpmdisk -Cz-f -Czampro -Cz--container=imd -D__AMPRO__
 SUBTYPE		attache   -Cz+cpmdisk -Cz-f -Czattache -lattache -D__ATTACHE__
 SUBTYPE		bondwell  -Cz+cpmdisk -Cz-f -Czbw12 -lbondwell -D__BONDWELL__ -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=25
-SUBTYPE		bw2       -Cz+cpmdisk -Cz-f -Czbw2 -lbondwell2 -D__BONDWELL2__ -pragma-define:CRT_ORG_GRAPHICS=47000 -pragma-define:REGISTER_SP=47000 -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=25 -Ca-IXIY -Cl-IXIY
+SUBTYPE		bw2       -Cz+cpmdisk -Cz-f -Czbw2 -lbondwell2 -D__BONDWELL2__ -pragma-define:CRT_ORG_GRAPHICS=47000 -pragma-define:REGISTER_SP=47000 -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=25 -mz80_ixiy
 SUBTYPE		gemini    -Cz+cpmdisk -Cz-f -Czgemini -Cz--container=imd -lgemini -D__GEMINI__
 SUBTYPE		kaypro83  -Cz+cpmdisk -Cz-f -Czkayproii -D__KAYPROII__ -D__KAYPRO83__ -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=24 -pragma-define:CRT_ORG_GRAPHICS=47000 -lgfxkp83 -pragma-export:GRAPHICS_CHAR_SET=31 -pragma-export:GRAPHICS_CHAR_UNSET=32
 SUBTYPE		kaypro84  -Cz+cpmdisk -Cz-f -Czkayproii -D__KAYPRO84__ -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=25  -lgfxkp

--- a/lib/config/kc.cfg
+++ b/lib/config/kc.cfg
@@ -11,7 +11,7 @@ CRT0		 DESTDIR/lib/target/kc/classic/kc_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2  -Ca-IXIY -Cl-IXIY -iquote. -DZ80 -DKC -D__KC__ -M -subtype=default -clib=default -Cc-standard-escape-chars -Ca-IDESTDIR/lib/target/kc/def
+OPTIONS		 -O2 -SO2  -mz80_ixiy -iquote. -DZ80 -DKC -D__KC__ -M -subtype=default -clib=default -Cc-standard-escape-chars -Ca-IDESTDIR/lib/target/kc/def
 
 CLIB		default -lkc_clib -lndos -LDESTDIR/lib/clibs/z80
 CLIB		ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lkc_clib -lndos -LDESTDIR/lib/clibs/z80

--- a/lib/config/lambda.cfg
+++ b/lib/config/lambda.cfg
@@ -13,7 +13,7 @@ CRT0		 DESTDIR/lib/target/zx81/classic/zx81_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2 -iquote. -Ca-IXIY -Cl-IXIY -Cc-standard-escape-chars -DZ80 -DLAMBDA -D__LAMBDA__ -M -subtype=default -clib=default -Cs--reserve-regs-iy -Ca-IDESTDIR/lib/target/lambda/def
+OPTIONS		 -O2 -SO2 -iquote. -mz80_ixiy -Cc-standard-escape-chars -DZ80 -DLAMBDA -D__LAMBDA__ -M -subtype=default -clib=default -Cs--reserve-regs-iy -Ca-IDESTDIR/lib/target/lambda/def
 
 CLIB      default -llambda_clib -lndos -lgfxlambda -LDESTDIR/lib/clibs/ixiy
 

--- a/lib/config/primo.cfg
+++ b/lib/config/primo.cfg
@@ -10,7 +10,7 @@ CRT0		 DESTDIR/lib/target/primo/classic/primo_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2 -iquote. -Ca-IXIY -Cl-IXIY -DZ80 -DPRIMO -D__PRIMO__ -M -clib=default -Cc-standard-escape-chars -subtype=default
+OPTIONS		 -O2 -SO2 -iquote. -mz80_ixiy -DZ80 -DPRIMO -D__PRIMO__ -M -clib=default -Cc-standard-escape-chars -subtype=default
 
 CLIB		default -lprimo_clib -lndos -LDESTDIR/lib/clibs/ixiy
 

--- a/lib/config/vg5k.cfg
+++ b/lib/config/vg5k.cfg
@@ -10,7 +10,7 @@ CRT0         DESTDIR/lib/target/vg5k/classic/vg5k_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS         -O2 -SO2 -iquote.  -Ca-IXIY -Cl-IXIY -DZ80 -DVG5000 -D__VG5000__ -M -subtype=default -clib=default
+OPTIONS         -O2 -SO2 -iquote.  -mz80_ixiy -DZ80 -DVG5000 -D__VG5000__ -M -subtype=default -clib=default
 
 CLIB      default -Cc-standard-escape-chars -lvg5k_clib -lndos  -LDESTDIR/lib/clibs/z80
 CLIB      ansi -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-define:ansicolumns=40 -lvg5k_clib -lndos -LDESTDIR/lib/clibs/z80

--- a/lib/config/zx81.cfg
+++ b/lib/config/zx81.cfg
@@ -13,7 +13,7 @@ CRT0		 DESTDIR/lib/target/zx81/classic/zx81_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2 -iquote. -Ca-IXIY -Cl-IXIY -Cc-standard-escape-chars -DZ80 -DZX81 -D__ZX81__ -M -subtype=default -clib=default -Cs--reserve-regs-iy -Ca-IDESTDIR/lib/target/zx81/def  -Cz+zx81 -IDESTDIR/include/arch/zx81  -LDESTDIR/lib/clibs/ixiy
+OPTIONS		 -O2 -SO2 -iquote. -mz80_ixiy -Cc-standard-escape-chars -DZ80 -DZX81 -D__ZX81__ -M -subtype=default -clib=default -Cs--reserve-regs-iy -Ca-IDESTDIR/lib/target/zx81/def  -Cz+zx81 -IDESTDIR/include/arch/zx81  -LDESTDIR/lib/clibs/ixiy
 
 CLIB      default -lzx81_clib -lndos -lgfx81
 CLIB      udg -lzx81_clib -lndos -lgfx81udg

--- a/libsrc/Make.config
+++ b/libsrc/Make.config
@@ -49,9 +49,15 @@ endef
 obj/z80/%.o: %.c
 	$(ZCC) +test -mz80 $(CFLAGS) -o $@  $^
 
-
 obj/z80/%.o: %.asm
 	$(Q)$(ASSEMBLER) -I../ -I$(Z88DK_LIB) -I$(Z88DK_LIBSRC) -mz80 -D__CLASSIC $(AFLAGS) -Oobj/z80 $^
+
+
+obj/ez80_z80/%.o: %.c
+	$(ZCC) +test -clib=ez80_z80 $(CFLAGS) -o $@  $^
+
+obj/ez80_z80/%.o: %.asm
+	$(Q)$(ASSEMBLER) -I../ -I$(Z88DK_LIB) -I$(Z88DK_LIBSRC) -mez80_z80 -D__CLASSIC $(AFLAGS) -Oobj/ez80_z80 $^
 
 obj/z180/%.o: %.c
 	$(ZCC) +test -mz180 -D__Z180__ $(CFLAGS) -o $@  $^

--- a/libsrc/math/daimath32/Makefile
+++ b/libsrc/math/daimath32/Makefile
@@ -10,11 +10,27 @@ OBJECTS = $(AFILES:.asm=.o) $(CFILES:.c=.o)
 
 CFLAGS += -fp-mode=am9511 -D__MATH_DAI32 -DFLOAT_IS_32BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/daimath32.lib $(OUTPUT_DIRECTORY)/daimath32_8080.lib
+all: dirs $(OUTPUT_DIRECTORY)/daimath32.lib $(OUTPUT_DIRECTORY)/daimath32_8080.lib \
+	$(OUTPUT_DIRECTORY)/daimath32_z80n.lib \
+	$(OUTPUT_DIRECTORY)/daimath32_z180.lib \
+	$(OUTPUT_DIRECTORY)/daimath32_r2k.lib \
+	$(OUTPUT_DIRECTORY)/daimath32_ez80_z80.lib 
 
 
 $(OUTPUT_DIRECTORY)/daimath32.lib: $(addprefix obj/z80/, $(OBJECTS))
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/daimath32 @daimath32.lst
+
+$(OUTPUT_DIRECTORY)/daimath32_z80n.lib: $(addprefix obj/z80n/, $(OBJECTS))
+	TYPE=z80n $(LIBLINKER) -mz80n -x$(OUTPUT_DIRECTORY)/daimath32_z80n @daimath32.lst
+
+$(OUTPUT_DIRECTORY)/daimath32_z180.lib: $(addprefix obj/z180/, $(OBJECTS))
+	TYPE=z180 $(LIBLINKER) -mz180 -x$(OUTPUT_DIRECTORY)/daimath32_z180 @daimath32.lst
+
+$(OUTPUT_DIRECTORY)/daimath32_r2k.lib: $(addprefix obj/r2k/, $(OBJECTS))
+	TYPE=r2k $(LIBLINKER) -mr2ka -x$(OUTPUT_DIRECTORY)/daimath32_r2k @daimath32.lst
+
+$(OUTPUT_DIRECTORY)/daimath32_ez80_z80.lib: $(addprefix obj/ez80_z80/, $(OBJECTS))
+	TYPE=ez80_z80 $(LIBLINKER) -mez80_z80 -x$(OUTPUT_DIRECTORY)/daimath32_ez80_z80 @daimath32.lst
 
 $(OUTPUT_DIRECTORY)/daimath32_8080.lib: $(addprefix obj/8080/, $(OBJECTS))
 	TYPE=8080 $(LIBLINKER) -m8080 -x$(OUTPUT_DIRECTORY)/daimath32_8080 @daimath32.lst
@@ -22,6 +38,8 @@ $(OUTPUT_DIRECTORY)/daimath32_8080.lib: $(addprefix obj/8080/, $(OBJECTS))
 
 dirs:
 	@mkdir -p obj/z80/c/sccz80 obj/z80/c/asm obj/8080/c/sccz80 obj/8080/c/asm obj/z80/z80 obj/8080/z80 
+	@mkdir -p obj/z80n/c/sccz80 obj/z80n/c/asm obj/z180/c/sccz80 obj/z180/c/asm  obj/r2k/c/sccz80 obj/r2k/c/asm 
+	@mkdir -p obj/ez80_z80/c/sccz80 obj/ez80_z80/c/asm 
 
 clean:
 	$(RM) *.o* *.sym *.map *.err zcc_opt.def *.i *.opt

--- a/libsrc/math/fastmath/Makefile
+++ b/libsrc/math/fastmath/Makefile
@@ -9,7 +9,8 @@ TARGET ?= test
 
 NEWLIBGLOBS := "$(NEWLIB_DIRECTORY)/math/integer/fast/*.asm" "$(NEWLIB_DIRECTORY)/math/integer/small/*.asm" "$(NEWLIB_DIRECTORY)/math/integer/*.asm"
 NEWLIBZXNGLOBS := "$(NEWLIB_DIRECTORY)/math/integer/z80n/*.asm" 
-NEWLIB_TARGETS := obj/newlib-z80 obj/newlib-z80n obj/newlib-r2k obj/newlib-ixiy
+NEWLIBZ180GLOBS := "$(NEWLIB_DIRECTORY)/math/integer/z180/*.asm" 
+NEWLIB_TARGETS := obj/newlib-z80 obj/newlib-z80n obj/newlib-r2k obj/newlib-ixiy obj/newlib-z180 obj/newlib-ez80_z80
 
 space :=
 space +=
@@ -18,7 +19,9 @@ OBJECTS = $(CLASSIC_OBJECTS)
 
 .PHONY: dirs  $(NEWLIB_TARGETS)
 
-all: dirs $(OBJECTS) $(NEWLIB_TARGETS) $(OUTPUT_DIRECTORY)/fastmath.lib $(OUTPUT_DIRECTORY)/fastmath_ixiy.lib $(OUTPUT_DIRECTORY)/fastmath_z80n.lib
+all: dirs $(OBJECTS) $(NEWLIB_TARGETS) $(OUTPUT_DIRECTORY)/fastmath.lib $(OUTPUT_DIRECTORY)/fastmath_ixiy.lib $(OUTPUT_DIRECTORY)/fastmath_z80n.lib \
+	 $(OUTPUT_DIRECTORY)/fastmath_z180.lib \
+	 $(OUTPUT_DIRECTORY)/fastmath_ez80_z80.lib
 
 obj/newlib-z80:  
 	@$(ASSEMBLER) -d -O=obj/z80/x -I.. -mz80 -D__CLASSIC $(NEWLIBGLOBS)
@@ -30,6 +33,14 @@ obj/newlib-z80n:
 	@$(ASSEMBLER) -d -O=obj/z80n/x -I.. -mz80n -D__CLASSIC $(NEWLIBGLOBS)
 	@$(ASSEMBLER) -d -O=obj/z80n/x -I.. -mz80n -D__CLASSIC $(NEWLIBZXNGLOBS)
 
+obj/newlib-z180:  
+	@$(ASSEMBLER) -d -O=obj/z180/x -I.. -mz180 -D__CLASSIC $(NEWLIBGLOBS)
+	@$(ASSEMBLER) -d -O=obj/z180/x -I.. -mz180 -D__CLASSIC $(NEWLIBZ180GLOBS)
+
+obj/newlib-ez80_z80:  
+	@$(ASSEMBLER) -d -O=obj/ez80_z80/x -I.. -mez80_z80 -D__CLASSIC $(NEWLIBGLOBS)
+	@$(ASSEMBLER) -d -O=obj/ez80_z80/x -I.. -mez80_z80 -D__CLASSIC $(NEWLIBZ180GLOBS)
+
 obj/newlib-ixiy:  
 	@$(ASSEMBLER) -d -O=obj/ixiy/x -I.. -mz80 -IXIY -D__CLASSIC $(NEWLIBGLOBS)
 
@@ -39,11 +50,17 @@ $(OUTPUT_DIRECTORY)/fastmath_z80n.lib: fastmath.lst
 $(OUTPUT_DIRECTORY)/fastmath.lib: fastmath.lst
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath.lib @fastmath.lst
 
+$(OUTPUT_DIRECTORY)/fastmath_z180.lib: fastmath.lst
+	TYPE=z180 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_z180.lib @fastmath.lst
+
+$(OUTPUT_DIRECTORY)/fastmath_ez80_z80.lib: fastmath.lst
+	TYPE=ez80_Z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_ez80_z80.lib @fastmath.lst
+
 $(OUTPUT_DIRECTORY)/fastmath_ixiy.lib: fastmath.lst
 	TYPE=ixiy $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_ixiy.lib @fastmath.lst
 
 dirs:
-	@mkdir -p obj/z80 obj/z80n obj/ixiy obj/r2k
+	@mkdir -p obj/z80 obj/z80n obj/ixiy obj/r2k obj/z180 obj/ez80_z80
 
 
 clean:

--- a/libsrc/math/fastmath/Makefile
+++ b/libsrc/math/fastmath/Makefile
@@ -54,7 +54,7 @@ $(OUTPUT_DIRECTORY)/fastmath_z180.lib: fastmath.lst
 	TYPE=z180 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_z180.lib @fastmath.lst
 
 $(OUTPUT_DIRECTORY)/fastmath_ez80_z80.lib: fastmath.lst
-	TYPE=ez80_Z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_ez80_z80.lib @fastmath.lst
+	TYPE=ez80_z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_ez80_z80.lib @fastmath.lst
 
 $(OUTPUT_DIRECTORY)/fastmath_ixiy.lib: fastmath.lst
 	TYPE=ixiy $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/fastmath_ixiy.lib @fastmath.lst

--- a/libsrc/math/genmath/Makefile
+++ b/libsrc/math/genmath/Makefile
@@ -10,14 +10,22 @@ OBJECTS = $(AFILES:.asm=.o) $(CFILES:.c=.o)
 
 CFLAGS += -fp-mode=z80 -DFLOAT_IS_48BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/genmath.lib $(OUTPUT_DIRECTORY)/genmath_iy.lib $(OUTPUT_DIRECTORY)/genmath_zx81.lib
+all: dirs $(OUTPUT_DIRECTORY)/genmath.lib $(OUTPUT_DIRECTORY)/genmath_ixiy.lib $(OUTPUT_DIRECTORY)/genmath_zx81.lib \
+	$(OUTPUT_DIRECTORY)/genmath_ez80_z80.lib \
+	$(OUTPUT_DIRECTORY)/genmath_z80n.lib
 
 
 $(OUTPUT_DIRECTORY)/genmath.lib: $(addprefix obj/z80/, $(OBJECTS))
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/genmath @genmath.lst
 
-$(OUTPUT_DIRECTORY)/genmath_iy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
-	TYPE=ixiy $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/genmath_iy @genmath.lst
+$(OUTPUT_DIRECTORY)/genmath_z80n.lib: $(addprefix obj/z80n/, $(OBJECTS))
+	TYPE=z80n $(LIBLINKER) -mz80n -x$(OUTPUT_DIRECTORY)/genmath_z80n @genmath.lst
+
+$(OUTPUT_DIRECTORY)/genmath_ez80_z80.lib: $(addprefix obj/ez80_z80/, $(OBJECTS))
+	TYPE=ez80_z80 $(LIBLINKER) -mez80_z80 -x$(OUTPUT_DIRECTORY)/genmath_ez80_z80 @genmath.lst
+
+$(OUTPUT_DIRECTORY)/genmath_ixiy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
+	TYPE=ixiy $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/genmath_ixiy @genmath.lst
 
 $(OUTPUT_DIRECTORY)/genmath_zx81.lib: $(addprefix obj/ixiy_zx81/, $(OBJECTS))
 	TYPE=ixiy_zx81 $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/genmath_zx81 @genmathzx81.lst

--- a/libsrc/math/math32/Makefile
+++ b/libsrc/math/math32/Makefile
@@ -12,11 +12,17 @@ OBJECTS = $(CFILES:.c=.o)
 
 CFLAGS += -fp-mode=ieee -DFLOAT_IS_32BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/math32.lib $(OUTPUT_DIRECTORY)/math32_ixiy.lib $(OUTPUT_DIRECTORY)/math32_z180.lib
+all: dirs $(OUTPUT_DIRECTORY)/math32.lib $(OUTPUT_DIRECTORY)/math32_ixiy.lib $(OUTPUT_DIRECTORY)/math32_z180.lib \
+	$(OUTPUT_DIRECTORY)/math32_ez80_z80.lib \
+	$(OUTPUT_DIRECTORY)/math32_z80n.lib
 
 $(OUTPUT_DIRECTORY)/math32.lib: $(addprefix obj/z80/, $(OBJECTS))
 	$(Q)$(ASSEMBLER) -d -I$(Z88DK_LIB) -O=obj/z80/x/x  -I.. -mz80 -D__CLASSIC @newlibfiles_z80.lst
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math32 @math32.lst
+
+$(OUTPUT_DIRECTORY)/math32_z80n.lib: $(addprefix obj/z80n/, $(OBJECTS))
+	$(Q)$(ASSEMBLER) -d -I$(Z88DK_LIB) -O=obj/z80n/x/x  -I.. -mz80 -D__CLASSIC @newlibfiles_z80n.lst
+	TYPE=z80n $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math32 @math32.lst
 
 $(OUTPUT_DIRECTORY)/math32_ixiy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
 	$(Q)$(ASSEMBLER) -d -I$(Z88DK_LIB) -O=obj/ixiy/x/x -I.. -IXIY -mz80 -D__CLASSIC @newlibfiles_z80.lst
@@ -26,9 +32,13 @@ $(OUTPUT_DIRECTORY)/math32_z180.lib: $(addprefix obj/z180/, $(OBJECTS))
 	$(Q)$(ASSEMBLER) -d -I$(Z88DK_LIB) -O=obj/z180/x/x -I.. -IXIY -mz80 -D__CLASSIC @newlibfiles_z180.lst
 	TYPE=z180 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math32_z180 @math32.lst
 
+$(OUTPUT_DIRECTORY)/math32_ez80_z80.lib: $(addprefix obj/ez80_z80/, $(OBJECTS))
+	$(Q)$(ASSEMBLER) -d -I$(Z88DK_LIB) -O=obj/ez80_z80/x/x -I.. -IXIY -mz80 -D__CLASSIC @newlibfiles_z180.lst
+	TYPE=ez80_z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math32_ez80_z80 @math32.lst
+
 
 dirs:
-	@mkdir -p obj/z80/c obj/ixiy/c  obj/z180/c
+	@mkdir -p obj/z80/c obj/ixiy/c  obj/z180/c obj/z80n/c obj/ez80_z80/c
 
 clean:
 	$(RM) *.o* *.sym *.map *.err zcc_opt.def *.i *.opt config_private.inc

--- a/libsrc/math/math32/newlibfiles_z80n.lst
+++ b/libsrc/math/math32/newlibfiles_z80n.lst
@@ -1,0 +1,4 @@
+../../_DEVELOPMENT/math/float/math32/z80/f32_z80n_mulu_32h_24x24
+../../_DEVELOPMENT/math/float/math32/z80/f32_z80n_mulu_32h_32x32
+../../_DEVELOPMENT/math/float/math32/z80/f32_z80n_sqr_32h_24x24
+@newlibfiles_z80.lst

--- a/libsrc/math/math48/Makefile
+++ b/libsrc/math/math48/Makefile
@@ -14,19 +14,34 @@ OBJECTS = $(CFILES:.c=.o) $(AFILES:.asm=.o)
 
 CFLAGS += -DFLOAT_IS_48BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/math48.lib $(OUTPUT_DIRECTORY)/math48_iy.lib
+all: dirs $(OUTPUT_DIRECTORY)/math48.lib $(OUTPUT_DIRECTORY)/math48_ixiy.lib \
+	$(OUTPUT_DIRECTORY)/math48_z80n.lib \
+	$(OUTPUT_DIRECTORY)/math48_z180.lib \
+	$(OUTPUT_DIRECTORY)/math48_ez80_z80.lib
 
 
 $(OUTPUT_DIRECTORY)/math48.lib: $(addprefix obj/z80/, $(OBJECTS))
 	@$(ASSEMBLER) -d -O=obj/z80/x/x -I.. -mz80 -D__CLASSIC @newlibfiles.lst
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math48 @math48.lst
 
-$(OUTPUT_DIRECTORY)/math48_iy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
+$(OUTPUT_DIRECTORY)/math48_z180.lib: $(addprefix obj/z180/, $(OBJECTS))
+	@$(ASSEMBLER) -d -O=obj/z180/x/x -I.. -mz180 -D__CLASSIC @newlibfiles.lst
+	TYPE=z180 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math48_z180 @math48.lst
+
+$(OUTPUT_DIRECTORY)/math48_z80n.lib: $(addprefix obj/z80n/, $(OBJECTS))
+	@$(ASSEMBLER) -d -O=obj/z80n/x/x -I.. -mz80n -D__CLASSIC @newlibfiles.lst
+	TYPE=z80n $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math48_z80n @math48.lst
+
+$(OUTPUT_DIRECTORY)/math48_ez80_z80.lib: $(addprefix obj/ez80_z80/, $(OBJECTS))
+	@$(ASSEMBLER) -d -O=obj/ez80_z80/x/x -I.. -mez80_z80 -D__CLASSIC @newlibfiles.lst
+	TYPE=ez80_z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math48_ez80_z80 @math48.lst
+
+$(OUTPUT_DIRECTORY)/math48_ixiy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
 	@$(ASSEMBLER) -d -O=obj/ixiy/x/x -I.. -mz80 -IXIY -D__CLASSIC @newlibfiles.lst
-	TYPE=ixiy $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math48_iy -IXIY @math48.lst
+	TYPE=ixiy $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/math48_ixiy -IXIY @math48.lst
 
 dirs:
-	@mkdir -p obj/z80 obj/ixiy obj/r2k obj/z80/cimpl
+	@mkdir -p obj/z80 obj/ixiy obj/r2k obj/z80/cimpl obj/z80n/cimpl obj/z180/cimpl obj/ez80_z80/cimpl
 
 .PHONY: dirs
 

--- a/libsrc/math/mbf32/Makefile
+++ b/libsrc/math/mbf32/Makefile
@@ -10,10 +10,16 @@ OBJECTS = $(AFILES:.asm=.o) $(CFILES:.c=.o)
 
 CFLAGS += -fp-mode=mbf32 -D__MATH_MBF32 -DFLOAT_IS_32BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/mbf32.lib $(OUTPUT_DIRECTORY)/mbf32_8080.lib $(OUTPUT_DIRECTORY)/mbf32_8085.lib $(OUTPUT_DIRECTORY)/mbf32_iy.lib $(OUTPUT_DIRECTORY)/mbf32_gbz80.lib
+all: dirs $(OUTPUT_DIRECTORY)/mbf32.lib $(OUTPUT_DIRECTORY)/mbf32_8080.lib $(OUTPUT_DIRECTORY)/mbf32_8085.lib $(OUTPUT_DIRECTORY)/mbf32_ixiy.lib $(OUTPUT_DIRECTORY)/mbf32_gbz80.lib \
+	$(OUTPUT_DIRECTORY)/mbf32_z80n.lib \
+	$(OUTPUT_DIRECTORY)/mbf32_z180.lib \
+	$(OUTPUT_DIRECTORY)/mbf32_ez80_z80.lib 
 
 $(OUTPUT_DIRECTORY)/mbf32.lib: $(addprefix obj/z80/, $(OBJECTS))
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/mbf32 @mbf32.lst
+
+$(OUTPUT_DIRECTORY)/mbf32_z80n.lib: $(addprefix obj/z80n/, $(OBJECTS))
+	TYPE=z80n $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/mbf32 @mbf32.lst
 
 $(OUTPUT_DIRECTORY)/mbf32_8080.lib: $(addprefix obj/8080/, $(OBJECTS))
 	TYPE=8080 $(LIBLINKER) -m8080 -x$(OUTPUT_DIRECTORY)/mbf32_8080 @mbf32.lst
@@ -21,18 +27,27 @@ $(OUTPUT_DIRECTORY)/mbf32_8080.lib: $(addprefix obj/8080/, $(OBJECTS))
 $(OUTPUT_DIRECTORY)/mbf32_8085.lib: $(addprefix obj/8085/, $(OBJECTS))
 	TYPE=8085 $(LIBLINKER) -m8085 -x$(OUTPUT_DIRECTORY)/mbf32_8085 @mbf32.lst
 
-$(OUTPUT_DIRECTORY)/mbf32_iy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
-	TYPE=ixiy $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/mbf32_iy @mbf32.lst
+$(OUTPUT_DIRECTORY)/mbf32_ixiy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
+	TYPE=ixiy $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/mbf32_ixiy @mbf32.lst
 
 $(OUTPUT_DIRECTORY)/mbf32_gbz80.lib: $(addprefix obj/gbz80/, $(OBJECTS))
 	TYPE=gbz80 $(LIBLINKER) -mgbz80 -x$(OUTPUT_DIRECTORY)/mbf32_gbz80 @mbf32.lst
 
+$(OUTPUT_DIRECTORY)/mbf32_z180.lib: $(addprefix obj/z180/, $(OBJECTS))
+	TYPE=z180 $(LIBLINKER) -mz180 -x$(OUTPUT_DIRECTORY)/mbf32_z180 @mbf32.lst
+
+$(OUTPUT_DIRECTORY)/mbf32_ez80_z80.lib: $(addprefix obj/ez80_z80/, $(OBJECTS))
+	TYPE=ez80_z80 $(LIBLINKER) -mez80_z80 -x$(OUTPUT_DIRECTORY)/mbf32_ez80_z80 @mbf32.lst
+
 dirs:
 	@mkdir -p obj/z80/c/sccz80 obj/z80/c/asm obj/z80/z80
+	@mkdir -p obj/z80n/c/sccz80 obj/z80n/c/asm obj/z80n/z80
 	@mkdir -p obj/8080/c/sccz80 obj/8080/c/asm obj/8080/z80
 	@mkdir -p obj/8085/c/sccz80 obj/8085/c/asm obj/8085/z80
 	@mkdir -p obj/ixiy/c/sccz80 obj/ixiy/c/asm obj/ixiy/z80
 	@mkdir -p obj/gbz80/c/sccz80 obj/gbz80/c/asm obj/gbz80/z80
+	@mkdir -p obj/z180/c/sccz80 obj/z180/c/asm obj/z180/z80
+	@mkdir -p obj/ez80_z80/c/sccz80 obj/ez80_z80/c/asm obj/ez80_z80/z80
 
 clean:
 	$(RM) *.o* *.sym *.map *.err zcc_opt.def *.i *.opt

--- a/libsrc/math/mbf64/Makefile
+++ b/libsrc/math/mbf64/Makefile
@@ -10,14 +10,14 @@ OBJECTS = $(AFILES:.asm=.o) $(CFILES:.c=.o)
 
 CFLAGS += -fp-mode=mbf64 -DFLOAT_IS_64BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/mbf64.lib $(OUTPUT_DIRECTORY)/mbf64_iy.lib 
+all: dirs $(OUTPUT_DIRECTORY)/mbf64.lib $(OUTPUT_DIRECTORY)/mbf64_ixiy.lib 
 
 
 $(OUTPUT_DIRECTORY)/mbf64.lib: $(addprefix obj/z80/, $(OBJECTS))
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/mbf64 @mbf64.lst
 
-$(OUTPUT_DIRECTORY)/mbf64_iy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
-	TYPE=ixiy $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/mbf64_iy @mbf64.lst
+$(OUTPUT_DIRECTORY)/mbf64_ixiy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
+	TYPE=ixiy $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/mbf64_ixiy @mbf64.lst
 
 dirs:
 	@mkdir -p obj/z80/c/sccz80 obj/ixiy/c/sccz80

--- a/libsrc/math/z88math/Makefile
+++ b/libsrc/math/z88math/Makefile
@@ -10,8 +10,10 @@ OBJECTS = $(AFILES:.asm=.o) $(CFILES:.c=.o)
 
 CFLAGS +=  -math-z88 -D__Z88__ -D__NATIVE_MATH__ -DFLOAT_IS_48BITS
 
-all: dirs $(OUTPUT_DIRECTORY)/z88_math.lib $(OUTPUT_DIRECTORY)/bbc_math.lib
-all: dirs $(OUTPUT_DIRECTORY)/z88_math.lib $(OUTPUT_DIRECTORY)/bbc_math.lib $(OUTPUT_DIRECTORY)/bbc_math_iy.lib
+all: dirs $(OUTPUT_DIRECTORY)/z88_math.lib $(OUTPUT_DIRECTORY)/bbc_math.lib $(OUTPUT_DIRECTORY)/bbc_math_ixiy.lib \
+	$(OUTPUT_DIRECTORY)/bbc_math_z80n.lib \
+	$(OUTPUT_DIRECTORY)/bbc_math_z180.lib \
+	$(OUTPUT_DIRECTORY)/bbc_math_ez80_z80.lib
 
 
 $(OUTPUT_DIRECTORY)/z88_math.lib: $(addprefix obj/z88/, $(OBJECTS))
@@ -20,8 +22,17 @@ $(OUTPUT_DIRECTORY)/z88_math.lib: $(addprefix obj/z88/, $(OBJECTS))
 $(OUTPUT_DIRECTORY)/bbc_math.lib: $(addprefix obj/z80/, $(OBJECTS))
 	TYPE=z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/bbc_math @z88math.lst
 
-$(OUTPUT_DIRECTORY)/bbc_math_iy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
-	TYPE=z80 $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/bbc_math_iy @z88math.lst
+$(OUTPUT_DIRECTORY)/bbc_math_z80n.lib: $(addprefix obj/z80n/, $(OBJECTS))
+	TYPE=z80n $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/bbc_math_z80n @z88math.lst
+
+$(OUTPUT_DIRECTORY)/bbc_math_ez80_z80.lib: $(addprefix obj/ez80_z80/, $(OBJECTS))
+	TYPE=ez80_z80 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/bbc_math_ez80_z80 @z88math.lst
+
+$(OUTPUT_DIRECTORY)/bbc_math_z180.lib: $(addprefix obj/z180/, $(OBJECTS))
+	TYPE=z180 $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/bbc_math_z180 @z88math.lst
+
+$(OUTPUT_DIRECTORY)/bbc_math_ixiy.lib: $(addprefix obj/ixiy/, $(OBJECTS))
+	TYPE=z80 $(LIBLINKER) -IXIY -x$(OUTPUT_DIRECTORY)/bbc_math_ixiy @z88math.lst
 
 obj/z88/%.o: %.c
 	$(ZCC) +test -mz80 $(CFLAGS) -o $@  $^

--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -68,6 +68,7 @@ enum {
     CPU_MAP_TOOL_ZSDCC,
     CPU_MAP_TOOL_COPT,
     CPU_MAP_TOOL_CPURULES,
+    CPU_MAP_TOOL_LIBNAME,
     CPU_MAP_TOOL_SIZE,
 };
 
@@ -81,6 +82,7 @@ enum {
     CPU_TYPE_8085,
     CPU_TYPE_GBZ80,
     CPU_TYPE_EZ80,
+    CPU_TYPE_IXIY,
     CPU_TYPE_SIZE
 };
 
@@ -459,6 +461,7 @@ static option options[] = {
     { 0, "m8080", OPT_ASSIGN|OPT_INT, "Generate output for the i8080", &c_cpu, NULL, CPU_TYPE_8080 },
     { 0, "m8085", OPT_ASSIGN|OPT_INT, "Generate output for the i8085", &c_cpu, NULL, CPU_TYPE_8085 },
     { 0, "mz80", OPT_ASSIGN|OPT_INT, "Generate output for the z80", &c_cpu, NULL, CPU_TYPE_Z80 },
+    { 0, "mz80_ixiy", OPT_ASSIGN|OPT_INT, "Generate output for the z80 with ix/iy swap", &c_cpu, NULL, CPU_TYPE_IXIY },
     { 0, "mz80n", OPT_ASSIGN|OPT_INT, "Generate output for the z80n", &c_cpu, NULL, CPU_TYPE_Z80N },
     { 0, "mz180", OPT_ASSIGN|OPT_INT, "Generate output for the z180", &c_cpu, NULL, CPU_TYPE_Z180 },
     { 0, "mr2ka", OPT_ASSIGN|OPT_INT, "Generate output for the Rabbit 2000", &c_cpu, NULL, CPU_TYPE_R2K },
@@ -560,15 +563,16 @@ static option options[] = {
 
 
 cpu_map_t cpu_map[CPU_TYPE_SIZE] = {
-    {{ "-mz80"   , "-mz80"   , "-mz80"   , "-mz80", "DESTDIR/lib/arch/z80/z80_rules.1"   }},          /* CPU_TYPE_Z80     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-mz80n"  , "-mz80n"  , "-mz80n"  , "-mz80n","DESTDIR/lib/arch/z80n/z80n_rules.1"  }},          /* CPU_TYPE_Z80N    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC                */
-    {{ "-mz180"  , "-mz180"  , "-mz180 -portmode=z180", "-mz180", "DESTDIR/lib/arch/z180/z180_rules.1" }},    /* CPU_TYPE_Z180    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-mr2ka"  , "-mr2ka"  , "-mr2ka"  , "-mr2ka", "DESTDIR/lib/arch/rabbit/rabbit_rules.1"  }},          /* CPU_TYPE_R2K     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-mr3k"   , "-mr3k"   , "-mr3ka"  , "-mr3k", "DESTDIR/lib/arch/rabbit/rabbit_rules.1"   }},          /* CPU_TYPE_R3K     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-m8080"  , "-m8080"  , "-mz80"   , "-m8080", "DESTDIR/lib/arch/8080/8080_rules.1"  }},          /* CPU_TYPE_8080    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-m8085"  , "-m8085"  , "-mz80"   , "-m8085", "DESTDIR/lib/arch/8085/8085_rules.1"  }},          /* CPU_TYPE_8085    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-mgbz80" , "-mgbz80" , "-msm83" , "-mgbz80", "DESTDIR/lib/arch/gbz80/gbz80_rules.1" }},       /* CPU_TYPE_GBZ80   : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
-    {{ "-mez80_z80"   , "-mez80_z80" ,  "-mez80_z80" ,   "-mez80", "DESTDIR/lib/arch/ez80/ez80_rules.1" }}           /* CPU_TYPE_EZ80   : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-mz80"   , "-mz80"   , "-mz80"   , "-mz80", "DESTDIR/lib/arch/z80/z80_rules.1", ""   }},          /* CPU_TYPE_Z80     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT, CPU_TOOL_LIBNAME */
+    {{ "-mz80n"  , "-mz80n"  , "-mz80n"  , "-mz80n","DESTDIR/lib/arch/z80n/z80n_rules.1", "_z80n"  }},          /* CPU_TYPE_Z80N    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC                */
+    {{ "-mz180"  , "-mz180"  , "-mz180 -portmode=z180", "-mz180", "DESTDIR/lib/arch/z180/z180_rules.1", "_z180" }},    /* CPU_TYPE_Z180    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-mr2ka"  , "-mr2ka"  , "-mr2ka"  , "-mr2ka", "DESTDIR/lib/arch/rabbit/rabbit_rules.1", "_r2k"  }},          /* CPU_TYPE_R2K     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-mr3k"   , "-mr3k"   , "-mr3ka"  , "-mr3k", "DESTDIR/lib/arch/rabbit/rabbit_rules.1", "_r2k"   }},          /* CPU_TYPE_R3K     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-m8080"  , "-m8080"  , "-mz80"   , "-m8080", "DESTDIR/lib/arch/8080/8080_rules.1", "_8080"  }},          /* CPU_TYPE_8080    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-m8085"  , "-m8085"  , "-mz80"   , "-m8085", "DESTDIR/lib/arch/8085/8085_rules.1", "_8085"  }},          /* CPU_TYPE_8085    : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-mgbz80" , "-mgbz80" , "-msm83" , "-mgbz80", "DESTDIR/lib/arch/gbz80/gbz80_rules.1", "_gbz80" }},       /* CPU_TYPE_GBZ80   : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-mez80_z80"   , "-mez80_z80" ,  "-mez80_z80" ,   "-mez80", "DESTDIR/lib/arch/ez80/ez80_rules.1", "_ez80_z80" }},           /* CPU_TYPE_EZ80   : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT */
+    {{ "-mz80 -IXIY"   , "-mz80"   , "-mz80"   , "-mz80", "DESTDIR/lib/arch/z80/z80_rules.1", "_ixiy"   }},          /* CPU_TYPE_IXIY     : CPU_MAP_TOOL_Z80ASM, CPU_MAP_TOOL_SCCZ80, CPU_MAP_TOOL_ZSDCC, CPU_TOOL_COPT, CPU_TOOL_LIBNAME */
 };
 
 
@@ -1137,7 +1141,7 @@ int main(int argc, char **argv)
     }
 
     /* Mangle math lib name but only for classic compiles */
-    if ((c_clib == 0) || (!strstr(c_clib, "new") && !strstr(c_clib, "sdcc") && !strstr(c_clib, "clang")))
+    if ((c_clib == NULL) || (!strstr(c_clib, "new") && !strstr(c_clib, "sdcc") && !strstr(c_clib, "clang")))
         if (linker_linklib_first) configure_maths_library(&linker_linklib_first);   /* -lm appears here */
 
     /* Options that must be sequenced in specific order */
@@ -1635,6 +1639,15 @@ int main(int argc, char **argv)
         if (lston) copy_output_files_to_destdir(".lis", 1);
         if (symbolson) copy_output_files_to_destdir(".sym", 1);
         outputfile = tempofile;
+    }
+
+    {
+        // Sort out linklibs for CPU markers (only for classic)
+        int cpu_libs = ((c_clib == NULL) || (!strstr(c_clib, "new") && !strstr(c_clib, "sdcc") && !strstr(c_clib, "clang")));
+        char *tmp = replace_str(linklibs, "@{ZCC_LIBCPU}", cpu_libs ? select_cpu(CPU_MAP_TOOL_LIBNAME) : "");
+
+        free(linklibs);
+        linklibs = tmp;
     }
 
     if (compileonly) {
@@ -2322,7 +2335,6 @@ void BuildOptions_start(char **list, char *arg)
     char           *orig = *list;
 
     zcc_asprintf(&val, "%s %s", arg, orig ? orig : "");
-
     free(orig);
     *list = val;
 }

--- a/test/suites/math/Makefile
+++ b/test/suites/math/Makefile
@@ -36,11 +36,11 @@ test_cpcmath.bin: $(FPSOURCES)
 	$(runtest)
 
 test_mbf32_8080.bin: $(FPSOURCES)
-	$(call compile_8080, -DMBF32 --math-mbf32_8080 -DMATH_LIBRARY="\"\\\"MBF32\\\"\"")
+	$(call compile_8080, -DMBF32 --math-mbf32 -DMATH_LIBRARY="\"\\\"MBF32\\\"\"")
 	$(runtest_8080)
 
 test_mbf32_8085.bin: $(FPSOURCES)
-	$(call compile_8085, -DMBF32 --math-mbf32_8085 -DMATH_LIBRARY="\"\\\"MBF32\\\"\"")
+	$(call compile_8085, -DMBF32 --math-mbf32 -DMATH_LIBRARY="\"\\\"MBF32\\\"\"")
 	$(runtest_8085)
 
 test_9511.bin: $(FPSOURCES)
@@ -48,11 +48,11 @@ test_9511.bin: $(FPSOURCES)
 	$(runtest)
 
 test_9511_8085.bin: $(FPSOURCES)
-	$(call compile_8085, -DAM9511 --math-am9511_8085 -DMATH_LIBRARY="\"\\\"AM9511-8085\\\"\"")
+	$(call compile_8085, -DAM9511 --math-am9511 -DMATH_LIBRARY="\"\\\"AM9511-8085\\\"\"")
 	$(runtest_8085)
 
 test_mbf32_gbz80.bin: $(FPSOURCES)
-	$(call compile_gbz80, -DMBF32 --math-mbf32_gbz80 -DMATH_LIBRARY="\"\\\"MBF32\\\"\"")
+	$(call compile_gbz80, -DMBF32 --math-mbf32 -DMATH_LIBRARY="\"\\\"MBF32\\\"\"")
 	$(runtest_gbz80)
 
 test_math48.bin: $(FPSOURCES)


### PR DESCRIPTION
Name libraries consistently according to the CPU choice.

Perform string replacement on `@{ZCC_LIBCPU}` with the mapping for -mXXXX CPU option.

This means that we no longer need multiple aliases for the same maths library for different CPUs.