### PR TITLE
Microbee low resolution gfx fix

### DIFF
--- a/libsrc/target/bee/graphics/plotpixl.asm
+++ b/libsrc/target/bee/graphics/plotpixl.asm
@@ -8,7 +8,7 @@
 ;       Plot pixel at (x,y) coordinate.
 ;
 ;
-;	$Id: plotpixl.asm,v 1.2 2016-11-21 11:18:38 stefano Exp $
+;	$Id: plotpixl.asm $
 ;
 
 
@@ -17,7 +17,7 @@
     SECTION code_clib
     PUBLIC  plotpixel
 
-    EXTERN  div3
+    EXTERN  div3_0
     EXTERN  __gfx_coords
 			;EXTERN	base_graphics
 
@@ -41,7 +41,7 @@ plotpixel:
 
     push    bc
 
-    ld      hl, div3
+    ld      hl, div3_0
     ld      d, 0
     ld      e, c
     inc     e

--- a/libsrc/target/bee/graphics/pointxy.asm
+++ b/libsrc/target/bee/graphics/pointxy.asm
@@ -9,7 +9,7 @@
 ;       Get pixel at (x,y) coordinate.
 ;
 ;
-;	$Id: pointxy.asm,v 1.2 2016-11-21 11:18:38 stefano Exp $
+;	$Id: pointxy.asm $
 ;
 
 
@@ -18,7 +18,7 @@
     SECTION code_clib
     PUBLIC  pointxy
 
-    EXTERN  div3
+    EXTERN  div3_0
     EXTERN  __gfx_coords
 			;EXTERN	base_graphics
 
@@ -46,7 +46,7 @@ pointxy:
 
     push    bc
 
-    ld      hl, div3
+    ld      hl, div3_0
     ld      d, 0
     ld      e, c
     inc     e

--- a/libsrc/target/bee/graphics/respixl.asm
+++ b/libsrc/target/bee/graphics/respixl.asm
@@ -9,7 +9,7 @@
 ;       Reset pixel at (x,y) coordinate.
 ;
 ;
-;	$Id: respixl.asm,v 1.2 2016-11-21 11:18:38 stefano Exp $
+;	$Id: respixl.asm $
 ;
 
 
@@ -18,7 +18,7 @@
     SECTION code_clib
     PUBLIC  respixel
 
-    EXTERN  div3
+    EXTERN  div3_0
     EXTERN  __gfx_coords
 			;EXTERN	base_graphics
 
@@ -42,7 +42,7 @@ respixel:
 
     push    bc
 
-    ld      hl, div3
+    ld      hl, div3_0
     ld      d, 0
     ld      e, c
     inc     e

--- a/libsrc/target/bee/graphics/xorpixl.asm
+++ b/libsrc/target/bee/graphics/xorpixl.asm
@@ -8,7 +8,7 @@
 ;       XOR pixel at (x,y) coordinate.
 ;
 ;
-;	$Id: xorpixl.asm,v 1.3 2016-11-21 11:18:38 stefano Exp $
+;	$Id: xorpixl.asm $
 ;
 
 
@@ -17,7 +17,7 @@
     SECTION code_clib
     PUBLIC  xorpixel
 
-    EXTERN  div3
+    EXTERN  div3_0
     EXTERN  __gfx_coords
     EXTERN  base_graphics
 
@@ -41,7 +41,7 @@ xorpixel:
 
     push    bc
 
-    ld      hl, div3
+    ld      hl, div3_0
     ld      d, 0
     ld      e, c
     inc     e


### PR DESCRIPTION
UDG based graphics, meant to draw a little bit in 80 columns mode (e.g. in CP/M) just by dealing with the pseudographics text6 set.   This had a bir of regression when the graphics codebase was sorted.