### PR TITLE
Fix no stub("asm(") programs for the ti83p

### DIFF
--- a/lib/target/ti83p/classic/ti83p_crt0.asm
+++ b/lib/target/ti83p/classic/ti83p_crt0.asm
@@ -125,9 +125,9 @@ ENDIF
 IF (startup=10)
 	DEFINE ASM
 	DEFINE NOT_DEFAULT_SHELL
-	org	$9D95
-	;org	$9D93
-	;defb         $BB,$6D
+	;org	$9D95
+	org	$9D93
+	defb         $BB,$6D
 ENDIF
 
 ;-----------------


### PR DESCRIPTION
For some reason the crt0 file had commented out the lines that add the AsmPrgm token to the beginning of the binary. This is required for both the ti83p and ti84p or the calculator will refuse to run the program and display "ERR: INVALID". It seems that "-create-app" still results in a garbled name, however this makes the binary compatible with binpac8x.py. But it should be noted that "-create-app" was broken before this PR, and #1622 mentions that it was a problem back then as well.

Related issues: #2410 and likely #1622 