### PR TITLE
(z80asm) The Rabbits lack rst 0, 8 and 0x30

### DIFF
--- a/src/z80asm/dev/cpu/cpu_test_r2ka_err.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r2ka_err.asm
@@ -13002,6 +13002,8 @@
  rrd (zhl)                      ; Error
  rsmix                          ; Error
  rst -1                         ; Error
+ rst 0                          ; Error
+ rst 1                          ; Error
  rst 10                         ; Error
  rst 11                         ; Error
  rst 12                         ; Error
@@ -13036,6 +13038,7 @@
  rst 45                         ; Error
  rst 46                         ; Error
  rst 47                         ; Error
+ rst 48                         ; Error
  rst 49                         ; Error
  rst 50                         ; Error
  rst 51                         ; Error
@@ -13046,11 +13049,13 @@
  rst 57                         ; Error
  rst 58                         ; Error
  rst 59                         ; Error
+ rst 6                          ; Error
  rst 60                         ; Error
  rst 61                         ; Error
  rst 62                         ; Error
  rst 63                         ; Error
  rst 64                         ; Error
+ rst 8                          ; Error
  rst 9                          ; Error
  rst v, 63                      ; Error
  rst v, 64                      ; Error

--- a/src/z80asm/dev/cpu/cpu_test_r2ka_ixiy_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r2ka_ixiy_ok.asm
@@ -7273,8 +7273,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -7282,12 +7280,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rv                             ; E8
  rz                             ; C8
  sbb a                          ; 9F

--- a/src/z80asm/dev/cpu/cpu_test_r2ka_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r2ka_ok.asm
@@ -7273,8 +7273,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -7282,12 +7280,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rv                             ; E8
  rz                             ; C8
  sbb a                          ; 9F

--- a/src/z80asm/dev/cpu/cpu_test_r3k_err.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r3k_err.asm
@@ -12980,6 +12980,8 @@
  rrd (zhl)                      ; Error
  rsmix                          ; Error
  rst -1                         ; Error
+ rst 0                          ; Error
+ rst 1                          ; Error
  rst 10                         ; Error
  rst 11                         ; Error
  rst 12                         ; Error
@@ -13014,6 +13016,7 @@
  rst 45                         ; Error
  rst 46                         ; Error
  rst 47                         ; Error
+ rst 48                         ; Error
  rst 49                         ; Error
  rst 50                         ; Error
  rst 51                         ; Error
@@ -13024,11 +13027,13 @@
  rst 57                         ; Error
  rst 58                         ; Error
  rst 59                         ; Error
+ rst 6                          ; Error
  rst 60                         ; Error
  rst 61                         ; Error
  rst 62                         ; Error
  rst 63                         ; Error
  rst 64                         ; Error
+ rst 8                          ; Error
  rst 9                          ; Error
  rst v, 63                      ; Error
  rst v, 64                      ; Error

--- a/src/z80asm/dev/cpu/cpu_test_r3k_ixiy_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r3k_ixiy_ok.asm
@@ -7295,8 +7295,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -7304,12 +7302,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rv                             ; E8
  rz                             ; C8
  sbb a                          ; 9F

--- a/src/z80asm/dev/cpu/cpu_test_r3k_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r3k_ok.asm
@@ -7295,8 +7295,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -7304,12 +7302,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rv                             ; E8
  rz                             ; C8
  sbb a                          ; 9F

--- a/src/z80asm/dev/cpu/cpu_test_r4k_err.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r4k_err.asm
@@ -10939,6 +10939,8 @@
  rrd (zhl)                      ; Error
  rsmix                          ; Error
  rst -1                         ; Error
+ rst 0                          ; Error
+ rst 1                          ; Error
  rst 10                         ; Error
  rst 11                         ; Error
  rst 12                         ; Error
@@ -10973,6 +10975,7 @@
  rst 45                         ; Error
  rst 46                         ; Error
  rst 47                         ; Error
+ rst 48                         ; Error
  rst 49                         ; Error
  rst 50                         ; Error
  rst 51                         ; Error
@@ -10983,11 +10986,13 @@
  rst 57                         ; Error
  rst 58                         ; Error
  rst 59                         ; Error
+ rst 6                          ; Error
  rst 60                         ; Error
  rst 61                         ; Error
  rst 62                         ; Error
  rst 63                         ; Error
  rst 64                         ; Error
+ rst 8                          ; Error
  rst 9                          ; Error
  rst v, 63                      ; Error
  rst v, 64                      ; Error

--- a/src/z80asm/dev/cpu/cpu_test_r4k_ixiy_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r4k_ixiy_ok.asm
@@ -9344,8 +9344,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -9353,12 +9351,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rz                             ; C8
  sbb a                          ; 7F 9F
  sbb b                          ; 7F 98

--- a/src/z80asm/dev/cpu/cpu_test_r4k_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r4k_ok.asm
@@ -9344,8 +9344,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -9353,12 +9351,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rz                             ; C8
  sbb a                          ; 7F 9F
  sbb b                          ; 7F 98

--- a/src/z80asm/dev/cpu/cpu_test_r5k_err.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r5k_err.asm
@@ -10939,6 +10939,8 @@
  rrd (zhl)                      ; Error
  rsmix                          ; Error
  rst -1                         ; Error
+ rst 0                          ; Error
+ rst 1                          ; Error
  rst 10                         ; Error
  rst 11                         ; Error
  rst 12                         ; Error
@@ -10973,6 +10975,7 @@
  rst 45                         ; Error
  rst 46                         ; Error
  rst 47                         ; Error
+ rst 48                         ; Error
  rst 49                         ; Error
  rst 50                         ; Error
  rst 51                         ; Error
@@ -10983,11 +10986,13 @@
  rst 57                         ; Error
  rst 58                         ; Error
  rst 59                         ; Error
+ rst 6                          ; Error
  rst 60                         ; Error
  rst 61                         ; Error
  rst 62                         ; Error
  rst 63                         ; Error
  rst 64                         ; Error
+ rst 8                          ; Error
  rst 9                          ; Error
  rst v, 63                      ; Error
  rst v, 64                      ; Error

--- a/src/z80asm/dev/cpu/cpu_test_r5k_ixiy_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r5k_ixiy_ok.asm
@@ -9344,8 +9344,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -9353,12 +9351,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rz                             ; C8
  sbb a                          ; 7F 9F
  sbb b                          ; 7F 98

--- a/src/z80asm/dev/cpu/cpu_test_r5k_ok.asm
+++ b/src/z80asm/dev/cpu/cpu_test_r5k_ok.asm
@@ -9344,8 +9344,6 @@
  rrca'                          ; 76 0F
  rrd                            ; CD @__z80asm__rrd
  rrhl                           ; CB 2C CB 1D
- rst 0                          ; CD 00 00
- rst 1                          ; CD 08 00
  rst 16                         ; D7
  rst 2                          ; D7
  rst 24                         ; DF
@@ -9353,12 +9351,9 @@
  rst 32                         ; E7
  rst 4                          ; E7
  rst 40                         ; EF
- rst 48                         ; CD 30 00
  rst 5                          ; EF
  rst 56                         ; FF
- rst 6                          ; CD 30 00
  rst 7                          ; FF
- rst 8                          ; CD 08 00
  rz                             ; C8
  sbb a                          ; 7F 9F
  sbb b                          ; 7F 98

--- a/src/z80asm/dev/cpu/dump_opcodes.pl
+++ b/src/z80asm/dev/cpu/dump_opcodes.pl
@@ -47,9 +47,9 @@ sub expand_consts {
 				my @range = find_range($asm, $cpu, @ops);
 				for my $c (@range) {
 					my($asm1, @ops1) = replace_const($c, $asm, @ops);
-					if ($asm =~ /^rst/ && $cpu =~ /^r2ka|^r3k/ && 
+					if ($asm =~ /^rst/ && $cpu =~ /^r\dk/ && 
 					    ($c == 0 || $c == 8 || $c == 0x30)) {
-						$opcodes_out{$asm1}{$cpu} = [[0xCD, $c, 0]];
+						# no RST 0, 8, 0x30 on Rabbits
 					}
 					else {    
 						$opcodes_out{$asm1}{$cpu} = \@ops1;

--- a/src/z80asm/dev/cpu/make_cpu_test.pl
+++ b/src/z80asm/dev/cpu/make_cpu_test.pl
@@ -115,10 +115,11 @@ sub add {
 			
 			# rabit lacks these restarts
 			if ($cpu =~ /^r2ka|^r3k|^r4k|^r5k/ && ($c==0 || $c==8 || $c==0x30)) {	
-				$bytes1 = sprintf("CD %02X 00", $c);
+				# Rabbits lack these restarts
 			}
-			
-			add($cpu, $asm1, $bytes1);
+			else {
+				add($cpu, $asm1, $bytes1);
+			}
 		}
 		
 		# create error cases

--- a/src/z80asm/dev/z80asm_lib/t/call_dd.t
+++ b/src/z80asm/dev/z80asm_lib/t/call_dd.t
@@ -25,7 +25,7 @@ for my $cpu (@CPUS) {
 					ld a, 0
 					ld $dd, r1
 					call ($dd)
-					rst 0
+					jp 0
 					
 				r1:	inc a
 					ret

--- a/src/z80asm/dev/z80asm_lib/t/clr.t
+++ b/src/z80asm/dev/z80asm_lib/t/clr.t
@@ -28,7 +28,7 @@ for my $cpu (@CPUS) {
 				ENDIF			
 					ld $reg, -1
 					clr $reg
-					rst 0
+					jp 0
 END
 				is $r->{$dd}, 0, "$dd result";
 				

--- a/src/z80asm/dev/z80asm_lib/t/daa_brute_force.t
+++ b/src/z80asm/dev/z80asm_lib/t/daa_brute_force.t
@@ -60,7 +60,7 @@ for my $cpu (@CPUS) {
 			}
 		}
 
-		push @asm, "rst 0";
+		push @asm, "jp 0";
 		my $r = ticks(join("\n", @asm), "-m$cpu");
 		my $data = 0;
 		for (@in) {

--- a/src/z80asm/dev/z80asm_lib/t/test_faster_loops.t
+++ b/src/z80asm/dev/z80asm_lib/t/test_faster_loops.t
@@ -65,7 +65,7 @@ loop:
 		ld		a, b
 		or		c
 		jr 		nz, loop
-		rst 0
+		jp 0
 END
 
 path("$test-new.asm")->spew(<<'END');
@@ -85,7 +85,7 @@ loop:
 		dec 	c       
 		jr 		nz,loop 
 		djnz    loop 
-		rst 0
+		jp 0
 END
 
 my %data;

--- a/src/z80asm/src/c/opcodes.c
+++ b/src/z80asm/src/c/opcodes.c
@@ -289,13 +289,14 @@ void add_rst_opcode(int arg) {
     case 0x00: case 0x08: case 0x30:
         if (option_cpu() == CPU_R2KA || option_cpu() == CPU_R3K ||
             option_cpu() == CPU_R4K || option_cpu() == CPU_R5K)
-            add_opcode(0xCD0000 + (arg << 8));
+            error_hex2(ErrIntRange, arg);
         else
             add_opcode(0xC7 + arg);
         break;
     case 0x10: case 0x18: case 0x20: case 0x28: case 0x38:
         add_opcode(0xC7 + arg); break;
-    default: error_hex2(ErrIntRange, arg);
+    default:
+        error_hex2(ErrIntRange, arg);
     }
 }
 

--- a/src/z80asm/t/issue_2670.t
+++ b/src/z80asm/t/issue_2670.t
@@ -1,0 +1,35 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+
+for my $rst (0, 8, 0x30) {
+	my $rst_hex = ($rst < 10) ? $rst : sprintf("\$%02X", $rst);
+	spew("$test.asm", <<END);
+rst $rst
+END
+
+	for my $cpu ('r2ka', 'r3k', 'r4k', 'r5k') {
+		capture_nok("z88dk-z80asm -m$cpu -l -b $test.asm", <<END);
+$test.asm:1: error: integer range: $rst_hex
+  ^---- rst $rst
+END
+	}
+}
+
+for my $rst (0x10, 0x18, 0x20, 0x28, 0x38) {
+	spew("$test.asm", <<END);
+		rst $rst
+END
+
+	for my $cpu ('r2ka', 'r3k', 'r4k', 'r5k') {
+		capture_ok("z88dk-z80asm -m$cpu -l -b $test.asm", "");
+		check_bin_file("$test.bin", bytes(0xC7+$rst));
+	}
+}
+
+unlink_testfiles;
+done_testing;
+
+


### PR DESCRIPTION
The assembler was assembling a call instruction for r2ka and r3k and a wrong z80 restart opcode for r4k and r5k.

Now all the Rabbits issue an integer range error if rst is called with 0, 8 or 0x30.
