### PR TITLE
add missing SP1 fastcall stubs after source migration to classic

### DIFF
--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DeleteSpr_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DeleteSpr_fastcall.asm
@@ -1,0 +1,11 @@
+
+; void sp1_DeleteSpr_fastcall(struct sp1_ss *s)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_DeleteSpr_fastcall
+
+EXTERN asm_sp1_DeleteSpr
+
+defc _sp1_DeleteSpr_fastcall = asm_sp1_DeleteSpr

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructAlways_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructAlways_fastcall.asm
@@ -1,0 +1,18 @@
+
+; sp1_DrawUpdateStructAlways(struct sp1_update *u)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_DrawUpdateStructAlways_fastcall
+
+EXTERN asm_sp1_DrawUpdateStructAlways
+
+_sp1_DrawUpdateStructAlways_fastcall:
+   
+   push ix
+   
+   call asm_sp1_DrawUpdateStructAlways
+   
+   pop ix
+   ret

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructIfInv_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructIfInv_fastcall.asm
@@ -1,0 +1,18 @@
+
+; sp1_DrawUpdateStructIfInv(struct sp1_update *u)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_DrawUpdateStructIfInv_fastcall
+
+EXTERN asm_sp1_DrawUpdateStructIfInv
+
+_sp1_DrawUpdateStructIfInv_fastcall:
+   
+   push ix
+   
+   call asm_sp1_DrawUpdateStructIfInv
+   
+   pop ix
+   ret

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructIfNotRem_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructIfNotRem_fastcall.asm
@@ -1,0 +1,18 @@
+
+; sp1_DrawUpdateStructIfNotRem(struct sp1_update *u)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_DrawUpdateStructIfNotRem_fastcall
+
+EXTERN asm_sp1_DrawUpdateStructIfNotRem
+
+_sp1_DrawUpdateStructIfNotRem_fastcall:
+   
+   push ix
+   
+   call asm_sp1_DrawUpdateStructIfNotRem
+   
+   push ix
+   ret

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructIfVal_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_DrawUpdateStructIfVal_fastcall.asm
@@ -1,0 +1,18 @@
+
+; sp1_DrawUpdateStructIfVal(struct sp1_update *u)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_DrawUpdateStructIfVal_fastcall
+
+EXTERN asm_sp1_DrawUpdateStructIfVal
+
+_sp1_DrawUpdateStructIfVal_fastcall:
+
+   push ix
+   
+   call asm_sp1_DrawUpdateStructIfVal
+   
+   pop ix
+   ret

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_InvUpdateStruct_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_InvUpdateStruct_fastcall.asm
@@ -1,0 +1,11 @@
+
+; sp1_InvUpdateStruct
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_InvUpdateStruct_fastcall
+
+EXTERN asm_sp1_InvUpdateStruct
+
+defc _sp1_InvUpdateStruct_fastcall = asm_sp1_InvUpdateStruct

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_Invalidate_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_Invalidate_fastcall.asm
@@ -1,0 +1,20 @@
+; void sp1_Invalidate(struct sp1_Rect *r)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_Invalidate_fastcall
+
+EXTERN asm_sp1_Invalidate
+
+_sp1_Invalidate_fastcall:
+
+   ld d,(hl)
+   inc hl
+   ld e,(hl)
+   inc hl
+   ld b,(hl)
+   inc hl
+   ld c,(hl)
+
+   jp asm_sp1_Invalidate

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_RemoveCharStruct_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_RemoveCharStruct_fastcall.asm
@@ -1,0 +1,11 @@
+
+; void  sp1_RemoveCharStruct_fastcall(struct sp1_cs *cs)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_RemoveCharStruct_fastcall
+
+EXTERN asm_sp1_RemoveCharStruct
+
+defc _sp1_RemoveCharStruct_fastcall = asm_sp1_RemoveCharStruct

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_RemoveUpdateStruct_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_RemoveUpdateStruct_fastcall.asm
@@ -1,0 +1,11 @@
+
+; sp1_RemoveUpdateStruct
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_RemoveUpdateStruct_fastcall
+
+EXTERN asm_sp1_RemoveUpdateStruct
+
+defc _sp1_RemoveUpdateStruct_fastcall = asm_sp1_RemoveUpdateStruct

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_RestoreUpdateStruct_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_RestoreUpdateStruct_fastcall.asm
@@ -1,0 +1,11 @@
+
+; sp1_RestoreUpdateStruct
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_RestoreUpdateStruct_fastcall
+
+EXTERN asm_sp1_RestoreUpdateStruct
+
+defc _sp1_RestoreUpdateStruct_fastcall = asm_sp1_RestoreUpdateStruct

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_ValUpdateStruct_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_ValUpdateStruct_fastcall.asm
@@ -1,0 +1,11 @@
+
+; sp1_ValUpdateStruct
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_ValUpdateStruct_fastcall
+
+EXTERN asm_sp1_ValUpdateStruct
+
+defc _sp1_ValUpdateStruct_fastcall = asm_sp1_ValUpdateStruct

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_Validate_fastcall.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/c/sccz80/sp1_Validate_fastcall.asm
@@ -1,0 +1,20 @@
+; void sp1_Validate(struct sp1_Rect *r)
+
+SECTION code_clib
+SECTION code_temp_sp1
+
+PUBLIC _sp1_Validate_fastcall
+
+EXTERN asm_sp1_Validate
+
+_sp1_Validate_fastcall:
+
+   ld d,(hl)
+   inc hl
+   ld e,(hl)
+   inc hl
+   ld b,(hl)
+   inc hl
+   ld c,(hl)
+
+   jp asm_sp1_Validate

--- a/libsrc/_DEVELOPMENT/temp/sp1/zx/sprites/asm_sp1_InitCharStruct.asm
+++ b/libsrc/_DEVELOPMENT/temp/sp1/zx/sprites/asm_sp1_InitCharStruct.asm
@@ -5,10 +5,11 @@
 SECTION code_clib
 SECTION code_temp_sp1
 
+INCLUDE "config_private.inc"
+
 PUBLIC asm_sp1_InitCharStruct
 
 EXTERN _sp1_struct_cs_prototype
-EXTERN SP1V_ROTTBL
 
 asm_sp1_InitCharStruct:
 


### PR DESCRIPTION
Hey @suborb, I just copied the `_fastcall` stubs from `sdcc_ix`, since they are the most restrictive (IX is preserved in them) and I think I recall using this same criteria when adapting the newlib sources to classic the first time.