### PR TITLE
Fix 8xp programs

### DIFF
--- a/examples/ticalc/Makefile
+++ b/examples/ticalc/Makefile
@@ -3,7 +3,7 @@
 # Note: just building hello worlds
 
 
-all: world82.82p world83.83p world83.8xk world83.8xp world85.85s world86.86p
+all: world.82p world.83p world.8xk world.8xp world.85s world.86p
 
 clean:
 	$(RM) build/*.8xp build/*.bin build/*.8xk build/*.82p build/*.83p build/*.85s build/*.86p

--- a/examples/ticalc/Makefile
+++ b/examples/ticalc/Makefile
@@ -11,21 +11,21 @@ clean:
 bclean: # Remove bins
 	$(RM) build/*.bin
 
-world82.82p: world.c # Build as a program for the ti82
+world.82p: world.c # Build as a program for the ti82
 	zcc +ti82 -o build/world.bin -create-app world.c
 
-world83.83p: world.c # Build as a program for the ti83
+world.83p: world.c # Build as a program for the ti83
 	zcc +ti83 -o build/world.bin -create-app world.c
 
-world83.8xk: world.c # Build as a flash app for the ti83p / ti84p
+world.8xk: world.c # Build as a flash app for the ti83p / ti84p
 	zcc +ti83p -o build/world.bin world.c -create-app -subtype=app_one_page
 	mv build/world.bin.8xk build/world.8xk
 
-world83.8xp: world.c  # Build as a program for the ti83p / ti84p
+world.8xp: world.c  # Build as a program for the ti83p / ti84p
 	zcc +ti83p -o build/world.bin -create-app world.c -subtype=asm
 
-world85.85s: world.c  # Build as a program for the ti85
+world.85s: world.c  # Build as a program for the ti85
 	zcc +ti85 -o build/world.bin -create-app world.c
 
-world86.86p: world.c  # Build as a program for the ti86
+world.86p: world.c  # Build as a program for the ti86
 	zcc +ti86 -o build/world.bin -create-app world.c

--- a/examples/ticalc/Makefile
+++ b/examples/ticalc/Makefile
@@ -12,20 +12,20 @@ bclean: # Remove bins
 	$(RM) build/*.bin
 
 world82.82p: world.c # Build as a program for the ti82
-	zcc +ti82 -o build/world82.bin -create-app world.c
+	zcc +ti82 -o build/world.bin -create-app world.c
 
 world83.83p: world.c # Build as a program for the ti83
-	zcc +ti83 -o build/world83.bin -create-app world.c
+	zcc +ti83 -o build/world.bin -create-app world.c
 
 world83.8xk: world.c # Build as a flash app for the ti83p / ti84p
 	zcc +ti83p -o build/world.bin world.c -create-app -subtype=app_one_page
-	mv build/world.bin.8xk build/world83.8xk
+	mv build/world.bin.8xk build/world.8xk
 
 world83.8xp: world.c  # Build as a program for the ti83p / ti84p
-	zcc +ti83p -o build/world83.bin -create-app world.c -subtype=asm
+	zcc +ti83p -o build/world.bin -create-app world.c -subtype=asm
 
 world85.85s: world.c  # Build as a program for the ti85
-	zcc +ti85 -o build/world85.bin -create-app world.c
+	zcc +ti85 -o build/world.bin -create-app world.c
 
 world86.86p: world.c  # Build as a program for the ti86
-	zcc +ti86 -o build/world86.bin -create-app world.c
+	zcc +ti86 -o build/world.bin -create-app world.c

--- a/examples/ticalc/build/README.md
+++ b/examples/ticalc/build/README.md
@@ -1,0 +1,1 @@
+# Output files will appear here.

--- a/examples/ticalc/build/README.md
+++ b/examples/ticalc/build/README.md
@@ -1,1 +1,0 @@
-# Output files will appear here.

--- a/examples/ticalc/multi_page_flash_app/main.c
+++ b/examples/ticalc/multi_page_flash_app/main.c
@@ -11,7 +11,7 @@ int main(){
 
 	// Adding a number to '0' is a quick way to get the ascii for a single diget number as text
 	putchar('0'+ add_three_numbers_(1, 2, 3));
-	puts("1+2+1:");
+	puts("\n1+2+1:");
 	putchar('0'+ add_plus_1_(1, 2));
 	
 

--- a/examples/ticalc/world.c
+++ b/examples/ticalc/world.c
@@ -1,8 +1,8 @@
 /* Hello world. See Makefile for building commands */
 
 #include <stdio.h>
-/* Description string for Ti calcs. This is truncated in apps */
-#pragma string name Hello World
+/* Description string for Ti calcs.  In apps this should be 8 or less characters or it can not be sent.*/
+#pragma string name WORLD
 
 /* Icon for Ti calcs ('waving' hand). This is not used in asm( or apps */
 #pragma data icon 0x18,0x3C,0x3C,0xBC,0x7C,0x7C,0x3C,0x38;

--- a/lib/target/ti83p/classic/ti83papp_crt0.asm
+++ b/lib/target/ti83p/classic/ti83papp_crt0.asm
@@ -156,8 +156,16 @@ IF (startup=0 || startup=1)
 
 
 	IF DEFINED_MULTI_PAGE_CALLS
-		
-		DEFB 0 ; Branch table must begin with multiple of 3
+	END_OF_HEADER:
+		; Pad Header until it is divisable by 8
+		defc header_length = END_OF_HEADER-HEADER_START
+		IF header_length%3 == 2
+			DEFB 0
+		ENDIF
+		IF header_length%3 == 1
+			DEFB 0
+			DEFB 0
+		ENDIF
 
 	start_branch_table:
 

--- a/lib/target/ti83p/classic/ti83papp_crt0.asm
+++ b/lib/target/ti83p/classic/ti83papp_crt0.asm
@@ -158,11 +158,11 @@ IF (startup=0 || startup=1)
 	IF DEFINED_MULTI_PAGE_CALLS
 	END_OF_HEADER:
 		; Pad Header until it is divisable by 8
-		defc header_length = END_OF_HEADER-HEADER_START
-		IF header_length%3 == 2
+		defc header_mod = (END_OF_HEADER-HEADER_START)%3
+		IF header_mod = 2
 			DEFB 0
 		ENDIF
-		IF header_length%3 == 1
+		IF header_mod = 1
 			DEFB 0
 			DEFB 0
 		ENDIF

--- a/lib/target/ti83p/classic/ti83papp_crt0.asm
+++ b/lib/target/ti83p/classic/ti83papp_crt0.asm
@@ -157,7 +157,7 @@ IF (startup=0 || startup=1)
 
 	IF DEFINED_MULTI_PAGE_CALLS
 	END_OF_HEADER:
-		; Pad Header until it is divisable by 8
+		; Pad Header until it is divisable by 3
 		defc header_mod = (END_OF_HEADER-HEADER_START)%3
 		IF header_mod = 2
 			DEFB 0

--- a/src/appmake/ti8xk.c
+++ b/src/appmake/ti8xk.c
@@ -694,7 +694,7 @@ int ti8xk_exec(char *target)
         return -1;
     }
     if (field_sz > 8)
-        printf("Warning: Appname is greater than 8 in length.\n");
+        printf("Warning: Appname is greater than 8 in length. App validation may fail, and the name may not show up in full on the calculator.\n");
     
     int lsize =  (field_sz >= 8) ? field_sz : 8;
     app_name = calloc(1, lsize+1); // Another small memory leak. 

--- a/src/appmake/ti8xk.c
+++ b/src/appmake/ti8xk.c
@@ -694,7 +694,7 @@ int ti8xk_exec(char *target)
         return -1;
     }
     if (field_sz > 8)
-        printf("Warning: Appname is greater than 8 in length. App validation may fail, and the name may not show up in full on the calculator.\n");
+        printf("Warning: Appname is greater than 8 in length.\n");
     
     int lsize =  (field_sz >= 8) ? field_sz : 8;
     app_name = calloc(1, lsize+1); // Another small memory leak. 

--- a/src/appmake/ti8xk.c
+++ b/src/appmake/ti8xk.c
@@ -1,4 +1,4 @@
-/** It should be notes that is is for compling FLASH APPS not ram programs.
+/** It should be notes that this is for compiling FLASH APPS not ram programs.
  *  For ram programs see tixx.c
  *
  *  This file originally made by HeronErin. (github.com/HeronErin)

--- a/src/appmake/tixx.c
+++ b/src/appmake/tixx.c
@@ -62,9 +62,6 @@ option_t tixx_options[] = {
 
 enum EXT { E_82P, E_83P, E_8XP, E_85S, E_86P, E_86S };
 
-// const unsigned char trailer83[] = { 0x3f, 0xd4, 0x3f, 0x30, 0x30, 0x30, 0x30, 0x3f, 0xd4 };
-
-
 
 void cfwritebyte(int i, FILE *fp, unsigned short *chk)
 {

--- a/src/appmake/tixx.c
+++ b/src/appmake/tixx.c
@@ -61,7 +61,7 @@ option_t tixx_options[] = {
 
 enum EXT { E_82P, E_83P, E_8XP, E_85S, E_86P, E_86S };
 
-const unsigned char trailer83[] = { 0x3f, 0xd4, 0x3f, 0x30, 0x30, 0x30, 0x30, 0x3f, 0xd4 };
+// const unsigned char trailer83[] = { 0x3f, 0xd4, 0x3f, 0x30, 0x30, 0x30, 0x30, 0x3f, 0xd4 };
 
 
 
@@ -190,7 +190,7 @@ int tixx_exec(char *target)
         exit_log(1,"Failed to open input file: %s\n", binname);
 
     file_size = base_size = get_file_size(fp);
-	
+	if ((oldfmt == 0) && (ext == E_8XP)) base_size+=2;
 
     buf = (char *)malloc(base_size);
     if (1 != fread(buf, file_size, 1, fp)) { fclose(fp); exit_log(1, "Could not read required data from <%s>\n",binname); }
@@ -256,7 +256,7 @@ int tixx_exec(char *target)
     /* VARIABLE LENGTH */
     file_size = base_size + 2;    
     cfwriteword(file_size, fp, &chk);
-    printf("asd");
+
     /* VARIABLE TYPE ID BYTE */
     if ((ext == E_82P) || (ext == E_83P) || (ext == E_8XP))
         cfwrite("\x06", 1, fp, &chk);
@@ -280,16 +280,19 @@ int tixx_exec(char *target)
     if ((oldfmt == 0) && (ext == E_8XP)) {
         cfwritebyte(0, fp, &chk);
 		cfwritebyte(0, fp, &chk);
+        base_size-=2; // Undo the extra size added earlier
     }
 
 
     /* VARIABLE LENGTH */
     file_size = base_size + 2;
+    
     n2 = base_size;
     cfwriteword(file_size, fp, &chk);
     cfwriteword(n2, fp, &chk);
     /*printf("Var Length (i) : %04X\n", i);
     printf("Var Length (n2) : %04X\n", n2); */
+
     /* TI83 Plus workaround */
     if ((oldfmt == 0) && (ext == E_8XP)) {
         cfwritebyte(0xBB, fp, &chk);

--- a/src/appmake/tixx.c
+++ b/src/appmake/tixx.c
@@ -100,9 +100,17 @@ void writecomment(FILE *fp, const char *comment)
 void genname(const char *fname, char *name)
 {
     char str[256], *c;
+    char* upperPath;
+
+    if (NULL!=(upperPath=strrchr(fname, '/'))) // Go to uppermost dir
+        fname = upperPath+1;
 
     strcpy(str, fname);
-    c = strchr(str, '.');
+
+
+    c = strrchr(str, '.');
+
+
     if ((c - str) > 8)
         c[8] = 0;
     else
@@ -126,7 +134,7 @@ int tixx_exec(char *target)
     FILE *fp;
     char *buf, str[256];
     char *suffix;
-    int i, n, ext = E_83P, n2;
+    int file_size, base_size, ext = E_83P, n2;
     unsigned short chk;
 
     if ( help || binname == NULL ) {
@@ -181,16 +189,16 @@ int tixx_exec(char *target)
     if (!fp)
         exit_log(1,"Failed to open input file: %s\n", binname);
 
-    i = n = get_file_size(fp);
-	if ((oldfmt == 0) && (ext == E_8XP))	n+=9;
+    file_size = base_size = get_file_size(fp);
+	
 
-    buf = (char *)malloc(n);
-    if (1 != fread(buf, i, 1, fp)) { fclose(fp); exit_log(1, "Could not read required data from <%s>\n",binname); }
+    buf = (char *)malloc(base_size);
+    if (1 != fread(buf, file_size, 1, fp)) { fclose(fp); exit_log(1, "Could not read required data from <%s>\n",binname); }
     if (ferror(fp))
         exit_log(1,"Error reading input file: %s\n", binname);
     fclose(fp);
-    if ((oldfmt == 0) && (ext == E_8XP))
-		strncpy(buf+i,trailer83,9);
+    // if ((oldfmt == 0) && (ext == E_8XP))
+		// strncpy(buf+file_size,trailer83,9);
     fp = fopen(filename, "wb");
     if (!fp)
         exit_log(1,"Failed to open output file: %s\n", filename);
@@ -212,12 +220,15 @@ int tixx_exec(char *target)
 
     /* DATA SECTION LENGTH */
     if ((ext == E_82P) || (ext == E_83P) || (ext == E_8XP))
-        i = n + 17;
+        file_size = base_size + 17;
     else if (ext == E_85S)
-        i = n + 10 + (int)strlen(str);
+        file_size = base_size + 10 + (int)strlen(str);
     else
-        i = n + 18;
-    writeword(i, fp);
+        file_size = base_size + 18;
+
+    if ((oldfmt == 0) && (ext == E_8XP))  file_size+=2;
+
+    writeword(file_size, fp);
     /* printf("Data Length: %04X\n", i); */
 
     /****************/
@@ -225,21 +236,27 @@ int tixx_exec(char *target)
     /****************/
 
     /* VARIABLE TYPE MARKER */
-    if ((ext == E_82P) || (ext == E_83P) || (ext == E_8XP))
+    if ((ext == E_82P) || (ext == E_83P))
         cfwrite("\x0b\0x00", 2, fp, &chk);
     else if (ext == E_85S)
     {
-        i = 4 + (int)strlen(str);
-        cfwritebyte(i, fp, &chk);
+        file_size = 4 + (int)strlen(str);
+        cfwritebyte(file_size, fp, &chk);
         cfwrite("\0x00", 1, fp, &chk);
+    }
+    else if (ext == E_8XP){
+        if (oldfmt == 0)
+            cfwrite("\x0D\0x00", 2, fp, &chk);
+        else
+            cfwrite("\x0B\0x00", 2, fp, &chk);
     }
     else
         cfwrite("\x0c\0x00", 2, fp, &chk);
     
     /* VARIABLE LENGTH */
-    i = n + 2;    
-    cfwriteword(i, fp, &chk);
-
+    file_size = base_size + 2;    
+    cfwriteword(file_size, fp, &chk);
+    printf("asd");
     /* VARIABLE TYPE ID BYTE */
     if ((ext == E_82P) || (ext == E_83P) || (ext == E_8XP))
         cfwrite("\x06", 1, fp, &chk);
@@ -248,20 +265,16 @@ int tixx_exec(char *target)
     else if ((ext == E_85S) || (ext == E_86S))
         cfwrite("\x0c", 1, fp, &chk);
 
-    /* TI83 Plus workaround */
-    if ((oldfmt == 0) && (ext == E_8XP)) {
-        cfwritebyte(0xBB, fp, &chk);
-		cfwritebyte(0x6D, fp, &chk);
-    }
+
 
     /* VARIABLE NAME */
-    i = (int)strlen(str);
+    file_size = (int)strlen(str);
     if ((ext == E_85S) || (ext == E_86P) || (ext == E_86S))
-        cfwritebyte(i, fp, &chk);
-    cfwrite(str, i, fp, &chk);
+        cfwritebyte(file_size, fp, &chk);
+    cfwrite(str, file_size, fp, &chk);
     memset(str, 0, 8);
     if (ext != E_85S)
-        cfwrite(str, 8 - i, fp, &chk);
+        cfwrite(str, 8 - file_size, fp, &chk);
 
     /* 83+ requires 2 extra bytes */
     if ((oldfmt == 0) && (ext == E_8XP)) {
@@ -271,14 +284,18 @@ int tixx_exec(char *target)
 
 
     /* VARIABLE LENGTH */
-    i = n + 2;
-    n2 = n;
-    cfwriteword(i, fp, &chk);
+    file_size = base_size + 2;
+    n2 = base_size;
+    cfwriteword(file_size, fp, &chk);
     cfwriteword(n2, fp, &chk);
     /*printf("Var Length (i) : %04X\n", i);
     printf("Var Length (n2) : %04X\n", n2); */
-
-    cfwrite(buf, n, fp, &chk);
+    /* TI83 Plus workaround */
+    if ((oldfmt == 0) && (ext == E_8XP)) {
+        cfwritebyte(0xBB, fp, &chk);
+		cfwritebyte(0x6D, fp, &chk);
+    }
+    cfwrite(buf, base_size, fp, &chk);
     writeword(chk, fp);
 
     if (ferror(fp))

--- a/src/appmake/tixx.c
+++ b/src/appmake/tixx.c
@@ -36,6 +36,7 @@ the real meaning of each written byte/word but only checked some of them).
 */
 
 #include "appmake.h"
+#include <ctype.h>
 
 #if !defined(__MSDOS__) && !defined(__TURBOC__)
 #ifndef _WIN32
@@ -116,9 +117,23 @@ void genname(const char *fname, char *name)
     else
         *c = 0;
     c = str - 1;
+
+    char has_warned_of_spaces = 0;
+    char has_warned_of_number = 0;
     do {
         c++;
         *c = toupper(*c);
+        
+        // Warnings of bad ideas in variable names
+        if (*c == ' ' && !has_warned_of_spaces){
+            has_warned_of_spaces=1;
+            fprintf(stderr, "Warning: Use of spaces in the variable name is not certain to work on all calculators!\n");
+        }
+        if (*c >= '0' && *c <= '9' && !has_warned_of_number){
+            has_warned_of_number=1;
+            fprintf(stderr, "Warning: Use of numbers in the variable name is not certain to work on all calculators!\n");
+        }
+
         if (!isalnum(*c))
             *c = 0;
     } while (*c != 0);

--- a/src/appmake/tixx.c
+++ b/src/appmake/tixx.c
@@ -276,11 +276,10 @@ int tixx_exec(char *target)
     if (ext != E_85S)
         cfwrite(str, 8 - file_size, fp, &chk);
 
-    /* 83+ requires 2 extra bytes */
+    /* TI83 Plus requires 2 extra bytes */
     if ((oldfmt == 0) && (ext == E_8XP)) {
         cfwritebyte(0, fp, &chk);
 		cfwritebyte(0, fp, &chk);
-        base_size-=2; // Undo the extra size added earlier
     }
 
 
@@ -293,10 +292,11 @@ int tixx_exec(char *target)
     /*printf("Var Length (i) : %04X\n", i);
     printf("Var Length (n2) : %04X\n", n2); */
 
-    /* TI83 Plus workaround */
+    /* TI83 Plus workaround (AsmPrgm token) */
     if ((oldfmt == 0) && (ext == E_8XP)) {
         cfwritebyte(0xBB, fp, &chk);
 		cfwritebyte(0x6D, fp, &chk);
+        base_size-=2; // Undo the extra size added earlier
     }
     cfwrite(buf, base_size, fp, &chk);
     writeword(chk, fp);


### PR DESCRIPTION
Fixed tixx.c in appmake so that now 8xp programs are accepted by both [jstified](https://www.cemetech.net/projects/jstified/) and my physical calculator. 

* I found that although spasm makes use of a `trailer83`, it is not actually something used for the TI-84, and is not used in other programs for building .8xp files. 
* The AsmProg token was placed at the wrong part of the file. It should be in the binary contents, not the header.
* Also made a change to allow for genname() to parse out the file name if the output dir is in another directory
* Corrected the length to be correct
* Also did some refactoring to make variable names less ambiguous   
