### PR TITLE
Nabu analog paddle support

### DIFF
--- a/examples/nabu/Makefile
+++ b/examples/nabu/Makefile
@@ -29,10 +29,10 @@ EXECFILES = $(CFILES:.c=.NABU)
 
 ifeq ($(COMPILER),sdcc)
    CFLAGS += -compiler=sdcc  -SO3 --max-allocs-per-node200000 --fsigned-char 
-all: ex1.NABU ex1b.NABU ex2.NABU ex3.NABU ex6.NABU ex7.NABU ex10.NABU ex10b.NABU vpoke.NABU vtstone.NABU
+all: ex1.NABU ex1b.NABU ex2.NABU ex3.NABU ex6.NABU ex7.NABU ex10.NABU ex10b.NABU vpoke.NABU vtstone.NABU retronet.NABU inputtest.NABU
 else
    CFLAGS += 
-all: $(EXECFILES) dstar.NABU microman.NABU othello.NABU globe.NABU snakes.NABU vtstone.NABU psgtest.NABU retronet.NABU
+all: $(EXECFILES) dstar.NABU microman.NABU othello.NABU globe.NABU snakes.NABU vtstone.NABU psgtest.NABU retronet.NABU inputtest.NABU
 endif
 
 showlib3d.NABU: ../msx/showlib3d.c
@@ -70,6 +70,9 @@ psgtest.NABU: ../sound/psgtest.c
 
 retronet.NABU: retronet.c
 	$(CC) $(CFLAGS) retronet.c -DNODELAY -create-app -oretronet.bin
+
+inputtest.NABU: inputtest.c
+	$(CC) $(CFLAGS) inputtest.c -DNODELAY -create-app -oinputtest.bin
 
 clean:
 	$(RM) *.obj *.sym *.map *.o* *.bin zcc_opt.def *.reloc *.NABU

--- a/examples/nabu/inputtest.c
+++ b/examples/nabu/inputtest.c
@@ -1,0 +1,121 @@
+#include <conio.h>
+#include <games.h>
+#include <arch/nabu/paddles.h>
+#include <font/font.h>
+#include <sys/ioctl.h>
+
+#define MODE_TEXT 0
+
+// decode and print joystick byte
+void printJoystick(uint8_t b)
+{
+	char state[6];
+
+	state[0] = '.';
+	state[1] = '.';
+	state[2] = '.';
+	state[3] = '.';
+	state[4] = '.';
+	state[5] = 0;
+
+	if (b & MOVE_LEFT) {
+		state[0] = 'L';
+	}
+	if (b & MOVE_DOWN) {
+		state[1] = 'D';
+	}
+	if (b & MOVE_RIGHT) {
+		state[2] = 'R';
+	}
+	if (b & MOVE_UP) {
+		state[3] = 'U';
+	}
+	if (b & MOVE_FIRE) {
+		state[4] = 'F';
+	}
+	printf("%s", state);
+}
+
+void main() {
+
+	uint8_t mode = MODE_TEXT;
+	void *font_ptr = &font_8x8_msx_system;
+
+	console_ioctl(IOCTL_GENCON_SET_MODE, &mode);
+	console_ioctl(IOCTL_GENCON_SET_FONT32, &font_ptr);
+
+	// print title
+	gotoxy(14, 0);
+	printf("Input Tester");
+
+	// print Paddle 1 header
+	gotoxy(5, 5);
+	printf("Paddle 1: ");
+
+	// print Paddle 2 header
+	gotoxy(23, 5);
+	printf("Paddle 2: ");
+
+	// print Paddle 3 header
+	gotoxy(5, 10);
+	printf("Paddle 3: ");
+
+	// print Paddle 4 header
+	gotoxy(23, 10);
+	printf("Paddle 4: ");
+
+	// print Joystick 1 header
+	gotoxy(2, 15);
+	printf("Joystick 1: ");
+
+	// print Joystick 2 header
+	gotoxy(21, 15);
+	printf("Joystick 2: ");
+
+	// print Keyboard header
+	gotoxy(14, 20);
+	printf("Keyboard: 00");
+
+	while (1) {
+		// read paddle 1 value
+		uint8_t p1 = paddle(PADDLE_1);
+		// read paddle 2 value
+		uint8_t p2 = paddle(PADDLE_2);
+		// read paddle 3 value
+		uint8_t p3 = paddle(PADDLE_3);
+		// read paddle 4 value
+		uint8_t p4 = paddle(PADDLE_4);
+
+		// read  joystick 1 status
+		uint8_t j1 = joystick(1);
+		// read  joystick 2 status
+		uint8_t j2 = joystick(2);
+
+		uint8_t key = getk();
+
+		// display paddle 1 value
+		gotoxy(15, 5);
+		printf("%02X", p1);
+		// display paddle 2 value
+		gotoxy(33, 5);
+		printf("%02X", p2);
+		// display paddle 3 value
+		gotoxy(15, 10);
+		printf("%02X", p3);
+		// display paddle 4 value
+		gotoxy(33, 10);
+		printf("%02X", p4);
+		// display joystick 1 state
+		gotoxy(14, 15);
+		printJoystick(j1);
+		// display joystick 2 state
+		gotoxy(33, 15);
+		printJoystick(j2);
+
+		// display last keyboard keycode
+		if (key != 0) {
+			gotoxy(24, 20);
+			printf("%02X", key);
+		}
+	}
+}

--- a/include/arch/nabu/paddles.h
+++ b/include/arch/nabu/paddles.h
@@ -1,0 +1,21 @@
+#ifndef ARCH_NABU_PADDLES_H
+#define ARCH_NABU_PADDLES_H
+
+#include <stdint.h>
+#include <sys/compiler.h>
+
+
+#define PADDLE_1   1
+#define PADDLE_2   2
+#define PADDLE_3   3
+#define PADDLE_4   4
+#define PADDLE_5   5
+#define PADDLE_6   6
+#define PADDLE_7   7
+#define PADDLE_8   8
+
+/* Paddle function */
+extern uint8_t __LIB__  paddle(uint8_t game_device) __z88dk_fastcall;
+
+#endif
+

--- a/libsrc/target/nabu/games/paddle.asm
+++ b/libsrc/target/nabu/games/paddle.asm
@@ -1,0 +1,27 @@
+;  Query analog paddle values
+
+
+        SECTION code_clib
+        PUBLIC    paddle
+        PUBLIC    _paddle
+
+        EXTERN  __nabu_p1
+
+.paddle
+._paddle
+    ;__FASTCALL__ : paddle no. in HL
+    ld      a,l
+    ld      hl,0
+    cp      0
+    ret     z
+    dec     a
+    and     7
+    ld      hl,__nabu_p1
+    add     a,l
+    ld      l,a
+    adc     a,h
+    sub     l
+    ld      h,a
+    ld      l,(hl)
+    ld      h,0
+    ret

--- a/libsrc/target/nabu/interrupts/asm_interrupt_init.asm
+++ b/libsrc/target/nabu/interrupts/asm_interrupt_init.asm
@@ -17,6 +17,7 @@ EXTERN __nabu_lastk
 EXTERN __nabu_key_mode
 EXTERN __nabu_j1
 EXTERN __nabu_j2
+EXTERN __nabu_p1
 
 
 ; It's assumed that im2 is already setup before entry
@@ -64,7 +65,13 @@ int_keyboard:
     di
     push    af
     push    hl
+    push    bc
+    push    ix
+    push    iy
     call    handle_keyboard
+    pop     iy
+    pop     ix
+    pop     bc
     pop     hl
     pop     af
     ei
@@ -100,6 +107,21 @@ handle_keyboard:
     inc     hl  ; __nabu_j3
     cp      $83
     jr      z,handle_joy
+    ld      ix,__nabu_p1
+    cp      $84
+    jr      z,handle_paddle
+    inc     ix
+    inc     ix
+    cp      $86
+    jr      z,handle_paddle
+    inc     ix
+    inc     ix
+    cp      $88
+    jr      z,handle_paddle
+    inc     ix
+    inc     ix
+    cp      $8a
+    jr      z,handle_paddle
     in      a,($90)
     cp      $80
     jr      z,set_joystick
@@ -108,6 +130,14 @@ handle_keyboard:
     cp      $82
     jr      z,set_joystick
     cp      $83
+    jr      z,set_joystick
+    cp      $84
+    jr      z,set_joystick
+    cp      $86
+    jr      z,set_joystick
+    cp      $88
+    jr      z,set_joystick
+    cp      $8a
     jr      z,set_joystick
     cp      $90
     jr      c,set_key
@@ -120,6 +150,8 @@ set_key:
 
 set_joystick:
     ld      (__nabu_key_mode),a
+    xor     a
+    ld      (paddle_input_index),a
     ret
 
 handle_joy:
@@ -128,6 +160,43 @@ handle_joy:
     ld      (hl),a
     xor     a
     ld      (__nabu_key_mode),a
+    ret
+
+handle_paddle:
+    ld      hl,paddle_input_array
+    ld      b,0
+    ld      a,(paddle_input_index)
+    ld      c,a
+    in      a,($90)
+    add     hl,bc
+    ld      (hl),a
+    ld      a,c
+    inc     a
+    ld      (paddle_input_index),a
+    cp      4
+    ret     nz
+    ld      iy,paddle_input_array
+    ld      a,(iy+0)
+    and     $0f
+    ld      b,(iy+1)
+    sla     b
+    sla     b
+    sla     b
+    sla     b
+    or      b
+    ld      (ix+0),a
+    ld      a,(iy+2)
+    and     $0f
+    ld      b,(iy+3)
+    sla     b
+    sla     b
+    sla     b
+    sla     b
+    or      b
+    ld      (ix+1),a
+    xor     a
+    ld      (__nabu_key_mode),a
+    ld      (paddle_input_index),a
     ret
 
 handle_vdp:
@@ -172,6 +241,11 @@ def_ints:
     defw    int_noop       ; Card1
     defw    int_noop       ; Card2
     defw    int_noop       ; Card3
+
+paddle_input_index:
+    defb    0
+paddle_input_array:
+    defb    0,0,0,0
 
 SECTION bss_clib
 

--- a/libsrc/target/nabu/nabu_cpm.lst
+++ b/libsrc/target/nabu/nabu_cpm.lst
@@ -13,4 +13,5 @@ target/nabu/psg/get_psg
 @psg/ay/wyz/psg_wyz.lst
 @psg/ay/vt2/psg_vt2.lst
 target/nabu/games/joystick.asm
+target/nabu/games/paddle.asm
 @games/games.lst

--- a/libsrc/target/nabu/stdio/vars.asm
+++ b/libsrc/target/nabu/stdio/vars.asm
@@ -11,6 +11,14 @@ PUBLIC __nabu_j2
 PUBLIC __nabu_j3
 PUBLIC __nabu_j4
 
+PUBLIC __nabu_p1
+PUBLIC __nabu_p2
+PUBLIC __nabu_p3
+PUBLIC __nabu_p4
+PUBLIC __nabu_p5
+PUBLIC __nabu_p6
+PUBLIC __nabu_p7
+PUBLIC __nabu_p8
 
 
 __nabu_lastk: defb 0
@@ -21,3 +29,12 @@ __nabu_j1:      defb    0
 __nabu_j2:      defb    0
 __nabu_j3:      defb    0
 __nabu_j4:      defb    0
+
+__nabu_p1:      defb    0
+__nabu_p2:      defb    0
+__nabu_p3:      defb    0
+__nabu_p4:      defb    0
+__nabu_p5:      defb    0
+__nabu_p6:      defb    0
+__nabu_p7:      defb    0
+__nabu_p8:      defb    0


### PR DESCRIPTION
This updates the NABU target to support receiving and decoding the analog data sent from the keyboard when using paddle controllers. I've also included an example program I used to test keyboard/controller input devices.