### PR TITLE
Fix #2725: CP/M file performance

### DIFF
--- a/include/cpm.h
+++ b/include/cpm.h
@@ -68,6 +68,8 @@ struct fcb {
     uint8_t    use;            /* use flag */
     uint8_t    uid;            /* user id belonging to this file */
     uint8_t    mode;           /* TEXT/BINARY discrimination */
+    uint8_t    rnr_dirty;    /* Set if the rwptr needs to be recalculatd */
+    uint32_t   record_nr;      /* Record number that that rwptr refers to */ 
 
     // 133 bytes used for caching
     unsigned long cached_record;   /* Record number that we have cached */
@@ -203,7 +205,7 @@ extern int __LIB__ bdosh_callee(int func,int arg) __smallc __z88dk_callee;
 
 
 /* Executes the BIOS function (1-85) passing BC and DE as arguments, error status in A on exit */
-extern int __LIB__ bios(int func,int arg,int arg2) __smallc;
+__ZPROTO3(int,,bios,int, func, int, arg, int, arg2)
 /* Executes the BIOS function (1-85) passing BC and DE as arguments, gets the result value from HL on exit */
 extern int __LIB__ biosh(int func,int arg,int arg2) __smallc;
 

--- a/lib/crt/classic/crt_cpm_fcntl.inc
+++ b/lib/crt/classic/crt_cpm_fcntl.inc
@@ -1,15 +1,8 @@
 ; CP/M style FCB support (CP/M + MSXDOS1)
 
 
-    ; Control whether extending a file will write an empty record
-    IFNDEF CPM_WRITE_EMPTY_RECORD
-        DEFC    CPM_WRITE_EMPTY_RECORD = 1
-    ENDIF
-    PUBLIC  __CPM_WRITE_EMPTY_RECORD
-    defc    __CPM_WRITE_EMPTY_RECORD = CPM_WRITE_EMPTY_RECORD
-
     IFNDEF CPM_READ_CACHE_ALWAYS
-        defc    CPM_READ_CACHE_ALWAYS = 0
+        defc    CPM_READ_CACHE_ALWAYS = 1
     ENDIF
     PUBLIC  __CPM_READ_CACHE_ALWAYS
     defc    __CPM_READ_CACHE_ALWAYS = CPM_READ_CACHE_ALWAYS
@@ -20,7 +13,7 @@ IF CLIB_OPEN_MAX > 0
     SECTION bss_crt
     PUBLIC  __fcb
 __fcb:
-    defs    CLIB_OPEN_MAX * 166	; Each FCB is 43 bytes long
+    defs    CLIB_OPEN_MAX * (36+12+133)	; 
 ENDIF
 
     PUBLIC  defltdsk

--- a/lib/crt/classic/crt_cpm_fcntl.inc
+++ b/lib/crt/classic/crt_cpm_fcntl.inc
@@ -1,8 +1,9 @@
 ; CP/M style FCB support (CP/M + MSXDOS1)
 
 
+    ; Read cache even for sector sized chunks
     IFNDEF CPM_READ_CACHE_ALWAYS
-        defc    CPM_READ_CACHE_ALWAYS = 1
+        defc    CPM_READ_CACHE_ALWAYS = 0
     ENDIF
     PUBLIC  __CPM_READ_CACHE_ALWAYS
     defc    __CPM_READ_CACHE_ALWAYS = CPM_READ_CACHE_ALWAYS

--- a/lib/z80_crt0.hdr
+++ b/lib/z80_crt0.hdr
@@ -186,6 +186,7 @@
 	EXTERN	l_long_asr_u	;Long unsigned >>
 	EXTERN	l_long_asr_uo	;Long unsigned >> shift in c
 	EXTERN	l_long_case
+	EXTERN	l_long_inc_mhl
 
 ;--------------------------------------------------------------
 ; Floating point support routines, mostly in library

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -7204,6 +7204,16 @@ $notcpu 8085
 	ld	h,(hl)
 	ld	l,a
 
+%title Avoid reloading hl
+	push	hl
+	dec	sp
+	ld	hl,1	;const
+	call	l_gintspsp	;%1
+=
+	push	hl
+	dec	sp
+	push	hl
+
 %title Avoid going via stack
 	push	hl
 	ld	hl,%1	;const

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -7219,8 +7219,3 @@ $notcpu 8085
 	call	l_gint	;%2
 	ld	a,(hl)
 	ld	(de),a
-
-%title Redundant push/pop cycle
-	push	%1
-	pop	%1
-=

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -7229,3 +7229,27 @@ $notcpu 8085
 	call	l_gint	;%2
 	ld	a,(hl)
 	ld	(de),a
+
+%title Increment long in place
+	push	hl
+	call	l_glong
+	call	l_inclong
+	pop	bc
+	call	l_plong
+	ld	hl,%1
+=
+	call	l_long_inc_mhl
+	ld	hl,%1
+
+%title Increment long in place
+	push	hl
+	call	l_glong
+	call	l_inclong
+	pop	bc
+	call	l_plong
+.%2
+	ld	hl,%3
+=
+	call	l_long_inc_mhl
+.%2
+	ld	hl,%3

--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -4226,6 +4226,23 @@ $notcpu 8085
 	ex	de,hl
 	ld	h,0
 
+%title Cleanup glong & 0xff
+	ld	e,(hl)
+	inc	hl
+	inc	hl
+	ld	l,(hl)
+	ld	h,0
+	ex	de,hl
+	pop	de
+	ld	a,l
+	ld	(de),a
+=
+	ld	a,(hl)
+	pop	de
+	ld	(de),a
+	ld	l,a
+	ld	h,0
+
 %check 9 <= %1 <= 15
 	ld	e,(hl)
 	inc	hl
@@ -7138,3 +7155,72 @@ $notcpu 8085
 	add	hl,bc
 	jr	nc,ASMPC+3
 	inc	de
+
+%title push/pop around
+%check 2 <= %1 <= 10
+	push	hl
+	call	l_gint%1sp	;
+	pop	de
+=
+	ex	de,hl
+	call	l_gint%eval(%1 2 -)sp
+
+%title 8 bit and of long value
+	call	l_glong
+	ld	a,l
+	and	%1
+	ld	l,a
+	ld	h,0
+	pop	de
+	call	l_pint
+	ld	hl,%2	;const
+=
+	ld	a,(hl)
+	and	%1
+	pop	de
+	ld	(de),a
+	ld	hl,%2	;const
+
+%title avoid subroutine call
+	ld	hl,%1	;const
+	add	hl,sp
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+	ld	hl,%2	;const
+	add	hl,sp
+	call	l_gint	;%3
+	ex	de,hl
+=
+	ld	hl,%2	;const
+	add	hl,sp
+	ld	e,(hl)
+	inc	hl
+	ld	d,(hl)
+	ld	hl,%1	;const
+	add	hl,sp
+	ld	a,(hl)
+	inc	hl
+	ld	h,(hl)
+	ld	l,a
+
+%title Avoid going via stack
+	push	hl
+	ld	hl,%1	;const
+	add	hl,sp
+	call	l_gint	;%2
+	ld	a,(hl)
+	pop	de
+	ld	(de),a
+=
+	ex	de,hl
+	ld	hl,%eval(%1 2 -)	;const
+	add	hl,sp
+	call	l_gint	;%2
+	ld	a,(hl)
+	ld	(de),a
+
+%title Redundant push/pop cycle
+	push	%1
+	pop	%1
+=

--- a/libsrc/target/cpm/fcntl/_putoffset.c
+++ b/libsrc/target/cpm/fcntl/_putoffset.c
@@ -12,8 +12,8 @@
 
 void _putoffset(unsigned char *where,long offset)
 {
-    where[0] = ((int)offset) & 0xFF;
-    where[1] = ((int)(offset >> 8 )) & 0xFF;
-    where[2] = ((int)(offset >> 16)) & 0xFF;
+    where[0] = offset & 0xFF;
+    where[1] = ((unsigned long)offset >> 8 ) & 0xFF;
+    where[2] = ((unsigned long)offset >> 16) & 0xFF;
 }
 

--- a/libsrc/target/cpm/fcntl/cache.c
+++ b/libsrc/target/cpm/fcntl/cache.c
@@ -5,19 +5,24 @@
 
 int cpm_cache_get(struct fcb *fcb, unsigned long record_nr, int for_read)
 {
-    // We've already got it cached, just use it
-    if ( record_nr == fcb->cached_record ) return 0;
+    int uid;
+    // We've already got it cached, just use it - check done in read/write
+    //if ( record_nr == fcb->cached_record ) return 0;
 
     if ( cpm_cache_flush(fcb) == -1 ) return -1;
+
+    uid = swapuid(fcb->uid);
 
     fcb->cached_record = 0xffffffff;
     _putoffset(fcb->ranrec,record_nr);
     bdos(CPM_SDMA,fcb->buffer);
     if ( bdos(CPM_RRAN,fcb) ) {
+        swapuid(uid);
         if ( for_read ) return -1;
         // It's for a write, unknown sector, fill with EOF marker
         memset(fcb->buffer, 26, SECSIZE);
     }
+    swapuid(uid);
     fcb->cached_record = record_nr;
     return 0;
 }
@@ -29,13 +34,18 @@ int cpm_cache_get(struct fcb *fcb, unsigned long record_nr, int for_read)
  */
 int cpm_cache_flush(struct fcb *fcb)
 {
+    int uid;
+
     if ( fcb->dirty ) {
         _putoffset(fcb->ranrec,fcb->cached_record);
+        uid = swapuid(fcb->uid);
         bdos(CPM_SDMA,fcb->buffer);
         if ( bdos(CPM_WRAN,fcb) == 0 ) {
+            swapuid(uid);
             fcb->dirty = 0;
             return 1;
         }
+        swapuid(uid);
         return -1;
     }
     return 0;

--- a/libsrc/target/cpm/fcntl/close.c
+++ b/libsrc/target/cpm/fcntl/close.c
@@ -17,10 +17,8 @@ int close(int fd)
     struct fcb *fc;
     unsigned char uid;
 
-    // if ( fd >= MAXFILE )
-	// return -1;
+    fc = (struct fcb *) fd; 
 
-    fc = fd; // &_fcb[fd];
     uid = swapuid(fc->uid);      /* Set it to that of the file */
     if ( fc->use < U_CON ) {
         cpm_cache_flush(fc);

--- a/libsrc/target/cpm/fcntl/close.c
+++ b/libsrc/target/cpm/fcntl/close.c
@@ -17,10 +17,10 @@ int close(int fd)
     struct fcb *fc;
     unsigned char uid;
 
-    if ( fd >= MAXFILE )
-	return -1;
+    // if ( fd >= MAXFILE )
+	// return -1;
 
-    fc = &_fcb[fd];
+    fc = fd; // &_fcb[fd];
     uid = swapuid(fc->uid);      /* Set it to that of the file */
     if ( fc->use < U_CON ) {
         cpm_cache_flush(fc);

--- a/libsrc/target/cpm/fcntl/creat.c
+++ b/libsrc/target/cpm/fcntl/creat.c
@@ -38,7 +38,7 @@ int creat(char *nam, mode_t mode)
     }
     
     fd =  (fc - &_fcb[0]);
-    return fd;
+    return fc;
 }
 
 

--- a/libsrc/target/cpm/fcntl/creat.c
+++ b/libsrc/target/cpm/fcntl/creat.c
@@ -17,7 +17,6 @@ int creat(char *nam, mode_t mode)
 {
     struct fcb *fc;
     char       *name;
-    int         fd;
     unsigned char pad,uid;
 
     name = nam;
@@ -36,9 +35,7 @@ int creat(char *nam, mode_t mode)
         swapuid(uid);
         fc->use = U_WRITE;
     }
-    
-    fd =  (fc - &_fcb[0]);
-    return fc;
+    return (int)fc;
 }
 
 

--- a/libsrc/target/cpm/fcntl/getfcb.c
+++ b/libsrc/target/cpm/fcntl/getfcb.c
@@ -22,6 +22,7 @@ struct fcb *getfcb(void)
             fcb->use   = U_READ;
             fcb->rwptr = 0;
             fcb->cached_record = 0xffffffff;
+            fcb->rnr_dirty = 0;
             return fcb;
         }
     }

--- a/libsrc/target/cpm/fcntl/lseek.c
+++ b/libsrc/target/cpm/fcntl/lseek.c
@@ -56,7 +56,7 @@ long lseek(int fd,long posn, int whence)
         return -1L;
     
     fc->rwptr = pos;
-    fc->rnr_dirty = 0;
+    fc->rnr_dirty = 1;
     return pos;
     
 }

--- a/libsrc/target/cpm/fcntl/lseek.c
+++ b/libsrc/target/cpm/fcntl/lseek.c
@@ -56,6 +56,7 @@ long lseek(int fd,long posn, int whence)
         return -1L;
     
     fc->rwptr = pos;
+    fc->rnr_dirty = 0;
     return pos;
     
 }

--- a/libsrc/target/cpm/fcntl/open.c
+++ b/libsrc/target/cpm/fcntl/open.c
@@ -69,5 +69,5 @@ int open(char *name, int flags, mode_t mode)
 		fc->use=U_RDWR;
         lseek(fd,0L,SEEK_END);
 	}
-    return fd;
+    return (int)fc;
 }

--- a/libsrc/target/cpm/fcntl/read.c
+++ b/libsrc/target/cpm/fcntl/read.c
@@ -56,40 +56,59 @@ ssize_t read(int fd, void *buf, size_t len)
     case U_READ:
     case U_RDWR:
         cnt = len;
-        while ( len ) {
+
+        if ( len == 1 ) {
             unsigned long record_nr = fc->record_nr;
-            
-            if ( fc->rnr_dirty ) { record_nr = fc->record_nr = fc->rwptr/SECSIZE; fc->rnr_dirty = 0; }
+            if ( fc->rnr_dirty ) { fc->record_nr = record_nr = fc->rwptr/SECSIZE; fc->rnr_dirty = 0; }
             offset = fc->rwptr%SECSIZE;
 
-            if ( ( size = SECSIZE - offset ) > len ) {
-                size = len;
-            }
-            if ( size == SECSIZE && CPM_READ_CACHE_ALWAYS == 0 ) {
-                _putoffset(fc->ranrec,record_nr);
-                uid = swapuid(fc->uid);
-                bdos(CPM_SDMA,buf);
-                if ( bdos(CPM_RRAN,fc) ) {
-                    swapuid(uid);
-                    return cnt-len;
+            if ( record_nr != fc->cached_record ) {
+                if ( cpm_cache_get(fc, record_nr, 1) ) {
+                    return 0;
                 }
-                swapuid(uid);
-            } else {
-                if ( record_nr != fc->cached_record ) {
-                    if ( cpm_cache_get(fc, record_nr, 1) ) {
-                        return cnt-len;
-                    }
-                }
-                if ( size == 1 ) {
-                    *(uint8_t *)buf = fc->buffer[offset];
-                } else memcpy(buf,fc->buffer+offset,size);
             }
-            buf += size;
-            fc->rwptr += size;
-            if ( size + offset == SECSIZE) {
+            *(uint8_t *)buf = fc->buffer[offset];
+            ++fc->rwptr;
+            if ( offset+1 == SECSIZE) {
                 ++fc->record_nr;
             }
-            len -= size;
+            return 1;
+        } else {
+            while ( len ) {
+                unsigned long record_nr = fc->record_nr;
+                
+                if ( fc->rnr_dirty ) { record_nr = fc->record_nr = fc->rwptr/SECSIZE; fc->rnr_dirty = 0; }
+                offset = fc->rwptr%SECSIZE;
+
+                if ( ( size = SECSIZE - offset ) > len ) {
+                    size = len;
+                }
+                if ( size == SECSIZE && CPM_READ_CACHE_ALWAYS == 0 ) {
+                    _putoffset(fc->ranrec,record_nr);
+                    uid = swapuid(fc->uid);
+                    bdos(CPM_SDMA,buf);
+                    if ( bdos(CPM_RRAN,fc) ) {
+                        swapuid(uid);
+                        return cnt-len;
+                    }
+                    swapuid(uid);
+                } else {
+                    if ( record_nr != fc->cached_record ) {
+                        if ( cpm_cache_get(fc, record_nr, 1) ) {
+                            return cnt-len;
+                        }
+                    }
+                    if ( size == 1 ) {
+                        *(uint8_t *)buf = fc->buffer[offset];
+                    } else memcpy(buf,fc->buffer+offset,size);
+                }
+                buf += size;
+                fc->rwptr += size;
+                if ( size + offset == SECSIZE) {
+                    ++fc->record_nr;
+                }
+                len -= size;
+            }
         }
         return cnt-len;
         break;

--- a/libsrc/target/cpm/fcntl/read.c
+++ b/libsrc/target/cpm/fcntl/read.c
@@ -56,7 +56,6 @@ ssize_t read(int fd, void *buf, size_t len)
     case U_READ:
     case U_RDWR:
         cnt = len;
-        uid = swapuid(fc->uid);
         while ( len ) {
             unsigned long record_nr = fc->record_nr;
             
@@ -68,15 +67,16 @@ ssize_t read(int fd, void *buf, size_t len)
             }
             if ( size == SECSIZE && CPM_READ_CACHE_ALWAYS == 0 ) {
                 _putoffset(fc->ranrec,record_nr);
+                uid = swapuid(fc->uid);
                 bdos(CPM_SDMA,buf);
                 if ( bdos(CPM_RRAN,fc) ) {
                     swapuid(uid);
                     return cnt-len;
                 }
+                swapuid(uid);
             } else {
                 if ( record_nr != fc->cached_record ) {
                     if ( cpm_cache_get(fc, record_nr, 1) ) {
-                        swapuid(uid);
                         return cnt-len;
                     }
                 }
@@ -91,7 +91,6 @@ ssize_t read(int fd, void *buf, size_t len)
             }
             len -= size;
         }
-        swapuid(uid);
         return cnt-len;
         break;
     default:

--- a/libsrc/target/cpm/fcntl/read.c
+++ b/libsrc/target/cpm/fcntl/read.c
@@ -20,12 +20,13 @@ ssize_t read(int fd, void *buf, size_t len)
 {
     unsigned char buffer[SECSIZE+2];
     unsigned char uid;
-    struct fcb *fc;
     size_t cnt,size,offset;
+    struct fcb *fc;
 
-    if ( fd >= MAXFILE )
-       return -1;
-    fc = &_fcb[fd];
+
+    // if ( fd >= MAXFILE )
+    //    return -1;
+    fc = fd; // &_fcb[fd];
     switch ( fc->use ) {
 #ifdef DEVICES
     case U_RDR:         /* Reader device */
@@ -57,27 +58,37 @@ ssize_t read(int fd, void *buf, size_t len)
         cnt = len;
         uid = swapuid(fc->uid);
         while ( len ) {
-            unsigned long record_nr = fc->rwptr/SECSIZE;
+            unsigned long record_nr = fc->record_nr;
+            
+            if ( fc->rnr_dirty ) { record_nr = fc->record_nr = fc->rwptr/SECSIZE; fc->rnr_dirty = 0; }
             offset = fc->rwptr%SECSIZE;
+
             if ( ( size = SECSIZE - offset ) > len ) {
                 size = len;
             }
-            _putoffset(fc->ranrec,record_nr);
             if ( size == SECSIZE && CPM_READ_CACHE_ALWAYS == 0 ) {
+                _putoffset(fc->ranrec,record_nr);
                 bdos(CPM_SDMA,buf);
                 if ( bdos(CPM_RRAN,fc) ) {
                     swapuid(uid);
                     return cnt-len;
                 }
             } else {
-                if ( cpm_cache_get(fc, record_nr, 1) ) {
-                    swapuid(uid);
-                    return cnt-len;
+                if ( record_nr != fc->cached_record ) {
+                    if ( cpm_cache_get(fc, record_nr, 1) ) {
+                        swapuid(uid);
+                        return cnt-len;
+                    }
                 }
-                memcpy(buf,fc->buffer+offset,size);
+                if ( size == 1 ) {
+                    *(uint8_t *)buf = fc->buffer[offset];
+                } else memcpy(buf,fc->buffer+offset,size);
             }
             buf += size;
             fc->rwptr += size;
+            if ( size + offset == SECSIZE) {
+                ++fc->record_nr;
+            }
             len -= size;
         }
         swapuid(uid);

--- a/libsrc/target/cpm/fcntl/read.c
+++ b/libsrc/target/cpm/fcntl/read.c
@@ -24,9 +24,7 @@ ssize_t read(int fd, void *buf, size_t len)
     struct fcb *fc;
 
 
-    // if ( fd >= MAXFILE )
-    //    return -1;
-    fc = fd; // &_fcb[fd];
+    fc = (struct fcb *) fd; 
     switch ( fc->use ) {
 #ifdef DEVICES
     case U_RDR:         /* Reader device */

--- a/libsrc/target/cpm/fcntl/readbyte.c
+++ b/libsrc/target/cpm/fcntl/readbyte.c
@@ -14,7 +14,7 @@
 int readbyte(int fd)
 {
     unsigned char  buffer;
-    if ( read(fd,&buffer,1) <= 0) {
+    if ( read(fd,&buffer,1) != 1) {
         return_c -1;
     }
     return_nc buffer;

--- a/libsrc/target/cpm/fcntl/swapuid.c
+++ b/libsrc/target/cpm/fcntl/swapuid.c
@@ -10,10 +10,9 @@ int swapuid(int id) __z88dk_fastcall __naked  {
     ld      c,CPM_SUID
     ld      e,0xff	;query
 	call __bdos
-    pop     hl
-    cp      l
+    pop     de
+    cp      e
     ret     z           ;Existing id was the same
-    ld      e,l         ;It was different, so set it
     push    af
     ld      c,CPM_SUID
 	call __bdos

--- a/libsrc/target/cpm/fcntl/write.c
+++ b/libsrc/target/cpm/fcntl/write.c
@@ -47,43 +47,63 @@ ssize_t write(int fd, void *buf, size_t len)
 #endif
     case U_WRITE:
     case U_RDWR:
-        while ( len ) {
+        if ( len == 1 ) {
             unsigned long record_nr = fc->record_nr;
-            
+                
             if ( fc->rnr_dirty ) { record_nr = fc->record_nr = fc->rwptr/SECSIZE; fc->rnr_dirty = 0; }
             offset = fc->rwptr%SECSIZE;
-            if ( (size = SECSIZE-offset) > len ) {
-                size = len;
-            }
-            if ( size == SECSIZE ) {
-                // Write the full sector now, flush whatever we've got cached so we don't 
-                // write out of order
-                cpm_cache_flush(fc);
 
-                _putoffset(fc->ranrec,fc->rwptr/SECSIZE);
-                uid = swapuid(fc->uid);
-                bdos(CPM_SDMA,buf);
-                if ( bdos(CPM_WRAN,fc) ) {
-                    swapuid(uid);
-                    return cnt-len;
+             if ( record_nr != fc->cached_record ) {
+                if ( cpm_cache_get(fc, record_nr, 0) == - 1 ) {
+                    return 0;
                 }
-                swapuid(uid);
-            } else {  /* Not the required size, read in the record to our cache */
-                if ( record_nr != fc->cached_record ) {
-                    if ( cpm_cache_get(fc, record_nr, 0) == - 1 ) {
-                        return cnt-len;
-                    }
-                }
-                fc->dirty = 1;
-                if ( size == 1 ) fc->buffer[offset] = *((uint8_t *)buf); 
-                else memcpy(fc->buffer+offset,buf,size);
             }
-            buf += size;
-            fc->rwptr += size;
-            if ( size + offset == SECSIZE) {
+            fc->dirty = 1;
+            fc->buffer[offset] = *((uint8_t *)buf); 
+            ++fc->rwptr;
+            if ( offset+1 == SECSIZE) {
                 ++fc->record_nr;
             }
-            len -= size;
+            return 1;
+        } else {
+            while ( len ) {
+                unsigned long record_nr = fc->record_nr;
+                
+                if ( fc->rnr_dirty ) { record_nr = fc->record_nr = fc->rwptr/SECSIZE; fc->rnr_dirty = 0; }
+                offset = fc->rwptr%SECSIZE;
+                if ( (size = SECSIZE-offset) > len ) {
+                    size = len;
+                }
+                if ( size == SECSIZE ) {
+                    // Write the full sector now, flush whatever we've got cached so we don't 
+                    // write out of order
+                    cpm_cache_flush(fc);
+
+                    _putoffset(fc->ranrec,fc->rwptr/SECSIZE);
+                    uid = swapuid(fc->uid);
+                    bdos(CPM_SDMA,buf);
+                    if ( bdos(CPM_WRAN,fc) ) {
+                        swapuid(uid);
+                        return cnt-len;
+                    }
+                    swapuid(uid);
+                } else {  /* Not the required size, read in the record to our cache */
+                    if ( record_nr != fc->cached_record ) {
+                        if ( cpm_cache_get(fc, record_nr, 0) == - 1 ) {
+                            return cnt-len;
+                        }
+                    }
+                    fc->dirty = 1;
+                    if ( size == 1 ) fc->buffer[offset] = *((uint8_t *)buf); 
+                    else memcpy(fc->buffer+offset,buf,size);
+                }
+                buf += size;
+                fc->rwptr += size;
+                if ( size + offset == SECSIZE) {
+                    ++fc->record_nr;
+                }
+                len -= size;
+            }
         }
         return cnt-len;
         break;

--- a/libsrc/target/cpm/fcntl/write.c
+++ b/libsrc/target/cpm/fcntl/write.c
@@ -21,10 +21,8 @@ ssize_t write(int fd, void *buf, size_t len)
     size_t cnt,size,offset;
     struct fcb *fc;
 
-    // if ( fd >= MAXFILE )
-    // return -1;
 
-    fc = fd; // &_fcb[fd];
+    fc = (struct fcb *) fd; 
     cnt = len;
     offset = CPM_WCON;  /* Double use of variable */
 

--- a/libsrc/target/cpm/fcntl/write.c
+++ b/libsrc/target/cpm/fcntl/write.c
@@ -47,7 +47,6 @@ ssize_t write(int fd, void *buf, size_t len)
 #endif
     case U_WRITE:
     case U_RDWR:
-        uid = swapuid(fc->uid);
         while ( len ) {
             unsigned long record_nr = fc->record_nr;
             
@@ -62,15 +61,16 @@ ssize_t write(int fd, void *buf, size_t len)
                 cpm_cache_flush(fc);
 
                 _putoffset(fc->ranrec,fc->rwptr/SECSIZE);
+                uid = swapuid(fc->uid);
                 bdos(CPM_SDMA,buf);
                 if ( bdos(CPM_WRAN,fc) ) {
                     swapuid(uid);
                     return cnt-len;
                 }
+                swapuid(uid);
             } else {  /* Not the required size, read in the record to our cache */
                 if ( record_nr != fc->cached_record ) {
                     if ( cpm_cache_get(fc, record_nr, 0) == - 1 ) {
-                        swapuid(uid);
                         return cnt-len;
                     }
                 }
@@ -85,7 +85,6 @@ ssize_t write(int fd, void *buf, size_t len)
             }
             len -= size;
         }
-        swapuid(uid);
         return cnt-len;
         break;
     default:

--- a/testsuite/results/Issue_2544_farspace.opt
+++ b/testsuite/results/Issue_2544_farspace.opt
@@ -32,9 +32,8 @@
 	ld	de,+(_i / 65536)
 	call	l_far_mapaddr
 	call	lp_gint
-	push	hl
-	call	l_gint4sp	;
-	pop	de
+	ex	de,hl
+	call	l_gint2sp
 	add	hl,de
 	ret
 

--- a/testsuite/results/Issue_489_variable_defn_in_forloop.opt
+++ b/testsuite/results/Issue_489_variable_defn_in_forloop.opt
@@ -55,11 +55,7 @@
 .i_5
 	ld	hl,0	;const
 	add	hl,sp
-	push	hl
-	call	l_glong
-	call	l_inclong
-	pop	bc
-	call	l_plong
+	call	l_long_inc_mhl
 .i_7
 	ld	hl,0	;const
 	add	hl,sp

--- a/testsuite/results/Issue_608_Arrays.opt
+++ b/testsuite/results/Issue_608_Arrays.opt
@@ -36,9 +36,8 @@
 
 ._func
 	ld	hl,_carray
-	push	hl
-	call	l_gint4sp	;
-	pop	de
+	ex	de,hl
+	call	l_gint2sp
 	add	hl,de
 	call	l_gchar
 	ret

--- a/testsuite/results/Issue_98_check_int.opt
+++ b/testsuite/results/Issue_98_check_int.opt
@@ -30,9 +30,8 @@
 
 ._mul3
 	ld	hl,(_g)
-	push	hl
-	call	l_gint4sp	;
-	pop	de
+	ex	de,hl
+	call	l_gint2sp
 	call	l_mult
 	ret
 
@@ -78,9 +77,8 @@
 
 ._div3
 	ld	hl,(_g)
-	push	hl
-	call	l_gint4sp	;
-	pop	de
+	ex	de,hl
+	call	l_gint2sp
 	call	l_div
 	ret
 
@@ -163,9 +161,8 @@
 
 ._sub3
 	ld	hl,(_g)
-	push	hl
-	call	l_gint4sp	;
-	pop	de
+	ex	de,hl
+	call	l_gint2sp
 	ex	de,hl
 	and	a
 	sbc	hl,de


### PR DESCRIPTION
These changes significantly improve the performance of CP/M file io when writing/reading by bytes.

Performance is also improved for larger block sizes, but not quite as significantly.

