### PR TITLE
IDE integration support fixes.

### DIFF
--- a/src/ucpp/cpp.c
+++ b/src/ucpp/cpp.c
@@ -2462,7 +2462,6 @@ static int parse_opt(int argc, char *argv[], struct lexer_state *ls)
 		} else if (!strcmp(argv[i], "-Z")) {
 			no_special_macros = 1;
 		} else if (!strcmp(argv[i], "-d")) {
-			ls->flags &= ~KEEP_OUTPUT;
 			print_defs = 1;
 		} else if (!strcmp(argv[i], "-e")) {
 			ls->flags &= ~KEEP_OUTPUT;

--- a/src/ucpp/lexer.c
+++ b/src/ucpp/lexer.c
@@ -450,6 +450,8 @@ void flush_output(struct lexer_state *ls)
 }
 #endif
 
+static char nl_flag = 0;
+
 /*
  * Output one character; flush the buffer if needed.
  * This function should not be called, except by put_char().
@@ -467,6 +469,23 @@ static inline void write_char(struct lexer_state *ls, unsigned char c)
 #endif
 	if (c == '\n') {
 		ls->oline ++;
+	} else {
+		nl_flag = 0;
+	}
+}
+
+/*
+ * Output one character; flush the buffer if needed.
+ * This function should not be called, except by put_char().
+ */
+static inline void write_char_nl(struct lexer_state *ls)
+{
+	if (nl_flag) {
+		ls->oline ++;
+		return;
+	} else {
+		write_char(ls, '\n');
+		nl_flag = 1;
 	}
 }
 
@@ -809,7 +828,7 @@ static inline int read_token(struct lexer_state *ls)
 		shift_state = 0;
 	}
 	if (!(ls->flags & LEXER) && (ls->flags & KEEP_OUTPUT))
-		for (; ls->line > ls->oline;) put_char(ls, '\n');
+		for (; ls->line > ls->oline;) write_char_nl(ls);
 	do {
 		c = next_char(ls);
 		if (c < 0) {

--- a/src/ucpp/macro.c
+++ b/src/ucpp/macro.c
@@ -113,6 +113,28 @@ static inline int check_special_macro(char *name)
 int c99_compliant = 1;
 int c99_hosted = 1;
 
+static void define_static_macro(const char *name, const char *value)
+{
+	struct macro *m;
+
+#ifndef LOW_MEM
+	struct token t;
+#endif
+	m = new_macro();
+#ifdef LOW_MEM
+	m->cval.t = getmem(strlen(value) + 2);
+	m->cval.t[0] = NUMBER;
+	mmv(m->cval.t + 1, value, strlen(value) + 1);
+	m->cval.length = strlen(value) + 2;
+#else
+	t.type = NUMBER;
+	t.line = 0;
+	t.name = sdup(value);
+	aol(m->val.t, m->val.nt, t, TOKEN_LIST_MEMG);
+#endif
+	HTT_put(&macros, m, name);
+}
+
 /*
  * add the special macros to the macro table
  */
@@ -147,6 +169,9 @@ static void add_special_macros(void)
 #endif
 		HTT_put(&macros, m, "__STDC_VERSION__");
 	}
+
+	define_static_macro("__SIZEOF_SIZE_T__", "2");
+
 	if (c99_hosted) {
 #ifndef LOW_MEM
 		struct token t;

--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -382,6 +382,7 @@ static char  *c_altmathflags = NULL;        /* "-math-z88 -D__NATIVE_MATH__"; */
 static char  *c_startuplib = "z80_crt0";
 static char  *c_genmathlib = "genmath@{ZCC_LIBCPU}";
 static int    c_stylecpp = outspecified;
+static char  *c_swallow_mf = NULL;
 
 static char  *c_extension = NULL;
 static char  *c_assembler = NULL;
@@ -568,6 +569,9 @@ static option options[] = {
     { 0, "lstcwd", OPT_BOOL|OPT_DOUBLE_DASH,  "Paths in .lst files are relative to the current working dir" , &lstcwd, NULL, 0},
     { 0, "custom-copt-rules", OPT_STRING,  "Custom user copt rules" , &c_coptrules_user, NULL, 0},
     { 'M', NULL, OPT_BOOL|OPT_PRIVATE,  "Swallow -M option in configs" , &swallow_M, NULL, 0},
+    { 0, "MD", OPT_BOOL|OPT_PRIVATE,  "Ignore -MD" , &swallow_M, NULL, 0},
+    { 0, "MT", OPT_BOOL|OPT_PRIVATE,  "Ignore -MT" , &c_swallow_mf, NULL, 0},
+    { 0, "MF", OPT_STRING|OPT_PRIVATE,  "Ignore -MF" , &c_swallow_mf, NULL, 0},
     { 0, "vn", OPT_BOOL_FALSE|OPT_PRIVATE,  "Turn off command tracing" , &verbose, NULL, 0},
     { 0, "no-cleanup", OPT_BOOL_FALSE, "Don't cleanup temporary files", &cleanup, NULL, 0 },
     { 0, "", 0, NULL },
@@ -768,8 +772,8 @@ int process(char *suffix, char *nextsuffix, char *processor, char *extraargs, en
     }
 
     if (verbose) {
-        printf("%s\n", buffer);
-        fflush(stdout);
+        fprintf(stderr, "%s\n", buffer);
+        fflush(stderr);
     }
 
     status = system(buffer);


### PR DESCRIPTION
Currently, CLion (and maybe other) IDE fails to properly recognize z88dk CMake projects, lile [z88dk-gdb-ide-test](https://github.com/speccytools/z88dk-gdb-ide-test), because for several reasons:

- z88dk-ucpp generates like 1000 of empty lines on the preprocessing output for no reason: CLion C Preprocessor (called ReSharper) fails with stack-overflow because of the way it parses regular expressions. So I modified uccp to no produce those empty lines. See the bottom to explanation.
- zcc's `+<x>` command line option interferes with basic CMake self-identification. So I added an exception when `CMakeCCompilerId.c` w/ no `+<x>` is called, to assume `zx`.
- Ignore `-MD`, `-MT` and `-MF` w/o error.
- Verbosity for zcc decreced, unless `-vv` is added. It is interferes with post-processing: basially CLion stops respecting defines that compiler generates (like `SPECTRUM` for zx), because of `PROCESSING ...` which gcc does NOT log with verbosity enabled.

EXPLANATION

CLion feed ucpp the following file for preprocessing to observe preprocessor abilities.

```
void ____CIDR_command() {
#define ___CIDR_FEATURES_START
#if defined(__STDC_VERSION__)
{ int __attribute__ ((unused)) ____CIDR_command_SET_LANGUAGE_STANDARD, ____CIDR_command_STANDARD_C = ((void) __STDC_VERSION__, 0); }
#endif
#if defined(__cplusplus)
{ int __attribute__ ((unused)) ____CIDR_command_SET_LANGUAGE_STANDARD, ____CIDR_command_STANDARD_CPP = ((void) __cplusplus, 0); }
#endif
#ifdef __FILE_NAME__
{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_macro__FILE_NAME__ = ((void) "_file_name_short_", 0); }
#endif
#if defined(__has_builtin)
#define __CIDR_HELPER_DEFINE_0
#endif
#if defined(__CIDR_HELPER_DEFINE_0)
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_BUILTIN = ((void) 1, 0); }
#else
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_BUILTIN = ((void) 0, 0); }
#endif
#if defined(__has_feature)
#define __CIDR_HELPER_DEFINE_1
#endif

... and it goes on
```

ucpp produces the following

```
void ____CIDR_command() {

{ int __attribute__ ((unused)) ____CIDR_command_SET_LANGUAGE_STANDARD, ____CIDR_command_STANDARD_C = ((void)  201710L , 0); }






{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_include = ((void) 0, 0); }



{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_include_next = ((void) 0, 0); }



{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_cpp_attribute = ((void) 0, 0); }



{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_VARIABLE_DECLARATION_RULES_ARE_C89_COMPATIBLE = ((void) 0, 0); }










<2000 of empty lines which crashes CLion>
```