### PR TITLE
SAGA FOX OS

### DIFF
--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -108,6 +108,7 @@ SUBTYPE    px8ansi   -Cz+px -lpx8 -Ca-IDESTDIR/lib/target/px8/def -pragma-need=a
 SUBTYPE    qc10      -Cz+cpmdisk -Cz-f -Czqc10 -D__QC10__ -D__QX10__
 SUBTYPE    rc700     -Cz+cpmdisk -Cz-f -Czrc700 -Cz--container=imd -D__RC700__ -pragma-define:CONSOLE_ROWS=25 -pragma-define:CONSOLE_COLUMNS=80 -lrc700 -pragma-export:GRAPHICS_CHAR_SET=127 -pragma-export:GRAPHICS_CHAR_UNSET=32
 SUBTYPE    rainbow   -Cz+cpmdisk -Cz-f -Czrainbow -Cz--container=imd -D__RAINBOW__
+SUBTYPE	   sagafox   -Cz+cpmdisk -Cz-f -Czsagafox -Cz--container=imd
 SUBTYPE	   seequa    -Cz+cpmdisk -Cz-f -Czseequa -Cz--container=imd
 SUBTYPE    smc777    -Cz+cpmdisk -Cz-f -Czsmc777 -D__SMC777__ -lsmc777_cpm -pragma-define:CONSOLE_COLUMNS=80 -pragma-define:CONSOLE_ROWS=25
 SUBTYPE    svi       -Cz+cpmdisk -Cz-f -Czsvi-40ss -D__SVI__ -pragma-define:__HAVE_TMS99X8=1

--- a/src/appmake/cpm2.c
+++ b/src/appmake/cpm2.c
@@ -1448,6 +1448,29 @@ static disc_spec alphatro_spec = {
 };
 
 
+// "FOX OS" for the SAGA FOX
+// (Torino - Italy)
+static disc_spec sagafox_spec = {
+    .name = "SAGA FOX",
+    .disk_mode = MFM250,
+    .sectors_per_track = 10,
+    .tracks = 35,
+    .sides = 2,
+    .alternate_sides = 1,
+    .sector_size = 512,
+    .gap3_length = 0x17,
+    .filler_byte = 0xe5,
+    .boottracks = 2,
+    .directory_entries = 64,
+    .extent_size = 2048,
+    .byte_size_extents = 1,
+    .first_sector_offset = 1,
+    .has_skew = 1,
+    .skew_tab = { 0, 2, 4, 6, 8, 1, 3, 5, 7, 9 },
+	.xor_data = 0xff
+};
+
+
 // Seequa Chameleon
 static disc_spec seequa_spec = {
     .name = "Seequa Chameleon",
@@ -1856,6 +1879,7 @@ static struct formats {
     { "qc10",      "Epson QC-10, QX-10",    &qc10_spec, 0, NULL, 1 },
     { "rainbow",   "DEC Rainbow 100",       &rainbow_spec, 0, NULL, 1 },
     { "rc700",     "Regnecentralen RC-700", &rc700_spec, 0, NULL, 1 },
+    { "sagafox",   "SAGA FOX OS",           &sagafox_spec, 0, NULL, 1 },
     { "seequa",    "Seequa Chameleon (SS)", &seequa_spec, 0, NULL, 1 },
     { "sharpx1",   "Sharp X1",              &sharpx1_spec, 0, NULL, 1 },
     { "smc777",    "Sony SMC-70/SMC-777",   &smc777_spec, 0, NULL, 1 },


### PR DESCRIPTION
This one is a format for a rare Italian series of computers, the "SAGA FOX" were business oriented systems.
A recent restoration activity showed they were quite robust, so the "FOX OS" deserves a little corner here :)

The data bits needs to be inverted, I'm relying on one of the options I've just introduced for the MZ80.
