### PR TITLE
Aquarius+ specific native console I/O routines.

### DIFF
--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -930,7 +930,7 @@ aqplus.lib: $(TARGET_CLIB_OBJS) aquarius_clib.lib
 	@echo '--- Building Mattel Aquarius Plus lib ---'
 	@echo ''
 	$(MAKE) -C gfx TARGET=aquarius SUBTYPE=aqplus FLAVOUR="wide"
-	TARGET=aqplus TYPE=z80 $(LIBLINKER) -DFORaqplus -x$(OUTPUT_DIRECTORY)/aqplus @$(TARGET_DIRECTORY)/aquarius/aqplus.lst
+	TARGET=aqplus TYPE=z80 $(LIBLINKER) -DFORaqplus -DSTANDARDESCAPECHARS -x$(OUTPUT_DIRECTORY)/aqplus @$(TARGET_DIRECTORY)/aquarius/aqplus.lst
 
 
 # Aussie Byte library - Stefano

--- a/libsrc/_DEVELOPMENT/sdcc_opt.1
+++ b/libsrc/_DEVELOPMENT/sdcc_opt.1
@@ -606,6 +606,14 @@ __xinit_%0
 	call	banked_call
 	defq	%2
 
+	ld	e,%1
+	ld	hl,%2
+	jp  ___sdcc_bcall_ehl
+=
+	call	banked_call
+	defq	%2
+	ret
+
 ;; 
 ;; ez80 instructions
 

--- a/libsrc/target/aquarius/aqplus.lst
+++ b/libsrc/target/aquarius/aqplus.lst
@@ -31,3 +31,5 @@ target/aquarius/fcntl/remove
 target/aquarius/fcntl/rename
 target/aquarius/fcntl/write
 target/aquarius/fcntl/writebyte
+target/aquarius/stdio/fputc_cons_aqplus
+target/aquarius/stdio/fgetc_cons_aqplus

--- a/libsrc/target/aquarius/stdio/fgetc_cons_aqplus.asm
+++ b/libsrc/target/aquarius/stdio/fgetc_cons_aqplus.asm
@@ -1,0 +1,44 @@
+;
+;	Mattel AQUARIUS Routines
+;
+;	getkey() Wait for keypress
+;
+;	Dec 2001 - Stefano Bodrato
+;
+;
+;	$Id: fgetc_cons.asm,v 1.4 2016-06-12 17:07:43 dom Exp $
+;
+
+	SECTION code_clib
+	PUBLIC	fgetc_cons
+	PUBLIC	_fgetc_cons
+
+INCHRH	 equ	$1E7E
+ext_call equ	$2103
+
+.fgetc_cons
+._fgetc_cons
+	push	ix
+.wkeyrelease
+	ld	iy, INCHRH
+	call	ext_call
+	and	a
+	jr	nz,wkeyrelease
+
+.wkey
+	ld	iy, INCHRH
+	call	ext_call
+	and	a
+	jr	z,wkey
+
+IF STANDARDESCAPECHARS
+	cp	13
+	jr	nz,not_return
+	ld	a,10
+.not_return
+ENDIF
+
+	ld	l,a
+	ld	h,0
+	pop	ix
+	ret

--- a/libsrc/target/aquarius/stdio/fputc_cons_aqplus.asm
+++ b/libsrc/target/aquarius/stdio/fputc_cons_aqplus.asm
@@ -1,0 +1,51 @@
+;
+;	Mattel Aquarius Routines
+;
+;	Print character to the screen
+;
+;       We can corrupt any register
+;
+;
+;	$Id: fputc_cons.asm,v 1.3 2016-05-15 20:15:45 dom Exp $
+;
+
+	SECTION	code_clib
+	PUBLIC  fputc_cons_native
+
+TTYCHR	 equ $1d72
+ext_call equ $2103
+
+;
+; Entry:   char to print
+;
+
+
+.fputc_cons_native
+	push	ix
+
+	ld	hl,4
+	add	hl,sp
+	ld	a,(hl); Now A contains the char
+IF STANDARDESCAPECHARS
+        cp      10      ; CR ?
+        jr      nz,nocrlf
+	ld	iy, TTYCHR
+	call	ext_call
+	ld	a,13
+ELSE
+	cp	13
+	jr	nz,nocrlf
+	ld	iy, TTYCHR
+	call	ext_call
+	ld	a,10
+ENDIF
+.nocrlf
+	cp	12
+	jr	nz,nocls
+	ld	a,$b
+.nocls	
+	ld	iy, TTYCHR
+	call	ext_call
+
+	pop	ix
+	ret

--- a/libsrc/target/aquarius/stdio/getk.asm
+++ b/libsrc/target/aquarius/stdio/getk.asm
@@ -14,9 +14,11 @@
 	PUBLIC	getk
 	PUBLIC	_getk
 	
+KEYASC	equ	$1f00
 	
 .getk
 ._getk
+	push	ix
 
         ld      bc,$00ff		; Scan all columns at once.
         in      a,(c)			; Read the results.
@@ -79,7 +81,7 @@ KCOLCNT:
 ;
 KFOUND:
 		ld		e,a
-		call	$1f01			; KDECODE + 1 (skip the scan count increment)
+		call	KEYASC+1	; KDECODE + 1 (skip the scan count increment)
 		
 
 IF STANDARDESCAPECHARS
@@ -94,5 +96,6 @@ ENDIF
 .getk_exit
 	ld	l,a
 	ld	h,0
+	pop	ix
 	ret
 


### PR DESCRIPTION
These changes are needed to fix problems when calling printf() or gets() from __banked functions on the Aq+.

1. Created Aq+ specific routines for _fputc_cons_native_ and _fgetc_cons_native_ and modified them so calls to the ROM are performed via _ext_call_ which correctly handles saving and restoring the memory bank paged in at $c000. _ext_call_ does clobber IX so these routines now save and restore the IX register also.
2. The _libsrc_ _Makefile_ has been updated to include _-DSTANDARDESCAPECHARS_ when building the sources for the aqplus_clib library so CR/LF are handled correctly.
3. The _getk_ routine calls the _KEYASC_ ROM routine ($1f01, actually KEYASC+1) which is available in both Aq and Aq+ ROMs and does not need to be called via _ext_call_. However, the IX register is clobbered so _getk_ now saves and restores IX.
