### PR TITLE
cpmdisk: avoiding regressions

### DIFF
--- a/src/appmake/cpm2.c
+++ b/src/appmake/cpm2.c
@@ -388,8 +388,11 @@ static disc_spec pcw80_spec = {
 };
 
 
+// Microbee 3.5" Modular DS80
+// approximated (wrong sector numbering on boot tracks)
 static disc_spec microbee_spec = {
     .name = "Microbee",
+    .disk_mode = MFM250,
     .sectors_per_track = 10,
     .tracks = 80,
     .sides = 2,
@@ -400,11 +403,10 @@ static disc_spec microbee_spec = {
     .directory_entries = 128,
     .extent_size = 4096,
     .byte_size_extents = 1,
-    .first_sector_offset = 0x15,
-    .boot_tracks_sector_offset = 1,
+    .first_sector_offset = 0x15,    // <- yet another oddity
     .alternate_sides = 1,
     .has_skew = 1,
-    .skew_track_start = 5,
+    .skew_track_start = 2,
     .skew_tab = { 1, 4, 7, 0, 3, 6, 9, 2, 5, 8 }
 };
 

--- a/src/appmake/cpmdisk.c
+++ b/src/appmake/cpmdisk.c
@@ -328,19 +328,36 @@ int disc_write_edsk(disc_handle* h, const char* filename)
                 *ptr++ = i; // Track
                 *ptr++ = s; // Side
 
-                // Implementing SKEW is not necessary (tested on MAME)
 				// side2_sector_numbering option tested on MAME (Kaypro4)
-				if ( (! h->spec.side2_sector_numbering) || (! (h->spec.inverted_sides ^ s)) ) {
-					if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
-						*ptr++ = skew_sector(h, j, i) + h->spec.boot_tracks_sector_offset; // Sector ID
+				if ( h->spec.side2_sector_numbering || h->spec.inverted_sides ) {
+					// SKEW table introduced to support the Sharp MZ80A, MZ80B..
+					if ( (! h->spec.side2_sector_numbering) || (! (h->spec.inverted_sides ^ s)) ) {
+						if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
+							*ptr++ = skew_sector(h, j, i) + h->spec.boot_tracks_sector_offset; // Sector ID
+						} else {
+							*ptr++ = skew_sector(h, j, i) + h->spec.first_sector_offset; // Sector ID
+						}
 					} else {
-						*ptr++ = skew_sector(h, j, i) + h->spec.first_sector_offset; // Sector ID
+						if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
+							*ptr++ = skew_sector(h, j, i) + h->spec.boot_tracks_sector_offset + h->spec.sectors_per_track; // Sector ID
+						} else {
+							*ptr++ = skew_sector(h, j, i) + h->spec.first_sector_offset + h->spec.sectors_per_track ; // Sector ID
+						}
 					}
 				} else {
-					if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
-						*ptr++ = skew_sector(h, j, i) + h->spec.boot_tracks_sector_offset + h->spec.sectors_per_track; // Sector ID
+					// Usually implementing SKEW is not necessary (tested on MAME)
+					if ( (! h->spec.side2_sector_numbering) || (! (h->spec.inverted_sides ^ s)) ) {
+						if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
+							*ptr++ = j + h->spec.boot_tracks_sector_offset; // Sector ID
+						} else {
+							*ptr++ = j + h->spec.first_sector_offset; // Sector ID
+						}
 					} else {
-						*ptr++ = skew_sector(h, j, i) + h->spec.first_sector_offset + h->spec.sectors_per_track ; // Sector ID
+						if (  i + (i*h->spec.sides) <= h->spec.boottracks && h->spec.boot_tracks_sector_offset ) {
+							*ptr++ = j + h->spec.boot_tracks_sector_offset + h->spec.sectors_per_track; // Sector ID
+						} else {
+							*ptr++ = j + h->spec.first_sector_offset + h->spec.sectors_per_track ; // Sector ID
+						}
 					}
 				}
 


### PR DESCRIPTION
For what I could understand, the disk dump utilities and the related formats allowed a bit of flexibility for permitting a last resort data gathering in case of trouble.
This means that, the format specifications are not 100% respected, it depends on the target, the emulator choices, the way a disk dump (or write back) is performed.
I tried to let appmake write the disk images as close as possible to the more probable configuration.
The result depends also on the chosen file format.
