### PR TITLE
(ticks) Handle f register according to hardware

### DIFF
--- a/libsrc/math/daimath32/c/sccz80/l_f32_swap.asm
+++ b/libsrc/math/daimath32/c/sccz80/l_f32_swap.asm
@@ -8,7 +8,7 @@
 ;        defw left hand LSW
 ;        defw left hand MSW
 l_f32_swap:
-IF  __CPU_INTEL__||CPU_GBZ80__
+IF  __CPU_INTEL__||__CPU_GBZ80__
     ld      c, l                        ;right lsw
     ld      b, h
     ld      hl, sp+2                    ;points to left hand lsw

--- a/libsrc/math/mbf32/c/sccz80/l_f32_swap.asm
+++ b/libsrc/math/mbf32/c/sccz80/l_f32_swap.asm
@@ -8,7 +8,7 @@
 ;        defw left hand LSW
 ;        defw left hand MSW
 l_f32_swap:
-IF  __CPU_INTEL__||CPU_GBZ80__
+IF  __CPU_INTEL__| __CPU_GBZ80__
     ld      c, l                        ;right lsw
     ld      b, h
     ld      hl, sp+2                    ;points to left hand lsw

--- a/libsrc/stdlib/l_bsearch.asm
+++ b/libsrc/stdlib/l_bsearch.asm
@@ -1,5 +1,5 @@
 ; CALLER linkage for function pointers
-
+IF !__CPU_INTEL__ && !__CPU_GBZ80__
     SECTION code_clib
     PUBLIC  l_bsearch
     PUBLIC  _l_bsearch
@@ -25,3 +25,4 @@ _l_bsearch:
     push    af
 
     jp      asm_l_bsearch
+ENDIF

--- a/libsrc/stdlib/l_bsearch_callee.asm
+++ b/libsrc/stdlib/l_bsearch_callee.asm
@@ -1,6 +1,6 @@
 ; void __CALLEE__ *l_bsearch_callee(void *key, void *base, unsigned int n, void *cmp)
 ; 01.2007 aralbrec
-
+IF !__CPU_GBZ80__ && !__CPU_INTEL__ 
     SECTION code_clib
     PUBLIC  l_bsearch_callee
     PUBLIC  _l_bsearch_callee
@@ -45,4 +45,5 @@ compare:
     pop     bc
     pop     de
     ret
+ENDIF
 

--- a/src/ticks/debugger.c
+++ b/src/ticks/debugger.c
@@ -15,6 +15,7 @@
 #endif
 
 #include "debugger.h"
+#include "cpu.h"
 #include "utlist.h"
 
 #include "disassembler.h"
@@ -1497,7 +1498,13 @@ static int cmd_registers(int argc, char **argv)
             FNT_CLR "[sp]" FNT_RST "$" FNT_BLD "%04X" FNT_RST "\n",
 
             bk.f()  | regs.a << 8,  regs.c  | regs.b  << 8, regs.e  | regs.d  << 8, regs.l  | regs.h  << 8, regs.xl | regs.xh << 8,
-            (bk.f()  & 0x80) ? 1 : 0, (bk.f()  & 0x40) ? 1 : 0, (bk.f()  & 0x10) ? 1 : 0, (bk.f()  & 0x04) ? 1 : 0, (bk.f()  & 0x02) ? 1 : 0, (bk.f()  & 0x01) ? 1 : 0,
+            (isgbz80() ? 0 : (bk.f()  & 0x80)) ? 1 : 0, // S: flag
+            (bk.f() & (isgbz80() ? 0x80 : 0x40)) ? 1 : 0,  // Z: flag
+            (bk.f()  & (isgbz80() ? 0x20 : 0x10)) ? 1 : 0, // H  flag
+            (isgbz80() ? 0 : (bk.f()  & 0x04)) ? 1 : 0, // P/V
+            (bk.f()  & (isgbz80() ? 0x40 : 0x02)) ? 1 : 0,  // N
+            (bk.f()  & (isgbz80() ? 0x10 : 0x01)) ? 1 : 0,  // C
+  
 
             bk.f_() | regs.a_ << 8, regs.c_ | regs.b_ << 8, regs.e_ | regs.d_ << 8, regs.l_ | regs.h_ << 8, regs.yl | regs.yh << 8,
 
@@ -1516,8 +1523,15 @@ static int cmd_registers(int argc, char **argv)
                "f: S=%d Z=%d H=%d P/V=%d N=%d C=%d (8085: K=%d)\n",
                pc, bk.get_memory(pc, MEM_TYPE_INST), regs.c | regs.b << 8, regs.e | regs.d << 8, regs.l | regs.h << 8, bk.f() | regs.a << 8, regs.xl | regs.xh << 8, regs.yl | regs.yh << 8,
                sp, (bk.get_memory(sp+1, MEM_TYPE_DATA) << 8 | bk.get_memory(sp, MEM_TYPE_DATA)), regs.c_ | regs.b_ << 8, regs.e_ | regs.d_ << 8, regs.l_ | regs.h_ << 8, bk.f_() | regs.a_ << 8,
-               (bk.f() & 0x80) ? 1 : 0, (bk.f() & 0x40) ? 1 : 0, (bk.f() & 0x10) ? 1 : 0, (bk.f() & 0x04) ? 1 : 0, (bk.f() & 0x02) ? 1 : 0, (bk.f() & 0x01) ? 1 : 0, (bk.f() & 0x20) ? 1 : 0);
 
+            (isgbz80() ? 0 : (bk.f()  & 0x80)) ? 1 : 0, // S: flag
+            (bk.f() & (isgbz80() ? 0x80 : 0x40)) ? 1 : 0,  // Z: flag
+            (bk.f()  & (isgbz80() ? 0x20 : 0x10)) ? 1 : 0, // H  flag
+            (isgbz80() ? 0 : (bk.f()  & 0x04)) ? 1 : 0, // P/V
+            (bk.f()  & (isgbz80() ? 0x40 : 0x02)) ? 1 : 0,  // N
+            (bk.f()  & (isgbz80() ? 0x10 : 0x01)) ? 1 : 0,  // C
+            (!is8085() ? 0  : (bk.f() & 0x20 )) ? 1 : 0 // K (8085)
+        );
         if (regs.clockh || regs.clockl)
         {
             bk.console("clockh=%04X, clockhl=%04X\n", regs.clockh, regs.clockl);

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -840,7 +840,7 @@ int f(void){
             | pv            // bit 2 parity
             | pv >> 1       // bit 1 v (cheat)
             ;
-    } else if ( is8080() ) {
+    } else if ( is8080() && !c_z80asm_tests ) {
         // bit 0 = carry
         // bit 1 = 1
         // bit 2 = P/V
@@ -849,16 +849,16 @@ int f(void){
         // bit 5 = 0
         // bit 6 = Z
         // bit 7 = S sign flag
-      return  ff & 128  // S bit 7
-            | 0x02      // bit 1 always set
-            | ff >> 8 & 1 // C bit 0, so value 256
-            | !fr << 6    // Z, bit 6
-            | (fr ^ fa ^ fb ^ fb >> 8) & 16 // H (half carry) bit 4
-            | (fa & -256
-                ? 154020 >> ((fr ^ fr >> 4) & 15)
-                : ((fr ^ fa) & (fr ^ fb)) >> 5) & 4; // P/V bit 2
-                ;
-    } else if ( isgbz80() ) {
+        return  ff & 128  // S bit 7
+                | 0x02      // bit 1 always set
+                | ff >> 8 & 1 // C bit 0, so value 256
+                | !fr << 6    // Z, bit 6
+                | (fr ^ fa ^ fb ^ fb >> 8) & 16 // H (half carry) bit 4
+                | (fa & -256
+                    ? 154020 >> ((fr ^ fr >> 4) & 15)
+                    : ((fr ^ fa) & (fr ^ fb)) >> 5) & 4; // P/V bit 2
+                    ;
+    } else if ( isgbz80() && !c_z80asm_tests  ) {
         // bit 0 = 0 
         // bit 1 = 0 
         // bit 2 = 0
@@ -867,7 +867,7 @@ int f(void){
         // bit 5 = flag h  0x20
         // bit 6 = flag n  0x40
         // bit 7 = zero    0x80
-        return (ff >> 4) & 0x10  // carry
+        return ((ff >> 4) & 0x10)  // carry
                 | ((fr ^ fa ^ fb ^ fb >> 8) & 16) << 1 // H 
                 | (fb >> 8 & 2) << 5  // N
                 | (!fr << 7);
@@ -880,15 +880,15 @@ int f(void){
         // bit 5 = copy of A
         // bit 6 = Z
         // bit 7 = S sign flag
-      return  ff & 168  // S, 5, 3: bits 7, 5, 3
-            | ff >> 8 & 1 // C bit 0, so value 256
-            | !fr << 6    // Z, bit 6
-            | fb >> 8 & 2 // N (subtract flag) bit 1, value 512
-            | (fr ^ fa ^ fb ^ fb >> 8) & 16 // H (half carry) bit 4
-            | (fa & -256
-                ? 154020 >> ((fr ^ fr >> 4) & 15)
-                : ((fr ^ fa) & (fr ^ fb)) >> 5) & 4; // P/V bit 2
-                ;
+        return  ff & 168  // S, 5, 3: bits 7, 5, 3
+                | ff >> 8 & 1 // C bit 0, so value 256
+                | !fr << 6    // Z, bit 6
+                | fb >> 8 & 2 // N (subtract flag) bit 1, value 512
+                | (fr ^ fa ^ fb ^ fb >> 8) & 16 // H (half carry) bit 4
+                | (fa & -256
+                    ? 154020 >> ((fr ^ fr >> 4) & 15)
+                    : ((fr ^ fa) & (fr ^ fb)) >> 5) & 4; // P/V bit 2
+                    ;
     }
 }
 
@@ -904,7 +904,7 @@ int f_(void){
 }
 
 void setf(int a){
-    if ( isgbz80() ) {
+    if ( isgbz80() && !c_z80asm_tests ) {
         // Rearrange the flag to match z80
         // bit 0 = 0 
         // bit 1 = 0 
@@ -2724,9 +2724,11 @@ void cpu_run(long long counter, long long stint, int intr, int start, int end)
 
             // 8080: S Z 0 AC 0 P 1 C
             // 8085: S Z K AC 0 P V C
+            #if 0
             if ( is8085() ) { flags &= 0xf7; }
-            else if ( is8080() ) { flags |= 2; flags &= 0xd7; }
-            else if ( isgbz80() ) { flags &= 0xf0; }
+            else if ( is8080() && !c_z80asm_tests ) { flags |= 2; flags &= 0xd7; }
+            else if ( isgbz80() && !c_z80asm_tests ) { flags &= 0xf0; }
+            #endif
 
             setf(flags);
             a= get_memory_data(sp++);

--- a/src/ticks/ticks.c
+++ b/src/ticks/ticks.c
@@ -867,7 +867,7 @@ int f(void){
         // bit 5 = flag h  0x20
         // bit 6 = flag n  0x40
         // bit 7 = zero    0x80
-        return (ff >> 4) & 0x40  // carry
+        return (ff >> 4) & 0x10  // carry
                 | ((fr ^ fa ^ fb ^ fb >> 8) & 16) << 1 // H 
                 | (fb >> 8 & 2) << 5  // N
                 | (!fr << 7);

--- a/src/ticks/ticks.h
+++ b/src/ticks/ticks.h
@@ -47,6 +47,7 @@ extern int c_ioport;
 extern int break_required;
 
 extern int c_rc2014_mode;
+extern int c_z80asm_tests;
 
 extern uint8_t verbose;
 extern char* script_file;

--- a/src/ticks/ticks_main.c
+++ b/src/ticks/ticks_main.c
@@ -45,7 +45,10 @@ static void write_output()
     FILE *fh;
     uint8_t t, r, w;
 
+    // Output is used by z80asm tests, pretend that we're a z80 so flags are
+    // written out in that way
     if( c_output ){
+        c_cpu = CPU_Z80;
         fh= fopen(c_output, "wb+");
         if( !fh ) {
             fprintf(stderr, "\nCannot create or write in file: %s\n", c_output);

--- a/src/ticks/ticks_main.c
+++ b/src/ticks/ticks_main.c
@@ -20,7 +20,7 @@ int    c_rc2014_mode = 0;
 int    c_rom_size = 0;
 int    c_ioport = -1;
 int    c_autolabel = 0;
-
+int    c_z80asm_tests = 0;
 
 static char   cmd_arguments[255];
 static int    cmd_arguments_len = 0;
@@ -48,7 +48,7 @@ static void write_output()
     // Output is used by z80asm tests, pretend that we're a z80 so flags are
     // written out in that way
     if( c_output ){
-        c_cpu = CPU_Z80;
+        if (c_z80asm_tests) c_cpu = CPU_Z80;
         fh= fopen(c_output, "wb+");
         if( !fh ) {
             fprintf(stderr, "\nCannot create or write in file: %s\n", c_output);
@@ -174,7 +174,7 @@ static void usage(void)
     printf("  -mr800         Emulate a r800 (ticks may not be accurate)\n");
     printf("  -mkc160        Emulate a kc160\n");
     printf("  -mkc160_z80    Emulate a kc160 (z80 mode)\n");
-    printf("  -ide0 <file>   Set file to be ide device 0\n");
+    printf("  -ide0 <file>    file to be ide device 0\n");
     printf("  -ide1 <file>   Set file to be ide device 1\n");
     printf("  -iochar X      Set port X to be character input/output\n");
     printf("  -output <file> dumps the RAM content to a 64K file\n");
@@ -334,6 +334,13 @@ int main (int argc, char **argv){
             memcpy(get_memory_addr(65281, MEM_TYPE_DATA), cmd_arguments, cmd_arguments_len % 256);
           }
           break;
+        case 'z':
+          if (strcmp(&argv[0][1], "z80asm-tests") == 0) {
+                c_z80asm_tests = 1;
+                argv--;
+                argc++;
+                break;
+          }
         default:
           fprintf(stderr, "\nWrong Argument: %s\n", argv[0]);
           exit(EXIT_FAILURE);

--- a/src/z80asm/t/testlib.pl
+++ b/src/z80asm/t/testlib.pl
@@ -112,7 +112,7 @@ sub ticks {
 	(Test::More->builder->is_passing) or die;
 
 	my $cpu = ($options =~ /(?:-m=?)(\S+)/) ? $1 : "z80";
-	run_ok("z88dk-ticks -m$cpu $test.bin -output $test.out");
+	run_ok("z88dk-ticks -z80asm-tests -m$cpu $test.bin -output $test.out");
 
 	(Test::More->builder->is_passing) or die;
 

--- a/test/suites/stdlib/bsearch.c
+++ b/test/suites/stdlib/bsearch.c
@@ -1,6 +1,8 @@
 #include "stdlib_tests.h"
 #include <stdint.h>
 
+#ifndef __8080
+
 struct lookup {
   int32_t codepoint;
   unsigned char byte1;
@@ -668,3 +670,4 @@ int test_bsearch()
     suite_add_test(bsearch_case1);
     return suite_run();
 }
+#endif

--- a/test/suites/stdlib/main.c
+++ b/test/suites/stdlib/main.c
@@ -16,8 +16,8 @@ int main(int argc, char *argv[])
 #ifndef __8080
     res += test_qsort();
     res += test_qsort_newlib();
-#endif
     res += test_bsearch();
+#endif
 
     return res;
 }

--- a/test/suites/stdlib/main.c
+++ b/test/suites/stdlib/main.c
@@ -14,9 +14,11 @@ int main(int argc, char *argv[])
     res += test_strtol();
     res += test_unbcd();
 #ifndef __8080
+  #ifndef __GBZ80
     res += test_qsort();
     res += test_qsort_newlib();
     res += test_bsearch();
+ #endif
 #endif
 
     return res;


### PR DESCRIPTION
* Rather than treat it the same as 8080, pack as per the CPU
* Disable some funcs that don't work
* Fudge the z80asm tests which check for flags