### PR TITLE
zx: Add “-clib=noclib” variant for cases when zx_clib library is not present

### DIFF
--- a/lib/config/zx.cfg
+++ b/lib/config/zx.cfg
@@ -17,6 +17,7 @@ OPTIONS		 -O2 -SO2 -iquote.  -D__SPECTRUM -DSPECTRUM -D__SPECTRUM__ -D__Z80 -D__
 
 # Classic variants
 CLIB      default -Cc-standard-escape-chars -lzx_clib -IDESTDIR/include/arch/zx -LDESTDIR/lib/clibs/z80
+CLIB      noclib -Cc-standard-escape-chars -IDESTDIR/include/arch/zx -LDESTDIR/lib/clibs/z80
 CLIB      ansi -Cc-standard-escape-chars -pragma-need=ansiterminal -D__CONIO_VT100 -lzx_clib -IDESTDIR/include/arch/zx -LDESTDIR/lib/clibs/z80
 
 


### PR DESCRIPTION
I have a rare setup when I build zx game without CLIB (hot-pluggable module). Modules in this case rely on main executable's clib, so when themselves are built, clib is not needed.

This change adds `-clib=noclib` variant so I can build w/o clib for zx when needed.