### PR TITLE
bios() and biosh() improved

### DIFF
--- a/include/arch/qc10.h
+++ b/include/arch/qc10.h
@@ -1,0 +1,20 @@
+#ifndef __ARCH_QX10_H__
+#define __ARCH_QX10_H__
+
+#include <stdlib.h>
+
+///////////////////////////
+//   EPSON QC-10 or QX-10 
+///////////////////////////
+
+// Check if the Colour monitor is connected
+#define qc10_have_color()  (inp(0x2c)==0xfd)
+
+// Determine if the program is running on an Epson QX-10 or QC-10
+// checking for a green or color monitor
+#define is_qc10()  ((inp(0x2c)==0xfe)||(inp(0x2c)==0xfd)))
+
+// Have BIOS in ($f603) ?
+#define qc10_m1bios()  (wpeek(1)==(-2557))
+
+#endif

--- a/libsrc/target/cpm/fcntl/bios.c
+++ b/libsrc/target/cpm/fcntl/bios.c
@@ -1,7 +1,7 @@
 /*
- *	Call a CPM BDOS routine
+ *	Call a CPM BIOS routine
  *
- *	$Id: bios.c,v 1.3 2015-11-11 18:40:54 stefano Exp $
+ *	$Id: bios.c$
  */
 
 #include <cpm.h>
@@ -9,8 +9,19 @@
 
 #asm
 cpm_bios:
+
 	ld	hl,4
 	add	hl,sp
+
+	push hl
+	ld c,12		; S_BDOSVER
+	call 5
+	cp 30h		; check for CP/M version below 3.0
+	pop hl
+
+IF !__CPU_INTEL__
+	push	ix
+ENDIF
 	ld	e,(hl)	;arg2
 	inc	hl
 	ld	d,(hl)
@@ -20,10 +31,35 @@ cpm_bios:
 	ld	b,(hl)
 	inc	hl
 	ld	a,(hl)  ; get function number (1-85)
-	
+	jr	c,use_vector	; CY set = CP/M version below 3.0
+
+	ld (BIOSPB),a	; FUNCTION
+	ld (BIOSPB+2),bc
+	ld (BIOSPB+4),de
+
+	ld de,BIOSPB
+	ld c,50  	; 32h (S_BIOS)
+	call 5
+IF !__CPU_INTEL__
+	pop	ix
+ENDIF
+	ret
+
+
+BIOSPB:
+	defb 0	; FUNC
+	defb 0	; A reg		; not assigned
+	defw 0  ; BC reg
+	defw 0  ; DE reg
+	defw 0  ; HL reg	; not assigned
+
+
+; if CP/M version is < 2.5, we spot the BIOS JP table
+; using the WBOOT entry (at position $0000, points to BIOS+3)
+use_vector:
 	ld hl,(1)   ; base+1 = addr of jump table + 3
 
-	dec hl
+	dec hl	; -3
 	dec hl
 	dec hl
 	
@@ -36,14 +72,17 @@ cpm_bios:
 	ld  d,0
 	add hl,de   ; add to base of jump table
 	pop de
-
-	push hl     ; save it
+	
+	push hl     ; save the computed entry
 
 	ld  hl,retadd
-	ex  (sp),hl
+	ex  (sp),hl ; ready
 	jp  (hl)
 
 retadd:
+IF !__CPU_INTEL__
+	pop	ix
+ENDIF
     ret
 
 #endasm


### PR DESCRIPTION
Now the bios calls protect IX and try to run also on CP/M 3 (via BDOS pivot).
The results are not astonishing but at least we have something not crashing when not supported.