### PR TITLE
Rework ungetc

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -145,7 +145,7 @@ typedef struct filestr FILE;
  * they are read/write always
  */
 
-#define _IOUSE          1
+#define _IOUNGETC       1
 #define _IOREAD         2
 #define _IOWRITE        4
 #define _IOEOF          8

--- a/lib/crt/classic/crt_section.inc
+++ b/lib/crt/classic/crt_section.inc
@@ -29,11 +29,11 @@ crt0_init:
 IF CRT_ENABLE_STDIO = 1 && CLIB_FOPEN_MAX > 0
     ; Setup std* streams
     ld      hl,__sgoioblk+2
-    ld      (hl),19 ;stdin
+    ld      (hl),18 ;stdin
     ld      hl,__sgoioblk+12
-    ld      (hl),21 ;stdout
+    ld      (hl),20 ;stdout
     ld      hl,__sgoioblk+22
-    ld      (hl),21 ;stderr
+    ld      (hl),20 ;stderr
 ENDIF
     INCLUDE "crt/classic/crt_copy_data_section.inc"
 

--- a/libsrc/stdio/_freopen1.c
+++ b/libsrc/stdio/_freopen1.c
@@ -19,15 +19,15 @@ FILE *_freopen1(const char* name, int fd, const char* mode, FILE* fp)
     switch (*(unsigned char*)mode++) {
     case 'r':
         access = O_RDONLY;
-        flags = _IOREAD | _IOUSE | _IOTEXT;
+        flags = _IOREAD | _IOTEXT;
         break;
     case 'w':
         access = O_WRONLY | O_TRUNC | O_CREAT;
-        flags = _IOWRITE | _IOUSE | _IOTEXT;
+        flags = _IOWRITE  | _IOTEXT;
         break;
     case 'a':
         access = O_APPEND | O_WRONLY | O_CREAT;
-        flags = _IOWRITE | _IOUSE | _IOTEXT;
+        flags = _IOWRITE  | _IOTEXT;
         break;
     default:
         return NULL;
@@ -37,10 +37,10 @@ FILE *_freopen1(const char* name, int fd, const char* mode, FILE* fp)
         mode++;
         if (access == O_RDONLY) {
             access = O_RDWR;
-			flags = _IOREAD | _IOWRITE | _IOUSE | _IOTEXT;
+			flags = _IOREAD | _IOWRITE  | _IOTEXT;
         } else if (access & O_TRUNC) {  // 'w'
             access = O_RDWR | O_TRUNC | O_CREAT;
-			flags = _IOREAD | _IOWRITE | _IOUSE | _IOTEXT;
+			flags = _IOREAD | _IOWRITE  | _IOTEXT;
         } else {
             access = O_RDWR | O_CREAT;
         }

--- a/libsrc/stdio/_sscanf.asm
+++ b/libsrc/stdio/_sscanf.asm
@@ -26,7 +26,7 @@ ENDIF
     ex      de,hl        ;de=&fmt
     ld      hl,65535        ;infinite length
     push    hl
-    ld      hl,1+2+128    ;h=ungetc, l=_IOREAD|_IOSTRING|_IOUSE
+    ld      hl,2+128    ;h=ungetc, l=_IOREAD|_IOSTRING
     push    hl        ;
     push    bc        ;buf
     ld      hl,0

--- a/libsrc/stdio/_vsscanf.asm
+++ b/libsrc/stdio/_vsscanf.asm
@@ -18,9 +18,9 @@ _vsscanf:
 IF !__CPU_INTEL__
     push    ix    ;save callers
 ENDIF
-        ld      bc,65535        ;infinite length
-        push    bc
-    ld      bc,1+2+128      ;h=ungetc, l=_IOREAD|_IOSTRING|_IOUSE
+    ld      bc,65535        ;infinite length
+    push    bc
+    ld      bc,2+128      ;h=ungetc, l=_IOREAD|_IOSTRING
     push    bc
     ld      c,(hl)        ;get buf
     inc     hl

--- a/libsrc/stdio/fclose.c
+++ b/libsrc/stdio/fclose.c
@@ -31,7 +31,7 @@ ENDIF
     ld      d,(hl)
     inc     hl
     ld      a,(hl)
-    and     _IOUSE        ;inuse?
+    and     a        ;inuse?
     jr      nz, fclose_inuse
 fclose_error:
     ld      hl,-1        ;EOF

--- a/libsrc/stdio/ferror.c
+++ b/libsrc/stdio/ferror.c
@@ -34,7 +34,7 @@ _ferror_fastcall:
     ld      a,(hl)
     ld      hl,1
     
-    and     _IOUSE        ; in use?
+    and     a        ; in use?
     ret     z
     
 ; check EOF only if not WRITE mode

--- a/libsrc/stdio/fflush.c
+++ b/libsrc/stdio/fflush.c
@@ -29,8 +29,8 @@ ENDIF
     ld      d,(hl)
     inc     hl
     ld      a,(hl)
-    and     _IOUSE|_IOSYSTEM|_IOWRITE
-    cp      _IOUSE|_IOWRITE
+    and     _IOSYSTEM|_IOWRITE
+    cp      _IOWRITE
 IF __CPU_INTEL__ | __CPU_GBZ80__ 
     jr      nz,fflush_error
 ELSE
@@ -43,8 +43,8 @@ ENDIF
 IF !__CPU_INTEL__ && !__CPU_GBZ80__
 check_extra:
     ld      a,(hl)
-    and     _IOUSE|_IOEXTRA
-    cp      _IOUSE|_IOEXTRA
+    and     _IOEXTRA
+    cp      _IOEXTRA
     jr      nz,fflush_error     ;not used
     push    ix    ;save callers ix
     dec     hl

--- a/libsrc/stdio/fgetc.c
+++ b/libsrc/stdio/fgetc.c
@@ -67,7 +67,6 @@ fgetc_assign_ret:
     ret
 .no_ungetc
 ; Now do strings
-    dec     de	;de=&fp_flags
     ld      a,(de)
     and     _IOSTRING
     jr      z,no_string	;not a string

--- a/libsrc/stdio/fgetpos.c
+++ b/libsrc/stdio/fgetpos.c
@@ -47,7 +47,7 @@ ENDIF
     ld      d,(hl)
     inc     hl
     ld      a,(hl)    ;flags
-    and     _IOUSE
+    and     a
     jr      z,fgetpos_abort
     and     _IOSYSTEM
     jr      nz,fgetpos_abort
@@ -98,7 +98,7 @@ ENDIF
 
 #endasm
 #else
-    if ( fp->flags&_IOUSE && fchkstd(fp)== 0 ) {
+    if ( fp->flags && fchkstd(fp)== 0 ) {
         return (fdgetpos(fp->fd,posn));
     }
     return -1;

--- a/libsrc/stdio/fseek.c
+++ b/libsrc/stdio/fseek.c
@@ -21,7 +21,7 @@ static long fseek1(FILE *fp, fpos_t posn, int whence) __z88dk_callee;
 
 int fseek(FILE *fp, fpos_t posn, int whence) __z88dk_saveframe
 {
-    if ( fp->flags&_IOUSE && fchkstd(fp)== 0 ) {
+    if ( fp->flags && fchkstd(fp)== 0 ) {
 #if CPU_8080 || CPU_8085 || CPU_GBZ80
         if (lseek(fp->desc.fd,posn,whence) != -1L ) {
 #else

--- a/libsrc/stdio/ftell.c
+++ b/libsrc/stdio/ftell.c
@@ -33,7 +33,7 @@ ENDIF
     ld      d,(hl)
     inc     hl
     ld      a,(hl)  ; flags
-    and    _IOUSE
+    and     a
     jr      z,ftell_abort
     ld      a,(hl)
     and     _IOSYSTEM
@@ -79,7 +79,7 @@ IF !__CPU_INTEL__ && !__CPU_GBZ80__
 ENDIF
 #endasm
 #else
-    if ( fp->flags&_IOUSE && fchkstd(fp)== 0 ) {
+    if ( fp->flags && fchkstd(fp)== 0 ) {
         return (fdtell(fp->fd));
     }
     return -1L;

--- a/libsrc/stdio/funopen.c
+++ b/libsrc/stdio/funopen.c
@@ -43,7 +43,7 @@ ELSE
     inc     hl
     ld      (hl),d
     inc     hl
-    ld      (hl),_IOUSE|_IOEXTRA|_IOREAD|_IOWRITE
+    ld      (hl),_IOEXTRA|_IOREAD|_IOWRITE
     inc     hl
     ld      (hl),0      ;ungetc
     inc     hl

--- a/libsrc/stdio/fwrite.c
+++ b/libsrc/stdio/fwrite.c
@@ -8,7 +8,7 @@
 
 #if __8080 || __8085
 int fwrite(void *ptr, size_t size, size_t nmemb, FILE *fp) {
-    if ( (fp->flags & (_IOUSE|_IOWRITE|_IOSYSTEM)) == (_IOUSE|_IOWRITE)) {
+    if ( (fp->flags & (_IOWRITE|_IOSYSTEM)) == (_IOWRITE)) {
     unsigned int len = size * nmemb;
 
     if ( len == 0 ) return 0;
@@ -66,8 +66,8 @@ ELSE
     ld      a,(ix + fp_flags)
     bit     4,a             ; _IOSYSTEM
     jr      nz,fwrite_done
-    and     _IOUSE | _IOWRITE
-    cp      _IOUSE | _IOWRITE
+    and     _IOWRITE
+    cp      _IOWRITE
     jr      nz,fwrite_done
     ; ix = fp
     ; bc = bytes to write

--- a/libsrc/stdio/sscanf.asm
+++ b/libsrc/stdio/sscanf.asm
@@ -32,7 +32,7 @@ ENDIF
     ex      de,hl      ;de=&fmy+1
     ld      hl,65535   ;infinite length
     push    hl
-    ld      hl,1+2+128 ;h=ungetc, l=_IOREAD|_IOSTRING|_IOUSE
+    ld      hl,2+128 ;h=ungetc, l=_IOREAD|_IOSTRING
     push    hl
     push    bc         ;buf
     ld      hl,0

--- a/libsrc/stdio/ungetc.c
+++ b/libsrc/stdio/ungetc.c
@@ -27,12 +27,15 @@ int ungetc(int c, FILE *fp)
     inc     de
     inc     de      ;now on flags
     ld      a,(de)
-    ld      b,a
-    and     _IOUSE
+    ld      b,a     ;b=flags
+    and     a
     ret     z       ;not being used
     ld      a,b
-    and     _IOEOF |_IOWRITE
+    and     _IOEOF |_IOWRITE|_IOUNGETC
     ret     nz      ;cant push back after EOF (or for write stream)
+    ld      a,b     ;indicate that we have a character ungot
+    or      _IOUNGETC
+    ld      (de),a
     inc     de      ;now on ungetc
     ld      a,(de)
     and     a
@@ -47,9 +50,10 @@ IF __CPU_GBZ80__
 ENDIF
 #endasm
 #else
-    if (fp == 0 || c == EOF || fp->ungetc || fp->flags&_IOWRITE ) return(EOF);
+    if (fp == 0 || c == EOF || fp->ungetc || fp->flags&(_IOEOF|_IOUNGETC|)IOWRITE ) return(EOF);
     
     fp->ungetc=(unsigned char)c;
+    fp->flags |= _IOUNGETC;
     return(c);
 #endif
 }

--- a/libsrc/stdio/ungetc.c
+++ b/libsrc/stdio/ungetc.c
@@ -30,16 +30,12 @@ int ungetc(int c, FILE *fp)
     ld      b,a     ;b=flags
     and     a
     ret     z       ;not being used
-    ld      a,b
     and     _IOEOF |_IOWRITE|_IOUNGETC
     ret     nz      ;cant push back after EOF (or for write stream)
     ld      a,b     ;indicate that we have a character ungot
     or      _IOUNGETC
     ld      (de),a
     inc     de      ;now on ungetc
-    ld      a,(de)
-    and     a
-    ret     nz
     ex      de,hl
     ld      (hl),c  ;store the char
     ld      l,c     ;return it

--- a/libsrc/stdio/vsscanf.asm
+++ b/libsrc/stdio/vsscanf.asm
@@ -28,9 +28,9 @@ ENDIF
     ld      c,(hl)
     dec     hl          ;&fmt+1
     ex      de,hl           ;de=&fmt+1
-    ld      hl,65535    ;ininite length
+    ld      hl,65535    ;infinite length
     push    hl 
-    ld      hl,1+2+128  ;h=ungetc, l=_IOREAD|_IOSTRING|_IOUSE
+    ld      hl,2+128  ;h=ungetc, l=_IOREAD|_IOSTRING
     push    hl
     push    bc          ;buf
     ld      hl,0

--- a/libsrc/stdio/zsock/fopen_zsock.c
+++ b/libsrc/stdio/zsock/fopen_zsock.c
@@ -45,7 +45,7 @@ FILE *fopen_zsock(char *name)
 	len=open_net1(host,atoi(++next2),proto);
 	if ( len ) {
 		fp->desc.ptr=(uint8_t *)len;
-		fp->flags=_IOEXTRA|_IOUSE;
+		fp->flags=_IOEXTRA;
 		fp->ungetc=0;
 		fp->extra = zsock_trampoline;
 		return fp;


### PR DESCRIPTION
Correct ungetc to use a flag rather than a non-zero ungetc byte. 

We’ve run out of flags so dump _IOUSE in favour of any flags being set to indicate in use. 

Ripple this through various functions. 

Optimise flag checking. 

Fix 8080 fread so it has the same logic as z80. 