### PR TITLE
buggy color on w_putsprite() on zx_common MODE0 

### DIFF
--- a/libsrc/target/zx-common/graphics/hl_inc_x_MODE6.asm
+++ b/libsrc/target/zx-common/graphics/hl_inc_x_MODE6.asm
@@ -6,16 +6,70 @@
 
     PUBLIC  hl_inc_x_MODE6
 
+    EXTERN  __zx_screenmode
+    EXTERN  __zx_console_attr
+
+  IF    FORsam
+    ; This code won't work on the same due to the lack of correct paging
+    ; but it is assembled as part of zx-common
+    EXTERN  SCREEN_BASE
+  ENDIF
+
 
 hl_inc_x_MODE6:
+    ld      a, (__zx_screenmode)
+	and     7
+  IF    FORts2068|zxn
+    cp      6
+    jr      z,MODE6_no_color            ;No colour in hires
+  ENDIF
 
+    cp      2                           ;High colour
+    jr      nz, standard_modes
+    set     5, h
+    ld      a, (__zx_console_attr)
+    ld      (hl), a
+    res     5, h
+    inc     hl
+    ret
+
+standard_modes:
+    ; We are on a standard zx screen
+    push    hl
+  IF    FORts2068|zxn
+    ld      a, h
+    and     @00100000
+    ld      c, a                        ;Save page flag
+  ENDIF
+    ld      a, h
+    rrca
+    rrca
+    rrca
+    and     3
+  IF    FORsam
+    or      +(SCREEN_BASE/256)+24
+  ELSE
+    or      88
+  ENDIF
+  IF    FORts2068|zxn
+    or      c                           ;Add in screen 1 bit
+  ENDIF
+    ld      h, a
+    ld      a, (__zx_console_attr)
+    ld      (hl), a
+    ; And increment the column
+    pop     hl
+    inc     hl
+
+    ret
+
+  IF    FORts2068|zxn
+MODE6_no_color:
     ld      a, h
     xor     @00100000
     cp      h
     ld      h, a
     ret     nc
     inc     hl
-
-    ret
-
-
+	ret
+  ENDIF

--- a/libsrc/target/zx-common/graphics/w_putsprite.asm
+++ b/libsrc/target/zx-common/graphics/w_putsprite.asm
@@ -13,10 +13,7 @@
     EXTERN  asm_zx_saddrpdown
     EXTERN  __zx_console_attr
 
-IF    FORts2068|FORzxn
     EXTERN  hl_inc_x_MODE6
-    EXTERN  __gfx_fatpix
-ENDIF
 
     EXTERN  swapgfxbk
     EXTERN  __graphics_end
@@ -80,15 +77,15 @@ fast_putsprite:
 ;;     ld      a, (__gfx_fatpix)
 ;;     and     a
 ;;     jr      z, not_fatpix
-;; 	
+;; 
 ;;     ; TODO: fatpix mode scaling (SMC ?)
 ;; 
 ;; not_fatpix:
 ;; ENDIF
 
     call    w_pixeladdress
-	ld      (_saddr+1), de
-	ld      (_saddr1+1), de
+    ld      (_saddr+1), de
+    ld      (_saddr1+1), de
       ; @@@@@@@@@@@@
     ld      hl, offsets_table
     ld      c, a
@@ -132,18 +129,11 @@ _noplot:
        ;@@@@@@@@@@
        ;Go to next byte
        ;@@@@@@@@@@
-IF    FORts2068|FORzxn
-    ex      af,af
-    ld      a, (__zx_screenmode)
-    and     a
-    jr      z,_mode0
+    push    af
+    push    bc
     call    hl_inc_x_MODE6
-    ex      af,af
-    jr      _notedge
-_mode0:
-    ex      af,af
-ENDIF
-    inc     hl
+    pop     bc
+    pop     af
        ;@@@@@@@@@@
 
 _notedge:
@@ -154,7 +144,7 @@ _notedge:
        ;Go to next line
        ;@@@@@@@@@@
 _saddr:
-	ld      hl, 0
+    ld      hl, 0
     call    asm_zx_saddrpdown
     ld      (_saddr+1), hl
        ;@@@@@@@@@@
@@ -195,18 +185,11 @@ wnoplot:
        ;@@@@@@@@@@
        ;Go to next byte
        ;@@@@@@@@@@
-IF    FORts2068|FORzxn
-    ex      af,af
-    ld      a, (__zx_screenmode)
-    and     a
-    jr      z,_wmode0
+    push    af
+    push    bc
     call    hl_inc_x_MODE6
-    ex      af,af
-    jr      wnotedge
-_wmode0:
-    ex      af,af
-ENDIF
-    inc     hl
+    pop     bc
+    pop     af
        ;@@@@@@@@@@
 
 wnotedge:
@@ -223,7 +206,7 @@ nextline:
        ;Go to next line
        ;@@@@@@@@@@
 _saddr1:
-	ld      hl, 0
+    ld      hl, 0
     call    asm_zx_saddrpdown
     ld      (_saddr1+1), hl
        ;@@@@@@@@@@


### PR DESCRIPTION
#1274

This pull merges the "next column" code originally in stencil_render() reusing it on w_putsprite.
w_putsprite now has an out of range problem on the rightmost edge when in mode0, needs to be tuned.