### PR TITLE
8085 - add saved_hl - remove saved_de

### DIFF
--- a/lib/crt/classic/crt_section.inc
+++ b/lib/crt/classic/crt_section.inc
@@ -117,7 +117,6 @@ _heap:
 ENDIF
 
 IF CLIB_BALLOC_TABLE_SIZE > 0
-
     ; create balloc table
     SECTION data_alloc_balloc
     PUBLIC  __balloc_array
@@ -128,5 +127,10 @@ __balloc_array:
     PUBLIC  __balloc_table
 __balloc_table:
     defs CLIB_BALLOC_TABLE_SIZE * 2
+ENDIF
 
+IF __CPU_INTEL__ || __CPU_GBZ80__
+    PUBLIC  saved_hl            ;Temporary store used by compiler for Intel & GB
+saved_hl:
+    defw    0                   ; Temp store for hl
 ENDIF

--- a/lib/target/altair8800/classic/altair8800_crt0.asm
+++ b/lib/target/altair8800/classic/altair8800_crt0.asm
@@ -92,3 +92,13 @@ ENDIF
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/altair8800/classic/altair8800_crt0.asm
+++ b/lib/target/altair8800/classic/altair8800_crt0.asm
@@ -93,12 +93,3 @@ ENDIF
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/cpm/classic/cpm_crt0.asm
+++ b/lib/target/cpm/classic/cpm_crt0.asm
@@ -360,16 +360,3 @@ ENDIF
     ld      c,14
     call    5
 
-IF __CPU_INTEL__
-
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de
-
-ENDIF

--- a/lib/target/cpm/classic/cpm_crt0.asm
+++ b/lib/target/cpm/classic/cpm_crt0.asm
@@ -360,5 +360,13 @@ ENDIF
     ld      c,14
     call    5
 
+    SECTION bss_crt
 
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de
 

--- a/lib/target/cpm/classic/cpm_crt0.asm
+++ b/lib/target/cpm/classic/cpm_crt0.asm
@@ -360,6 +360,8 @@ ENDIF
     ld      c,14
     call    5
 
+IF __CPU_INTEL__
+
     SECTION bss_crt
 
     PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
@@ -370,3 +372,4 @@ saved_hl:
 saved_de:
     defw    0                   ; Temp store for de
 
+ENDIF

--- a/lib/target/dai/classic/dai_crt0.asm
+++ b/lib/target/dai/classic/dai_crt0.asm
@@ -70,3 +70,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/dai/classic/dai_crt0.asm
+++ b/lib/target/dai/classic/dai_crt0.asm
@@ -71,12 +71,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/krokha/classic/krokha_crt0.asm
+++ b/lib/target/krokha/classic/krokha_crt0.asm
@@ -89,12 +89,3 @@ ENDIF
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/krokha/classic/krokha_crt0.asm
+++ b/lib/target/krokha/classic/krokha_crt0.asm
@@ -88,3 +88,13 @@ ENDIF
 
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/lviv/classic/lviv_crt0.asm
+++ b/lib/target/lviv/classic/lviv_crt0.asm
@@ -82,3 +82,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/lviv/classic/lviv_crt0.asm
+++ b/lib/target/lviv/classic/lviv_crt0.asm
@@ -83,12 +83,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/m100/classic/m100_crt0.asm
+++ b/lib/target/m100/classic/m100_crt0.asm
@@ -75,3 +75,12 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/m100/classic/m100_crt0.asm
+++ b/lib/target/m100/classic/m100_crt0.asm
@@ -75,12 +75,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/micro8085/classic/micro8085_crt0.asm
+++ b/lib/target/micro8085/classic/micro8085_crt0.asm
@@ -222,14 +222,4 @@ target_init:
         INCLUDE "crt/classic/crt_runtime_selection.inc" 
         INCLUDE "crt/classic/crt_section.inc"
 
-        SECTION bss_crt
-
-        PUBLIC  saved_hl        ;Temporary store used by compiler
-        PUBLIC  saved_de        ;for hl and de
-
-saved_hl:
-        defw    0               ; Temp store for hl
-saved_de:
-        defw    0               ; Temp store for de
-
 ;-------------------------------------------------------------------------

--- a/lib/target/micro8085/classic/micro8085_crt0.asm
+++ b/lib/target/micro8085/classic/micro8085_crt0.asm
@@ -221,5 +221,14 @@ target_init:
 
         INCLUDE "crt/classic/crt_runtime_selection.inc" 
         INCLUDE "crt/classic/crt_section.inc"
- 
+
+        SECTION bss_crt
+
+        PUBLIC  saved_hl        ;Temporary store used by compiler
+        PUBLIC  saved_de        ;for hl and de
+
+saved_hl:
+        defw    0               ; Temp store for hl
+saved_de:
+        defw    0               ; Temp store for de
 ;-------------------------------------------------------------------------

--- a/lib/target/micro8085/classic/micro8085_crt0.asm
+++ b/lib/target/micro8085/classic/micro8085_crt0.asm
@@ -231,4 +231,5 @@ saved_hl:
         defw    0               ; Temp store for hl
 saved_de:
         defw    0               ; Temp store for de
+
 ;-------------------------------------------------------------------------

--- a/lib/target/mikro80/classic/mikro80_crt0.asm
+++ b/lib/target/mikro80/classic/mikro80_crt0.asm
@@ -75,12 +75,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     ;INCLUDE	"target/mikro80/classic/bootstrap.asm"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/mikro80/classic/mikro80_crt0.asm
+++ b/lib/target/mikro80/classic/mikro80_crt0.asm
@@ -74,3 +74,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE	"crt/classic/crt_section.inc"
 
     ;INCLUDE	"target/mikro80/classic/bootstrap.asm"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/oz/classic/oz_crt0.asm
+++ b/lib/target/oz/classic/oz_crt0.asm
@@ -39,9 +39,6 @@
 
     PUBLIC  s_filetypetable
 
-    PUBLIC  saved_hl                    ;Temporary store used by compiler
-    PUBLIC  saved_de                    ;for hl and de
-
 ; --- OZ related stuff---
 
     PUBLIC  ozactivepage                ;current mem page
@@ -450,10 +447,6 @@ ENDIF
 
     SECTION bss_crt
 
-saved_hl:
-    defw    0                           ; Temp store for hl
-saved_de:
-    defw    0                           ; Temp store for de
 ozactivepage:
     defw    0                           ; Page number for the graph map (0400h for 0A000h)
 ozmodel:
@@ -475,6 +468,7 @@ s_filetypetable:
 
 ; --- settings - leave untouched ---
     SECTION data_crt
+
 ozkeyrepeatspeed:
     defb    5
 ozkeyrepeatdelay:

--- a/lib/target/pk8000/classic/pk8000_crt0.asm
+++ b/lib/target/pk8000/classic/pk8000_crt0.asm
@@ -73,12 +73,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/pk8000/classic/pk8000_crt0.asm
+++ b/lib/target/pk8000/classic/pk8000_crt0.asm
@@ -72,3 +72,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/pmd85/classic/pmd85_crt0.asm
+++ b/lib/target/pmd85/classic/pmd85_crt0.asm
@@ -88,3 +88,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE	"crt/classic/crt_section.inc"
 
     ;INCLUDE	"target/pmd85/classic/bootstrap.asm"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/pmd85/classic/pmd85_crt0.asm
+++ b/lib/target/pmd85/classic/pmd85_crt0.asm
@@ -89,12 +89,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     ;INCLUDE	"target/pmd85/classic/bootstrap.asm"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/radio86/classic/radio86_crt0.asm
+++ b/lib/target/radio86/classic/radio86_crt0.asm
@@ -82,12 +82,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/radio86/classic/radio86_crt0.asm
+++ b/lib/target/radio86/classic/radio86_crt0.asm
@@ -81,3 +81,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/sol20/classic/sol20_crt0.asm
+++ b/lib/target/sol20/classic/sol20_crt0.asm
@@ -82,3 +82,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE "crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/sol20/classic/sol20_crt0.asm
+++ b/lib/target/sol20/classic/sol20_crt0.asm
@@ -83,12 +83,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE "crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/special/classic/special_crt0.asm
+++ b/lib/target/special/classic/special_crt0.asm
@@ -76,3 +76,13 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/special/classic/special_crt0.asm
+++ b/lib/target/special/classic/special_crt0.asm
@@ -77,12 +77,3 @@ l_dcal: jp      (hl)            ;Used for function pointer calls
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/lib/target/test/classic/test_crt0.asm
+++ b/lib/target/test/classic/test_crt0.asm
@@ -109,16 +109,3 @@ l_dcal:
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
     INCLUDE	"crt/classic/crt_section.inc"
 
-IF __CPU_INTEL__
-
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de
-
-ENDIF

--- a/lib/target/test/classic/test_crt0.asm
+++ b/lib/target/test/classic/test_crt0.asm
@@ -109,3 +109,16 @@ l_dcal:
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
     INCLUDE	"crt/classic/crt_section.inc"
 
+IF __CPU_INTEL__
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de
+
+ENDIF

--- a/lib/target/vector06c/classic/vector06c_crt0.asm
+++ b/lib/target/vector06c/classic/vector06c_crt0.asm
@@ -120,3 +120,13 @@ palette:
     INCLUDE "crt/classic/crt_runtime_selection.inc" 
 
     INCLUDE	"crt/classic/crt_section.inc"
+
+    SECTION bss_crt
+
+    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
+    PUBLIC  saved_de            ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de

--- a/lib/target/vector06c/classic/vector06c_crt0.asm
+++ b/lib/target/vector06c/classic/vector06c_crt0.asm
@@ -121,12 +121,3 @@ palette:
 
     INCLUDE	"crt/classic/crt_section.inc"
 
-    SECTION bss_crt
-
-    PUBLIC  saved_hl            ;Temporary store used by compiler for 8080/8085
-    PUBLIC  saved_de            ;for hl and de
-
-saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_acosh.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_acosh.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:43 2024
 
 
 	C_LINE	0,"am9511_acosh.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -243,6 +244,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_asinh.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_asinh.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:43 2024
 
 
 	C_LINE	0,"am9511_asinh.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -247,6 +248,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_atan2.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_atan2.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:44 2024
 
 
 	C_LINE	0,"am9511_atan2.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -398,6 +399,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 	defc	i_6 = i_4
 	defc	i_9 = i_7

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_atanh.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_atanh.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:46 2024
 
 
 	C_LINE	0,"am9511_atanh.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -241,6 +242,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_cosh.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_cosh.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:46 2024
 
 
 	C_LINE	0,"am9511_cosh.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -239,6 +240,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_exp10.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_exp10.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:46 2024
 
 
 	C_LINE	0,"am9511_exp10.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -247,6 +248,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_exp2.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_exp2.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:46 2024
 
 
 	C_LINE	0,"am9511_exp2.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -247,6 +248,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_fmax.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_fmax.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:46 2024
 
 
 	C_LINE	0,"am9511_fmax.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -272,6 +273,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_fmin.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_fmin.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:47 2024
 
 
 	C_LINE	0,"am9511_fmin.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -272,6 +273,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_fmod.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_fmod.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:47 2024
 
 
 	C_LINE	0,"am9511_fmod.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -304,6 +305,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_log2.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_log2.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:47 2024
 
 
 	C_LINE	0,"am9511_log2.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -271,6 +272,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_modf.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_modf.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:48 2024
 
 
 	C_LINE	0,"am9511_modf.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -258,6 +259,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_round.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_round.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:56 2023
+;	Module compile time: Sat Jul 20 11:52:49 2024
 
 
 	C_LINE	0,"am9511_round.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -285,8 +286,8 @@
 	call	l_plong
 	pop	hl
 	push	hl
-	ld	de,65535
-	call	l_eq
+	ld	bc,65535
+	call	l_eq_hlbc	;bc==hl
 	jp	nc,i_4	;
 	ld	de,sp+2
 	ex	de,hl
@@ -383,8 +384,8 @@
 .i_2
 	pop	hl
 	push	hl
-	ld	de,128
-	call	l_eq
+	ld	bc,128
+	call	l_eq_hlbc	;bc==hl
 	jp	nc,i_8	;
 	ld	de,sp+12
 	ex	de,hl
@@ -439,6 +440,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 	defc	i_9 = i_7
 	defc	i_4 = i_5

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_sinh.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_sinh.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:57 2023
+;	Module compile time: Sat Jul 20 11:52:51 2024
 
 
 	C_LINE	0,"am9511_sinh.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -239,6 +240,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_tanh.asm
+++ b/libsrc/_DEVELOPMENT/math/float/am9511/c/8085/am9511_tanh.asm
@@ -1,9 +1,9 @@
 ;* * * * *  Small-C/Plus z88dk * * * * *
-;  Version: 21234-4d9c2f0cbb-20230615
+;  Version: 22783-cb702d0cc0-20240720
 ;
 ;	Reconstructed for z80 Module Assembler
 ;
-;	Module compile time: Thu Jun 15 13:54:57 2023
+;	Module compile time: Sat Jul 20 11:52:52 2024
 
 
 	C_LINE	0,"am9511_tanh.c"
@@ -15,33 +15,34 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	C_LINE	0,"am9511_math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
+	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/proto.h"
+	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/compiler.h"
 	C_LINE	10,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	17,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	26,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	50,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	55,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	60,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	65,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	70,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	75,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	80,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	85,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	49,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	54,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	59,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	64,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	69,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	74,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	79,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	84,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	89,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	90,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	91,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	93,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	94,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	95,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	101,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
-	C_LINE	106,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	97,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	98,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	99,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	105,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
+	C_LINE	110,"/home/phillip/Z80/z88dk/lib/config/../..//include/sys/types.h"
 	C_LINE	11,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	13,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
 	C_LINE	14,"/home/phillip/Z80/z88dk/lib/config/../..//include/stdint.h"
@@ -80,20 +81,20 @@
 	C_LINE	6,"/home/phillip/Z80/z88dk/lib/config/../..//include/float.h"
 	C_LINE	8,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	28,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	29,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	30,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	31,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	32,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	33,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	35,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	36,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	38,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	39,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	40,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	41,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	42,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	43,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	44,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	45,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	46,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	120,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	121,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	122,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
@@ -105,28 +106,28 @@
 	C_LINE	131,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	132,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	133,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	136,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	137,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	138,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	139,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	141,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	140,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	142,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	143,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	146,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	144,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	147,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	148,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	149,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	150,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	151,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	152,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	155,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	153,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	156,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	162,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	157,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	163,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	167,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	164,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	168,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
-	C_LINE	171,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	169,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	172,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
+	C_LINE	173,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_math16.h"
 	C_LINE	34,"/home/phillip/Z80/z88dk/lib/config/../..//include/math.h"
 	C_LINE	0,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
 	C_LINE	37,"/home/phillip/Z80/z88dk/lib/config/../..//include/math/math_am9511.h"
@@ -262,6 +263,8 @@
 	ret
 
 
+	SECTION	bss_compiler
+	SECTION	code_compiler
 ; --- Start of Optimiser additions ---
 
 

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_2.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_2.asm.m4
@@ -367,13 +367,9 @@ include "../crt_jump_vectors_8085.inc"
 
     SECTION bss_crt
 
-PUBLIC  saved_hl                ;Temporary store used by compiler
-PUBLIC  saved_de                ;for hl and de
-
+PUBLIC  saved_hl                ;Temporary store used by compiler for 8085
 saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de
+    defw    0                   ;for hl
 
 IF CRT_ENABLE_STDIO = 1 && CLIB_FOPEN_MAX > 0
     PUBLIC  __sgoioblk

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_2.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_2.asm.m4
@@ -367,6 +367,14 @@ include "../crt_jump_vectors_8085.inc"
 
     SECTION bss_crt
 
+PUBLIC  saved_hl                ;Temporary store used by compiler
+PUBLIC  saved_de                ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de
+
 IF CRT_ENABLE_STDIO = 1 && CLIB_FOPEN_MAX > 0
     PUBLIC  __sgoioblk
     PUBLIC  __sgoioblk_end

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_32.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_32.asm.m4
@@ -337,6 +337,14 @@ include "../../../../lib/crt/classic/crt_runtime_selection.inc"
 
     SECTION bss_crt
 
+PUBLIC  saved_hl                ;Temporary store used by compiler
+PUBLIC  saved_de                ;for hl and de
+
+saved_hl:
+    defw    0                   ; Temp store for hl
+saved_de:
+    defw    0                   ; Temp store for de
+
 IF CRT_ENABLE_STDIO = 1 && CLIB_FOPEN_MAX > 0
     PUBLIC  __sgoioblk
     PUBLIC  __sgoioblk_end

--- a/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_32.asm.m4
+++ b/libsrc/_DEVELOPMENT/target/rc2014/startup/rc2014_crt_32.asm.m4
@@ -337,13 +337,9 @@ include "../../../../lib/crt/classic/crt_runtime_selection.inc"
 
     SECTION bss_crt
 
-PUBLIC  saved_hl                ;Temporary store used by compiler
-PUBLIC  saved_de                ;for hl and de
-
+PUBLIC  saved_hl                ;Temporary store used by compiler for 8085
 saved_hl:
-    defw    0                   ; Temp store for hl
-saved_de:
-    defw    0                   ; Temp store for de
+    defw    0                   ;for hl
 
 IF CRT_ENABLE_STDIO = 1 && CLIB_FOPEN_MAX > 0
     PUBLIC  __sgoioblk

--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -234,7 +234,6 @@ void DoLibHeader(void)
     outstr("\n\n\tINCLUDE \"z80_crt0.hdr\"\n\n\n");
     if (c_notaltreg) {
         ol("EXTERN\tsaved_hl");
-        ol("EXTERN\tsaved_de");
     }
     donelibheader = 1;
 }
@@ -1609,7 +1608,7 @@ int modstk(int newsp, Kind save, int saveaf, int usebc)
 
     // Handle short cases
     if (k > 0) {
-        if (k < 11 ) {
+        if (k < 11) {
             if (k & 1) {
                 ol("inc\tsp");
                 --k;

--- a/testsuite/results/8080/Issue_1431_8080_long_promotion.opt
+++ b/testsuite/results/8080/Issue_1431_8080_long_promotion.opt
@@ -7,7 +7,6 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	SECTION	code_compiler
 
 ._func

--- a/testsuite/results/8080/Issue_1531_opt_rule.opt
+++ b/testsuite/results/8080/Issue_1531_opt_rule.opt
@@ -7,7 +7,6 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	SECTION	data_compiler
 ._A
 	defw	11

--- a/testsuite/results/8080/Issue_2586_8080_callee.opt
+++ b/testsuite/results/8080/Issue_2586_8080_callee.opt
@@ -7,7 +7,6 @@
 
 
 	EXTERN	saved_hl
-	EXTERN	saved_de
 	SECTION	code_compiler
 
 ._size10_i


### PR DESCRIPTION
Found compiling for 8085 using `__z88dk_callee` the `saved_hl` and `saved_de` locations are used by sccz80, but are not provided in 8085 crt0 for CP/M and other targets.

Improvement - there could be a `IF __8080 |  __8085` protection around the locations in the CP/M crt0 to create these locations only for 8080 or 8085, but I've been unable to find the right solution to make it work.

Also, additional 8080 and 8085 targets should have this added to their crt0. 