### PR TITLE
Fixes interrupt-induced race condition in math32 lib for sdcc

### DIFF
--- a/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc___uchar2fs_callee.asm
+++ b/libsrc/_DEVELOPMENT/math/float/math32/c/sdcc/cm32_sdcc___uchar2fs_callee.asm
@@ -7,8 +7,9 @@ EXTERN m32_float16u
 
 cm32_sdcc___uchar2fs_callee:
 	pop	bc	;return
-	pop	hl	;value
 	dec	sp
+	pop	hl	;value
 	push	bc
+    ld  l,h
 	ld	h,0
 	jp	m32_float16u


### PR DESCRIPTION
Tricky one: in the original core, the stack is left vulnerable to interruptions:

```asm
cm32_sdcc___uchar2fs_callee:
	pop	bc	; return address
	pop	hl	; meant to recover 1 byte value in L (the next instructions increases the stack pointer)
                         ; however, if an interruption is triggered at this point, a byte of the stack will be overwritten.
	dec	sp
	push	bc
	ld	h,0
	jp	m32_float16u
```

The solution involves decrementing SP before the pop:
```asm
cm32_sdcc___uchar2fs_callee:
	pop	bc	;return
	dec	sp
	pop	hl	; the stack is not left vulnerable to interruptions. The required value from the stack is stored in H 
	push	bc
        ld  l,h.      ; Value copied to L
	ld	h,0  ; H set to 0.... now we are good to go
	jp	m32_float16u
```

I wonder if similar patterns lurk somewhere else... this kind of bugs are really tricky to catch.
