### PR TITLE
[laser500] fix joystick fire2 button stuck high

### DIFF
--- a/libsrc/target/laser500/games/joystick.asm
+++ b/libsrc/target/laser500/games/joystick.asm
@@ -48,7 +48,7 @@ got_it:
 	set	4,l
 not_fire1:
 	in	a,($27)
-	bit	5,a
+	bit	4,a
 	ret	nz
 	set	5,l
 	ret


### PR DESCRIPTION
on laser500 the joystick "fire2" button is bit 4 not 5 of I/O port $27. Currently the fire2 is stuck high when calling the `joystick()` function.