### PR TITLE
Fix #2552: Fix up so that l_eq/l_ne use dehl entry (8085)

### DIFF
--- a/lib/arch/8085/8085_rules.1
+++ b/lib/arch/8085/8085_rules.1
@@ -304,40 +304,40 @@
 	call	l_eq
 =
 	ld	bc,%1
-	call	l_eq	;bc==hl
+	call	l_eq_hlbc	;bc==hl
 
 	ld	hl,(_%1
 	call	l_eq
 =
 	ld	hl,(_%1
 	ld	bc,de
-	call	l_eq	;bc==hl
+	call	l_eq_hlbc	;bc==hl
 
 	pop	de
-	call	l_eq
+	call	l_eq_hlbc
 =
 	pop	bc
-	call	l_eq	;bc==hl
+	call	l_eq_hlbc	;bc==hl
 
 %title inequality comparisons
 	ld	de,%1
 	call	l_ne
 =
 	ld	bc,%1
-	call	l_ne	;bc!=hl
+	call	l_ne_hlbc	;bc!=hl
 
 	ld	hl,(_%1
 	call	l_ne
 =
 	ld	hl,(_%1
 	ld	bc,de
-	call	l_ne	;bc!=hl
+	call	l_ne_hlbc	;bc!=hl
 
 	pop	de
 	call	l_ne
 =
 	pop	bc
-	call	l_ne	;bc!=hl
+	call	l_ne_hlbc	;bc!=hl
 
 %title Clear up a misoptimisation
 	push	de

--- a/lib/z80_crt0.hdr
+++ b/lib/z80_crt0.hdr
@@ -93,7 +93,9 @@
 	EXTERN	l_xor		;Int logical xor
 	EXTERN	l_and		;Int logical and
 	EXTERN	l_eq		;Int equality
+	EXTERN	l_eq_hlbc	;Int equality (hl==bc)
 	EXTERN	l_ne		;Int inequality
+	EXTERN	l_ne_hlbc	;Int inequality
 	EXTERN	l_gt		;Int signed de >  hl
 	EXTERN	l_le		;Int signed de <= hl
 	EXTERN	l_ge		;Int signed de >= hl

--- a/libsrc/_DEVELOPMENT/l/sccz80/7-8085/l_eq.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/7-8085/l_eq.asm
@@ -10,9 +10,11 @@ SECTION code_clib
 SECTION code_l_sccz80
 
 PUBLIC l_eq
+PUBLIC l_eq_hlbc
 
 .l_eq
-
+    ld bc,de
+.l_eq_hlbc
     ; bc == hl
     ; carry set if true
 

--- a/libsrc/_DEVELOPMENT/l/sccz80/7-8085/l_ne.asm
+++ b/libsrc/_DEVELOPMENT/l/sccz80/7-8085/l_ne.asm
@@ -10,9 +10,13 @@ SECTION code_clib
 SECTION code_l_sccz80
 
 PUBLIC l_ne
+PUBLIC l_ne_hlbc
 
 .l_ne
 
+    ld bc,de
+
+.l_ne_hlbc
     ; BC != HL
     ; set carry if true
 


### PR DESCRIPTION
This covers the case where the optimisation doesn't fire and we need move a de,hl and hl,bc entry point.