### PR TITLE
Fixed the problem of freezing when outputting line feeds to the console on MSX-DOS in Kanji display mode.

### DIFF
--- a/libsrc/target/msx/stdio/fputc_cons.asm
+++ b/libsrc/target/msx/stdio/fputc_cons.asm
@@ -45,6 +45,7 @@ fputc_cons_native:
     ld      a, 10
   ENDIF
 
+    ld      ix, CHPUT                   ; Print char
 nocrlf:
     cp      12                          ; CLS ?
     jr      nz, nocls


### PR DESCRIPTION
On MSX2+ or later models, start in MSX-DOS, use the BASIC command to start BASIC, then execute CALL KANJI to enter Kanji display mode. Then, when executing CALL SYSTEM to return to DOS and execute a program that outputs a newline to the console, it freezes.

When '\n' is output in fputc_cons_native, 0x0a and 0x0d are called twice in BIOS CHPUT by interslot call. fputc_cons_native sets the address of CHPUT in the IX register only before the first CHPUT. CHPUT does not change the IX register in ANK mode, but in Kanji display mode, the IX register is changed. Therefore, the second call to CHPUT will fail.

Before the second CHPUT, the address of the CHPUT is changed to set the address of the CHPUT in the IX register.