### PR TITLE
Changed aqx to aqex.

### DIFF
--- a/lib/config/aquarius.cfg
+++ b/lib/config/aquarius.cfg
@@ -17,7 +17,7 @@ CLIB		aqplus -laqplus -laquarius_clib -D__AQUARIUSPLUS__ -pragma-define:CLIB_AQU
 
 SUBTYPE         none
 SUBTYPE		default -Cz+aquarius 
-SUBTYPE		aqx -Cz+aquarius -Cz--aqx
+SUBTYPE		aqex -Cz+aquarius -Cz--aqex
 SUBTYPE		banked -Cz+noop 
 SUBTYPE		rom -Cz+rom -Cz--romsize=8192 -pragma-define:CLIB_AQUARIUS_ROM=1 -Cz--rombase=0xe000 -D__ROM__
 

--- a/src/appmake/aquarius.c
+++ b/src/appmake/aquarius.c
@@ -9,7 +9,7 @@
  *
  *   Stefano Bodrato - December 2001: first release
  *   Stefano Bodrato - Fall 2022: WAV output options
- *   Craig Hackney   - September 2024: Addition of .aqx output for Aquarius+
+ *   Craig Hackney   - September 2024: Addition of .aqex output for Aquarius+
  *
  *   $Id: aquarius.c $
  */
@@ -25,7 +25,7 @@ static char              khz_22       = 0;
 static char              dumb         = 0;
 static char              loud         = 0;
 static char              help         = 0;
-static char              aqx          = 0;
+static char              aqex         = 0;
 static int				 origin       = -1;
 
 static uint8_t           h_lvl;
@@ -42,7 +42,7 @@ option_t aquarius_options[] = {
     {  0,  "22",       "22050hz bitrate option",     OPT_BOOL,  &khz_22 },
     {  0,  "dumb",     "Just convert to WAV a tape file",  OPT_BOOL,  &dumb },
     {  0,  "loud",     "Louder audio volume",        OPT_BOOL,  &loud },
-    {  0,  "aqx",      "Output .aqx file for Aquarius+",  OPT_BOOL,  &aqx },
+    {  0,  "aqex",     "Output .aqex file for Aquarius+",  OPT_BOOL,  &aqex },
     { 'c', "crt0file", "crt0 file used in linking",  OPT_STR,   &crtfile },
     {  0 , "org",      "Origin of the binary",       OPT_INT,   &origin },
     {  0,  NULL,       NULL,                         OPT_NONE,  NULL }
@@ -166,8 +166,8 @@ int aquarius_exec(char *target)
     } else {
 		if ( outfile == NULL ) {
 			strcpy(filename,binname);
-			if ( aqx ) {
-				suffix_change(filename,".aqx");
+			if ( aqex ) {
+				suffix_change(filename,".aqex");
 			} else {
 				suffix_change(filename,".caq");
 			}
@@ -197,7 +197,7 @@ int aquarius_exec(char *target)
 		
 		fseek(fpin,0L,SEEK_SET);
 		
-		if ( aqx ) {
+		if ( aqex ) {
 		    char   crtname[FILENAME_MAX];
 			long loadAddr;
 


### PR DESCRIPTION
The filename extension for a self executing binary file which can be loaded and run using the BASIC _run_ command has been changed from .aqx to .aqex. This is to prevent confusion with existing .aqx files which consist of a BASIC portion followed by binary code. .aqx files can be _run_ directly or loaded and then run whereas a .aqex file can only be _run_.

plusBASIC will be updated in the future to report an error if an attempt is made to _load_ a .aqex file as these files can only be run. There are also plans for .aqex files to contain multiple assets, banks, etc.