### PR TITLE
Correct extended DSK signature

### DIFF
--- a/src/appmake/cpmdisk.c
+++ b/src/appmake/cpmdisk.c
@@ -1,4 +1,4 @@
--/*
+/*
  * Disc image handling
  */
 

--- a/src/appmake/cpmdisk.c
+++ b/src/appmake/cpmdisk.c
@@ -1,4 +1,4 @@
-/*
+-/*
  * Disc image handling
  */
 
@@ -296,7 +296,7 @@ int disc_write_edsk(disc_handle* h, const char* filename)
         return -1;
     }
     memset(header, 0, 256);
-    memcpy(header, "EXTENDED CPC DSK FILE\r\nDisk-Info\r\n", 34);
+    memcpy(header, "EXTENDED CPC DSK File\r\nDisk-Info\r\n", 34);
     snprintf(title,sizeof(title),"z88dk/%s", h->spec.name ? h->spec.name : "appmake");
     memcpy(header + 0x22, title, strlen(title));
     header[0x30] = h->spec.tracks % 256;


### PR DESCRIPTION
The disk signature for generated .dsk files is slightly incorrect causing the image to not be loadable into various tools such as Spectaculator and Disk Image Manager.

The spec at https://www.cpcwiki.eu/index.php/Format:DSK_disk_image_file_format indicates that offset 00 should include the sequence:

`"EXTENDED CPC DSK File\r\nDisk-Info\r\n"`

Unfortunately it is generated with the wrong case right now as the word File has been capitalized. Manually editing the signature in generated disk images indicated the image is otherwise correct.