### PR TITLE
[ZX81] G007 HRG - 64 rows mode

### DIFF
--- a/lib/config/zx81.cfg
+++ b/lib/config/zx81.cfg
@@ -30,6 +30,7 @@ CLIB      wrx  -lzx81_clib -lndos -lgfx81hr192
 CLIB      wrxi  -lzx81_clib -lndos -lgfx81hr384
 CLIB      mt64  -lzx81_clib -lndos -lgfx81mt64
 CLIB      mt  -lzx81_clib -lndos -lgfx81mt192
+CLIB      g064  -lzx81_clib -lndos -lgfx81g064
 CLIB      g007  -lzx81_clib -lndos -lgfx81g007
 CLIB      wrx64ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=8 -lzx81_clib -lndos -lgfx81hr64
 CLIB      wrx128ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=16 -lzx81_clib -lndos -lgfx81hr128
@@ -38,9 +39,10 @@ CLIB      wrxiansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ans
 CLIB      arx64ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=8 -lzx81_clib -lndos -lgfx81arx64
 CLIB      arx128ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=16 -lzx81_clib -lndos -lgfx81arx128
 CLIB      arxansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lzx81_clib -lndos -lgfx81arx192
+CLIB      g064ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=8 -lzx81_clib -lndos -lgfx81g064
 CLIB      g007ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lzx81_clib -lndos -lgfx81g007
-CLIB      mtansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lzx81_clib -lndos -lgfx81mt192
 CLIB      mt64ansi  -pragma-need=ansiterminal -D__CONIO_VT100 -pragma-export:ansirows=8 -lzx81_clib -lndos -lgfx81mt64
+CLIB      mtansi  -pragma-need=ansiterminal -D__CONIO_VT100 -lzx81_clib -lndos -lgfx81mt192
 
 SUBTYPE     none 
 SUBTYPE		default -startup=2 

--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -569,6 +569,9 @@ gfx81hr64.lib: $(TARGET_CLIB_OBJS) gfx81udg.lib
 	$(MAKE) -C gfx TARGET=zx81 FLAVOUR="narrow gray" SUBTYPE=zx81hr64
 	TARGET=zx81hr64 TYPE=ixiy $(LIBLINKER) -IXIY -DFORzx81hr64 -DARX816 -x$(OUTPUT_DIRECTORY)/gfx81arx64 @$(TARGET_DIRECTORY)/zx81/gfx81arx.lst
 	$(call zx81deps)
+	$(MAKE) -C gfx TARGET=zx81 FLAVOUR="narrow gray" SUBTYPE=zx81g64
+	TARGET=zx81g64 TYPE=ixiy $(LIBLINKER) -IXIY -DFORzx81g64 -DG007 -x$(OUTPUT_DIRECTORY)/gfx81g064 @$(TARGET_DIRECTORY)/zx81/gfx81g007.lst
+	$(call zx81deps)
 	$(MAKE) -C gfx TARGET=zx81 FLAVOUR="narrow gray" SUBTYPE=zx81mt64
 	TARGET=zx81mt64 TYPE=ixiy $(LIBLINKER) -IXIY -DFORzx81mt64 -DMTHRG -x$(OUTPUT_DIRECTORY)/gfx81mt64 @$(TARGET_DIRECTORY)/zx81/gfx81mt.lst
 	$(call zx81deps)

--- a/libsrc/graphics/grafix.inc
+++ b/libsrc/graphics/grafix.inc
@@ -223,6 +223,12 @@ IF FORzx81g007
     defc maxy    = 185
 ENDIF
 
+IF FORzx81g64
+    DEFINE gotgfx
+    defc maxx    = 256    ; It could be 272 but we should switch to 'wide' mode
+    defc maxy    = 64
+ENDIF
+
 IF FORaceudg
     DEFINE gotgfx
     defc maxx    = 64

--- a/libsrc/target/zx81/graphics_hr/g007_hrg_on.asm
+++ b/libsrc/target/zx81/graphics_hr/g007_hrg_on.asm
@@ -22,12 +22,42 @@ hrg_on:
 _hrg_on:
 
 
+; if hrgpage has not been specified, then set a default value
+; TODO: this check should be improved, when the BASIC program is modified, the D-FILE shifts.
+;       We also miss an option to provide a fixed position for the HRG page avoiding the
+;       ROM's MAKE-ROOM approach.
+;
+;	ld      hl,(base_graphics)
+;	ld      a,h
+;	or      l
+;	jr      nz,gotpage
 
   IF    FORzx81g64
 
-	; TODO; find a working way to allocate a lower amount of memory
+	LD HL,($400C)    ; D-FILE
+	LD A,$76
+	DEC HL
+	DEC HL
+	CP (HL)
+	jr z,__zx81g64_no_init
+
+; ;$2DF8  01;92;19    LD BC,$1992         ; 6546 -> (6528+18) -> (34*192+18)
+; ;$2DFB  2A;0C;40    LD HL,($400C)
+; ;$2DFE  2B          DEC HL
+; ;$2DFF  CD;9E;09    CALL $099E          ; [MAKE-ROOM]
+; ;$2E02  3E;76       LD A,$76
+; 
+ 	ld a,64
+ 	ld ($2318),a
+; 	; TODO: find a working way to allocate a lower amount of memory
+; 	;ld bc,34*64+18	;  an $2DF8 it uses to be $1992 (34*192+18)
+; 	ld bc,192*64+18
+; 	inc hl          ; points to D-FILE -1
+; 	call $2DFF
+
 	call $2DF8
 
+__zx81g64_no_init:
   ELSE
 
 	; check if we already have reserved graphics memory
@@ -41,11 +71,6 @@ _hrg_on:
 
   ENDIF
 
-;; if hrgpage has not been specified, then set a default value
-;	ld      hl,(base_graphics)
-;	ld      a,h
-;	or      l
-;	jr		nz,gotpage
 ;IF FORzx81g64
 ;	ld		hl,29000		; on a 16K system we leave a space of abt 1.5K bytes for stack
 ;ELSE
@@ -53,8 +78,8 @@ _hrg_on:
 ;ENDIF
 ;	ld		(base_graphics),hl
 ;	ld      ($2306),hl                  ; Current HRG page
-;gotpage:
 
+;gotpage:
     ld      hl, ($2306)                 ; Current HRG page
     ld      (base_graphics), hl
 


### PR DESCRIPTION
New, 64 rows graphics mode to gain CPU speed.
The reserved space in BASIC is still the same as for a normal 192 rows picture, but the program will run faster.