### PR TITLE
Added generation of .aqx files for Aquarius+

### DIFF
--- a/lib/config/aquarius.cfg
+++ b/lib/config/aquarius.cfg
@@ -17,6 +17,7 @@ CLIB		aqplus -laqplus -laquarius_clib -D__AQUARIUSPLUS__ -pragma-define:CLIB_AQU
 
 SUBTYPE         none
 SUBTYPE		default -Cz+aquarius 
+SUBTYPE		aqplus -Cz+aquarius -Cz--aqx
 SUBTYPE		banked -Cz+noop 
 SUBTYPE		rom -Cz+rom -Cz--romsize=8192 -pragma-define:CLIB_AQUARIUS_ROM=1 -Cz--rombase=0xe000 -D__ROM__
 

--- a/lib/config/aquarius.cfg
+++ b/lib/config/aquarius.cfg
@@ -17,7 +17,7 @@ CLIB		aqplus -laqplus -laquarius_clib -D__AQUARIUSPLUS__ -pragma-define:CLIB_AQU
 
 SUBTYPE         none
 SUBTYPE		default -Cz+aquarius 
-SUBTYPE		aqplus -Cz+aquarius -Cz--aqx
+SUBTYPE		aqx -Cz+aquarius -Cz--aqx
 SUBTYPE		banked -Cz+noop 
 SUBTYPE		rom -Cz+rom -Cz--romsize=8192 -pragma-define:CLIB_AQUARIUS_ROM=1 -Cz--rombase=0xe000 -D__ROM__
 

--- a/src/appmake/aquarius.c
+++ b/src/appmake/aquarius.c
@@ -23,6 +23,7 @@ static char              khz_22       = 0;
 static char              dumb         = 0;
 static char              loud         = 0;
 static char              help         = 0;
+static char              aqx          = 0;
 
 static uint8_t           h_lvl;
 static uint8_t           l_lvl;
@@ -38,6 +39,7 @@ option_t aquarius_options[] = {
     {  0,  "22",       "22050hz bitrate option",     OPT_BOOL,  &khz_22 },
     {  0,  "dumb",     "Just convert to WAV a tape file",  OPT_BOOL,  &dumb },
     {  0,  "loud",     "Louder audio volume",        OPT_BOOL,  &loud },
+    {  0,  "aqx",      "Output .aqx file for Aquarius+",  OPT_BOOL,  &aqx },
     {  0,  NULL,       NULL,                         OPT_NONE,  NULL }
 };
 
@@ -159,7 +161,11 @@ int aquarius_exec(char *target)
     } else {
 		if ( outfile == NULL ) {
 			strcpy(filename,binname);
-			suffix_change(filename,".caq");
+			if ( aqx ) {
+				suffix_change(filename,".aqx");
+			} else {
+				suffix_change(filename,".caq");
+			}
 		} else {
 			strcpy(filename,outfile);
 		}
@@ -190,161 +196,172 @@ int aquarius_exec(char *target)
 	/* BASIC loader */
 	/****************/
 
-		// Create the loader name, we need to take the zdirname, add an underscore, then the filename
-		copy1 = strdup(filename);
-		copy2 = strdup(filename);
-		snprintf(ldr_name, sizeof(ldr_name), "%s/_%s", zdirname(copy1), zbasename(copy2));
-		free(copy1);
-		free(copy2);
-		if ( (fpout=fopen(ldr_name,"wb") ) == NULL ) {
-			printf("Can't create the loader file\n");
-			exit(1);
+		if ( !aqx ) {
+			// Create the loader name, we need to take the zdirname, add an underscore, then the filename
+			copy1 = strdup(filename);
+			copy2 = strdup(filename);
+			snprintf(ldr_name, sizeof(ldr_name), "%s/_%s", zdirname(copy1), zbasename(copy2));
+			free(copy1);
+			free(copy2);
+			if ( (fpout=fopen(ldr_name,"wb") ) == NULL ) {
+				printf("Can't create the loader file\n");
+				exit(1);
+			}
+
+			/* Write out the header  */
+			for	(i=1;i<=12;i++)
+				writebyte(255,fpout);
+			writebyte(0,fpout);
+			writestring("LOADR",fpout);
+			writebyte(0,fpout);
+			for	(i=1;i<=12;i++)
+				writebyte(255,fpout);
+
+			writebyte(0,fpout);
+
+			writeword(14601,fpout);	/* points to line 10 */
+
+			writeword(5,fpout);	/*  5 U=0 */
+			writebyte('U',fpout);
+			writebyte(0xB0,fpout);
+			writebyte('0',fpout);
+
+			writebyte(0,fpout);
+			writeword(14609,fpout);	/* points to line 20 */
+
+			writeword(10,fpout);	/*  10 X=0 */
+			writebyte('X',fpout);
+			writebyte(0xB0,fpout);
+			writebyte('0',fpout);
+
+			writebyte(0,fpout);
+			writeword(14621+2,fpout);	/* points to line 30 */
+
+			writeword(20,fpout);	/*  20 DIMA(xxxxx) */
+			writebyte(0x85,fpout);
+			writebyte('A',fpout);
+			writebyte('(',fpout);
+			sprintf(mybuf,"%i",dlen);
+			for	(i=1;i<=(5-strlen(mybuf));i++)
+				writebyte('0',fpout);
+			writestring(mybuf,fpout);
+			writebyte(')',fpout);
+
+			writebyte(0,fpout);
+			writeword(14629+2,fpout);	/* points to line 40 */
+
+			writeword(30,fpout);	/*  30 CLOAD*A */
+			writebyte(0x9A,fpout);
+			writebyte(0xAA,fpout);
+			writebyte('A',fpout);
+
+			writebyte(0,fpout);
+			writeword(14651+2,fpout);	/* points to line 50 */
+
+			writeword(40,fpout);	/*  40 POKE14340,PEEK(14552)+7 */
+			writebyte(0x94,fpout);
+			writestring("14340,",fpout);
+			writebyte(0xC1,fpout);
+			writestring("(14552)",fpout);
+			writebyte(0xA8,fpout);
+			writebyte('7',fpout);
+
+			writebyte(0,fpout);
+			writeword(14671+2,fpout);	/* points to line 60 */
+
+			writeword(50,fpout);	/*  50 POKE14341,PEEK(14553) */
+			writebyte(0x94,fpout);
+			writestring("14341,",fpout);
+			writebyte(0xC1,fpout);
+			writestring("(14553)",fpout);
+
+			writebyte(0,fpout);
+			writeword(14682+2,fpout);	/* points to end of program */
+
+			writeword(60,fpout);	/*  60 X=USR(0) */
+			writebyte('X',fpout);
+			writebyte(0xB0,fpout);
+			writebyte(0xB5,fpout);
+			writestring("(0)",fpout);
+
+			for	(i=1;i<=25;i++)
+				writebyte(0,fpout);
+
+			fclose(fpout);
 		}
 
-	/* Write out the header  */
-		for	(i=1;i<=12;i++)
-			writebyte(255,fpout);
-		writebyte(0,fpout);
-		writestring("LOADR",fpout);
-		writebyte(0,fpout);
-		for	(i=1;i<=12;i++)
-			writebyte(255,fpout);
 
-		writebyte(0,fpout);
-		writeword(14601,fpout);	/* points to line 10 */
+		/*********************/
+		/* Binary array file */
+		/*********************/
 
-		writeword(5,fpout);	/*  5 U=0 */
-		writebyte('U',fpout);
-		writebyte(0xB0,fpout);
-		writebyte('0',fpout);
-
-		writebyte(0,fpout);
-		writeword(14609,fpout);	/* points to line 20 */
-
-		writeword(10,fpout);	/*  10 X=0 */
-		writebyte('X',fpout);
-		writebyte(0xB0,fpout);
-		writebyte('0',fpout);
-
-		writebyte(0,fpout);
-		writeword(14621+2,fpout);	/* points to line 30 */
-
-		writeword(20,fpout);	/*  20 DIMA(xxxxx) */
-		writebyte(0x85,fpout);
-		writebyte('A',fpout);
-		writebyte('(',fpout);
-		sprintf(mybuf,"%i",dlen);
-		for	(i=1;i<=(5-strlen(mybuf));i++)
-			writebyte('0',fpout);
-		writestring(mybuf,fpout);
-		writebyte(')',fpout);
-		
-		writebyte(0,fpout);
-		writeword(14629+2,fpout);	/* points to line 40 */
-		
-		writeword(30,fpout);	/*  30 CLOAD*A */
-		writebyte(0x9A,fpout);
-		writebyte(0xAA,fpout);
-		writebyte('A',fpout);
-		
-		writebyte(0,fpout);
-		writeword(14651+2,fpout);	/* points to line 50 */
-
-		writeword(40,fpout);	/*  40 POKE14340,PEEK(14552)+7 */
-		writebyte(0x94,fpout);
-		writestring("14340,",fpout);
-		writebyte(0xC1,fpout);
-		writestring("(14552)",fpout);
-		writebyte(0xA8,fpout);
-		writebyte('7',fpout);
-
-		writebyte(0,fpout);
-		writeword(14671+2,fpout);	/* points to line 60 */
-
-		writeword(50,fpout);	/*  50 POKE14341,PEEK(14553) */
-		writebyte(0x94,fpout);
-		writestring("14341,",fpout);
-		writebyte(0xC1,fpout);
-		writestring("(14553)",fpout);
-
-		writebyte(0,fpout);
-		writeword(14682+2,fpout);	/* points to end of program */
-
-		writeword(60,fpout);	/*  60 X=USR(0) */
-		writebyte('X',fpout);
-		writebyte(0xB0,fpout);
-		writebyte(0xB5,fpout);
-		writestring("(0)",fpout);
-
-		for	(i=1;i<=25;i++)
-			writebyte(0,fpout);
-		
-		fclose(fpout);
-
-
-	/*********************/
-	/* Binary array file */
-	/*********************/
-
-	/* Write out the header  */
-
+		/* Write out the header  */
 		if ( (fpout=fopen(filename,"wb") ) == NULL ) {
 			printf("Can't create the data file\n");
 			exit(1);
 		}
 
-	// "ffffffffffffffffffffffff 
+		if ( aqx ) {
+			sprintf(mybuf,"AQPLUSEXEC");
+			for	(i=0;i<strlen(mybuf);i++)
+				writebyte(mybuf[i],fpout);
 
-	/* Write out the header  */
-		for	(i=1;i<=12;i++)
-			writebyte(255,fpout);
+			writeword(0x4000,fpout); // load address
+			writeword(len,fpout); // length
+			writeword(0x4000,fpout); // exec address
 
-	//00
-		writebyte(0,fpout);
+		} else {
+			// "ffffffffffffffffffffffff 
 
-	/* Write out the "file name" */
-		for	(i=1;i<=6;i++)
-			writebyte('#',fpout);
+			/* Write out the header  */
+			for	(i=1;i<=12;i++)
+				writebyte(255,fpout);
 
-		for	(i=1;i<=6;i++)
+			//00
 			writebyte(0,fpout);
 
+			/* Write out the "file name" */
+			for	(i=1;i<=6;i++)
+				writebyte('#',fpout);
 
-	/* Mattel games loader relocator */
-
-		writebyte(0x2A,fpout);	// ld	hl,(14552)
-		writeword(14552,fpout);
-		writebyte(0x23,fpout);	// inc	hl	
-		writebyte(0x23,fpout);	// inc	hl	
-		writebyte(0x4e,fpout);	// ld	c,(hl)	
-		writebyte(0x23,fpout);	// inc	hl	
-		writebyte(0x46,fpout);	// ld	b,(hl)	
-		writebyte(0x11,fpout);	// le	de,67	
-		writeword(67,fpout);
-		writebyte(0x19,fpout);	// add	hl,de	
-		writebyte(0xe5,fpout);	// push	hl	
-		writebyte(0xc5,fpout);	// push	bc	
-		writebyte(0xe1,fpout);	// pop	hl	
-		writebyte(0xb7,fpout);	// or	a	
-		writebyte(0xed,fpout);	// sbc	hl,de	
-		writebyte(0x52,fpout);
-		writebyte(0xe5,fpout);	// push hl
-		writebyte(0xc1,fpout);	// pop	bc
-		writebyte(0xe1,fpout);	// pop	hl
-		writebyte(0x23,fpout);	// inc hl	
-		writebyte(0x7e,fpout);	// ld	a,(hl)	
-		writebyte(0xb7,fpout);	// or	a	
-		writebyte(0x28,fpout);	// jr	z,-4	
-		writebyte(0xfb,fpout);
-		writebyte(0x11,fpout);	// ld de,14768	
-		writeword(14768,fpout);
-		writebyte(0xed,fpout);	// ldir	
-		writebyte(0xb0,fpout);
-
-		for	(i=1;i<=41;i++)
-			writebyte(0,fpout);
+			for	(i=1;i<=6;i++)
+				writebyte(0,fpout);
 
 
+			/* Mattel games loader relocator */
+
+			writebyte(0x2A,fpout);	// ld	hl,(14552)
+			writeword(14552,fpout);
+			writebyte(0x23,fpout);	// inc	hl
+			writebyte(0x23,fpout);	// inc	hl
+			writebyte(0x4e,fpout);	// ld	c,(hl)
+			writebyte(0x23,fpout);	// inc	hl
+			writebyte(0x46,fpout);	// ld	b,(hl)
+			writebyte(0x11,fpout);	// le	de,67
+			writeword(67,fpout);
+			writebyte(0x19,fpout);	// add	hl,de
+			writebyte(0xe5,fpout);	// push	hl
+			writebyte(0xc5,fpout);	// push	bc
+			writebyte(0xe1,fpout);	// pop	hl
+			writebyte(0xb7,fpout);	// or	a
+			writebyte(0xed,fpout);	// sbc	hl,de
+			writebyte(0x52,fpout);
+			writebyte(0xe5,fpout);	// push hl
+			writebyte(0xc1,fpout);	// pop	bc
+			writebyte(0xe1,fpout);	// pop	hl
+			writebyte(0x23,fpout);	// inc hl
+			writebyte(0x7e,fpout);	// ld	a,(hl)
+			writebyte(0xb7,fpout);	// or	a
+			writebyte(0x28,fpout);	// jr	z,-4
+			writebyte(0xfb,fpout);
+			writebyte(0x11,fpout);	// ld de,14768
+			writeword(14768,fpout);
+			writebyte(0xed,fpout);	// ldir
+			writebyte(0xb0,fpout);
+
+			for	(i=1;i<=41;i++)
+				writebyte(0,fpout);
+		}
 
 	/* We append the binary file */
 


### PR DESCRIPTION
Aquarius+ BASIC has a new feature, the capability to "run" a binary file directly from BASIC using the "run" command.

- e.g. run main.aqx

The .aqx file format is a header followed by the binary image. The header consists of the following.

| Name | Size | Value|
|--------|--------|--------|
|Signature| 10 bytes|AQPLUSEXEC|
|Load address| 2 bytes | Populated by appmake |
|Binary length| 2 bytes | Populated by appmake |
|Exec address| 2 bytes| Populated by appmake|

A new subtype has been added to the aquarius target 'aqx' which will pass the --aqx parameter to appmake. Also, appmake for the Aquarius now accepts --crt0file and --org parameters.
