### PR TITLE
Increase flexibility on the MSX platform

### DIFF
--- a/lib/config/msx.cfg
+++ b/lib/config/msx.cfg
@@ -20,6 +20,7 @@ SUBTYPE		diskio -Cz+msx -Cz--disk -startup=1
 SUBTYPE		wav -Cz+msx -Cz--fmsx -Cz--audio -Cz--fast -startup=1 -lndos
 SUBTYPE		wavio -Cz+msx -Cz--fmsx -Cz--audio -Cz--fast -startup=1 
 SUBTYPE		rom	-Cz+msxrom  -startup=3 -lndos -D__ROM__
+SUBTYPE		callext -Cz+msxrom  -startup=3 -lndos -D__ROM__  -pragma-define:CRT_MSX_CUSTOM_HEADER=1 -pragma-define:CRT_ON_EXIT=0x10002 -pragma-define:REGISTER_SP=-1
 SUBTYPE		rom2	-Cz+msxrom  -startup=3 -lndos -D__ROM__ -D__MSX2__ -lmsx2
 SUBTYPE		msxdos  -Cz+fat -Cz-f -Czmsxdos -startup=2 -D__MSXDOS -D__MSXDOS_MSXDOS1  -pragma-define:CLIB_MSXDOS=1 
 SUBTYPE		msxdost  -Cz+fat -Cz-f -Czmsxdos-tak -startup=2 -D__MSXDOS_MSXDOS1  -pragma-define:CLIB_MSXDOS=1

--- a/lib/target/msx/classic/rom.asm
+++ b/lib/target/msx/classic/rom.asm
@@ -13,9 +13,17 @@
 
 
     defc    TAR__clib_exit_stack_size = 0
+IFNDEF REGISTER_SP
     defc    TAR__register_sp = -0xfc4a
+ELSE
+    defc    TAR__register_sp = REGISTER_SP
+ENDIF
     defc    TAR__crt_enable_eidi = $02 ; ei on entry
+IFNDEF CRT_ON_EXIT
     defc    TAR__crt_on_exit = 0x10001  ;loop forever
+ELSE
+    defc    TAR__crt_on_exit = CRT_ON_EXIT
+ENDIF
     INCLUDE "crt/classic/crt_rules.inc"
 
 ;


### PR DESCRIPTION
Add the following optional defines:
* CRT_ON_EXIT allows cartridge programs to return control to MSX-BASIC, which is necessasry for call extensions;
* REGISTER_SP allow the MSX to define the stack by itself (useful for cartridges programs that return control to MSX-BASIC);

Reference: https://www.z88dk.org/forum/viewtopic.php?p=24313#p24313