### PR TITLE
Continuation of #2519 - sdcc_enter_ix

### DIFF
--- a/libsrc/_DEVELOPMENT/l/util/5-z80/l_compare_de_hl.asm
+++ b/libsrc/_DEVELOPMENT/l/util/5-z80/l_compare_de_hl.asm
@@ -25,7 +25,7 @@ l_compare_de_hl:
    push ix
 
 ;******************************
-IF __SDCC | __SDCC_IX | __SDCC_IY
+IF (__SDCC | __SDCC_IX | __SDCC_IY) && !__CLASSIC
 ;******************************
 
    push hl

--- a/libsrc/z80_crt0s/Makefile
+++ b/libsrc/z80_crt0s/Makefile
@@ -8,43 +8,43 @@ all: obj/z80-crt0 obj/ixiy-crt0 obj/8080-crt0 obj/8085-crt0 \
 	obj/ez80_z80-crt0 obj/z180-crt0 obj/z80n-crt0  obj/r4k-crt0 obj/kc160-crt0
 
 obj/z80-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/z80/z80 -I.. -D__SDCC_IX -mz80 @crt0_z80.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/z80/z80 -I.. -D__SDCC_IX -D__CLASSIC  -mz80 @crt0_z80.lst
 	@touch $@
 
 obj/z80n-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/z80n/z80n -I.. -mz80n  @crt0_z80n.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/z80n/z80n -I.. -D__SDCC_IX -D__CLASSIC -mz80n  @crt0_z80n.lst
 	@touch $@
 
 obj/8080-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/8080/8080 -I..  -DCPU_8080 -m8080 @crt0_8080.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/8080/8080 -I..  -DCPU_8080 -D__CLASSIC -m8080 @crt0_8080.lst
 	@touch $@
 
 obj/8085-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/8085/8085 -I..  -DCPU_8085 -m8085 @crt0_8085.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/8085/8085 -I..  -DCPU_8085 -D__CLASSIC -m8085 @crt0_8085.lst
 	@touch $@
 
 obj/gbz80-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/gbz80/gbz80 -I..  -DCPU_GBZ80 -mgbz80 @crt0_gbz80.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/gbz80/gbz80 -I..  -DCPU_GBZ80 -D__CLASSIC -mgbz80 @crt0_gbz80.lst
 	@touch $@
 
 obj/z180-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/z180/z180 -I.. -D__SDCC_IX  -mz180 @crt0_z180.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/z180/z180 -I.. -D__SDCC_IX -D__CLASSIC -mz180 @crt0_z180.lst
 	@touch $@
 
 obj/ez80_z80-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/ez80_z80/ez80 -I.. -D__SDCC_IX -mez80_z80 -DEZ80 @crt0_ez80.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/ez80_z80/ez80 -I.. -D__SDCC_IX -D__CLASSIC -mez80_z80 -DEZ80 @crt0_ez80.lst
 	@touch $@
 
 obj/r2ka-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/r2ka/r2ka -I.. -D__SDCC_IX -mr2ka  @crt0_r2ka.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/r2ka/r2ka -I.. -D__SDCC_IX -D__CLASSIC -mr2ka  @crt0_r2ka.lst
 	@touch $@
 
 obj/r4k-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/r4k/r4k -I.. -D__SDCC_IX -mr4k  @crt0_r2ka.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/r4k/r4k -I.. -D__SDCC_IX -D__CLASSIC -mr4k  @crt0_r2ka.lst
 	@touch $@
 
 obj/kc160-crt0:
-	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/kc160/kc160 -I.. -D__SDCC_IX -mkc160  @crt0_kc160.lst
+	NEWLIB_ROOT=$(NEWLIB_ROOT) $(ASSEMBLER) -Oobj/kc160/kc160 -I.. -D__SDCC_IX -D__CLASSIC -mkc160  @crt0_kc160.lst
 	@touch $@
 
 


### PR DESCRIPTION
* Classic should be compiled with sdcc_ix
* crt0 routines weren't being
* As a result --opt-code-size pulled in a routine with ix/iy swapped
