### PR TITLE
[WIP] Agon light MOS 3 alpha api

### DIFF
--- a/lib/target/agon/def/mos_api.inc
+++ b/lib/target/agon/def/mos_api.inc
@@ -21,6 +21,10 @@
 ; 13/04/2023:	Added FatFS file structures (FFOBJID, FIL, DIR, FILINFO)
 ; 15/04/2023:	Added mos_getfil, mos_fread, mos_fwrite and mos_flseek
 ; 19/05/2023:	Added sysvar_scrMode
+; 05/06/2023:	Added sysvar_rtcEnable
+; 03/08/2023:	Added mos_setkbvector
+; 10/08/2023:	Added mos_getkbmap
+; 11/11/2023:	Added mos_i2c_open, mos_i2c_close, mos_i2c_write and mos_i2c_read
 
 ; VDP control (VDU 23, 0, n)
 ;
@@ -67,6 +71,40 @@ mos_getfil:		EQU	19h
 mos_fread:		EQU	1Ah
 mos_fwrite:		EQU	1Bh
 mos_flseek:		EQU	1Ch
+mos_setkbvector:	EQU	1Dh
+mos_getkbmap:		EQU	1Eh
+mos_i2c_open:		EQU	1Fh
+mos_i2c_close:		EQU	20h
+mos_i2c_write:		EQU	21h
+mos_i2c_read:		EQU	22h
+mos_unpackrtc:		EQU	23h
+
+; MOS string functions
+;
+mos_pmatch:		EQU	28h
+mos_getargument:	EQU	29h
+mos_extractstring:	EQU	2Ah
+mos_extractnumber:	EQU	2Bh
+mos_escapestring:	EQU	2Ch
+
+; System variables and related functions
+;
+mos_setvarval:		EQU	30h
+mos_readvarval:		EQU	31h
+mos_gsinit:		EQU	32h
+mos_gsread:		EQU	33h
+mos_gstrans:		EQU	34h
+mos_substituteargs:	EQU	35h
+mos_evaluateexpression:	EQU	36h	; not implemented, yet
+; 37h not yet used
+
+; Path resolution functions
+;
+mos_resolvepath:	EQU	38h
+mos_getdirforpath:	EQU	39h
+mos_getleafname:	EQU	3Ah
+mos_isdirectory:	EQU	3Bh
+mos_getabsolutepath:	EQU	3Ch
 
 ; FatFS file access functions
 ;
@@ -148,13 +186,22 @@ sysvar_scrRows:		EQU	14h	; 1: Screen rows in characters
 sysvar_scrColours:	EQU	15h	; 1: Number of colours displayed
 sysvar_scrpixelIndex:	EQU	16h	; 1: Index of pixel data read from screen
 sysvar_vkeycode:	EQU	17h	; 1: Virtual key code from FabGL
-sysvar_vkeydown		EQU	18h	; 1: Virtual key state from FabGL (0=up, 1=down)
+sysvar_vkeydown:	EQU	18h	; 1: Virtual key state from FabGL (0=up, 1=down)
 sysvar_vkeycount:	EQU	19h	; 1: Incremented every time a key packet is received
-sysvar_rtc:		EQU	1Ah	; 8: Real time clock data
+sysvar_rtc:		EQU	1Ah	; 6: Real time clock data
+sysvar_spare:		EQU	20h	; 2: Spare, previously used by rtc
 sysvar_keydelay:	EQU	22h	; 2: Keyboard repeat delay
 sysvar_keyrate:		EQU	24h	; 2: Keyboard repeat reat
 sysvar_keyled:		EQU	26h	; 1: Keyboard LED status
 sysvar_scrMode:		EQU	27h	; 1: Screen mode
+sysvar_rtcEnable:	EQU	28h	; 1: RTC enable flag (0: disabled, 1: use ESP32 RTC)
+sysvar_mouseX:		EQU	29h	; 2: Mouse X position
+sysvar_mouseY:		EQU	2Bh	; 2: Mouse Y position
+sysvar_mouseButtons:	EQU	2Dh	; 1: Mouse button state
+sysvar_mouseWheel:	EQU	2Eh	; 1: Mouse wheel delta
+sysvar_mouseXDelta:	EQU	2Fh	; 2: Mouse X delta
+sysvar_mouseYDelta:	EQU	31h	; 2: Mouse Y delta
+sysvar_gp:		EQU	37h	; 1: General poll packet data
 	
 ; Flags for the VPD protocol
 ;
@@ -164,6 +211,8 @@ vdp_pflag_point:	EQU	00000100b
 vdp_pflag_audio:	EQU	00001000b
 vdp_pflag_mode:		EQU	00010000b
 vdp_pflag_rtc:		EQU	00100000b
+vdp_pflag_mouse:	EQU	01000000b
+; vdp_pflag_buffered:	EQU	10000000b
 
 MACRO MOSCALL func
     ld   a,func


### PR DESCRIPTION
This are small changes taken from the agon-mos 3 alpha 2 [PR](https://github.com/AgonConsole8/agon-mos/pull/123)

> Whilst APIs were added in MOS 3 alpha 2 to expose new underlying functionality, unfortunately some mistakes were made in their creation. A notable flaw was the use of the A register as an API parameter - it isn't actually possible to use the A register as that is used to specify which API call is being made with RST 8.
>
>This PR aims to address that by changing the APIs to use different registers.
>
>There may also be a few enhancements too, such as the addition of a flag byte to the "unpack RTC" API to control whether/how an RTC refresh call will be made to the VDP.

I placed the WIP tag because some parts are not well tested


Thanks to @stevesims
