### PR TITLE
Updated snap to fix runtime errors with asmpp and asmstyle.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,18 +55,18 @@ parts:
       - libtemplate-plugin-yaml-perl
       - libyaml-perl 
       - liblocal-lib-perl 
-      - libcapture-tiny-perl 
       - libpath-tiny-perl 
       - libtest-differences-perl 
       - libtext-table-perl 
       - libdata-hexdump-perl
-      - libregexp-common-perl 
       - libclone-perl
       - libfile-slurp-perl
       - libyaml-tiny-perl
       - libgmp3-dev
       - pkg-config
     stage-packages:
+      - libregexp-common-perl
+      - libcapture-tiny-perl
       - libicu66
       - perl-modules-5.30
       - libperl5.30
@@ -123,12 +123,12 @@ apps:
     plugs: [home, removable-media]
   z88dk-asmpp:
     environment:
-      PERL5LIB: "$SNAP/lib/perl5:$SNAP/usr/share/perl/5.30:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.30"
+      PERL5LIB: "$SNAP/perl5/lib/perl5:$SNAP/usr/share/perl5:$SNAP/usr/share/perl/5.30:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.30"
     command: bin/z88dk-asmpp
     plugs: [home, removable-media]
   z88dk-asmstyle:
     environment:
-      PERL5LIB: "$SNAP/lib/perl5:$SNAP/usr/share/perl/5.30:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.30"
+      PERL5LIB: "$SNAP/perl5/lib/perl5:$SNAP/usr/share/perl/5.30:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.30"
     command: bin/z88dk-asmstyle
     plugs: [home, removable-media]
 


### PR DESCRIPTION
The following errors have been fixed.

```
$ z88dk-asmstyle 
Can't locate Modern/Perl.pm in @INC (you may need to install the Modern::Perl module) (@INC contains: /snap/z88dk/7281/lib/perl5 /snap/z88dk/7281/usr/share/perl/5.30 /snap/z88dk/7281/usr/lib/x86_64-linux-gnu/perl/5.30 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /snap/z88dk/7281/bin/z88dk-asmstyle line 10.
BEGIN failed--compilation aborted at /snap/z88dk/7281/bin/z88dk-asmstyle line 10.

$ z88dk.z88dk-asmpp
Can't locate Capture/Tiny.pm in @INC (you may need to install the Capture::Tiny module) (@INC contains: /snap/z88dk/7281/lib/perl5 /snap/z88dk/7281/usr/share/perl/5.30 /snap/z88dk/7281/usr/lib/x86_64-linux-gnu/perl/5.30 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /snap/z88dk/7281/bin/z88dk-asmpp line 28.
BEGIN failed--compilation aborted at /snap/z88dk/7281/bin/z88dk-asmpp line 28.
```
