### PR TITLE
(zx) Move towards functions rather than macros using gencon bridge

### DIFF
--- a/include/arch/newbrain/newbrain.h
+++ b/include/arch/newbrain/newbrain.h
@@ -4,8 +4,8 @@
  *      $Id: newbrain.h,v 1.12 2016-06-23 21:11:24 dom Exp $
  */
 
-#ifndef __NEWBRAIN_H__
-#define __NEWBRAIN_H__
+#ifndef __ARCH_NEWBRAIN_H__
+#define __ARCH_NEWBRAIN_H__
 
 #include <sys/compiler.h>
 #include <sys/types.h>

--- a/include/arch/zx/spectrum.h
+++ b/include/arch/zx/spectrum.h
@@ -397,17 +397,17 @@ extern void __LIB__ zx_cls_attr_fastcall(int attr) __z88dk_fastcall;
 // Set or unset the flash attribute for now on
 extern void zx_setattrflash(uint f);
 extern void zx_setattrflash_fastcall(uint f) __z88dk_fastcall;
-#define zx_setattrflash(f) zx_settattrflash_fastcall(f)
+#define zx_setattrflash(f) zx_setattrflash_fastcall(f)
 
 // Set or unset the bright attribute for now on
 extern void zx_setattrbright(uint f);
 extern void zx_setattrbright_fastcall(uint f) __z88dk_fastcall;
-#define zx_setattrbright(f) zx_settattrbright_fastcall(f)
+#define zx_setattrbright(f) zx_setattrbright_fastcall(f)
 
 // Set or unset the inverse attribute for now on
 extern void zx_setattrinverse(uint f);
 extern void zx_setattrinverse_fastcall(uint f) __z88dk_fastcall;
-#define zx_setattrinverse(f) zx_settattrinverse_fastcall(f)
+#define zx_setattrinverse(f) zx_setattrinverse_fastcall(f)
 
 // Set the border color
 // Param colour can be any of: INK_BLACK, INK_BLUE,... to INK_WHITE

--- a/include/arch/zx/spectrum.h
+++ b/include/arch/zx/spectrum.h
@@ -385,44 +385,56 @@ extern int  __LIB__  tape_load_block_callee(void *addr, size_t len, unsigned cha
 // DISPLAY FILE FUNCTIONS
 //////////////////////////
 
-// NOTE: remember to compile with -pragma-define:CLIB_CONIO_NATIVE_COLOUR=1
-// in order to use INK_BLACK to INK_WHITE and PAPER_BLACK to PAPER_WHITE.
-// Clear the screen
-
+/// \brief  Clear the screen with the currently set attribute
 extern void __LIB__ zx_cls(void);
 
-// Clears the screen and sets the screen and current attribute to attr
+/// \brief  Clears the screen and sets the screen and current attribute to attr
+//  \param attr - The full attribute byte
 extern void __LIB__ zx_cls_attr(int attr);
 extern void __LIB__ zx_cls_attr_fastcall(int attr) __z88dk_fastcall;
 #define zx_cls_attr(a)                 zx_cls_attr_fastcall(a)
 
 // Set or unset the flash attribute for now on
-#define zx_setattrflash(b)        fputc_cons(18); fputc_cons((b)? 49: 48)
+extern void zx_setattrflash(uint f);
+extern void zx_setattrflash_fastcall(uint f) __z88dk_fastcall;
+#define zx_setattrflash(f) zx_settattrflash_fastcall(f)
 
 // Set or unset the bright attribute for now on
-#define zx_setattrbright(b)       fputc_cons(19); fputc_cons((b)? 49: 48)
+extern void zx_setattrbright(uint f);
+extern void zx_setattrbright_fastcall(uint f) __z88dk_fastcall;
+#define zx_setattrbright(f) zx_settattrbright_fastcall(f)
 
 // Set or unset the inverse attribute for now on
-#define zx_setattrinverse(b)      fputc_cons(20); fputc_cons((b)? 49: 48)
+extern void zx_setattrinverse(uint f);
+extern void zx_setattrinverse_fastcall(uint f) __z88dk_fastcall;
+#define zx_setattrinverse(f) zx_settattrinverse_fastcall(f)
 
 // Set the border color
 // Param colour can be any of: INK_BLACK, INK_BLUE,... to INK_WHITE
-extern void  __LIB__  zx_border(uchar colour) __z88dk_fastcall;
+extern void  __LIB__  zx_border(uint colour);
+extern void  __LIB__  zx_border_fastcall(uint colour) __z88dk_fastcall;
+#define zx_border(c) zx_border_fastcall(c)
+
+
 // Quickly set the whole screen color attributes
 // Param colour must be in the form i | p, where
 // i can be any of: INK_BLACK, INK_BLUE,... to INK_WHITE
 // p can be any of: PAPER_BLACK, PAPER_BLUE,... to PAPER_WHITE
-extern void  __LIB__  zx_colour(uchar colour) __z88dk_fastcall;
+extern void  __LIB__  zx_colour(uint colour);
+extern void  __LIB__  zx_colour_fastcall(uint colour) __z88dk_fastcall;
+#define zx_colour(a) zx_colour_fastcall(a)
 
 // Change the ink attr from now on
 // i can be any of: INK_BLACK, INK_BLUE,... to INK_WHITE
+extern void zx_setink(uint i);
+extern void __LIB__ zx_setink_fastcall(uint i) __z88dk_fastcall;
 #define zx_setink(i) zx_setink_fastcall(i)
-extern void __LIB__ zx_setink_fastcall(uint i);
 
 // Change the paper attr from now on
 // p can be any of: INK_BLACK, INK_BLUE,... to INK_WHITE
+extern void zx_setpaper(uint p);
+extern void __LIB__ zx_setpaper_fastcall(uint p) __z88dk_fastcall;
 #define zx_setpaper(p) zx_setpaper_fastcall(p)
-extern void __LIB__ zx_setpaper_fastcall(uint p);
 
 
 // Get color attribute at given position

--- a/lib/config/newbrain.cfg
+++ b/lib/config/newbrain.cfg
@@ -9,6 +9,6 @@ CRT0		 DESTDIR/lib/target/newbrain/classic/newbrain_crt0
 
 # Any default options you want - these are options to zcc which are fed
 # through to compiler, assembler etc as necessary
-OPTIONS		 -O2 -SO2 -iquote. -lnewbrain_clib -D__Z80__ -D__Z80 -DNEWBRAIN -D__NEWBRAIN__ -M -Cc-standard-escape-chars -Cz+newbrain -LDESTDIR/lib/clibs/z80
+OPTIONS		 -O2 -SO2 -iquote. -lnewbrain_clib -D__Z80__ -D__Z80 -DNEWBRAIN -D__NEWBRAIN__ -M -Cc-standard-escape-chars -Cz+newbrain -LDESTDIR/lib/clibs/z80 -IDESTDIR/include/arch/newbrain
 
 INCLUDE alias.inc

--- a/libsrc/target/zx/spectrum.lst
+++ b/libsrc/target/zx/spectrum.lst
@@ -5,6 +5,11 @@ target/zx/obj/${TARGET}/zx_cls
 target/zx/obj/${TARGET}/zx_border
 target/zx/obj/${TARGET}/zx_break
 target/zx/obj/${TARGET}/zx_colour
+target/zx/obj/${TARGET}/zx_setink
+target/zx/obj/${TARGET}/zx_setpaper
+target/zx/obj/${TARGET}/zx_setattrbright
+target/zx/obj/${TARGET}/zx_setattrflash
+target/zx/obj/${TARGET}/zx_setattrinverse
 target/zx/obj/${TARGET}/zx_screenstr
 target/zx/obj/${TARGET}/zx_screenstr_callee
 target/zx/obj/${TARGET}/zx_lprintc

--- a/libsrc/target/zx/zx_border.asm
+++ b/libsrc/target/zx/zx_border.asm
@@ -6,12 +6,19 @@
     SECTION code_clib
     PUBLIC  zx_border
     PUBLIC  _zx_border
+    PUBLIC  zx_border_fastcall
+    PUBLIC  _zx_border_fastcall
 
     EXTERN  __SYSVAR_BORDCR
 
 zx_border:
 _zx_border:
+    ld       hl,2
+    add      hl,sp
+    ld       l,(hl)
 
+zx_border_fastcall:
+_zx_border_fastcall:
     in      a, (254)
     and     $40
 

--- a/libsrc/target/zx/zx_colour.asm
+++ b/libsrc/target/zx/zx_colour.asm
@@ -1,14 +1,22 @@
 ; 09.2009 stefano
 
-; void __FASTCALL__ zx_colour(uchar colour)
+; void zx_colour(uint colour)
 
     SECTION code_clib
     PUBLIC  zx_colour
     PUBLIC  _zx_colour
+    PUBLIC  zx_colour_fastcall
+    PUBLIC  _zx_colour_fastcall
     EXTERN  __zx_console_attr
 
 zx_colour:
 _zx_colour:
+   ld      hl,2
+   add     hl,sp
+   ld      l,(hl)
+
+zx_colour_fastcall:
+_zx_colour_fastcall:
     ld      a, i
     push    af
     di

--- a/libsrc/target/zx/zx_setattrbright.asm
+++ b/libsrc/target/zx/zx_setattrbright.asm
@@ -1,0 +1,26 @@
+; Valid for +zx, +ts2068, +zxn
+; 
+
+   SECTION  code_driver
+   PUBLIC   zx_setattrbright
+   PUBLIC   _zx_setattrbright
+   PUBLIC   zx_setattrbright_fastcall
+   PUBLIC   _zx_setattrbright_fastcall
+   EXTERN   __zx_console_attr
+
+zx_setattrbright:
+_zx_setattrbright:
+    ld     hl,2
+    add    hl,sp
+    ld     c,(hl)
+zx_setattrbright_fastcall:
+_zx_setattrbright_fastcall:
+    ld      hl, __zx_console_attr
+    ld      a,(hl)
+    and     @10111111
+    rl      c
+    jr      nc,save
+    or      @01000000
+save:
+    ld      (hl),a
+    ret

--- a/libsrc/target/zx/zx_setattrbright.asm
+++ b/libsrc/target/zx/zx_setattrbright.asm
@@ -10,17 +10,18 @@
 
 zx_setattrbright:
 _zx_setattrbright:
-    ld     hl,2
-    add    hl,sp
-    ld     c,(hl)
+    ld      hl,2
+    add     hl,sp
+    ld      l,(hl)
 zx_setattrbright_fastcall:
 _zx_setattrbright_fastcall:
+    ld      c,l
     ld      hl, __zx_console_attr
     ld      a,(hl)
-    and     @10111111
-    rl      c
-    jr      nc,save
-    or      @01000000
+    rlca        ;bit 7 -> bit 0
+    rla         ;dump out the bright bit
+    rr      c
+    rra
 save:
     ld      (hl),a
     ret

--- a/libsrc/target/zx/zx_setattrflash.asm
+++ b/libsrc/target/zx/zx_setattrflash.asm
@@ -1,0 +1,23 @@
+; Valid for +zx, +ts2068, +zxn
+; 
+
+   SECTION  code_driver
+   PUBLIC   zx_setattrflash
+   PUBLIC   _zx_setattrflash
+   PUBLIC   zx_setattrflash_fastcall
+   PUBLIC   _zx_setattrflash_fastcall
+   EXTERN   __zx_console_attr
+
+zx_setattrflash:
+_zx_setattrflash:
+    ld     hl,2
+    add    hl,sp
+    ld     l,(hl)
+zx_setattrflash_fastcall:
+_zx_setattrflash_fastcall:
+    ld      a,l
+    ld      hl, __zx_console_attr
+    rl      (hl)	;drop flash bit
+    rra      		;lsb of parameter into carry
+    rr      (hl)	;and then carry into flash bit
+    ret

--- a/libsrc/target/zx/zx_setattrinverse.asm
+++ b/libsrc/target/zx/zx_setattrinverse.asm
@@ -1,0 +1,23 @@
+; Valid for +zx, +ts2068, +zxn
+; 
+
+   SECTION  code_driver
+   PUBLIC   zx_setattrinverse
+   PUBLIC   _zx_setattrinverse
+   PUBLIC   zx_setattrinverse_fastcall
+   PUBLIC   _zx_setattrinverse_fastcall
+   EXTERN   generic_console_flags
+
+zx_setattrinverse:
+_zx_setattrinverse:
+    ld     hl,2
+    add    hl,sp
+    ld     l,(hl)
+zx_setattrinverse_fastcall:
+_zx_setattrinverse_fastcall:
+    ld      a,l
+    ld      hl, generic_console_flags
+    rl      (hl)  ; drop inverse bit
+    rra      
+    rr      (hl)  ; rotate new bit in
+    ret

--- a/libsrc/target/zx/zx_setink.asm
+++ b/libsrc/target/zx/zx_setink.asm
@@ -1,0 +1,30 @@
+; Valid for +zx, +ts2068, +zxn
+; 
+
+   SECTION  code_driver
+   PUBLIC   zx_setink
+   PUBLIC   _zx_setink
+   PUBLIC   zx_setink_fastcall
+   PUBLIC   _zx_setink_fastcall
+   EXTERN   __zx_console_attr
+   EXTERN   __zx_ink_colour
+
+zx_setink:
+_zx_setink:
+    ld     hl,2
+    add    hl,sp
+    ld     l,(hl)
+zx_setink_fastcall:
+_zx_setink_fastcall:
+     ld    a,l
+IF    FORzxn
+    ld      (__zx_ink_colour), a
+ENDIF
+    and     7
+    ld      c, a
+    ld      hl, __zx_console_attr
+    ld      a, (hl)
+    and     @11111000
+    or      c
+    ld      (hl), a
+    ret

--- a/libsrc/target/zx/zx_setpaper.asm
+++ b/libsrc/target/zx/zx_setpaper.asm
@@ -1,0 +1,25 @@
+; Valid for +zx, +ts2068, +zxn
+
+   SECTION  code_driver
+   PUBLIC   zx_setpaper
+   PUBLIC   _zx_setpaper
+   PUBLIC   zx_setpaper_fastcall
+   PUBLIC   _zx_setpaper_fastcall
+   EXTERN   __zx_console_attr
+
+zx_setpaper:
+_zx_setpaper:
+    ld     hl,2
+    add    hl,sp
+    ld     l,(hl)
+zx_setpaper_fastcall:
+_zx_setpaper_fastcall:
+    ld      a,l
+    and     @00111000
+    ld      c, a
+    ld      hl, __zx_console_attr
+    ld      a, (hl)
+    and     @11000111
+    or      c
+    ld      (hl), a
+    ret


### PR DESCRIPTION
This sorts out the confusion with what colour you should use.

zx_ funcs should use zx native colours