### PR TITLE
Fix build for FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,10 @@ case `uname -s` in                      # Insert default values for MAKE and INS
     MAKE="gmake"
     INSTALL="install"
     export INSTALL
+    if [ -z "$CC" ]; then                   # Insert default value for CC if CC is empty
+      CC="cc"
+      export CC
+    fi
     ;;
   Darwin)
     if ! command -v gmake &> /dev/null
@@ -161,7 +165,6 @@ if [ -z "$CC" ]; then                   # Insert default value for CC if CC is e
   CC="gcc"
   export CC
 fi
-
 
 if [ -z "$CFLAGS" ]; then               # Insert default value for CFLAGS if CFLAGS is empty
   CFLAGS="-g -O2"

--- a/libsrc/sprites/software/sp1/Makefile
+++ b/libsrc/sprites/software/sp1/Makefile
@@ -9,11 +9,11 @@ sp1-all:
 	$(LIBLINKER) -x$(OUTPUT_DIRECTORY)/sp1-ts2068 @ts2068hr.lst
 	$(LIBLINKER) -x$(OUTPUT_DIRECTORY)/sp1-zx81hr -IXIY @zx81hr.lst
 	# sdcc + classic library
-	make -C zx all
+	$(MAKE) -C zx all
 	cp zx/sp1-zx.lib $(OUTPUT_DIRECTORY)
 
 clean:
-	@make -s -C zx clean
+	@$(MAKE) -C zx clean
 	$(RM) *.o
 	$(RM) deprecated/ts2068hr/sprites/*.o
 	$(RM) deprecated/ts2068hr/sprites/draw/*.o

--- a/src/z80asm/Makefile
+++ b/src/z80asm/Makefile
@@ -101,7 +101,7 @@ dev: src/c/scan_rules.h
 src/c/scan_rules.h: src/c/scan_rules.rl src/c/tokens.h src/c/scan_def.h \
 				parse_ragel.pl Makefile 
 	perl parse_ragel.pl src/c/scan_rules.rl
-	dos2unix -q src/c/scan_rules.h
+	dos2unix src/c/scan_rules.h > /dev/null
 	
 dev: src/c/parse_rules.h
 
@@ -109,11 +109,11 @@ src/c/parse_rules.h: src/c/parse_rules.rl src/c/tokens.h src/c/scan_def.h \
 				parse_ragel.pl Makefile \
 				dev/cpu/cpu_rules.h
 	perl parse_ragel.pl src/c/parse_rules.rl
-	dos2unix -q src/c/parse_rules.h
+	dos2unix src/c/parse_rules.h > /dev/null
 
 src/c/tokens.h : make_tokens.pl Makefile
 	perl make_tokens.pl > src/c/tokens.h
-	dos2unix -q src/c/tokens.h
+	dos2unix src/c/tokens.h > /dev/null
 
 # opcode tables generator
 dev: dev/cpu/opcodes.yaml \
@@ -122,23 +122,23 @@ dev: dev/cpu/opcodes.yaml \
 	 dev/cpu/cpu_rules.h
 
 dev/cpu/opcodes.yaml: dev/cpu/make_opcodes.pl Makefile
-	cd dev/cpu && perl make_opcodes.pl && dos2unix -q opcodes.yaml
+	cd dev/cpu && perl make_opcodes.pl && dos2unix opcodes.yaml > /dev/null
 
 dev/cpu/opcodes.txt: dev/cpu/opcodes.yaml dev/cpu/dump_opcodes.pl Makefile
-	cd dev/cpu && perl dump_opcodes.pl && dos2unix -q opcodes.txt
+	cd dev/cpu && perl dump_opcodes.pl && dos2unix opcodes.txt > /dev/null
 
 dev/cpu/cpu_test_z80_ok.asm: dev/cpu/opcodes.yaml dev/cpu/make_cpu_test.pl Makefile
-	cd dev/cpu && perl make_cpu_test.pl && dos2unix -q cpu_test_*.asm
+	cd dev/cpu && perl make_cpu_test.pl && dos2unix cpu_test_*.asm > /dev/null
 
 dev/cpu/cpu_rules.h: dev/cpu/opcodes.yaml dev/cpu/make_cpu_rules.pl Makefile
-	cd dev/cpu && perl make_cpu_rules.pl && dos2unix -q cpu_rules.h
+	cd dev/cpu && perl make_cpu_rules.pl && dos2unix cpu_rules.h > /dev/null
 
 # reloc routine
 dev: src/c/reloc_code.c
 
 src/c/reloc_code.c: dev/reloc_code.asm dev/make_reloc_code.pl Makefile
-	cd dev && perl make_reloc_code.pl && dos2unix -q reloc_code.[ch] && \
-		mv -f reloc_code.[ch] ../src/c/
+	cd dev && perl make_reloc_code.pl && dos2unix reloc_code.[ch] && \
+		mv -f reloc_code.[ch] ../src/c/ > /dev/null
 
 # re2c
 define MAKE_RE2C
@@ -146,7 +146,7 @@ dev: $(1).o
 
 $(1).cpp: $(1).re Makefile
 	$(RE2C) -o $(1).cpp $(1).re
-	dos2unix -q $(1).cpp
+	dos2unix $(1).cpp > /dev/null
 endef
 
 $(eval $(call MAKE_RE2C,src/cpp/lex))

--- a/src/z80asm/parse_ragel.pl
+++ b/src/z80asm/parse_ragel.pl
@@ -33,7 +33,9 @@ copy("$FILE.rl1", "$FILE.c") or die "read $FILE.rl failed: $!\n";
 push @TEMP, "$FILE.c";
 
 # preprocess to .c -> .rl2
-my $cmd = "gcc -E $FILE.c";
+my $cc = $ENV{CC};
+$cc = 'gcc' if !defined($cc);
+my $cmd = "$cc -E $FILE.c";
 open(my $in, "$cmd |") or die "Input from '$cmd' failed: $!\n";
 open(my $out, ">", "$FILE.rl2") or die "Output to $FILE.rl2 failed: $!\n";
 push @TEMP, "$FILE.rl2";


### PR DESCRIPTION
Use $(MAKE) instead of make
Don't use -q with dos2unix (Not supported on FreeBSD 12 and 13)
Use a default CC of cc on *BSD instead of gcc