### PR TITLE
cpmdisk: Sharp MZ-80A and MZ-80B, inverted data and sides options

### DIFF
--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -80,6 +80,7 @@ SUBTYPE    micromate -Cz+cpmdisk -Cz-f -Czmicromate -Cz--container=imd -D__MICRO
 SUBTYPE    montezuma -Cz+cpmdisk -Cz-f -Czmontezuma -Cz--container=imd -ltrs80_cpm -D__TRS80__
 SUBTYPE    m4cpm3    -Cz+cpmdisk -Cz-f -Czm4cpm3 -Cz--container=imd -ltrs80_cpm -D__TRS80__
 SUBTYPE    msx       -Cz+fat -Cz-f -Czmsxdos -Cz--container -Czdsk -D__MSX__ -pragma-define:__HAVE_TMS99X8=1
+SUBTYPE    mz80      -Cz+cpmdisk -Cz-f -Czmz80 -Cz--container=dsk -DSHARPMZ -D__SHARPMZ__
 SUBTYPE    mz800     -Cz+cpmdisk -Cz-f -Czmz800 -Cz--container=dsk -DSHARPMZ -D__SHARPMZ__
 SUBTYPE    mz2500    -Cz+cpmdisk -Cz-f -Czmz2500cpm -D__MZ2500__
 SUBTYPE    nabu      -Cz+cpmdisk -Cz-f -Cznabupc -Cz--container=raw -lnabu_cpm -pragma-define:CONSOLE_COLUMNS=32 -pragma-define:CONSOLE_ROWS=24 -D__NABUPC__ -Ca-D__NABUPC__ -pragma-define:__HAVE_TMS99X8=1

--- a/src/appmake/cpm2.c
+++ b/src/appmake/cpm2.c
@@ -658,7 +658,7 @@ static disc_spec kaypro4_spec = {
 // a valid boot track on side 0 should have SKEW4,
 // ..on side 1 SKEW8, 16 tracks x 256 sectors
 static disc_spec mz800_spec = {
-    .name = "Sharp MZ80",
+    .name = "Sharp MZ800",
     .disk_mode = MFM250,
     .sectors_per_track = 8,
     .tracks = 40,
@@ -670,7 +670,35 @@ static disc_spec mz800_spec = {
     .directory_entries = 64,
     .extent_size = 2048,
     .byte_size_extents = 1,
-    .first_sector_offset = 1
+    .first_sector_offset = 1,
+    .has_skew = 1,
+    .skew_track_start = 0,
+    .skew_tab = { 0, 4, 1, 5, 2, 6, 3, 7 }
+};
+
+
+// Sharp MZ-80A and MZ-80B
+static disc_spec mz80_spec = {
+    .name = "Sharp MZ80",
+    .disk_mode = MFM250,
+    .sectors_per_track = 10,
+    .tracks = 35,
+    .sides = 2,
+    .alternate_sides = 1,
+    .sector_size = 512,
+    .gap3_length = 0x17,
+    .filler_byte = 0xe5,
+    .boottracks = 2,
+    .directory_entries = 128,
+    .extent_size = 2048,
+    .byte_size_extents = 1,
+    .first_sector_offset = 1,
+	.xor_data = 0xff,
+    .has_skew = 1,
+    .skew_track_start = 0,
+    .skew_tab = { 0, 5, 1, 6, 2, 7, 3, 8, 4, 9 },
+	.inverted_sides = 1,
+	.side2_sector_numbering = 1
 };
 
 
@@ -1808,6 +1836,7 @@ static struct formats {
     { "nabupc",    "Nabu PC",               &nabupc_spec, 0, NULL, 1 },
     { "nascomcpm", "Nascom CPM",            &nascom_spec, 0, NULL, 1 },
     { "nshd8",     "Northstar Virtual 8",   &nshd8_spec, 0, NULL, 1 },
+    { "mz80",      "Sharp MZ80A/80B",       &mz80_spec, 0, NULL, 1 },
     { "mz800",     "Sharp MZ800",           &mz800_spec, 0, NULL, 1 },
     { "mz2500cpm", "Sharp MZ2500 - CPM",    &mz2500cpm_spec, 0, NULL, 1 },
     { "osborne1",  "Osborne 1 DD",          &osborne_spec, 0, NULL, 1 },

--- a/src/appmake/cpmdisk.c
+++ b/src/appmake/cpmdisk.c
@@ -103,12 +103,9 @@ void disc_write_sector_lba(disc_handle *h, int sector_nr, int count, const void 
         int sector = sector_nr % h->spec.sectors_per_track;
         int head;
 
-        if ( h->spec.alternate_sides == 0 ) {
             head = track % 2;
                    track /= 2;
-            } else {
-                   head = track >= h->spec.tracks ? 1 : 0;
-        }
+
         disc_write_sector(h, track, sector, head, ptr);
         sector_nr++;
         ptr += h->spec.sector_size;
@@ -121,9 +118,9 @@ void disc_write_sector(disc_handle *h, int track, int sector, int head, const vo
     size_t track_length = h->spec.sectors_per_track * h->spec.sector_size;
 
     if ( h->spec.alternate_sides == 0 ) {
-        offset = track_length * track + (head * track_length * h->spec.tracks);
+        offset = track_length * track + ((h->spec.inverted_sides ^ head) * track_length * h->spec.tracks);
     } else {
-        offset = track_length * ( 2* track + head);
+        offset = track_length * ( 2* track + (h->spec.inverted_sides ^ head));
     }
 
     offset += sector * h->spec.sector_size;
@@ -140,12 +137,9 @@ void disc_read_sector_lba(disc_handle *h, int sector_nr, int count, void *data)
         int sector = sector_nr % h->spec.sectors_per_track;
         int head;
 
-        if ( h->spec.alternate_sides == 0 ) {
             head = track % 2;
                    track /= 2;
-            } else {
-                   head = track >= h->spec.tracks ? 1 : 0;
-        }
+
         disc_read_sector(h, track, sector, head, ptr);
         sector_nr++;
         ptr += h->spec.sector_size;
@@ -158,9 +152,9 @@ void disc_read_sector(disc_handle *h, int track, int sector, int head, void *dat
     size_t track_length = h->spec.sectors_per_track * h->spec.sector_size;
 
     if ( h->spec.alternate_sides == 0 ) {
-        offset = track_length * track + (head * track_length * h->spec.tracks);
+        offset = track_length * track + ((h->spec.inverted_sides ^ head) * track_length * h->spec.tracks);
     } else {
-        offset = track_length * ( 2* track + head);
+        offset = track_length * ( 2* track + (h->spec.inverted_sides ^ head));
     }
 
     offset += sector * h->spec.sector_size;
@@ -267,9 +261,9 @@ int disc_write_raw(disc_handle* h, const char* filename)
     for (i = 0; i < h->spec.tracks; i++) {
         for (s = 0; s < h->spec.sides; s++) {
             if ( h->spec.alternate_sides == 0 ) {
-                offs = track_length * i + (s * track_length * h->spec.tracks);
+                offs = track_length * i + ((h->spec.inverted_sides ^ s) * track_length * h->spec.tracks);
             } else {
-                offs = track_length * ( 2* i + s);
+                offs = track_length * ( 2* i + (h->spec.inverted_sides ^ s));
             }
             for (j = 0; j < h->spec.sectors_per_track; j++) {
                  xorblock(h->image + offs + (skew_sector(h, j, i) * h->spec.sector_size), h->spec.sector_size, h->spec.xor_data);
@@ -317,9 +311,9 @@ int disc_write_edsk(disc_handle* h, const char* filename)
             uint8_t* ptr;
 
             if ( h->spec.alternate_sides == 0 ) {
-                offs = track_length * i + (s * track_length * h->spec.tracks);
+                offs = track_length * i + ((h->spec.inverted_sides ^ s) * track_length * h->spec.tracks);
             } else {
-                offs = track_length * ( 2* i + s);
+                offs = track_length * ( 2* i + (h->spec.inverted_sides ^ s));
             }
             memset(header, 0, 256);
             memcpy(header, "Track-Info\r\n", 12);
@@ -336,11 +330,11 @@ int disc_write_edsk(disc_handle* h, const char* filename)
 
                 // Implementing SKEW is not necessary (tested on MAME)
 				// side2_sector_numbering option tested on MAME (Kaypro4)
-				if ( (! h->spec.side2_sector_numbering) || (! s) ) {
+				if ( (! h->spec.side2_sector_numbering) || (! (h->spec.inverted_sides ^ s)) ) {
 					if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
-						*ptr++ = j + h->spec.boot_tracks_sector_offset; // Sector ID
+						*ptr++ = skew_sector(h, j, i) + h->spec.boot_tracks_sector_offset; // Sector ID
 					} else {
-						*ptr++ = j + h->spec.first_sector_offset; // Sector ID
+						*ptr++ = skew_sector(h, j, i) + h->spec.first_sector_offset; // Sector ID
 					}
 				} else {
 					if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
@@ -426,17 +420,18 @@ int disc_write_d88(disc_handle* h, const char* filename)
         for (s = 0; s < h->spec.sides; s++) {
 
             if ( h->spec.alternate_sides == 0 ) {
-                offs = track_length * i + (s * track_length * h->spec.tracks);
+                offs = track_length * i + ((h->spec.inverted_sides ^ s) * track_length * h->spec.tracks);
             } else {
-                offs = track_length * (2*i + s);
+                offs = track_length * ( 2* i + (h->spec.inverted_sides ^ s));
             }
+
             for (j = 0; j < h->spec.sectors_per_track; j++) {
                  uint8_t *ptr = header;
 
                  *ptr++ = i;                //track
                  *ptr++ = s;                //head
 
-                 if ( (! h->spec.side2_sector_numbering) || (! s) )
+                 if ( (! h->spec.side2_sector_numbering) || (! (h->spec.inverted_sides ^ s)) )
                     *ptr++ =  skew_sector(h, j, i) + h->spec.first_sector_offset;       //sector
                  else
                     *ptr++ =  skew_sector(h, j, i) + h->spec.first_sector_offset + h->spec.sectors_per_track ;   //sector (2nd side)
@@ -488,9 +483,9 @@ int disc_write_anadisk(disc_handle* h, const char* filename)
         for (s = 0; s < h->spec.sides; s++) {
 
             if ( h->spec.alternate_sides == 0 ) {
-                offs = track_length * i + (s * track_length * h->spec.tracks);
+                offs = track_length * i + ((h->spec.inverted_sides ^ s) * track_length * h->spec.tracks);
             } else {
-                offs = track_length * ( 2* i + s);
+                offs = track_length * ( 2* i + (h->spec.inverted_sides ^ s));
             }
             for (j = 0; j < h->spec.sectors_per_track; j++) {
                 uint8_t header[8] = { 0 };
@@ -583,9 +578,9 @@ int disc_write_imd(disc_handle* h, const char* filename)
 
             // And now write each sector - we don't do compression and all sectors are good
             if ( h->spec.alternate_sides == 0 ) {
-                offs = track_length * i + (s * track_length * h->spec.tracks);
+                offs = track_length * i + ((h->spec.inverted_sides ^ s) * track_length * h->spec.tracks);
             } else {
-                offs = track_length * ( 2* i + s);
+                offs = track_length * ( 2* i + (h->spec.inverted_sides ^ s));
             }
             for (j = 0; j < h->spec.sectors_per_track; j++) {
                 fputc(1, fp);   // Sector type 1  = has data

--- a/src/appmake/cpmdisk.h
+++ b/src/appmake/cpmdisk.h
@@ -38,6 +38,7 @@ typedef struct {
     uint8_t   alternate_sides;
     uint8_t   has_skew;
     uint8_t   xor_data;
+    uint8_t   inverted_sides;
     uint16_t  skew_track_start;
     uint8_t   skew_tab[32];
 


### PR DESCRIPTION
The xor_data and inverted_sides options at the moment work only on .D88 and .DSK images