### PR TITLE
Some missing zxn definitions for sprites and tilemap registers

### DIFF
--- a/libsrc/_DEVELOPMENT/Makefile
+++ b/libsrc/_DEVELOPMENT/Makefile
@@ -55,9 +55,9 @@ target/$(1)/obj/config_private.inc: target/$(1)/config.m4
 		else \
 			echo "";  \
 		fi) )
-	m4 -DCFG_ASM_DEF target/$(1)/config.m4 > target/$(1)/config_$(1)_private.inc
-	m4 -DCFG_ASM_PUB target/$(1)/config.m4 > target/$(1)/config_$(1)_public.inc
-	m4 -DCFG_C_DEF target/$(1)/config.m4 > target/$(1)/config_$(1).h
+	m4 -DCFG_ASM_DEF -I../../src/m4 target/$(1)/config.m4 > target/$(1)/config_$(1)_private.inc
+	m4 -DCFG_ASM_PUB  -I../../src/m4 target/$(1)/config.m4 > target/$(1)/config_$(1)_public.inc
+	m4 -DCFG_C_DEF  -I../../src/m4 target/$(1)/config.m4 > target/$(1)/config_$(1).h
 	cp target/$(1)/config_$(1)_private.inc target/$(1)/obj/config_private.inc
 	@if [ "$(1)" = "zx" ]; then \
 		zcc +z80 -vn -clib=new --no-crt -g -Ca"-DSTRIPVECTOR" -Cm-Itarget/$(1)/obj arch/zx/bifrost2/z80/BIFROST2_ENGINE.asm.m4 -o target/zx/obj/bifrost2_engine_48.bin; \

--- a/libsrc/_DEVELOPMENT/target/zxn/config.m4
+++ b/libsrc/_DEVELOPMENT/target/zxn/config.m4
@@ -65,6 +65,7 @@ include(`target/zxn/config/config_zxn_sprites.m4')
 include(`target/zxn/config/config_zxn_sysvar.m4')
 include(`target/zxn/config/config_zxn_uart.m4')
 include(`target/zxn/config/config_zxn_ula.m4')
+include(`target/zxn/config/config_zxn_from_headers.m4')
 
 dnl############################################################
 dnl# END IF GUARDS

--- a/libsrc/_DEVELOPMENT/target/zxn/config/config_zxn_from_headers.m4
+++ b/libsrc/_DEVELOPMENT/target/zxn/config/config_zxn_from_headers.m4
@@ -1,0 +1,10 @@
+divert(-1)
+# Constants created from regular header files (limited to comments and #define entries)
+# to facilitate maintenance and improve documentation
+
+include(`z88dk.m4')
+
+divert(0)
+
+Z88DK_PROCESS_CONSTANTS_H(`target/zxn/config/config_zxn_tilemap.h')
+Z88DK_PROCESS_CONSTANTS_H(`target/zxn/config/config_zxn_sprites.h')

--- a/libsrc/_DEVELOPMENT/target/zxn/config/config_zxn_sprites.h
+++ b/libsrc/_DEVELOPMENT/target/zxn/config/config_zxn_sprites.h
@@ -1,0 +1,66 @@
+// ------------------------------------------
+// Hardware sprites registers and flags
+// ------------------------------------------
+
+// Register for selection of the active sprite attribute and pattern slot index
+#define REG_SPRITE_NUMBER 0x34
+
+// Low 8 bits of sprite X position registers
+#define REG_SPRITE_ATTR_X 0x35
+#define REG_SPRITE_ATTR_0 0x35
+#define REG_SPRITE_ATTR_X_INCREMENT 0x75
+#define REG_SPRITE_ATTR_0_INCREMENT 0x75
+
+// Low 8 bits of sprite Y position registers
+#define REG_SPRITE_ATTR_Y 0x36
+#define REG_SPRITE_ATTR_1 0x36
+#define REG_SPRITE_ATTR_Y_INCREMENT 0x76
+#define REG_SPRITE_ATTR_1_INCREMENT 0x76
+
+// Sprite attr 2 registers
+#define REG_SPRITE_ATTR2 0x37
+#define REG_SPRITE_ATTR2_INCREMENT 0x77
+
+// Sprite attr 2 flags
+#define RSA2_ENABLE_X_MIRRORING 0x08
+#define RSA2_ENABLE_Y_MIRRORING 0x04
+#define RSA2_ROTATE_CLOCKWISE 0x02
+#define RSA2_RELATIVE_ANCHOR_PALETTE 0x01
+
+// Sprite attr 3 registers
+#define REG_SPRITE_ATTR3 0x38
+#define REG_SPRITE_ATTR3_INCREMENT 0x78
+
+// Sprite attr 3 flags
+#define RSA3_VISIBLE 0x80
+#define RSA3_USE_BYTE_4 0x40
+
+// Sprite attr 4 register
+#define REG_SPRITE_ATTR4 0x39
+#define REG_SPRITE_ATTR4_INCREMENT 0x79
+
+// Sprite attr 4 flags for anchor sprites
+#define RSA4_ANCHOR_SPRITE_8BIT 0b00000000
+#define RSA4_ANCHOR_SPRITE_4BIT_0_127_PATTERN 0b10000000
+#define RSA4_ANCHOR_SPRITE_4BIT_128_255_PATTERN 0b11000000
+#define RSA4_ANCHOR_UNIFIED 0b00100000
+#define RSA4_ANCHOR_COMPOSITE 0b00000000
+
+// Sprite attr 4 flags for composite relative sprites
+#define RSA4_RELATIVE_SPRITE 0b01000000
+#define RSA4_RELATIVE_ANCHOR_PATTERN 0b00000001
+
+// Sprite attr 4 flags for scaling
+#define RSA4_X_SCALE_2X 0b00001000
+#define RSA4_X_SCALE_4X 0b00010000
+#define RSA4_X_SCALE_8X 0b00011000
+#define RSA4_Y_SCALE_2X 0b00000100
+#define RSA4_Y_SCALE_4X 0b00000010
+#define RSA4_Y_SCALE_8X 0b00000110
+
+// ----------------------------------------------------------------------------
+// Sprite flags for Sprite and Layers System register (REG_SPRITE_LAYER_SYSTEM)
+// ----------------------------------------------------------------------------
+
+// Enable cliping of sprites over the border
+#define RSLS_ENABLE_SPRITES_CLIPING_OVER_BORDER 0x20

--- a/libsrc/_DEVELOPMENT/target/zxn/config/config_zxn_tilemap.h
+++ b/libsrc/_DEVELOPMENT/target/zxn/config/config_zxn_tilemap.h
@@ -1,0 +1,35 @@
+// ------------------------------------------
+// Hardware tilemap (aka layer 3) registers
+// ------------------------------------------
+
+// Sets and reads the clip-window for Tilemap graphics
+#define REG_CLIP_WINDOW_TILEMAP 0x1B
+
+// Sets the X pixel offset (two high bits) used for drawing Tilemap graphics on the screen
+#define REG_TILEMAP_OFFSET_X_MSB 0x2f
+
+// Sets the X pixel offset (two low bits) used for drawing Tilemap graphics on the screen
+#define REG_TILEMAP_OFFSET_X_LSB 0x3
+
+// Sets the Y pixel offset used for drawing Tilemap graphics on the screen
+#define REG_TILEMAP_OFFSET_Y 0x31
+
+// Sets the transparency index for Tilemap graphics
+#define REG_TILEMAP_TRANSPARENCY_INDEX 0x4C
+
+// ----------------------------------------------------------------
+// Tilemap values for clip window control (REG_CLIP_WINDOW_CONTROL)
+// ----------------------------------------------------------------
+
+// Reset the tilemap clip index
+#define RCWC_RESET_TILEMAP_CLIP_INDEX 0x08
+
+// ------------------------------------------------------------------------
+// Tilemap selection for the palette control register (REG_PALETTE_CONTROL)
+// ------------------------------------------------------------------------
+
+// Tilemap first palette
+#define RPC_SELECT_TILEMAP_PALETTE_0 0x30
+
+// Tilemap second palette
+#define RPC_SELECT_TILEMAP_PALETTE_1 0x70

--- a/libsrc/_DEVELOPMENT/target/zxn/config_zxn.h
+++ b/libsrc/_DEVELOPMENT/target/zxn/config_zxn.h
@@ -2933,6 +2933,120 @@
 
 
 
+
+// ------------------------------------------
+// Hardware tilemap (aka layer 3) registers
+// ------------------------------------------
+
+// Sets and reads the clip-window for Tilemap graphics
+#define REG_CLIP_WINDOW_TILEMAP 0x1B
+
+// Sets the X pixel offset (two high bits) used for drawing Tilemap graphics on the screen
+#define REG_TILEMAP_OFFSET_X_MSB 0x2f
+
+// Sets the X pixel offset (two low bits) used for drawing Tilemap graphics on the screen
+#define REG_TILEMAP_OFFSET_X_LSB 0x3
+
+// Sets the Y pixel offset used for drawing Tilemap graphics on the screen
+#define REG_TILEMAP_OFFSET_Y 0x31
+
+// Sets the transparency index for Tilemap graphics
+#define REG_TILEMAP_TRANSPARENCY_INDEX 0x4C
+
+// ----------------------------------------------------------------
+// Tilemap values for clip window control (REG_CLIP_WINDOW_CONTROL)
+// ----------------------------------------------------------------
+
+// Reset the tilemap clip index
+#define RCWC_RESET_TILEMAP_CLIP_INDEX 0x08
+
+// ------------------------------------------------------------------------
+// Tilemap selection for the palette control register (REG_PALETTE_CONTROL)
+// ------------------------------------------------------------------------
+
+// Tilemap first palette
+#define RPC_SELECT_TILEMAP_PALETTE_0 0x30
+
+// Tilemap second palette
+#define RPC_SELECT_TILEMAP_PALETTE_1 0x70
+
+
+
+
+
+// ------------------------------------------
+// Hardware sprites registers and flags
+// ------------------------------------------
+
+// Register for selection of the active sprite attribute and pattern slot index
+#define REG_SPRITE_NUMBER 0x34
+
+// Low 8 bits of sprite X position registers
+#define REG_SPRITE_ATTR_X 0x35
+#define REG_SPRITE_ATTR_0 0x35
+#define REG_SPRITE_ATTR_X_INCREMENT 0x75
+#define REG_SPRITE_ATTR_0_INCREMENT 0x75
+
+// Low 8 bits of sprite Y position registers
+#define REG_SPRITE_ATTR_Y 0x36
+#define REG_SPRITE_ATTR_1 0x36
+#define REG_SPRITE_ATTR_Y_INCREMENT 0x76
+#define REG_SPRITE_ATTR_1_INCREMENT 0x76
+
+// Sprite attr 2 registers
+#define REG_SPRITE_ATTR2 0x37
+#define REG_SPRITE_ATTR2_INCREMENT 0x77
+
+// Sprite attr 2 flags
+#define RSA2_ENABLE_X_MIRRORING 0x08
+#define RSA2_ENABLE_Y_MIRRORING 0x04
+#define RSA2_ROTATE_CLOCKWISE 0x02
+#define RSA2_RELATIVE_ANCHOR_PALETTE 0x01
+
+// Sprite attr 3 registers
+#define REG_SPRITE_ATTR3 0x38
+#define REG_SPRITE_ATTR3_INCREMENT 0x78
+
+// Sprite attr 3 flags
+#define RSA3_VISIBLE 0x80
+#define RSA3_USE_BYTE_4 0x40
+
+// Sprite attr 4 register
+#define REG_SPRITE_ATTR4 0x39
+#define REG_SPRITE_ATTR4_INCREMENT 0x79
+
+// Sprite attr 4 flags for anchor sprites
+#define RSA4_ANCHOR_SPRITE_8BIT 0b00000000
+#define RSA4_ANCHOR_SPRITE_4BIT_0_127_PATTERN 0b10000000
+#define RSA4_ANCHOR_SPRITE_4BIT_128_255_PATTERN 0b11000000
+#define RSA4_ANCHOR_UNIFIED 0b00100000
+#define RSA4_ANCHOR_COMPOSITE 0b00000000
+
+// Sprite attr 4 flags for composite relative sprites
+#define RSA4_RELATIVE_SPRITE 0b01000000
+#define RSA4_RELATIVE_ANCHOR_PATTERN 0b00000001
+
+// Sprite attr 4 flags for scaling
+#define RSA4_X_SCALE_2X 0b00001000
+#define RSA4_X_SCALE_4X 0b00010000
+#define RSA4_X_SCALE_8X 0b00011000
+#define RSA4_Y_SCALE_2X 0b00000100
+#define RSA4_Y_SCALE_4X 0b00000010
+#define RSA4_Y_SCALE_8X 0b00000110
+
+// ----------------------------------------------------------------------------
+// Sprite flags for Sprite and Layers System register (REG_SPRITE_LAYER_SYSTEM)
+// ----------------------------------------------------------------------------
+
+// Enable cliping of sprites over the border
+#define RSLS_ENABLE_SPRITES_CLIPING_OVER_BORDER 0x20
+
+
+
+
+
+
+
 #endif
 
 

--- a/libsrc/_DEVELOPMENT/target/zxn/config_zxn_private.inc
+++ b/libsrc/_DEVELOPMENT/target/zxn/config_zxn_private.inc
@@ -2949,6 +2949,120 @@ defc __IO_FF_HIRES_WHITE = 0x3e
 
 
 
+; ------------------------------------------
+; Hardware tilemap (aka layer 3) registers
+; ------------------------------------------
+
+; Sets and reads the clip-window for Tilemap graphics
+defc __REG_CLIP_WINDOW_TILEMAP = 0x1B
+
+; Sets the X pixel offset (two high bits) used for drawing Tilemap graphics on the screen
+defc __REG_TILEMAP_OFFSET_X_MSB = 0x2f
+
+; Sets the X pixel offset (two low bits) used for drawing Tilemap graphics on the screen
+defc __REG_TILEMAP_OFFSET_X_LSB = 0x3
+
+; Sets the Y pixel offset used for drawing Tilemap graphics on the screen
+defc __REG_TILEMAP_OFFSET_Y = 0x31
+
+; Sets the transparency index for Tilemap graphics
+defc __REG_TILEMAP_TRANSPARENCY_INDEX = 0x4C
+
+; ----------------------------------------------------------------
+; Tilemap values for clip window control (REG_CLIP_WINDOW_CONTROL)
+; ----------------------------------------------------------------
+
+; Reset the tilemap clip index
+defc __RCWC_RESET_TILEMAP_CLIP_INDEX = 0x08
+
+; ------------------------------------------------------------------------
+; Tilemap selection for the palette control register (REG_PALETTE_CONTROL)
+; ------------------------------------------------------------------------
+
+; Tilemap first palette
+defc __RPC_SELECT_TILEMAP_PALETTE_0 = 0x30
+
+; Tilemap second palette
+defc __RPC_SELECT_TILEMAP_PALETTE_1 = 0x70
+
+
+
+
+
+; ------------------------------------------
+; Hardware sprites registers and flags
+; ------------------------------------------
+
+; Register for selection of the active sprite attribute and pattern slot index
+defc __REG_SPRITE_NUMBER = 0x34
+
+; Low 8 bits of sprite X position registers
+defc __REG_SPRITE_ATTR_X = 0x35
+defc __REG_SPRITE_ATTR_0 = 0x35
+defc __REG_SPRITE_ATTR_X_INCREMENT = 0x75
+defc __REG_SPRITE_ATTR_0_INCREMENT = 0x75
+
+; Low 8 bits of sprite Y position registers
+defc __REG_SPRITE_ATTR_Y = 0x36
+defc __REG_SPRITE_ATTR_1 = 0x36
+defc __REG_SPRITE_ATTR_Y_INCREMENT = 0x76
+defc __REG_SPRITE_ATTR_1_INCREMENT = 0x76
+
+; Sprite attr 2 registers
+defc __REG_SPRITE_ATTR2 = 0x37
+defc __REG_SPRITE_ATTR2_INCREMENT = 0x77
+
+; Sprite attr 2 flags
+defc __RSA2_ENABLE_X_MIRRORING = 0x08
+defc __RSA2_ENABLE_Y_MIRRORING = 0x04
+defc __RSA2_ROTATE_CLOCKWISE = 0x02
+defc __RSA2_RELATIVE_ANCHOR_PALETTE = 0x01
+
+; Sprite attr 3 registers
+defc __REG_SPRITE_ATTR3 = 0x38
+defc __REG_SPRITE_ATTR3_INCREMENT = 0x78
+
+; Sprite attr 3 flags
+defc __RSA3_VISIBLE = 0x80
+defc __RSA3_USE_BYTE_4 = 0x40
+
+; Sprite attr 4 register
+defc __REG_SPRITE_ATTR4 = 0x39
+defc __REG_SPRITE_ATTR4_INCREMENT = 0x79
+
+; Sprite attr 4 flags for anchor sprites
+defc __RSA4_ANCHOR_SPRITE_8BIT = 0b00000000
+defc __RSA4_ANCHOR_SPRITE_4BIT_0_127_PATTERN = 0b10000000
+defc __RSA4_ANCHOR_SPRITE_4BIT_128_255_PATTERN = 0b11000000
+defc __RSA4_ANCHOR_UNIFIED = 0b00100000
+defc __RSA4_ANCHOR_COMPOSITE = 0b00000000
+
+; Sprite attr 4 flags for composite relative sprites
+defc __RSA4_RELATIVE_SPRITE = 0b01000000
+defc __RSA4_RELATIVE_ANCHOR_PATTERN = 0b00000001
+
+; Sprite attr 4 flags for scaling
+defc __RSA4_X_SCALE_2X = 0b00001000
+defc __RSA4_X_SCALE_4X = 0b00010000
+defc __RSA4_X_SCALE_8X = 0b00011000
+defc __RSA4_Y_SCALE_2X = 0b00000100
+defc __RSA4_Y_SCALE_4X = 0b00000010
+defc __RSA4_Y_SCALE_8X = 0b00000110
+
+; ----------------------------------------------------------------------------
+; Sprite flags for Sprite and Layers System register (REG_SPRITE_LAYER_SYSTEM)
+; ----------------------------------------------------------------------------
+
+; Enable cliping of sprites over the border
+defc __RSLS_ENABLE_SPRITES_CLIPING_OVER_BORDER = 0x20
+
+
+
+
+
+
+
+
 
 
 ENDIF

--- a/libsrc/_DEVELOPMENT/target/zxn/config_zxn_public.inc
+++ b/libsrc/_DEVELOPMENT/target/zxn/config_zxn_public.inc
@@ -5521,6 +5521,163 @@ defc __IO_FF_HIRES_WHITE = 0x3e
 
 
 
+; ------------------------------------------
+; Hardware tilemap (aka layer 3) registers
+; ------------------------------------------
+
+; Sets and reads the clip-window for Tilemap graphics
+defc __REG_CLIP_WINDOW_TILEMAP = 0x1B
+
+; Sets the X pixel offset (two high bits) used for drawing Tilemap graphics on the screen
+defc __REG_TILEMAP_OFFSET_X_MSB = 0x2f
+
+; Sets the X pixel offset (two low bits) used for drawing Tilemap graphics on the screen
+defc __REG_TILEMAP_OFFSET_X_LSB = 0x3
+
+; Sets the Y pixel offset used for drawing Tilemap graphics on the screen
+defc __REG_TILEMAP_OFFSET_Y = 0x31
+
+; Sets the transparency index for Tilemap graphics
+defc __REG_TILEMAP_TRANSPARENCY_INDEX = 0x4C
+
+; ----------------------------------------------------------------
+; Tilemap values for clip window control (REG_CLIP_WINDOW_CONTROL)
+; ----------------------------------------------------------------
+
+; Reset the tilemap clip index
+defc __RCWC_RESET_TILEMAP_CLIP_INDEX = 0x08
+
+; ------------------------------------------------------------------------
+; Tilemap selection for the palette control register (REG_PALETTE_CONTROL)
+; ------------------------------------------------------------------------
+
+; Tilemap first palette
+defc __RPC_SELECT_TILEMAP_PALETTE_0 = 0x30
+
+; Tilemap second palette
+defc __RPC_SELECT_TILEMAP_PALETTE_1 = 0x70
+
+
+PUBLIC __REG_CLIP_WINDOW_TILEMAP
+PUBLIC __REG_TILEMAP_OFFSET_X_MSB
+PUBLIC __REG_TILEMAP_OFFSET_X_LSB
+PUBLIC __REG_TILEMAP_OFFSET_Y
+PUBLIC __REG_TILEMAP_TRANSPARENCY_INDEX
+PUBLIC __RCWC_RESET_TILEMAP_CLIP_INDEX
+PUBLIC __RPC_SELECT_TILEMAP_PALETTE_0
+PUBLIC __RPC_SELECT_TILEMAP_PALETTE_1
+
+
+
+; ------------------------------------------
+; Hardware sprites registers and flags
+; ------------------------------------------
+
+; Register for selection of the active sprite attribute and pattern slot index
+defc __REG_SPRITE_NUMBER = 0x34
+
+; Low 8 bits of sprite X position registers
+defc __REG_SPRITE_ATTR_X = 0x35
+defc __REG_SPRITE_ATTR_0 = 0x35
+defc __REG_SPRITE_ATTR_X_INCREMENT = 0x75
+defc __REG_SPRITE_ATTR_0_INCREMENT = 0x75
+
+; Low 8 bits of sprite Y position registers
+defc __REG_SPRITE_ATTR_Y = 0x36
+defc __REG_SPRITE_ATTR_1 = 0x36
+defc __REG_SPRITE_ATTR_Y_INCREMENT = 0x76
+defc __REG_SPRITE_ATTR_1_INCREMENT = 0x76
+
+; Sprite attr 2 registers
+defc __REG_SPRITE_ATTR2 = 0x37
+defc __REG_SPRITE_ATTR2_INCREMENT = 0x77
+
+; Sprite attr 2 flags
+defc __RSA2_ENABLE_X_MIRRORING = 0x08
+defc __RSA2_ENABLE_Y_MIRRORING = 0x04
+defc __RSA2_ROTATE_CLOCKWISE = 0x02
+defc __RSA2_RELATIVE_ANCHOR_PALETTE = 0x01
+
+; Sprite attr 3 registers
+defc __REG_SPRITE_ATTR3 = 0x38
+defc __REG_SPRITE_ATTR3_INCREMENT = 0x78
+
+; Sprite attr 3 flags
+defc __RSA3_VISIBLE = 0x80
+defc __RSA3_USE_BYTE_4 = 0x40
+
+; Sprite attr 4 register
+defc __REG_SPRITE_ATTR4 = 0x39
+defc __REG_SPRITE_ATTR4_INCREMENT = 0x79
+
+; Sprite attr 4 flags for anchor sprites
+defc __RSA4_ANCHOR_SPRITE_8BIT = 0b00000000
+defc __RSA4_ANCHOR_SPRITE_4BIT_0_127_PATTERN = 0b10000000
+defc __RSA4_ANCHOR_SPRITE_4BIT_128_255_PATTERN = 0b11000000
+defc __RSA4_ANCHOR_UNIFIED = 0b00100000
+defc __RSA4_ANCHOR_COMPOSITE = 0b00000000
+
+; Sprite attr 4 flags for composite relative sprites
+defc __RSA4_RELATIVE_SPRITE = 0b01000000
+defc __RSA4_RELATIVE_ANCHOR_PATTERN = 0b00000001
+
+; Sprite attr 4 flags for scaling
+defc __RSA4_X_SCALE_2X = 0b00001000
+defc __RSA4_X_SCALE_4X = 0b00010000
+defc __RSA4_X_SCALE_8X = 0b00011000
+defc __RSA4_Y_SCALE_2X = 0b00000100
+defc __RSA4_Y_SCALE_4X = 0b00000010
+defc __RSA4_Y_SCALE_8X = 0b00000110
+
+; ----------------------------------------------------------------------------
+; Sprite flags for Sprite and Layers System register (REG_SPRITE_LAYER_SYSTEM)
+; ----------------------------------------------------------------------------
+
+; Enable cliping of sprites over the border
+defc __RSLS_ENABLE_SPRITES_CLIPING_OVER_BORDER = 0x20
+
+
+PUBLIC __REG_SPRITE_NUMBER
+PUBLIC __REG_SPRITE_ATTR_X
+PUBLIC __REG_SPRITE_ATTR_0
+PUBLIC __REG_SPRITE_ATTR_X_INCREMENT
+PUBLIC __REG_SPRITE_ATTR_0_INCREMENT
+PUBLIC __REG_SPRITE_ATTR_Y
+PUBLIC __REG_SPRITE_ATTR_1
+PUBLIC __REG_SPRITE_ATTR_Y_INCREMENT
+PUBLIC __REG_SPRITE_ATTR_1_INCREMENT
+PUBLIC __REG_SPRITE_ATTR2
+PUBLIC __REG_SPRITE_ATTR2_INCREMENT
+PUBLIC __RSA2_ENABLE_X_MIRRORING
+PUBLIC __RSA2_ENABLE_Y_MIRRORING
+PUBLIC __RSA2_ROTATE_CLOCKWISE
+PUBLIC __RSA2_RELATIVE_ANCHOR_PALETTE
+PUBLIC __REG_SPRITE_ATTR3
+PUBLIC __REG_SPRITE_ATTR3_INCREMENT
+PUBLIC __RSA3_VISIBLE
+PUBLIC __RSA3_USE_BYTE_4
+PUBLIC __REG_SPRITE_ATTR4
+PUBLIC __REG_SPRITE_ATTR4_INCREMENT
+PUBLIC __RSA4_ANCHOR_SPRITE_8BIT
+PUBLIC __RSA4_ANCHOR_SPRITE_4BIT_0_127_PATTERN
+PUBLIC __RSA4_ANCHOR_SPRITE_4BIT_128_255_PATTERN
+PUBLIC __RSA4_ANCHOR_UNIFIED
+PUBLIC __RSA4_ANCHOR_COMPOSITE
+PUBLIC __RSA4_RELATIVE_SPRITE
+PUBLIC __RSA4_RELATIVE_ANCHOR_PATTERN
+PUBLIC __RSA4_X_SCALE_2X
+PUBLIC __RSA4_X_SCALE_4X
+PUBLIC __RSA4_X_SCALE_8X
+PUBLIC __RSA4_Y_SCALE_2X
+PUBLIC __RSA4_Y_SCALE_4X
+PUBLIC __RSA4_Y_SCALE_8X
+PUBLIC __RSLS_ENABLE_SPRITES_CLIPING_OVER_BORDER
+
+
+
+
+
+
 
 
 ENDIF

--- a/src/m4/z88dk.m4
+++ b/src/m4/z88dk.m4
@@ -56,5 +56,17 @@ ifelse($1,, __uniq_, $1_)`'eval(_Z88DK_UNIQ_ID_$1, 10, 4)')
 define(`Z88DK_CLBL', `define(`_Z88DK_UNIQ_ID_$2', ifdef(`_Z88DK_UNIQ_ID_$2', _Z88DK_UNIQ_ID_$2, 0))dnl
 ifelse($2,, __uniq_, $2_)`'ifelse($1,, eval(_Z88DK_UNIQ_ID_$2, 10, 4), `eval(_Z88DK_UNIQ_ID_$2 + $1, 10, 4)')')
 
+define(`Z88DK_H2ASMDEF', `syscmd(`sed -E -e "s/\/\//;/g" -e "s/^#define[ \t]+([A-Z_][A-Z0-9_]*)[ \t]+(.*)$/defc __\1 = \2/" $1')')
+define(`Z88DK_H2ASMPUB', `syscmd(`sed -n -E -e "s/^#define[ \t]+([A-Z_][A-Z0-9_]*)[ \t]+(.*)$/PUBLIC __\1/p" $1')')
+
+# Process a .h file with constants definitions for architecture config files
+define(`Z88DK_PROCESS_CONSTANTS_H', `
+ifdef(`CFG_ASM_DEF', `Z88DK_H2ASMDEF($1)')
+ifdef(`CFG_C_DEF', `include($1)')
+ifdef(`CFG_ASM_PUB',`Z88DK_H2ASMPUB($1)')
+')
+
+
+
 divert(Z88DK_DIVNUM)
 dnl`'popdef(`Z88DK_DIVNUM')


### PR DESCRIPTION
Given the high number of registers and flags in the Spec Next architecture, I am suggesting a simplified approach to maintain them. In this approach, the definitions are included in .h files that are included from a .m4 script. The macro takes care of adding the content of the .h to config_zxn.h and transforming those definitions to the syntax required by the ASM files config_zxn_public.inc and config_zxn_private.inc.