### PR TITLE
Issue #2402: Add non-prefixed KC160 instructions

### DIFF
--- a/src/ticks/cpu.h
+++ b/src/ticks/cpu.h
@@ -15,6 +15,7 @@ extern int c_adl_mode;
 #define CPU_8085     256
 #define CPU_EZ80     512
 #define CPU_R4K      1024
+#define CPU_KC160    2048
 
 #define is8080() ( (c_cpu & CPU_8080) )
 #define is8085() ( (c_cpu & CPU_8085) )
@@ -27,6 +28,7 @@ extern int israbbit4k(void);
 #define isz180() ( c_cpu & (CPU_Z180))
 #define isez80() ( c_cpu & (CPU_EZ80))
 #define isz80n() ( c_cpu & CPU_Z80N )
+#define iskc160() ( c_cpu & CPU_KC160 )
 #define canaltreg() ( ( c_cpu & (CPU_8080|CPU_8085|CPU_GBZ80)) == 0 )
 #define canindex() ( ( c_cpu & (CPU_8080|CPU_8085|CPU_GBZ80)) == 0 )
 #define canixh() ( c_cpu & (CPU_Z80|CPU_Z80N|CPU_R800|CPU_EZ80))

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -918,6 +918,7 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
                                         else if ( q == 1 && z == 6 && p < 3) BUF_PRINTF("%-10s%s,%s","ld", kc160_handle_register_r24(state, p),handle_immed24(state, opbuf1, sizeof(opbuf1)));
                                         else if ( q == 0 && z == 3 && p < 3) BUF_PRINTF("%-10s(%s),%s", "ldf", handle_addr24(state, opbuf1, sizeof(opbuf1)), kc160_handle_register_r24(state,p));
                                         else if ( q == 1 && z == 3 && p < 3) BUF_PRINTF("%-10s%s,(%s)", "ldf", kc160_handle_register_r24(state,p), handle_addr24(state, opbuf1, sizeof(opbuf1)));
+                                        else if ( q == 0 && z == 6 && p < 3) BUF_PRINTF("%-10s%s,sp", "ld", p == 0 ? "ix" : p == 1 ? "iy" : "hl");
                                         else if ( b == 0x33 ) BUF_PRINTF("%-10s(%s),a", "ldf", handle_addr24(state, opbuf1, sizeof(opbuf1)));
                                         else if ( b == 0x3b ) BUF_PRINTF("%-10sa,(%s)", "ldf", handle_addr24(state, opbuf1, sizeof(opbuf1)));
                                         else BUF_PRINTF("nop");

--- a/src/ticks/disassembler_alg.c
+++ b/src/ticks/disassembler_alg.c
@@ -20,6 +20,8 @@ static char *r4k_ps_table[] = { "pw", "px", "py", "pz" };
 static char *r4k_32b_table[] = { "bcde", "jkhl" };
 static char *r4k_16b_table[] = { "bc", "de", "ix", "iy" }; // Used for 6d page
 
+static char *kc160_p_table[] = {  "a", "xp", "yp", "zp" };
+
 typedef struct {
     int       index;
     unsigned int    pc;
@@ -1118,6 +1120,11 @@ int disassemble2(int pc, char *bufstart, size_t buflen, int compact)
                                         char *instrs[] = { "ld        i,hl", "nop", "ld        hl,i"};
                                         BUF_PRINTF("%s",instrs[y]);
                                     } else if ( iskc160() && y >= 4 && z < 4) BUF_PRINTF("%-10s%s", handle_ez80_am(state, handle_block_instruction(state, z, y)), z == 0 ? "xy" : "x");                       
+                                    else if( iskc160() && z == 2 ) BUF_PRINTF("%-10s%s,%s", "jp3", cc_table[y], handle_addr24(state,opbuf1,sizeof(opbuf1)));
+                                    else if ( iskc160() && b == 0xc3 ) BUF_PRINTF("%-10s%s", "jp3", handle_addr24(state,opbuf1,sizeof(opbuf1)));
+                                    else if ( iskc160() && q == 0 && z == 4 ) BUF_PRINTF("%-10s%s,%s","ld", kc160_p_table[p], kc160_p_table[3-p]);
+                                    else if ( iskc160() && q == 0 && z == 5 ) BUF_PRINTF("%-10s%s,%s","ld", kc160_p_table[p], kc160_p_table[(3-p+2)%4]);
+                                    else if ( iskc160() && q == 1 && z == 4 ) BUF_PRINTF("%-10s%s,%s","ld", kc160_p_table[p], kc160_p_table[(p+2)%4]);
                                     else if ( q == 1 && z == 1 && y == 3 && israbbit4k()) BUF_PRINTF("%-10s","exp");
                                     else if ( q == 1 && z == 2 && y == 5 && israbbit4k()) BUF_PRINTF("%-10s(hl)","call");
                                     else if ( q == 1 && z == 2 && y == 7 && israbbit4k()) BUF_PRINTF("%-10s(jkhl)","llcall");

--- a/src/ticks/disassembler_main.c
+++ b/src/ticks/disassembler_main.c
@@ -43,6 +43,7 @@ static void usage(char *program)
     printf("  -mgbz80        Disassemble Gameboy z80 code\n");
     printf("  -m8080         Disassemble 8080 code (with z80 mnenomics)\n");
     printf("  -m8085         Disassemble 8085 code (with z80 mnenomics)\n");
+    printf("  -mkc160        Disassemble KC160\n");
     
     exit(1);
 }
@@ -129,6 +130,8 @@ int main(int argc, char **argv)
                 } else if ( strcmp(&argv[0][1],"mez80") == 0 ) {
                     c_cpu = CPU_EZ80;
                     c_adl_mode = 1;
+                } else if ( strcmp(&argv[0][1],"mkc160") == 0 ) {
+                    c_cpu = CPU_KC160;
                 } else {
                     printf("Unknown CPU: %s\n",&argv[0][2]);
                 }


### PR DESCRIPTION
Covers the 0xed page (prefixed instructions don't seem to exist in compatiblility/z80 mode).