### PR TITLE
cpm - 8085 stdio fnctl library build

### DIFF
--- a/lib/config/cpm.cfg
+++ b/lib/config/cpm.cfg
@@ -15,7 +15,7 @@ CLIB    default -lcpm_clib -D__Z80__ -D__Z80 -Cc-standard-escape-chars -LDESTDIR
 CLIB    ixiy -lcpmixiy_clib -D__Z80__ -D__Z80 -mz80_ixiy -startuplib=z80iy_crt0 -Ca-IXIY -Cl-IXIY -Cc-standard-escape-chars -LDESTDIR/lib/clibs/ixiy
 CLIB    z180 -lcpmz180_clib -startuplib=z180_crt0 -Cc-standard-escape-chars -LDESTDIR/lib/clibs/z180 -LDESTDIR/lib/clibs/z180 -mz180 -D__Z180
 CLIB    8080 -lcpm8080_clib -Cc-standard-escape-chars -m8080 -D__8080 -startuplib=8080_crt0 -pragma-define:CLIB_DISABLE_FGETS_CURSOR=1 -LDESTDIR/lib/clibs/8080
-CLIB    8085 -lcpm8080_clib -Cc-standard-escape-chars -m8085 -D__8085 -startuplib=8085_crt0 -l8085_opt -pragma-define:CLIB_DISABLE_FGETS_CURSOR=1 -LDESTDIR/lib/clibs/8085
+CLIB    8085 -lcpm8085_clib -Cc-standard-escape-chars -m8085 -D__8085 -startuplib=8085_crt0 -l8085_opt -pragma-define:CLIB_DISABLE_FGETS_CURSOR=1 -LDESTDIR/lib/clibs/8085
 CLIB    ansi -lcpm_clib -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-define:ansicolumns=80 -pragma-define:ansirows=25 -LDESTDIR/lib/clibs/z80 -D__Z80__ -D__Z80
 CLIB    ansi40 -lcpm_clib -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-define:ansicolumns=40 -pragma-define:ansirows=25 -LDESTDIR/lib/clibs/z80 -D__Z80__ -D__Z80
 CLIB    new -Cc-standard-escape-chars  -D__Z88DK_NEWLIB -nostdlib -isystemDESTDIR/include/_DEVELOPMENT/sccz80 -Ca-IDESTDIR/libsrc/_DEVELOPMENT/target/cpm -lcpm -LDESTDIR/libsrc/_DEVELOPMENT/lib/sccz80 -Cl-IDESTDIR/libsrc/_DEVELOPMENT/target/cpm -crt0=DESTDIR/libsrc/_DEVELOPMENT/target/cpm/cpm_crt.asm.m4

--- a/lib/config/test.cfg
+++ b/lib/config/test.cfg
@@ -9,7 +9,7 @@ CRT0    DESTDIR/lib/target/test/classic/test_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS -O2 -SO2 -iquote. -D__TESTTARGET__  -M -subtype=default -clib=default -Ca-IDESTDIR/lib/target/test/def 
+OPTIONS -O2 -SO2 -iquote. -D__TESTTARGET__ -M -subtype=default -clib=default -Ca-IDESTDIR/lib/target/test/def 
 
 CLIB    default     -Cc-standard-escape-chars -D__Z80__ -D__Z80 -ltest_clib -LDESTDIR/lib/clibs/z80
 CLIB    classic     -Cc-standard-escape-chars -D__Z80__ -D__Z80 -ltest_clib -LDESTDIR/lib/clibs/z80 
@@ -18,7 +18,7 @@ CLIB    rabbit4k    -mr4k -Cc-standard-escape-chars -ltestrcm4k_clib -DRCMX000 -
 CLIB    r2ka        -mr2ka -Cc-standard-escape-chars -ltestrcm_clib -DRCMX000 -D__RCMX000__ -startuplib=r2ka_crt0 -LDESTDIR/lib/clibs/r2ka
 CLIB    zxn         -mz80n -Cc-mz80n -Cc-standard-escape-chars -D__Z80__ -D__Z80 -D__Z80N -ltest_clib -startuplib=z80n_crt0 -LDESTDIR/lib/clibs/z80n -LDESTDIR/lib/clibs/z80
 CLIB    z80n        -mz80n -Cc-mz80n -Cc-standard-escape-chars -D__Z80__ -D__Z80 -D__Z80N -ltest_clib -startuplib=z80n_crt0 -LDESTDIR/lib/clibs/z80n -LDESTDIR/lib/clibs/z80
-CLIB    kc160	    -mkc160 -Cc-mkc160 -Cc-standard-escape-chars -D__KC160_Z80 -ltestkc160_clib -startuplib=kc160_crt0 -LDESTDIR/lib/clibs/kc160 
+CLIB    kc160       -mkc160 -Cc-mkc160 -Cc-standard-escape-chars -D__KC160_Z80 -ltestkc160_clib -startuplib=kc160_crt0 -LDESTDIR/lib/clibs/kc160 
 CLIB    z180        -mz180 -Cc-mz180 -Cc-standard-escape-chars -D__Z180 -ltestz180_clib -startuplib=z180_crt0 -LDESTDIR/lib/clibs/z180
 CLIB    ez80_z80    -mez80_z80 -Cc-standard-escape-chars -D__EZ80_Z80 -ltestez80_z80_clib -startuplib=ez80_z80_crt0 -LDESTDIR/lib/clibs/ez80_z80
 CLIB    8080        -m8080 -Cc-standard-escape-chars -ltest8080_clib -startuplib=8080_crt0 -D__8080 -LDESTDIR/lib/clibs/8080

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -16,7 +16,7 @@ TOCREATE =
 # $2 = libs
 check_target = $(if $(or $(filter $(1),$(TARGETS)), $(filter all,$(TARGETS))),$(2),)
 
-CPMLIBS = cpm_clib.lib cpmixiy_clib.lib cpmz180_clib.lib cpm8080_clib.lib cpmdevice.lib cpmdevice_8080.lib gfxh19.lib gfxvio.lib
+CPMLIBS = cpm_clib.lib cpmixiy_clib.lib cpmz180_clib.lib cpm8080_clib.lib cpm8085_clib.lib cpmdevice.lib cpmdevice_8080.lib cpmdevice_8085.lib gfxh19.lib gfxvio.lib
 GENLIBS = z80_crt0.lib z80iy_crt0.lib z80n_crt0.lib z180_crt0.lib 8080_crt0.lib 8085_crt0.lib gbz80_crt0.lib r2ka_crt0.lib r4k_crt0.lib ez80_z80_crt0.lib kc160_crt0.lib math48.lib genmath.lib mbf32.lib mbf64.lib math16.lib math32.lib daimath32.lib am9511.lib gendos.lib ndos.lib fastmath.lib preempt.lib sp1-all
 GENLIBS += 8080_opt.lib 8085_opt.lib
 GENLIBS += gfxtek.lib gfxregis.lib
@@ -784,11 +784,35 @@ cpm_clib.lib: $(TARGET_CLIB_OBJS)
 	$(MAKE) -C gfx TARGET=cpm SUBTYPE=gsx FLAVOUR=wide
 	TARGET=gsx TYPE=z80 $(LIBLINKER) -DFORcpm -DFORgsx -x$(OUTPUT_DIRECTORY)/gfxgsx @$(TARGET_DIRECTORY)/cpm/gfxgsx.lst
 
+cpmdevice.lib: cpm_clib.lib
+	@echo ''
+	@echo '--- Building CP/M Device fnctl Library ---'
+	@echo ''
+	TARGET=cpm TYPE=z80 DEVICE=device $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/cpmdevice @$(TARGET_DIRECTORY)/cpm/fcntl/fcntl.lst
+
 cpm8080_clib.lib: $(TARGET_CLIB_OBJS) cpm_clib.lib
 	@echo ''
 	@echo '--- Building CP/M Library (8080)---'
 	@echo ''
 	TARGET=cpm TYPE=8080 DEVICE=nodevice $(LIBLINKER) -m8080 -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/cpm8080_clib @$(TARGET_DIRECTORY)/cpm/cpm_8080.lst
+
+cpmdevice_8080.lib: cpm8080_clib.lib
+	@echo ''
+	@echo '--- Building CP/M Device fnctl Library (8080) ---'
+	@echo ''
+	TARGET=cpm TYPE=8080 DEVICE=device $(LIBLINKER) -m8080 -x$(OUTPUT_DIRECTORY)/cpmdevice_8080 @$(TARGET_DIRECTORY)/cpm/fcntl/fcntl.lst
+
+cpm8085_clib.lib: $(TARGET_CLIB_OBJS) cpm_clib.lib
+	@echo ''
+	@echo '--- Building CP/M Library (8085)---'
+	@echo ''
+	TARGET=cpm TYPE=8085 DEVICE=nodevice $(LIBLINKER) -m8085 -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/cpm8085_clib @$(TARGET_DIRECTORY)/cpm/cpm_8080.lst
+
+cpmdevice_8085.lib: cpm8085_clib.lib
+	@echo ''
+	@echo '--- Building CP/M Device fnctl Library (8085) ---'
+	@echo ''
+	TARGET=cpm TYPE=8085 DEVICE=device $(LIBLINKER) -m8085 -x$(OUTPUT_DIRECTORY)/cpmdevice_8085 @$(TARGET_DIRECTORY)/cpm/fcntl/fcntl.lst
 
 cpmixiy_clib.lib: $(TARGET_CLIB_OBJS) cpm_clib.lib
 	@echo ''
@@ -801,20 +825,6 @@ cpmz180_clib.lib: $(TARGET_CLIB_OBJS) cpm_clib.lib
 	@echo '--- Building CP/M Library (z180)---'
 	@echo ''
 	TARGET=cpm TYPE=z180 DEVICE=nodevice $(LIBLINKER) -mz180 -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/cpmz180_clib @$(TARGET_DIRECTORY)/cpm/cpm.lst
-
-
-cpmdevice.lib: cpm_clib.lib
-	@echo ''
-	@echo '--- Building CP/M Device fnctl Library ---'
-	@echo ''
-	TARGET=cpm TYPE=z80 DEVICE=device $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/cpmdevice @$(TARGET_DIRECTORY)/cpm/fcntl/fcntl.lst
-
-cpmdevice_8080.lib: cpm8080_clib.lib
-	@echo ''
-	@echo '--- Building CP/M Device fnctl Library (8080) ---'
-	@echo ''
-	TARGET=cpm TYPE=8080 DEVICE=device $(LIBLINKER) -x$(OUTPUT_DIRECTORY)/cpmdevice_8080 @$(TARGET_DIRECTORY)/cpm/fcntl/fcntl.lst
-
 
 # Sorcerer Exidy lib - Stefano
 srr_clib.lib: $(TARGET_CLIB_OBJS)

--- a/libsrc/_DEVELOPMENT/stdlib/stdlib_sccz80.lst
+++ b/libsrc/_DEVELOPMENT/stdlib/stdlib_sccz80.lst
@@ -4,7 +4,9 @@ stdlib/c/sccz80/abs_fastcall
 stdlib/c/sccz80/atexit
 stdlib/c/sccz80/atof
 stdlib/c/sccz80/atoi
+stdlib/c/sccz80/atoi_fastcall
 stdlib/c/sccz80/atol
+stdlib/c/sccz80/atol_fastcall
 stdlib/c/sccz80/atoll
 stdlib/c/sccz80/atoll_callee
 stdlib/c/sccz80/at_quick_exit

--- a/libsrc/stdio/fread.c
+++ b/libsrc/stdio/fread.c
@@ -4,7 +4,7 @@
 #define STDIO_ASM
 #include <stdio.h>
 
-#if CPU_8080 || CPU_8085
+#if __8080 || __8085
 int fread(void *ptr, size_t size, size_t nmemb, FILE *fp) {
     if ( (fp->flags & (_IOUSE|_IOREAD|_IOSYSTEM)) == (_IOUSE|_IOREAD)) {
         unsigned int len = size * nmemb;

--- a/libsrc/stdio/fread.c
+++ b/libsrc/stdio/fread.c
@@ -4,7 +4,7 @@
 #define STDIO_ASM
 #include <stdio.h>
 
-#ifdef __8080
+#if CPU_8080 || CPU_8085
 int fread(void *ptr, size_t size, size_t nmemb, FILE *fp) {
     if ( (fp->flags & (_IOUSE|_IOREAD|_IOSYSTEM)) == (_IOUSE|_IOREAD)) {
         unsigned int len = size * nmemb;

--- a/libsrc/stdio/fseek.c
+++ b/libsrc/stdio/fseek.c
@@ -76,11 +76,3 @@ call_trampoline:
 ENDIF
 #endasm
 
-
-
-
-
-
-    
-
-

--- a/libsrc/stdio/fwrite.c
+++ b/libsrc/stdio/fwrite.c
@@ -6,7 +6,7 @@
 
 
 
-#ifdef __8080
+#if CPU_8080 || CPU_8085
 int fwrite(void *ptr, size_t size, size_t nmemb, FILE *fp) {
     if ( (fp->flags & (_IOUSE|_IOWRITE|_IOSYSTEM)) == (_IOUSE|_IOWRITE)) {
     unsigned int len = size * nmemb;

--- a/libsrc/stdio/fwrite.c
+++ b/libsrc/stdio/fwrite.c
@@ -6,7 +6,7 @@
 
 
 
-#if CPU_8080 || CPU_8085
+#if __8080 || __8085
 int fwrite(void *ptr, size_t size, size_t nmemb, FILE *fp) {
     if ( (fp->flags & (_IOUSE|_IOWRITE|_IOSYSTEM)) == (_IOUSE|_IOWRITE)) {
     unsigned int len = size * nmemb;

--- a/libsrc/stdio/stdio.mak
+++ b/libsrc/stdio/stdio.mak
@@ -17,12 +17,17 @@ STDIO_8080_AFILES := $(notdir $(wildcard stdio/*.asm))  \
 		$(patsubst %,conio/%,$(notdir $(wildcard stdio/conio/*.asm))) \
 		$(patsubst %,inkey/%,$(notdir $(wildcard stdio/inkey/*.asm)))
 
+STDIO_8085_AFILES := $(notdir $(wildcard stdio/*.asm))  \
+		$(patsubst %,conio/%,$(notdir $(wildcard stdio/conio/*.asm))) \
+		$(patsubst %,inkey/%,$(notdir $(wildcard stdio/inkey/*.asm)))
+
 STDIO_GBZ80_AFILES := $(notdir $(filter-out $(wildcard stdio/*scanf*.asm),$(wildcard stdio/*.asm))) \
 		$(patsubst %,conio/%,$(notdir $(wildcard stdio/conio/*.asm))) \
 		$(patsubst %,inkey/%,$(notdir $(wildcard stdio/inkey/*.asm)))
 
 STDIO_OBJECTS := $(STDIO_CFILES:.c=.o) $(STDIO_AFILES:.asm=.o)
 STDIO_8080_OBJECTS := $(STDIO_CFILES:.c=.o) $(STDIO_8080_AFILES:.asm=.o)
+STDIO_8085_OBJECTS := $(STDIO_CFILES:.c=.o) $(STDIO_8085_AFILES:.asm=.o)
 STDIO_GBZ80_OBJECTS := $(STDIO_CFILES:.c=.o) $(STDIO_GBZ80_AFILES:.asm=.o)
 
 STDIO_OBJS := $(addprefix stdio/obj/z80/, $(STDIO_OBJECTS)) \
@@ -35,8 +40,9 @@ STDIO_OBJS := $(addprefix stdio/obj/z80/, $(STDIO_OBJECTS)) \
 	$(addprefix stdio/obj/r2ka/,$(STDIO_OBJECTS)) \
 	$(addprefix stdio/obj/r4k/,$(STDIO_OBJECTS)) \
 	$(addprefix stdio/obj/8080/,$(STDIO_8080_OBJECTS)) \
-	$(addprefix stdio/obj/8085/,$(STDIO_8080_OBJECTS)) \
+	$(addprefix stdio/obj/8085/,$(STDIO_8085_OBJECTS)) \
 	$(addprefix stdio/obj/8080-binary/,$(STDIO_8080_OBJECTS)) \
+	$(addprefix stdio/obj/8085-binary/,$(STDIO_8085_OBJECTS)) \
 	$(addprefix stdio/obj/gbz80/,$(STDIO_GBZ80_OBJECTS)) \
 	$(addprefix stdio/obj/ez80_z80/,$(STDIO_OBJECTS)) \
 	$(addprefix stdio/obj/kc160/,$(STDIO_OBJECTS)) \
@@ -56,6 +62,7 @@ $(eval $(call buildbit,stdio,ixiy-binary,cpm,-Ca-IXIY,-mz80 -IXIY))
 $(eval $(call buildbit,stdio,8080,test,-DCPU_8080 -clib=8080,-m8080))
 $(eval $(call buildbit,stdio,8085,test,-DCPU_8085 -clib=8085,-m8085))
 $(eval $(call buildbit,stdio,8080-binary,cpm,-DCPU_8080 -clib=8080,-m8080))
+$(eval $(call buildbit,stdio,8085-binary,cpm,-DCPU_8085 -clib=8085,-m8085))
 $(eval $(call buildbit,stdio,gbz80,test,-DCPU_GBZ80 -clib=gbz80,-mgbz80))
 $(eval $(call buildbit,stdio,r2ka,test,-clib=rabbit,-mr2ka))
 $(eval $(call buildbit,stdio,r4k,test,-clib=rabbit4k,-mr4k))

--- a/libsrc/stdlib/stdlib.mak
+++ b/libsrc/stdlib/stdlib.mak
@@ -2,11 +2,13 @@ STDLIB_AFILES := $(notdir $(wildcard stdlib/*.asm))
 STDLIB_CFILES := unbcd.c wcmatch.c getopt.c
 
 STDLIB_8080_AFILES := $(notdir $(filter-out $(wildcard stdlib/*sqrt*.asm stdlib/*inp*.asm stdlib/*outp*.asm stdlib/*extract*.asm) , $(wildcard stdlib/*.asm))) $(patsubst stdlib/%,%,$(wildcard stdlib/8080/*.asm))
+STDLIB_8085_AFILES := $(notdir $(filter-out $(wildcard stdlib/*sqrt*.asm stdlib/*inp*.asm stdlib/*outp*.asm stdlib/*extract*.asm) , $(wildcard stdlib/*.asm))) $(patsubst stdlib/%,%,$(wildcard stdlib/8080/*.asm))
 STDLIB_GBZ80_AFILES := $(notdir $(filter-out $(wildcard stdlib/*sqrt*.asm stdlib/*inp*.asm stdlib/*outp*.asm stdlib/*extract*.asm) , $(wildcard stdlib/*.asm))) $(patsubst stdlib/%,%,$(wildcard stdlib/8080/*.asm))
 
 
 STDLIB_OBJECTS := $(STDLIB_CFILES:.c=.o) $(STDLIB_AFILES:.asm=.o)
 STDLIB_8080_OBJECTS := $(STDLIB_CFILES:.c=.o) $(STDLIB_8080_AFILES:.asm=.o)
+STDLIB_8085_OBJECTS := $(STDLIB_CFILES:.c=.o) $(STDLIB_8085_AFILES:.asm=.o)
 STDLIB_GBZ80_OBJECTS := $(STDLIB_CFILES:.c=.o) $(STDLIB_GBZ80_AFILES:.asm=.o)
 
 STDLIB_NEWLIBGLOBS := "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*.asm" "$(NEWLIB_DIRECTORY)/stdlib/z80/*.asm" "$(NEWLIB_DIRECTORY)/stdlib/z80/random/*.asm"
@@ -67,7 +69,7 @@ STDLIB_OBJS := $(addprefix stdlib/obj/z80/, $(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/ixiy/,$(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/z80n/,$(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/8080/,$(STDLIB_8080_OBJECTS)) \
-	$(addprefix stdlib/obj/8085/,$(STDLIB_8080_OBJECTS)) \
+	$(addprefix stdlib/obj/8085/,$(STDLIB_8085_OBJECTS)) \
 	$(addprefix stdlib/obj/gbz80/,$(STDLIB_GBZ80_OBJECTS)) \
 	$(addprefix stdlib/obj/ez80_z80/,$(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/z180/,$(STDLIB_OBJECTS)) \

--- a/libsrc/stdlib/stdlib.mak
+++ b/libsrc/stdlib/stdlib.mak
@@ -45,10 +45,11 @@ STDLIB_8080_NEWLIBGLOBS_ex := $(wildcard $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*ra
         $(wildcard $(NEWLIB_DIRECTORY)/stdlib/z80/random/*.asm) \
         $(NEWLIB_DIRECTORY)/stdlib/z80/__stdlib_seed.asm
 
+STDLIB_8085_NEWLIBGLOBS := $(STDLIB_8080_NEWLIBGLOBS)
+STDLIB_8085_NEWLIBGLOBS_ex := $(STDLIB_8080_NEWLIBGLOBS_ex)
+
 STDLIB_GBZ80_NEWLIBGLOBS := $(STDLIB_8080_NEWLIBGLOBS)
 STDLIB_GBZ80_NEWLIBGLOBS_ex := $(STDLIB_8080_NEWLIBGLOBS_ex)
-
-
 
 STDLIB_NEWLIB_TARGETS := stdlib/obj/newlib-z80-stdlib \
 		stdlib/obj/newlib-z80n-stdlib \
@@ -102,7 +103,7 @@ $(eval $(call buildnew,stdlib,r4k,-mr4k,$(STDLIB_NEWLIBGLOBS),$(STDLIB_NEWLIBGLO
 $(eval $(call buildnew,stdlib,z80n,-mz80n,$(STDLIB_NEWLIBGLOBS),$(STDLIB_NEWLIBGLOBS_ex)))
 $(eval $(call buildnew,stdlib,ixiy,-mz80 -IXIY,$(STDLIB_NEWLIBGLOBS),$(STDLIB_NEWLIBGLOBS_ex)))
 $(eval $(call buildnew,stdlib,8080,-m8080,$(STDLIB_8080_NEWLIBGLOBS),$(STDLIB_8080_NEWLIBGLOBS_ex)))
-$(eval $(call buildnew,stdlib,8085,-m8085,$(STDLIB_8080_NEWLIBGLOBS),$(STDLIB_8080_NEWLIBGLOBS_ex)))
+$(eval $(call buildnew,stdlib,8085,-m8085,$(STDLIB_8085_NEWLIBGLOBS),$(STDLIB_8085_NEWLIBGLOBS_ex)))
 $(eval $(call buildnew,stdlib,gbz80,-mgbz80,$(STDLIB_GBZ80_NEWLIBGLOBS),$(STDLIB_GBZ80_NEWLIBGLOBS_ex)))
 $(eval $(call buildnew,stdlib,z180,-mz180,$(STDLIB_NEWLIBGLOBS),$(STDLIB_NEWLIBGLOBS_ex)))
 $(eval $(call buildnew,stdlib,ez80_z80,-mez80_z80,$(STDLIB_NEWLIBGLOBS),$(STDLIB_NEWLIBGLOBS_ex)))

--- a/libsrc/stdlib/stdlib.mak
+++ b/libsrc/stdlib/stdlib.mak
@@ -14,11 +14,13 @@ STDLIB_GBZ80_OBJECTS := $(STDLIB_CFILES:.c=.o) $(STDLIB_GBZ80_AFILES:.asm=.o)
 STDLIB_NEWLIBGLOBS := "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*.asm" "$(NEWLIB_DIRECTORY)/stdlib/z80/*.asm" "$(NEWLIB_DIRECTORY)/stdlib/z80/random/*.asm"
 STDLIB_NEWLIBGLOBS_ex := $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*.asm $(NEWLIB_DIRECTORY)/stdlib/z80/*.asm $(NEWLIB_DIRECTORY)/stdlib/z80/random/*.asm
 
-STDLIB_8080_NEWLIBGLOBS := "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*rand*.asm" \
+STDLIB_8080_NEWLIBGLOBS := \
+        "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*rand*.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/abs*.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/labs*.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/atoi*.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/atol.asm" \
+        "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/atol_fastcall.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/itoa*.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/strtol.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/strtol_callee.asm" \
@@ -29,7 +31,8 @@ STDLIB_8080_NEWLIBGLOBS := "$(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*rand*.asm" \
         "$(NEWLIB_DIRECTORY)/stdlib/z80/random/*.asm" \
         $(NEWLIB_DIRECTORY)/stdlib/z80/__stdlib_seed.asm
 
-STDLIB_8080_NEWLIBGLOBS_ex := $(wildcard $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*rand*.asm) \
+STDLIB_8080_NEWLIBGLOBS_ex := \
+        $(wildcard $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/*rand*.asm) \
         $(wildcard $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/abs*.asm) \
         $(wildcard $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/labs*.asm) \
         $(wildcard $(NEWLIB_DIRECTORY)/stdlib/c/sccz80/atoi*.asm) \
@@ -51,7 +54,8 @@ STDLIB_8085_NEWLIBGLOBS_ex := $(STDLIB_8080_NEWLIBGLOBS_ex)
 STDLIB_GBZ80_NEWLIBGLOBS := $(STDLIB_8080_NEWLIBGLOBS)
 STDLIB_GBZ80_NEWLIBGLOBS_ex := $(STDLIB_8080_NEWLIBGLOBS_ex)
 
-STDLIB_NEWLIB_TARGETS := stdlib/obj/newlib-z80-stdlib \
+STDLIB_NEWLIB_TARGETS := \
+		stdlib/obj/newlib-z80-stdlib \
 		stdlib/obj/newlib-z80n-stdlib \
 		stdlib/obj/newlib-r2ka-stdlib \
 		stdlib/obj/newlib-ixiy-stdlib \
@@ -65,7 +69,8 @@ STDLIB_NEWLIB_TARGETS := stdlib/obj/newlib-z80-stdlib \
 
 STDLIB_OBJECTS := $(STDLIB_CFILES:.c=.o) $(STDLIB_AFILES:.asm=.o)
 
-STDLIB_OBJS := $(addprefix stdlib/obj/z80/, $(STDLIB_OBJECTS)) \
+STDLIB_OBJS := \
+	$(addprefix stdlib/obj/z80/, $(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/r2ka/,$(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/ixiy/,$(STDLIB_OBJECTS)) \
 	$(addprefix stdlib/obj/z80n/,$(STDLIB_OBJECTS)) \

--- a/libsrc/target/cpm/cpm/Makefile
+++ b/libsrc/target/cpm/cpm/Makefile
@@ -6,7 +6,7 @@ TARGET = cpm
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
 
-all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
+all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/8085/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
 
 
 
@@ -15,5 +15,5 @@ clean:
 	$(RM) zcc_opt.def *.err *.o
 
 dirs:
-	@mkdir -p obj/8080 obj/z80
+	@mkdir -p obj/8080 obj/8085 obj/z80
 

--- a/libsrc/target/cpm/fcntl/Makefile
+++ b/libsrc/target/cpm/fcntl/Makefile
@@ -22,7 +22,7 @@ CFILES = \
 	get_dir_name.c \
 	fdtell.c \
 	fdgetpos.c \
-        fsync.c \
+	fsync.c \
 	getfcb.c \
 	lseek.c \
 	open.c \
@@ -41,6 +41,7 @@ AFILES = $(CFILES:.c=.asm)
 OFILES = $(CFILES:.c=.o)
 OBJECTS = $(addprefix obj/z80/nodevice/,$(OFILES)) $(addprefix obj/z80/device/,$(OFILES)) \
 	$(addprefix obj/8080/nodevice/,$(OFILES)) $(addprefix obj/8080/device/,$(OFILES)) \
+	$(addprefix obj/8085/nodevice/,$(OFILES)) $(addprefix obj/8085/device/,$(OFILES)) \
 	$(addprefix obj/ixiy/nodevice/,$(OFILES)) $(addprefix obj/ixiy/device/,$(OFILES)) \
 	$(addprefix obj/z180/nodevice/,$(OFILES)) $(addprefix obj/z180/device/,$(OFILES))
 
@@ -65,6 +66,12 @@ obj/8080/nodevice/%.o: %.c
 obj/8080/device/%.o: %.c
 	$(ZCC) +cpm -clib=8080 $(CFLAGS) -DDEVICES $^ -o $@
 
+obj/8085/nodevice/%.o: %.c
+	$(ZCC) +cpm -clib=8085 $(CFLAGS) $^ -o $@
+
+obj/8085/device/%.o: %.c
+	$(ZCC) +cpm -clib=8085 $(CFLAGS) -DDEVICES $^ -o $@
+
 obj/ixiy/nodevice/%.o: %.c
 	$(ZCC) +cpm -clib=ixiy $(CFLAGS) $^ -o $@
 
@@ -75,7 +82,11 @@ obj/ixiy/device/%.o: %.c
 .PHONY:	dirs
 
 dirs:
-	@mkdir -p obj obj/z80/device obj/z80/nodevice obj/8080/device obj/8080/nodevice  obj/ixiy/device obj/ixiy/nodevice obj/z180/nodevice obj/z180/device
+	@mkdir -p obj obj/z80/device obj/z80/nodevice \
+	obj/8080/device obj/8080/nodevice \
+	obj/8085/device obj/8085/nodevice \
+	obj/ixiy/device obj/ixiy/nodevice \
+	obj/z180/nodevice obj/z180/device
 
 clean:
 	$(RM) -fr obj zcc_opt.def

--- a/libsrc/target/cpm/fcntl/README
+++ b/libsrc/target/cpm/fcntl/README
@@ -5,6 +5,3 @@ These routines are a port of the Hitech C routines.
 They've been modified to work within the z88dk stdio framework and
 seem to quite well within the tests that I've made. There is no distinction
 between binary and text files.
-
-May 2020 - feilipu. Added sequential read and write to try to improve performance for large buffer moves. Issue uncovered through performance comparision with CP/M PIP tool.
-

--- a/libsrc/target/cpm/graphics/Makefile
+++ b/libsrc/target/cpm/graphics/Makefile
@@ -7,7 +7,7 @@ CFILES = $(wildcard *.c)
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o) $(CFILES:.c=.o)
 
-all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
+all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/8085/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
 
 
 
@@ -16,5 +16,5 @@ clean:
 	$(RM) zcc_opt.def *.err *.o
 
 dirs:
-	@mkdir -p obj/8080 obj/z80
+	@mkdir -p obj/8080 obj/8085 obj/z80
 

--- a/libsrc/target/cpm/gsx/Makefile
+++ b/libsrc/target/cpm/gsx/Makefile
@@ -6,7 +6,7 @@ TARGET = cpm
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
 
-all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
+all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/8085/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
 
 
 
@@ -15,5 +15,5 @@ clean:
 	$(RM) zcc_opt.def *.err *.o
 
 dirs:
-	@mkdir -p obj/8080 obj/z80
+	@mkdir -p obj/8080 obj/8085 obj/z80
 

--- a/libsrc/target/cpm/stdio/Makefile
+++ b/libsrc/target/cpm/stdio/Makefile
@@ -8,7 +8,7 @@ OBJECTS = $(ASMFILES:.asm=.o)
 
 AFLAGS += -DSTANDARDESCAPECHARS
 
-all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
+all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/8085/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
 
 
 
@@ -17,5 +17,5 @@ clean:
 	$(RM) zcc_opt.def *.err *.o
 
 dirs:
-	@mkdir -p obj/8080 obj/z80
+	@mkdir -p obj/8080 obj/8085 obj/z80
 

--- a/libsrc/target/cpm/time/Makefile
+++ b/libsrc/target/cpm/time/Makefile
@@ -6,7 +6,7 @@ TARGET = cpm
 ASMFILES = $(wildcard *.asm)
 OBJECTS = $(ASMFILES:.asm=.o)
 
-all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
+all: dirs $(addprefix obj/8080/,$(OBJECTS)) $(addprefix obj/8085/,$(OBJECTS)) $(addprefix obj/z80/,$(OBJECTS)) $(addprefix obj/ixiy/,$(OBJECTS)) $(addprefix obj/z180/,$(OBJECTS))
 
 
 clean: 
@@ -14,5 +14,5 @@ clean:
 	$(RM) zcc_opt.def *.err *.o
 
 dirs:
-	@mkdir -p obj/8080 obj/z80
+	@mkdir -p obj/8080 obj/8085 obj/z80
 


### PR DESCRIPTION
As quite a lot of the classic library stdio and fnctl code is still in C, it is worth doing a specific CP/M 8085 build to make use of the improvements in sccz80 and 8085 libraries (vs 8080).