### PR TITLE
appmake +cpmdisk:  HP-125 (and probably HP-120)

### DIFF
--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -53,6 +53,7 @@ SUBTYPE		fmgcpm    -Cz+cpmdisk -Cz-f -Czfmgcpm -Cz--container=imd -ltrs80_cpm -D
 SUBTYPE		fp1100    -Cz+cpmdisk -Cz-f -Czfp1100 -Cz--container=d88 -D__FP1100__ -pragma-define:CONSOLE_ROWS=24 -pragma-define:CONSOLE_COLUMNS=40 
 SUBTYPE		gemini    -Cz+cpmdisk -Cz-f -Czgemini -Cz--container=imd -lgemini -D__GEMINI__
 SUBTYPE		holmes    -Cz+cpmdisk -Cz-f -Czholmes -Cz--container=imd -ltrs80_cpm -D__TRS80__
+SUBTYPE		hp125     -Cz+cpmdisk -Cz-f -Czhp125 -Cz--container=imd -D__HP125__
 SUBTYPE		hz89      -Cz+cpmdisk -Cz-f -Czhz89 -Cz--container=imd -lgfxh19 -D__ZENITH__
 SUBTYPE		hz100     -Cz+cpmdisk -Cz-f -Czhz100 -Cz--container=imd -lgfxh19 -D__ZENITH__
 SUBTYPE		kaypro83  -Cz+cpmdisk -Cz-f -Czkayproii -D__KAYPROII__ -D__KAYPRO83__ -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=24 -pragma-define:CRT_ORG_GRAPHICS=47000 -lgfxkp83 -pragma-export:GRAPHICS_CHAR_SET=31 -pragma-export:GRAPHICS_CHAR_UNSET=32

--- a/src/appmake/cpm2.c
+++ b/src/appmake/cpm2.c
@@ -915,6 +915,25 @@ static disc_spec gemini_spec = {
 };
 
 
+// HP 120/125, DSDD
+static disc_spec hp125_spec = {
+    .name = "HP125",
+    .disk_mode = MFM250,
+    .sectors_per_track = 16,
+    .tracks = 35,
+    .sides = 2,
+    .alternate_sides = 1,
+    .sector_size = 256,
+    .gap3_length = 0x17,
+    .filler_byte = 0xe5,
+    .boottracks = 3,
+    .directory_entries = 128,
+    .extent_size = 1024,
+    .byte_size_extents = 1,
+    .first_sector_offset = 0,
+};
+
+
 static disc_spec lynx_spec = {
     .name = "CampLynx",
     .disk_mode = FM500,           // possibly wrong information gathered online, IMD format is UNTESTED
@@ -1316,6 +1335,7 @@ static struct formats {
     { "excali64",  "Excalibur 64",          &excali_spec, 0, NULL, 1 },
     { "fp1100",    "Casio FP1100",          &fp1100_spec, 0, NULL, 1 },
     { "gemini",    "GeminiGalaxy",          &gemini_spec, 0, NULL, 1 },
+    { "hp125",     "HP 125/120",            &hp125_spec, 0, NULL, 1 },
     { "idpfdd",    "Iskra Delta Partner",   &idpfdd_spec, 0, NULL, 1 },
     { "kayproii",  "Kaypro ii",             &kayproii_spec, 0, NULL, 1 },
     { "lnw80",     "LNW80 TRS80 Clone",     &lnw80_spec, 0, NULL, 1 },


### PR DESCRIPTION
This code is only partially tested using the Montezuma CP/M disk conversion tool.
Don Maslin claims that the same boot disk image (checked on the mentioned tool) is valid also for the HP-120.