### PR TITLE
[Agon8] small change to fix the plot functions

### DIFF
--- a/libsrc/target/agon/graphics/__agon_draw.asm
+++ b/libsrc/target/agon/graphics/__agon_draw.asm
@@ -21,7 +21,7 @@ __agon_draw:
     ; Plot the origin pixel
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     ld      hl,(ix+6)
     call    __agon_putword

--- a/libsrc/target/agon/graphics/__agon_drawr.asm
+++ b/libsrc/target/agon/graphics/__agon_drawr.asm
@@ -21,7 +21,7 @@ __agon_drawr:
     ;Plot pixel
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     ld      hl,(__gfx_coords)
     call    __agon_putword

--- a/libsrc/target/agon/graphics/__agon_drawto.asm
+++ b/libsrc/target/agon/graphics/__agon_drawto.asm
@@ -21,7 +21,7 @@ __agon_drawto:
     ; Plot pixel at start
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     ld      hl,(__gfx_coords)
     call    __agon_putword

--- a/libsrc/target/agon/graphics/plotpixl.asm
+++ b/libsrc/target/agon/graphics/plotpixl.asm
@@ -41,7 +41,7 @@ w_plotpixel:
     ; VDU 25, n, 640; 512;
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     call    __agon_putword
     ex      de,hl

--- a/libsrc/target/agon/graphics/w_plotpixl.asm
+++ b/libsrc/target/agon/graphics/w_plotpixl.asm
@@ -41,7 +41,7 @@ w_plotpixel:
     ; VDU 25, n, 640; 512;
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     call    __agon_putword
     ex      de,hl

--- a/libsrc/target/agon/graphics/w_respixl.asm
+++ b/libsrc/target/agon/graphics/w_respixl.asm
@@ -41,7 +41,7 @@ w_respixel:
     ; VDU 25, n, 640; 512;
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     call    __agon_putword
     ex      de,hl

--- a/libsrc/target/agon/graphics/w_xorpixl.asm
+++ b/libsrc/target/agon/graphics/w_xorpixl.asm
@@ -74,7 +74,7 @@ ck:
     ; VDU 25, n, 640; 512;
     ld      a,25
     call    __agon_putc
-    ld      a,$41
+    ld      a,$45
     call    __agon_putc
     ld      hl,(__gfx_coords) ;x
     call    __agon_putword


### PR DESCRIPTION
Hello,  first contribution here :)

Since the latest VDP firmware fixed some commands plot wasn't doing well, here is a screenshot of the emulator showing a 10x10 pixels square

![imagen](https://github.com/z88dk/z88dk/assets/184088/3e60eba7-ac0c-4345-8dce-b806c051c66c)

Thanks to ss7 for the info

https://agonconsole8.github.io/agon-docs/VDP---PLOT-Commands.html

Thanks!