### PR TITLE
Review ZX getting started guide

### DIFF
--- a/doc/ZXSpectrumZSDCCnewlib_01_GettingStarted.md
+++ b/doc/ZXSpectrumZSDCCnewlib_01_GettingStarted.md
@@ -97,7 +97,7 @@ to get this program to compile and run:
   
   #include <arch/zx.h>
   
-  int main()
+  int main(void)
   {
     zx_border(INK_BLACK);
     return 0;
@@ -207,7 +207,7 @@ header files and only a some of them are for use with zsdcc and the
 Spectrum.
 
 The answer can be found by running our compilation command again with -v instead
-of -vn and looking for the -I argument on the zsdccp command. How this affects
+of -vn and looking for the -isystem argument on the z88dk-ucpp command. How this affects
 the compilation is beyond the scope of a getting started guide, but suffice to
 say it shows that when using the zsdcc compiler the header files come from this
 directory:
@@ -234,7 +234,7 @@ zx_border() code come from? The answer is the sdcc_iy standard library specified
 in the zcc compilation command via the -clib argument.
 
 Another peek at the output of zcc with the -v argument shows a -L argument being
-passed into an embedded z80asm command. Again, details are beyond the scope of
+passed into an embedded z88dk-z80asm command. Again, details are beyond the scope of
 this document, but the value for that argument tells us that the library code is
 coming from:
 ```
@@ -255,6 +255,6 @@ can inspect the contents of the library with the z88dk-z80nm command:
 Do a search and you'll find the zx_border() function listed in there.
 
 The actual source code used to build the library is rooted in [z88dk/libsrc/_DEVELOPMENT](https://github.com/z88dk/z88dk/tree/master/libsrc/_DEVELOPMENT)
-and a search using the header path `arch/zx` as clue locates the [asm_zx_border.asm](https://github.com/z88dk/z88dk/blob/master/libsrc/_DEVELOPMENT/arch/zx/misc/z80/asm_zx_border.asm) function in `arch/zx/misc/z80`.
+and a search using the header path `arch/zx` as a clue locates the [asm_zx_border.asm](https://github.com/z88dk/z88dk/blob/master/libsrc/_DEVELOPMENT/arch/zx/misc/z80/asm_zx_border.asm) function in `arch/zx/misc/z80`.
 
 [... continue to Part 2: Hello World](https://github.com/z88dk/z88dk/blob/master/doc/ZXSpectrumZSDCCnewlib_02_HelloWorld.md)

--- a/doc/ZXSpectrumZSDCCnewlib_02_HelloWorld.md
+++ b/doc/ZXSpectrumZSDCCnewlib_02_HelloWorld.md
@@ -16,7 +16,7 @@ It might be a reasonable assumption that most people picking up Spectrum
 programming for the first time are looking to write games, and so are interested
 in sprites, joysticks, music, and so on. First things first, however. Simple
 text based programs allow programmers to experiment with library routines, to
-feed them inputs and see the outputs. Runtime debugging will go a long way away in
+feed them inputs and see the outputs. Runtime debugging is a long way away in
 this "getting started" series, so for the time being text IO is going to be
 useful.
 
@@ -30,7 +30,7 @@ powerful. It looks a bit strange in 32 columns.
 
 The stdio library talks to a "driver." A driver is some Z88DK code that is
 attached to the end of a byte stream.  These drivers can handle screen output
-and keyboard input like PRINT and INPUT do in basic.
+and keyboard input like PRINT and INPUT do in BASIC.
 
 ### Hello World
 
@@ -44,7 +44,7 @@ file called hello_world.c:
   #include <arch/zx.h>
   #include <stdio.h>
 
-  int main()
+  int main(void)
   {
     zx_cls(PAPER_WHITE);
 
@@ -112,7 +112,7 @@ few bytes of the Spectrum's ROM:
   #include <arch/zx.h>
   #include <stdio.h>
 
-  int main()
+  int main(void)
   {
     unsigned char* rom_addr = 0;
     unsigned char i, j;
@@ -169,7 +169,7 @@ called question.c:
   #include <arch/zx.h>
   #include <stdio.h>
 
-  int main()
+  int main(void)
   {
     unsigned char name[15];
 

--- a/doc/ZXSpectrumZSDCCnewlib_03_SimpleGraphics.md
+++ b/doc/ZXSpectrumZSDCCnewlib_03_SimpleGraphics.md
@@ -36,7 +36,7 @@ series, [here](https://github.com/z88dk/z88dk/tree/master/include/_DEVELOPMENT/s
 The explanation is that the header files in the include/ directory relate to
 functions in the _classic_ library. We're using the newer compiler with the _new_
 library, and you'll notice that there's no graphics.h file in the
-include/_DEVELOPMENT/sdcc directory. As of this writing, June 2017, the graphics
+include/_DEVELOPMENT/sdcc directory. As of this writing, October 2024, the graphics
 routines haven't yet been ported to the new library.
 
 Thus, for now at least, we meet a dead end. If your application requires the
@@ -185,7 +185,7 @@ that draws lines using the Bresenham algorithm. The results here will be quick b
 not going to be the fastest possible way to draw lines.
 
 It really isn't important to understand the Bresenham algorithm. The important
-point here is that Z88DK provides the low level tools which enable such a
+point here is that Z88DK provides the low level tools which enable such an
 algorithm to be implemented.
 
 Retaining our plot function and borrowing the internet line code, save the following in

--- a/doc/ZXSpectrumZSDCCnewlib_04_InputDevices.md
+++ b/doc/ZXSpectrumZSDCCnewlib_04_InputDevices.md
@@ -58,7 +58,7 @@ simple:
 #include <arch/zx.h>
 #include <input.h>
 
-int main()
+int main(void)
 {
 
   while( 1 )
@@ -104,7 +104,7 @@ the information we're seeing from the keyboard:
 #include <stdio.h>
 #include <input.h>
 
-int main()
+int main(void)
 {
   unsigned char c;
 
@@ -176,7 +176,7 @@ an example which reads 5 keys and shows the results:
 #include <input.h>
 #include <arch/zx.h>
 
-int main()
+int main(void)
 {
   zx_cls(PAPER_WHITE);
   while( 1 ) {
@@ -227,7 +227,7 @@ scancode. For example:
 #include <input.h>
 #include <arch/zx.h>
 
-int main()
+int main(void)
 {
   uint16_t dollar_scancode = in_key_scancode('$');
 
@@ -266,7 +266,7 @@ scancode for BREAK, which is CAPS+Space like this:
 #include <input.h>
 #include <arch/zx.h>
 
-int main()
+int main(void)
 {
   /* Space, plus top bit set means CAPS */
   uint16_t break_scancode = IN_KEY_SCANCODE_SPACE | 0x8000;
@@ -300,7 +300,7 @@ which Fuse is quite happy with):
 #include <input.h>
 #include <arch/zx.h>
 
-int main()
+int main(void)
 {
   uint16_t kempston_input;
 
@@ -378,7 +378,7 @@ diagonal positions and/or pressing fire makes the border swirl with colour.
 #include <input.h>
 #include <arch/zx.h>
 
-int main()
+int main(void)
 {
   uint16_t kempston_input;
 

--- a/doc/ZXSpectrumZSDCCnewlib_05_MultipleFiles.md
+++ b/doc/ZXSpectrumZSDCCnewlib_05_MultipleFiles.md
@@ -42,7 +42,7 @@ As always, we start simple. Here's a source file containing a *main()* function:
 
 extern unsigned char message[];
 
-int main()
+int main(void)
 {
   printf("Message is: \"%s\"\n", message);
 

--- a/doc/ZXSpectrumZSDCCnewlib_06_SomeDetails.md
+++ b/doc/ZXSpectrumZSDCCnewlib_06_SomeDetails.md
@@ -158,7 +158,7 @@ On the other hand, you can turn off the heap entirely with:
 The default heap size on Spectrum programs is set to -1, which is a special
 value which says "use all the memory above the program's BBS section and the
 below the stack for heap." This is frequently the best option since it allows
-the program to malloc as much memory as it needs it. The problem is
+the program to malloc as much memory as it needs. The problem is
 that the heap memory is pre-formatted for allocation with malloc():
 
 ```

--- a/doc/ZXSpectrumZSDCCnewlib_06_SomeDetails.md
+++ b/doc/ZXSpectrumZSDCCnewlib_06_SomeDetails.md
@@ -158,8 +158,8 @@ On the other hand, you can turn off the heap entirely with:
 The default heap size on Spectrum programs is set to -1, which is a special
 value which says "use all the memory above the program's BBS section and the
 below the stack for heap." This is frequently the best option since it allows
-the program to malloc as much memory as possible as it needs it. The problem is
-that the heap memory is formatted for allocation with malloc():
+the program to malloc as much memory as it needs it. The problem is
+that the heap memory is pre-formatted for allocation with malloc():
 
 ```
 |             |
@@ -183,7 +183,7 @@ that the heap memory is formatted for allocation with malloc():
 ```
 
 Normally that's fine, but if you've already loaded something else into that
-memory, having it initialised (e.g. reset to zeroes) in order to use as heap
+memory, having it reinitialised (e.g. reset to zeroes) in order to use as heap
 would be unwelcome. Specifically setting a heap size to zero (or, if you do
 actually need some heap, any other amount which leaves your valuable memory
 areas alone) stops this initialisation of memory. As we'll see in another

--- a/doc/ZXSpectrumZSDCCnewlib_07_BiFrost.md
+++ b/doc/ZXSpectrumZSDCCnewlib_07_BiFrost.md
@@ -22,9 +22,9 @@ If you would like to jump to the beginning, click on [installment 1](https://git
 
 ## Z88DK's BiFrost Library
 
-[BiFrost](http://www.worldofspectrum.org/infoseekid.cgi?id=0027405)
+[BiFrost](https://spectrumcomputing.co.uk/entry/27405/ZX-Spectrum/BIFROST*_ENGINE)
 is a multicolour graphics library written by
-[Einar Saukas](https://www.ime.usp.br/~einar/bifrost/), which has
+[Einar Saukas](https://spectrumcomputing.co.uk/list?label_id=1), which has
 been embedded into, and interfaced with, the Z88DK C development
 kit. "Multicolour" means it's capable of drawing blocks of pixels which are 8
 pixels wide by 1 pixel high, each with 2 colour attributes. This works much the
@@ -74,7 +74,8 @@ aligned to 8 pixel horizonal coordinates, at the expense of more memory
 consumption and greater CPU processing requirement over the low resolution
 version.
 
-BiFrost*2 is an improvement on the high resolution version of BiFrost. It can
+[BiFrost*2](https://spectrumcomputing.co.uk/entry/30003/ZX-Spectrum/BIFROST*2_ENGINE)
+is an improvement on the high resolution version of BiFrost. It can
 place a 16x16 pixel multicolour tile at any vertical pixel, on any 8 pixel
 horizontal boundary, and can do so within a 20x22 character grid. That's a
 160x176 pixel area of the screen.
@@ -130,7 +131,7 @@ PAPER in traditional Spectrum terms.
 The ctile data format is very simple: 32 bytes of bitmap data followed by 32
 bytes of attribute data. Even so, a graphical editor makes life a lot easier
 when designing tiles, and [ZX
-Paintbrush](http://www.zx-modules.de/zxpaintbrush/zxpaintbrush.html) supports
+Paintbrush](https://www.alessandrogrussu.it/zx-modules.html) supports
 them natively. Sadly, from a Linux user's perspective, this is a Windows-only
 tool. although it does appear to run under WINE.
 
@@ -188,7 +189,7 @@ bifrost_01.c:
 
 extern unsigned char ctiles[];
 
-int main()
+int main(void)
 {
   unsigned char blank_tile_index;
   unsigned char row, col;
@@ -205,7 +206,7 @@ int main()
     for(col = 1; col <= 17; col+=2)
       BIFROSTL_fillTileAttrL(row, col, INK_WHITE+PAPER_WHITE);
 
-  BIFROSTL_setTile(0, 0, 0+BIFROSTL_STATIC);
+  BIFROSTL_setTile(0, 0, (unsigned char)(0+BIFROSTL_STATIC));
 
   BIFROSTL_start();
 
@@ -250,13 +251,13 @@ return to BASIC BiFrost stops.)
 If you change the line:
 
 ```
-BIFROSTL_setTile(0, 0, 0+BIFROSTL_STATIC);
+BIFROSTL_setTile(0, 0, (unsigned char)(0+BIFROSTL_STATIC));
 ```
 
 to:
 
 ```
-BIFROSTL_setTile(1, 1, 0+BIFROSTL_STATIC);
+BIFROSTL_setTile(1, 1, (unsigned char)(0+BIFROSTL_STATIC));
 ```
 
 and rebuild, you'll see that the ball tile is now placed a complete tile's width
@@ -505,7 +506,7 @@ for the BiFrost high resolution library:
 
 extern unsigned char ctiles[];
 
-int main()
+int main(void)
 {
   unsigned char line, col;
 
@@ -519,7 +520,7 @@ int main()
     for(col = 0; col <= 18; col++)
       BIFROSTH_fillTileAttrH(line, col, INK_WHITE+PAPER_WHITE);
 
-  BIFROSTH_setTile(4, 4, 0+BIFROSTH_STATIC);
+  BIFROSTH_setTile(4, 4, (unsigned char)(0+BIFROSTH_STATIC));
 
   BIFROSTH_start();
 
@@ -560,7 +561,7 @@ The main difference is the screen location positioning. The set tile function wo
 same way as with the low resolution code:
 
 ```
-BIFROSTH_setTile(4, 4, 0+BIFROSTH_STATIC);
+BIFROSTH_setTile(4, 4, (unsigned char)(0+BIFROSTH_STATIC));
 ```
 
 This sets the centre tile's entry in the memory map containing the tiles to be
@@ -626,7 +627,7 @@ horizontally:
 
 extern unsigned char ctiles[];
 
-int main()
+int main(void)
 {
   unsigned char line, col;
 
@@ -723,7 +724,7 @@ Given this basic understanding of how Z88DK and BiFrost work together, the Z88DK
 BiFrost examples are the next logical step. They're
 [here](https://github.com/z88dk/z88dk/tree/master/libsrc/_DEVELOPMENT/EXAMPLES/zx).
 
-The [advanced tutorials](https://www.ime.usp.br/~einar/bifrost/), from the
+The [advanced tutorials](https://spectrumcomputing.co.uk/zxdb/sinclair/entries/0027405/BIFROSTENGINEV1.2.txt), from the
 BiFrost author, describe further possibilities, including animation and
 pre-shifted tiles for horizontal pixel level precision. The timing contraints of
 BiFrost need to be explored and understood before the library can be expertly

--- a/doc/ZXSpectrumZSDCCnewlib_08_Interrupts.md
+++ b/doc/ZXSpectrumZSDCCnewlib_08_Interrupts.md
@@ -44,7 +44,7 @@ generates the interrupt signal in sync with the TV picture it's generating, and
 it does so 50 times a second. This 50Hz signal is the Spectrum's interrupt, and
 it's this which we'll be using from Z88DK.
 
-The second key detail the reader needs to understand is concept of the
+The second key detail the reader needs to understand is the concept of the
 [interrupt mode 2](https://www.z88dk.org/wiki/doku.php?id=library:interrupts#im_2) "identifier
 byte supplied by the interrupting peripheral". On the Spectrum the interrupting
 peripheral, the video hardware, doesn't supply this identifier byte. It
@@ -238,7 +238,7 @@ IM2_DEFINE_ISR(isr)
 #define TABLE_ADDR             ((void*)(TABLE_HIGH_BYTE*UI_256))
 #define JUMP_POINT             ((unsigned char*)( (unsigned int)(JUMP_POINT_HIGH_BYTE*UI_256) + JUMP_POINT_HIGH_BYTE ))
 
-int main()
+int main(void)
 {
   memset( TABLE_ADDR, JUMP_POINT_HIGH_BYTE, 257 );
 
@@ -447,7 +447,7 @@ IM2_DEFINE_ISR_WITH_BASIC(isr)
 #define TABLE_ADDR             ((void*)(TABLE_HIGH_BYTE*UI_256))
 #define JUMP_POINT             ((unsigned char*)( (unsigned int)(JUMP_POINT_HIGH_BYTE*UI_256) + JUMP_POINT_HIGH_BYTE ))
 
-int main()
+int main(void)
 {
   /*
    * Initialise the ticker and its buffer

--- a/doc/ZXSpectrumZSDCCnewlib_GettingStartedGuide.md
+++ b/doc/ZXSpectrumZSDCCnewlib_GettingStartedGuide.md
@@ -46,4 +46,4 @@ the [Z88DK Sinclair ZX forum](https://www.z88dk.org/forum/viewforum.php?f=2).
 
 And of course, the [Programming Forum](https://spectrumcomputing.co.uk/forums/viewforum.php?f=6) at [Spectrum Computing](https://spectrumcomputing.co.uk/), where many of the best Spectrum developers are always ready to discuss everything to do with programming the ZX Spectrum.
 
-[Derek Fountain](http://www.derekfountain.org/), January, 2023
+[Derek Fountain](http://www.derekfountain.org/), October, 2024

--- a/doc/ZXSpectrumZSDCCnewlib_SP1_01_GettingStarted.md
+++ b/doc/ZXSpectrumZSDCCnewlib_SP1_01_GettingStarted.md
@@ -132,7 +132,7 @@ Save this listing to a file named 'circle.c':
 
 extern unsigned char circle[];
 
-int main()
+int main(void)
 {
   static struct sp1_Rect full_screen = {0, 0, 32, 24};
   struct sp1_ss  *circle_sprite;

--- a/doc/ZXSpectrumZSDCCnewlib_SP1_02_SimpleMaskedSprite.md
+++ b/doc/ZXSpectrumZSDCCnewlib_SP1_02_SimpleMaskedSprite.md
@@ -195,7 +195,7 @@ extern unsigned char circle_masked[];
 
 struct sp1_Rect full_screen = {0, 0, 32, 24};
 
-int main()
+int main(void)
 {
   struct sp1_ss  *circle_sprite;
   unsigned char x;
@@ -322,7 +322,7 @@ typedef struct
 
 CIRCLE_SPRITE circle_sprites[NUM_SPRITES];
 
-int main()
+int main(void)
 {
   unsigned char i;
 

--- a/doc/ZXSpectrumZSDCCnewlib_SP1_03_AnimatedSprite.md
+++ b/doc/ZXSpectrumZSDCCnewlib_SP1_03_AnimatedSprite.md
@@ -248,7 +248,7 @@ the next frame each time the sprite moves on screen. Our character runs from
 left to right, so we can move to the next frame each time he moves one pixel.
 
 An alternative approach might be to advance to the next frame each time a timer
-expires. This has the advantage that the sprite can be animated event when it's
+expires. This has the advantage that the sprite can be animated even when it's
 stationary, but it doesn't really work for our *runner* character. Another
 approach is to react to the user's input, which might be made to work with our
 *runner* as long as the user only ever presses the *right* key. :)
@@ -325,7 +325,7 @@ extern unsigned char runner_f1[];
 
 struct sp1_Rect full_screen = {0, 0, 32, 24};
 
-int main()
+int main(void)
 {
   struct sp1_ss  *runner_sprite;
   unsigned char   x;
@@ -477,7 +477,7 @@ struct
 arrow_state[] = { {IN_KEY_SCANCODE_o, arrow_left,  -1},
                   {IN_KEY_SCANCODE_p, arrow_right, +1} };
 
-int main()
+int main(void)
 {
   struct sp1_ss  *arrow_sprite;
 

--- a/doc/ZXSpectrumZSDCCnewlib_SP1_04_BiggerSprites.md
+++ b/doc/ZXSpectrumZSDCCnewlib_SP1_04_BiggerSprites.md
@@ -159,7 +159,7 @@ extern unsigned char bubble_col2[];
 
 struct sp1_Rect full_screen = {0, 0, 32, 24};
 
-int main()
+int main(void)
 {
   struct sp1_ss *bubble_sprite;
   unsigned char x;
@@ -219,7 +219,7 @@ the listing above, just achieved slightly differently.
 ### A Bigger Example
 
 Here's an example of a bigger *mothership* type of sprite, seen in [ZX
-Paintbrush](http://www.zx-modules.de/zxpaintbrush/zxpaintbrush.html) as graphic and mask:
+Paintbrush](https://www.alessandrogrussu.it/zx-modules.html) as graphic and mask:
 
 ![alt text](images/mothership.png "mothership sprite")
 
@@ -520,7 +520,7 @@ extern unsigned char mothership_col6[];
 
 struct sp1_Rect full_screen = {0, 0, 32, 24};
 
-int main()
+int main(void)
 {
   struct sp1_ss  *mothership_sprite;
   unsigned char x;
@@ -622,7 +622,7 @@ void initialiseColour(unsigned int count, struct sp1_cs *c)
   c->attr      = INK_BLUE;
 }
 
-int main()
+int main(void)
 {
   struct sp1_ss  *bubble_sprite;
   unsigned char x;
@@ -690,7 +690,6 @@ struct sp1_Rect full_screen = {0, 0, 32, 24};
 
 void initialiseColour(unsigned int count, struct sp1_cs *c)
 {
-
   if( count == 2 || count == 3 || count == 4 )
   {
     c->attr_mask = SP1_AMASK_INK;
@@ -717,7 +716,7 @@ void invalidateAntenna(unsigned int count, struct sp1_update *u)
 
 struct sp1_ss  *mothership_sprite;
 
-int main()
+int main(void)
 {
   unsigned char y;
 


### PR DESCRIPTION
I noticed that recent updates to sdcc have made it a bit more pedantic, and the example code in the ZX getting started guide now produces some (harmless) warnings.

I fixed the example code and took the opportunity to check all the documents, fixing a bit a link rot and one or two other things.