### PR TITLE
zsdcc __nonbanked section

### DIFF
--- a/lib/crt/classic/crt_section_code.inc
+++ b/lib/crt/classic/crt_section_code.inc
@@ -16,6 +16,7 @@ IF !__crt_org_far
 ENDIF
     SECTION code_z80
     SECTION rodata_driver       ;Keep it in low memoey
+    SECTION code_home
     SECTION code_compiler
     SECTION code_clib
     SECTION code_compress_zx7

--- a/libsrc/_DEVELOPMENT/sdcc_opt.1
+++ b/libsrc/_DEVELOPMENT/sdcc_opt.1
@@ -317,7 +317,7 @@
 
 %"[ \t]*"0.%"(AREA|area)"9%"[ \t]+"1_HOME
 =
-%0SECTION%1IGNORE
+%0SECTION%1code_home
 
 %"[ \t]*"0.%"(AREA|area)"9%"[ \t]+"1_CABS (ABS)
 =

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.bak
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.bak
@@ -35,6 +35,7 @@ section code_font
 section code_clib
   include "../../clib_code.inc"
 section code_lib
+section code_home
 section code_compiler
 section code_user
 

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.inc
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z180.inc
@@ -35,6 +35,7 @@ section code_font
 section code_clib
   include "../../clib_code.inc"
 section code_lib
+section code_home
 section code_compiler
 section code_user
 

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.bak
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.bak
@@ -35,6 +35,7 @@ section code_font
 section code_clib
   include "../../clib_code.inc"
 section code_lib
+section code_home
 section code_compiler
 section code_user
 

--- a/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.inc
+++ b/libsrc/_DEVELOPMENT/target/crt_memory_model_z80.inc
@@ -35,6 +35,7 @@ section code_font
 section code_clib
   include "../../clib_code.inc"
 section code_lib
+section code_home
 section code_compiler
 section code_user
 

--- a/libsrc/_DEVELOPMENT/target/zx/crt_memory_model_dotx.inc
+++ b/libsrc/_DEVELOPMENT/target/zx/crt_memory_model_dotx.inc
@@ -124,6 +124,7 @@ section code_threads
 section code_threads_mutex
 
 section code_lib
+section code_home
 section code_compiler
 section code_user
 

--- a/libsrc/_DEVELOPMENT/target/zxn/crt_memory_model_dotn.inc
+++ b/libsrc/_DEVELOPMENT/target/zxn/crt_memory_model_dotn.inc
@@ -155,6 +155,7 @@ section code_SMSlib
 section code_temp_sp1
 
 section code_lib
+section code_home
 section code_compiler
 section code_user
 

--- a/libsrc/_DEVELOPMENT/target/zxn/crt_memory_model_dotx.inc
+++ b/libsrc/_DEVELOPMENT/target/zxn/crt_memory_model_dotx.inc
@@ -124,6 +124,7 @@ section code_threads
 section code_threads_mutex
 
 section code_lib
+section code_home
 section code_compiler
 section code_user
 


### PR DESCRIPTION
A partial resolution for #2660.

Adds the section `code_home`, which is used where the function declaration `__nonbanked` is provided to zsdcc.