### PR TITLE
[ZX81] HR graphics: more fixes

### DIFF
--- a/libsrc/target/zx81/gfx81g007.lst
+++ b/libsrc/target/zx81/gfx81g007.lst
@@ -14,6 +14,8 @@ target/zx81/graphics_hr/g007_hrg_on
 target/zx81/graphics_hr/g007_hrg_off
 gfx/narrow/obj/${TARGET}/stencil_render
 gfx/narrow/obj/${TARGET}/putsprite
+gfx/narrow/obj/${TARGET}/bksave
+gfx/narrow/obj/${TARGET}/bkrestore
 gfx/narrow/obj/${TARGET}/clrarea2
 gfx/narrow/obj/${TARGET}/fillarea2
 gfx/narrow/obj/${TARGET}/xorclrarea2

--- a/libsrc/target/zx81/gfx81hr.lst
+++ b/libsrc/target/zx81/gfx81hr.lst
@@ -18,6 +18,8 @@ target/zx81/graphics_gray/g_clg
 @gfx/gray/gfx_gray.lst
 gfx/narrow/obj/${TARGET}/stencil_render
 gfx/narrow/obj/${TARGET}/putsprite
+gfx/narrow/obj/${TARGET}/bksave
+gfx/narrow/obj/${TARGET}/bkrestore
 gfx/narrow/obj/${TARGET}/clrarea2
 gfx/narrow/obj/${TARGET}/fillarea2
 gfx/narrow/obj/${TARGET}/xorclrarea2

--- a/libsrc/target/zx81/gfx81mt.lst
+++ b/libsrc/target/zx81/gfx81mt.lst
@@ -13,8 +13,10 @@ target/zx81/graphics_hr/mt_pixladdr
 target/zx81/graphics_hr/mt_hrg_on
 target/zx81/graphics_hr/mt_hrg_off
 target/zx81/graphics_hr/mt_invhrg
-gfx/narrow/obj/${TARGET}/stencil_render
+target/zx81/graphics_hr/mt_stencil_render
 target/zx81/graphics_hr/mt_putsprite
+gfx/narrow/obj/${TARGET}/bksave
+gfx/narrow/obj/${TARGET}/bkrestore
 gfx/narrow/obj/${TARGET}/clrarea2
 gfx/narrow/obj/${TARGET}/fillarea2
 gfx/narrow/obj/${TARGET}/xorclrarea2

--- a/libsrc/target/zx81/gfx81mt.lst
+++ b/libsrc/target/zx81/gfx81mt.lst
@@ -14,7 +14,7 @@ target/zx81/graphics_hr/mt_hrg_on
 target/zx81/graphics_hr/mt_hrg_off
 target/zx81/graphics_hr/mt_invhrg
 gfx/narrow/obj/${TARGET}/stencil_render
-gfx/narrow/obj/${TARGET}/putsprite
+target/zx81/graphics_hr/mt_putsprite
 gfx/narrow/obj/${TARGET}/clrarea2
 gfx/narrow/obj/${TARGET}/fillarea2
 gfx/narrow/obj/${TARGET}/xorclrarea2

--- a/libsrc/target/zx81/graphics/swapgfxbk.asm
+++ b/libsrc/target/zx81/graphics/swapgfxbk.asm
@@ -23,8 +23,13 @@ _swapgfxbk:
 		;jp	save81
 swapgfxbk1:
 _swapgfxbk1:
-		; This will become IY when swapped !
-    ld      ix, 16384
+
+; NOTE:  IX now should be preserved, using IY for any kind of ROM call will require "IX"
+;        to be saved, set to 16384 while the ROM is being engaged, and restored back on exit.
+
+; This will become IY when swapped !
+;    ld      ix, 16384
+
 		;jp	$207
     ret
                 ;jp	restore81

--- a/libsrc/target/zx81/graphics_hr/mt_putsprite.asm
+++ b/libsrc/target/zx81/graphics_hr/mt_putsprite.asm
@@ -3,7 +3,7 @@
 ; original code by Patrick Davidson (TI 85)
 ; modified by Stefano Bodrato - Jan 2001
 ;
-; ZX81 - ARX816 mode version
+; ZX81 - Memotech WRX mode version
 ;
 ;
 ; $Id: mt_putsprite.asm  $

--- a/libsrc/target/zx81/graphics_hr/mt_putsprite.asm
+++ b/libsrc/target/zx81/graphics_hr/mt_putsprite.asm
@@ -1,0 +1,234 @@
+;
+; Sprite Rendering Routine
+; original code by Patrick Davidson (TI 85)
+; modified by Stefano Bodrato - Jan 2001
+;
+; ZX81 - ARX816 mode version
+;
+;
+; $Id: mt_putsprite.asm  $
+;
+
+
+IF  !__CPU_INTEL__&!__CPU_GBZ80__
+    SECTION smc_clib
+    PUBLIC  putsprite
+    PUBLIC  _putsprite
+    PUBLIC  ___putsprite
+    EXTERN  pixeladdress
+    EXTERN  swapgfxbk
+    EXTERN  __graphics_end
+
+    INCLUDE "graphics/grafix.inc"
+
+; __gfx_coords: d,e (vert-horz)
+; sprite: (ix)
+
+
+
+
+putsprite:
+_putsprite:
+___putsprite:
+    push    ix
+    ld      hl, 4
+    add     hl, sp
+    ld      e, (hl)
+    inc     hl
+    ld      d, (hl)                     ; sprite address
+    push    de
+    pop     ix
+
+    inc     hl
+    ld      e, (hl)
+    inc     hl
+    inc     hl
+    ld      d, (hl)                     ; x and y __gfx_coords
+
+    inc     hl
+
+    inc     hl
+    ld      a, (hl)                     ; and/or/xor mode
+    ld      (ortype+1), a               ; Self modifying code
+    ld      (ortype2+1), a              ; Self modifying code
+
+    inc     hl
+    ld      a, (hl)
+    ld      (ortype), a                 ; Self modifying code
+    ld      (ortype2), a                ; Self modifying code
+
+
+    ld      h, d
+    ld      l, e
+
+  IF    NEED_swapgfxbk=1
+    call    swapgfxbk
+  ENDIF
+    call    pixeladdress
+
+    ld      hl, offsets_table
+    ld      c, a
+    ld      b, 0
+    add     hl, bc
+    ld      a, (hl)
+    ld      (wsmc1+1), a
+    ld      (wsmc2+1), a
+    ld      (_smc1+1), a
+    ld      h, d
+    ld      l, e
+    ld      (rowadr+1), hl              ; save current coordinates
+    ld      (rowadr2+1), hl              ; save current coordinates
+    ld      (rowadr3+1), hl              ; save current coordinates
+
+    ld      a, (ix+0)
+    cp      9
+    jr      nc, putspritew
+
+    ld      d, (ix+0)
+    ld      b, (ix+1)
+_oloop:
+    push    bc                          ;Save # of rows
+    ld      b, d                        ;Load width
+    ld      c, (ix+2)                   ;Load one line of image
+    inc     ix
+_smc1:
+    ld      a, 1                        ;Load pixel mask
+_iloop:
+    sla     c                           ;Test leftmost pixel
+    jr      nc, _noplot                 ;See if a plot is needed
+    ld      e, a
+
+ortype:
+    nop                                 ; changed into nop / cpl
+    nop                                 ; changed into and/or/xor (hl)
+    cp      0x76
+    jr      nz,_no_halt
+    ld      a,0x56
+_no_halt:
+    ld      (hl), a
+    ld      a, e
+_noplot:
+IF BITS_reversed = 1
+    rlca
+ELSE
+    rrca
+ENDIF
+    jr      nc, _notedge                ;Test if edge of byte reached
+    inc     hl                          ;Go to next byte
+_notedge:
+    djnz    _iloop
+
+    ; ---------
+    push    de
+rowadr:
+    ld      hl,0
+    ld      de,33
+    add     hl,de
+    ld      (rowadr+1), hl
+    pop     de
+    ; ---------
+
+    pop     bc                          ;Restore data
+    djnz    _oloop
+  IF    NEED_swapgfxbk
+    jp      __graphics_end
+  ELSE
+    IF  !__CPU_INTEL__&!__CPU_GBZ80__
+    pop     ix
+    ENDIF
+    ret
+  ENDIF
+
+putspritew:
+    ld      d, (ix+0)
+    ld      b, (ix+1)
+woloop:
+    push    bc                          ;Save # of rows
+    ld      b, d                        ;Load width
+    ld      c, (ix+2)                   ;Load one line of image
+    inc     ix
+wsmc1:
+    ld      a, 1                        ;Load pixel mask
+wiloop:
+    sla     c                           ;Test leftmost pixel
+    jr      nc, wnoplot                 ;See if a plot is needed
+    ld      e, a
+
+ortype2:
+    nop                                 ; changed into nop / cpl
+    nop                                 ; changed into and/or/xor (hl)
+    cp      0x76
+    jr      nz,no_halt
+    ld      a,0x56
+no_halt:
+    ld      (hl), a
+    ld      a, e
+wnoplot:
+IF BITS_reversed = 1
+    rlca
+ELSE
+    rrca
+ENDIF
+    jr      nc, wnotedge                ;Test if edge of byte reached
+    inc     hl                          ;Go to next byte
+wnotedge:
+wsmc2:
+    cp      1
+    jr      z, wover_1
+
+    djnz    wiloop
+
+    ; ---------
+    push    de
+rowadr2:
+    ld      hl,0
+    ld      de,33
+    add     hl,de
+    ld      (rowadr2+1), hl
+    pop     de
+    ; ---------
+
+    pop     bc                          ;Restore data
+    djnz    woloop
+  IF    NEED_swapgfxbk
+    jp      __graphics_end
+  ELSE
+    IF  !__CPU_INTEL__&!__CPU_GBZ80__
+    pop     ix
+    ENDIF
+    ret
+  ENDIF
+
+wover_1:
+    ld      c, (ix+2)
+    inc     ix
+    djnz    wiloop
+    dec     ix
+
+    ; ---------
+    push    de
+rowadr3:
+    ld      hl,0
+    ld      de,33
+    add     hl,de
+    ld      (rowadr3+1), hl
+    pop     de
+    ; ---------
+
+    pop     bc
+    djnz    woloop
+  IF    NEED_swapgfxbk
+    jp      __graphics_end
+  ELSE
+    IF  !__CPU_INTEL__&!__CPU_GBZ80__
+    pop     ix
+    ENDIF
+    ret
+  ENDIF
+
+
+    SECTION rodata_clib
+
+offsets_table:
+    defb    1, 2, 4, 8, 16, 32, 64, 128
+ENDIF

--- a/libsrc/target/zx81/graphics_hr/mt_stencil_render.asm
+++ b/libsrc/target/zx81/graphics_hr/mt_stencil_render.asm
@@ -1,0 +1,185 @@
+;
+;    z88dk GFX library
+;
+;    Render the "stencil".
+;    The dithered horizontal lines base their pattern on the Y coordinate
+;    and on an 'intensity' parameter (0..11).
+;    Basic concept by Rafael de Oliveira Jannone
+;
+;    Machine code version by Stefano Bodrato, 22/4/2009
+;
+;    stencil_render(unsigned char *stencil, unsigned char intensity)
+;
+
+    INCLUDE "graphics/grafix.inc"
+
+IF  !__CPU_INTEL__&!__CPU_GBZ80__
+    SECTION smc_clib
+    PUBLIC  stencil_render
+    PUBLIC  _stencil_render
+    EXTERN  dither_pattern
+
+    EXTERN  swapgfxbk
+    EXTERN  pixeladdress
+    EXTERN  leftbitmask, rightbitmask
+;    EXTERN  swapgfxbk1
+    EXTERN  __graphics_end
+
+;
+;    $Id: mt_stencil_render.asm $
+;
+
+stencil_render:
+_stencil_render:
+    push    ix
+    ld      ix, 4
+    add     ix, sp
+
+  IF    NEED_swapgfxbk=1
+    call    swapgfxbk
+  ENDIF
+    ld      bc, __graphics_end
+    push    bc
+
+  IF    maxy<>256
+    ld      c, maxy
+  ELSE
+    ld      c, 0
+  ENDIF
+    push    bc
+yloop:
+    pop     bc
+    dec     c
+    ;jp    z,swapgfxbk1
+    ret     z
+    push    bc
+
+    ld      d, 0
+    ld      e, c
+
+    ld      l, (ix+2)                   ; stencil
+    ld      h, (ix+3)
+    add     hl, de
+    ld      a, (hl)                     ;X1
+
+
+  IF    maxy<>256
+    ld      e, maxy
+    add     hl, de
+  ELSE
+    ld      e, 0
+    inc     h
+  ENDIF
+    cp      (hl)                        ; if x1>x2, return
+    jr      nc, yloop
+
+       ; C still holds Y
+    push    af                          ; X1
+    ld      a, (hl)
+    ld      b, a                        ; X2
+
+    ld      a, (ix+0)                   ; intensity
+    call    dither_pattern
+    ld      (pattern1+1), a
+    ld      (pattern2+1), a
+
+    pop     af
+    ld      h, a                        ; X1
+    ld      l, c                        ; Y
+
+    push    bc
+    call    pixeladdress                ; bitpos0 = pixeladdress(x,y)
+    call    leftbitmask                 ; LeftBitMask(bitpos0)
+    pop     bc
+    push    de
+
+    ld      h, d
+    ld      l, e
+
+    call    mask_pattern
+    push    af
+    ;ld    (hl),a
+
+    ld      h, b                        ; X2
+    ld      l, c                        ; Y
+
+    call    pixeladdress                ; bitpos1 = pixeladdress(x+width-1,y)
+    call    rightbitmask                ; RightBitMask(bitpos1)
+    ld      (bitmaskr+1), a             ; bitmask1 = LeftBitMask(bitpos0)
+
+    pop     af                          ; pattern to be drawn (left-masked)
+    pop     hl                          ; adr0
+    push    hl
+    ex      de, hl
+    and     a
+    sbc     hl, de
+
+    jr      z, onebyte                  ; area is within the same address...
+
+    ld      b, l                        ; number of full bytes in a row
+    pop     hl
+
+    ;ld    de,8
+    cp      0x76
+    jr      nz,_no_halt
+    ld      a,0x56
+_no_halt:
+
+    ld      (hl), a                     ; (offset) = (offset) AND bitmask0
+
+    ;add    hl,de
+    inc     hl                          ; offset += 1 (8 bits)
+
+pattern2:
+    ld      a, 0
+    dec     b
+    jr      z, bitmaskr
+
+fill_row_loop:                          ; do
+    cp      0x76
+    jr      nz,_no_halt2
+    ld      a,0x56
+_no_halt2:
+
+    ld      (hl), a                     ; (offset) = pattern
+    ;add    hl,de
+    inc     hl                          ; offset += 1 (8 bits)
+    djnz    fill_row_loop               ; while ( r-- != 0 )
+
+
+bitmaskr:
+    ld      a, 0
+    call    mask_pattern
+
+    cp      0x76
+    jr      nz,_no_halt3
+    ld      a,0x56
+_no_halt3:
+
+    ld      (hl), a
+
+    jr      yloop
+
+
+onebyte:
+    pop     hl
+    ld      (pattern1+1), a
+    jr      bitmaskr
+
+
+    ; Prepare an edge byte, basing on the byte mask in A
+    ; and on the pattern being set in (pattern1+1)
+mask_pattern:
+  IF    BITS_reversed
+    xor     255
+  ENDIF
+    ld      d, a                        ; keep a copy of mask
+    and     (hl)                        ; mask data on screen
+    ld      e, a                        ; save masked data
+    ld      a, d                        ; retrieve mask
+    cpl                                 ; invert it
+pattern1:
+    and     0                           ; prepare fill pattern portion
+    or      e                           ; mix with masked data
+    ret
+ENDIF


### PR DESCRIPTION
bksave/bkrestore now working on WRX,ARX,G007,Memotech HRG
Memotech has glitches when the HALT opcode pattern is used on the HRG D-FILE,
workaround applied on putsprite and stencil_render.

TODO:
Extend the workaround for the Memotech HRG to more graphics functions
Memotech HRG initialization is broke, MT192 initializes a 64 rows only area, MT64 just doesn't work properly (crashes, but possibly also wrong timing for 50hz/60hz TV raster).
bksave/bkrestore for the ARX mode