### PR TITLE
appmake +cpmdisk: Toshiba Pasopia/T100 CP/M disk format

### DIFF
--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -83,7 +83,7 @@ SUBTYPE		omikron   -Cz+cpmdisk -Cz-f -Czomikron -Cz--container=imd -ltrs80_cpm -
 SUBTYPE		osborne1  -Cz+cpmdisk -Cz-f -Czosborne1 -lgfxosborne1 -Cz--container=imd -D__OSBORNE1__
 SUBTYPE		osborne1sd -Cz+cpmdisk -Cz-f -Czosborne1sd -lgfxosborne1 -Cz--container=imd -D__OSBORNE1__
 SUBTYPE		partner   -Cz+cpmdisk -Cz-f -Czidpfdd -Cz--container=raw -D__PARTNER__ 
-SUBTYPE		pasopia   -Cz+cpmdisk -Cz-f -Czpasopia -D__PASOPIA__
+SUBTYPE		pasopia   -Cz+cpmdisk -Cz-f -Czpasopia -Cz--container=d88 -D__PASOPIA__
 SUBTYPE		pc6001    -Cz+cpmdisk -Cz-f -Czpc6001 -Cz--container=d88 -D__PC6001__
 SUBTYPE		pc8001    -Cz+cpmdisk -Cz-f -Czpc8001 -Cz--container=d88 -D__PC88__
 SUBTYPE		pc88      -Cz+cpmdisk -Cz-f -Czpc88 -Cz--container=d88 -D__PC88__

--- a/src/appmake/cpm2.c
+++ b/src/appmake/cpm2.c
@@ -518,6 +518,27 @@ static disc_spec nascom_spec = {
 };
 
 
+// Toshiba T100/PASOPIA
+static disc_spec pasopia_spec = {
+    .name = "PASOPIA",
+    .disk_mode = MFM250,
+    .sectors_per_track = 16,
+    .tracks = 35,
+    .sides = 2,
+    .sector_size = 256,
+    .gap3_length = 0x23,
+    .filler_byte = 0xE5,
+    .boottracks = 6,
+    .directory_entries = 64,
+    .extent_size = 1024,
+    .byte_size_extents = 1,
+    .first_sector_offset = 1,
+    .alternate_sides = 1,
+    .has_skew = 1,
+    .skew_tab = { 0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15 }
+};
+
+
 // NEC PC-6001/6601
 static disc_spec pc6001_spec = {
     .name = "NEC PC6001",
@@ -1407,6 +1428,7 @@ static struct formats {
     { "mz2500cpm", "Sharp MZ2500 - CPM",    &mz2500cpm_spec, 0, NULL, 1 },
     { "osborne1",  "Osborne 1 DD",          &osborne_spec, 0, NULL, 1 },
     { "osborne1sd", "Osborne 1 SD",         &osborne_sd_spec, 0, NULL, 1 },
+    { "pasopia",   "Toshiba Pasopia/T100",  &pasopia_spec, 0, NULL, 1 },
     { "pc6001",    "NEC PC6001/6601",       &pc6001_spec, 0, NULL, 1 },
     { "pc8001",    "NEC PC8001",            &pc8001_spec, 0, NULL, 1 },
     { "pc88",      "NEC PC8001/8801,FM7/8", &pc88_spec, 0, NULL, 1 },


### PR DESCRIPTION
#1075
This disk format is for the ORIGINAL Toshiba CP/M (e.g. the buggy sample available on archive.org)

The modern CP/M implementation  (https://github.com/beijingduckx/pasopia7_cpm22)  requires a different disk format.

The first sector generated by appmake is not adequate to allow sysgen (config.com) to succeed, but this shouldn't be a problem for non-system disks.

To produce a valid image in D88 format I had to double the boot_tracks value.