### PR TITLE
Ensure hardware and stdio are sync'd during init.

### DIFF
--- a/lib/target/aquarius/classic/aquarius_crt0.asm
+++ b/lib/target/aquarius/classic/aquarius_crt0.asm
@@ -90,6 +90,25 @@ l_dcal:
 
 IF CLIB_AQUARIUS_PLUS = 1
     INCLUDE	"target/aquarius/classic/banks.asm"
-ENDIF
-    
 
+  IF __HAVE_GENCON = 1
+    INCLUDE "ioctl.def"
+    SECTION code_crt_init
+    EXTERN  set_default_palette
+    EXTERN  generic_console_ioctl
+    EXTERN  __aquarius_mode
+
+    call    set_default_palette
+
+    ; Remap the border color character for aqplus
+    in      a, (IO_VCTRL)
+    or      VCTRL_REMAP_BC
+    ld      de, __aquarius_mode
+    ld      (de), a
+    ld      a, IOCTL_GENCON_SET_MODE
+    ; This will setup the mode and screen size
+    ; so that it matches the hardware during init.
+    call    generic_console_ioctl
+  ENDIF
+
+ENDIF

--- a/libsrc/target/aquarius/stdio/generic_console.asm
+++ b/libsrc/target/aquarius/stdio/generic_console.asm
@@ -18,8 +18,6 @@
     EXTERN      scrollup_BITMAP
     EXTERN      scrollup_TEXT
 
-    EXTERN      generic_console_ioctl
-
     EXTERN      __aquarius_mode
 
     INCLUDE     "ioctl.def"
@@ -62,26 +60,3 @@ generic_console_scrollup:
     bit     2,(hl)
     jp      nz,scrollup_BITMAP
     ret
-
-
-    SECTION code_crt_init
-
-    EXTERN  set_default_palette
-
-    ; On an Aquarius+ we modify the caps so that we can define the font
-    ld      c, CLIB_AQUARIUS_PLUS
-    rr      c
-    jr      nc, not_plus
-
-    call    set_default_palette
-
-    ; Remap the border color character for aqplus
-    in      a, (IO_VCTRL)
-    or      VCTRL_REMAP_BC
-    ld      de, __aquarius_mode
-    ld      (de), a
-    ld      a, IOCTL_GENCON_SET_MODE
-    ; This will setup the mode and screen size
-    ; so that it matches the hardware during init.
-    call    generic_console_ioctl
-not_plus:

--- a/libsrc/target/aquarius/stdio/generic_console.asm
+++ b/libsrc/target/aquarius/stdio/generic_console.asm
@@ -11,7 +11,6 @@
 
     EXTERN  CLIB_AQUARIUS_PLUS
 
-
     EXTERN      printc_BITMAP
     EXTERN      printc_TEXT
     EXTERN      cls_BITMAP
@@ -19,7 +18,7 @@
     EXTERN      scrollup_BITMAP
     EXTERN      scrollup_TEXT
 
-    EXTERN      ck_mode
+    EXTERN      generic_console_ioctl
 
     EXTERN      __aquarius_mode
 
@@ -79,10 +78,10 @@ generic_console_scrollup:
     ; Remap the border color character for aqplus
     in      a, (IO_VCTRL)
     or      VCTRL_REMAP_BC
-    ld      e, a
+    ld      de, __aquarius_mode
+    ld      (de), a
     ld      a, IOCTL_GENCON_SET_MODE
     ; This will setup the mode and screen size
     ; so that it matches the hardware during init.
-    call    ck_mode
+    call    generic_console_ioctl
 not_plus:
-

--- a/libsrc/target/aquarius/stdio/generic_console.asm
+++ b/libsrc/target/aquarius/stdio/generic_console.asm
@@ -1,15 +1,12 @@
 ;
 
 
-    INCLUDE "target/aquarius/def/aqplus.def"
 
     SECTION		code_clib
 
     PUBLIC		generic_console_cls
     PUBLIC		generic_console_scrollup
     PUBLIC		generic_console_printc
-
-    EXTERN  CLIB_AQUARIUS_PLUS
 
     EXTERN      printc_BITMAP
     EXTERN      printc_TEXT

--- a/libsrc/target/aquarius/stdio/generic_console.asm
+++ b/libsrc/target/aquarius/stdio/generic_console.asm
@@ -1,6 +1,7 @@
 ;
 
 
+    INCLUDE "target/aquarius/def/aqplus.def"
 
     SECTION		code_clib
 
@@ -8,12 +9,17 @@
     PUBLIC		generic_console_scrollup
     PUBLIC		generic_console_printc
 
+    EXTERN  CLIB_AQUARIUS_PLUS
+
+
     EXTERN      printc_BITMAP
     EXTERN      printc_TEXT
     EXTERN      cls_BITMAP
     EXTERN      cls_TEXT
     EXTERN      scrollup_BITMAP
     EXTERN      scrollup_TEXT
+
+    EXTERN      ck_mode
 
     EXTERN      __aquarius_mode
 
@@ -57,3 +63,26 @@ generic_console_scrollup:
     bit     2,(hl)
     jp      nz,scrollup_BITMAP
     ret
+
+
+    SECTION code_crt_init
+
+    EXTERN  set_default_palette
+
+    ; On an Aquarius+ we modify the caps so that we can define the font
+    ld      c, CLIB_AQUARIUS_PLUS
+    rr      c
+    jr      nc, not_plus
+
+    call    set_default_palette
+
+    ; Remap the border color character for aqplus
+    in      a, (IO_VCTRL)
+    or      VCTRL_REMAP_BC
+    ld      e, a
+    ld      a, IOCTL_GENCON_SET_MODE
+    ; This will setup the mode and screen size
+    ; so that it matches the hardware during init.
+    call    ck_mode
+not_plus:
+

--- a/libsrc/target/aquarius/stdio/generic_console_ioctl.asm
+++ b/libsrc/target/aquarius/stdio/generic_console_ioctl.asm
@@ -3,6 +3,8 @@
         MODULE  generic_console_ioctl
         PUBLIC  generic_console_ioctl
 
+        PUBLIC  ck_mode
+
         SECTION code_clib
         INCLUDE "ioctl.def"
         INCLUDE "target/aquarius/def/aqplus.def"
@@ -123,26 +125,4 @@ set_caps:
 failure:
         scf
         ret
-
-
-        SECTION code_crt_init
-
-        EXTERN  set_default_palette
-
-        ; On an Aquarius+ we modify the caps so that we can define the font
-        ld      c, CLIB_AQUARIUS_PLUS
-        rr      c
-        jr      nc, not_plus
-
-        call    set_default_palette
-
-        ; Remap the border color character for aqplus
-        in      a, (IO_VCTRL)
-        or      VCTRL_REMAP_BC
-        ld      e, a
-        ld      a, IOCTL_GENCON_SET_MODE
-        ; This will setup the mode and screen size
-        ; so that it matches the hardware during init.
-        call    ck_mode
-not_plus:
 

--- a/libsrc/target/aquarius/stdio/generic_console_ioctl.asm
+++ b/libsrc/target/aquarius/stdio/generic_console_ioctl.asm
@@ -3,8 +3,6 @@
         MODULE  generic_console_ioctl
         PUBLIC  generic_console_ioctl
 
-        PUBLIC  ck_mode
-
         SECTION code_clib
         INCLUDE "ioctl.def"
         INCLUDE "target/aquarius/def/aqplus.def"


### PR DESCRIPTION
@suborb , hopefully this addresses the issue you identified. My testing does show that when adding --generic-console, the correct crt0_init code is pulled in.
