### PR TITLE
Updated filenames used for banking to match zcc output

### DIFF
--- a/lib/target/aquarius/classic/aqplusram.asm
+++ b/lib/target/aquarius/classic/aqplusram.asm
@@ -245,9 +245,8 @@ _basename:
     DEFINE NEED_basename
     INCLUDE "zcc_opt.def"
     UNDEFINE NEED_basename
-    defb    '.'
 __basename_ext:
-    defm    "00"
+    defm    "00.bin"
     defb    0
 
 mainsp:     defw    0


### PR DESCRIPTION
The existing _loadbanks_ routine for the Aquarius+ uses the following file name convention for the bank files,

_basename.xx_,  where _basename_ is set by _#pragma string basename_ and _xx_ is the bank number.

However, zcc uses _name_BANK_xx.bin_ where _name_ is something like _myproj_ and _xx_ is the bank number.

This PR changes the fixed portion of the file name from _.00_ to _00.bin_. _basename_ can then be set to _myproj_BANK__