### PR TITLE
Don't apply optimization with RES instruction for 8080 target

### DIFF
--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -5211,6 +5211,8 @@ $notcpu 8085
 	jp	nz,%1	;EOS
 	jp	i_%3	;EOS
 
+%notcpu 8080
+%notcpu 8085
 	ld	de,32767
 	call	l_and
 =


### PR DESCRIPTION
8080/8085 has no such instruction, so it could break compilation for that targets.