### PR TITLE
Disable peephole optimization that could break i8085 code

### DIFF
--- a/lib/z80rules.1
+++ b/lib/z80rules.1
@@ -7222,6 +7222,7 @@ $notcpu 8085
 	dec	sp
 	push	hl
 
+%notcpu 8085
 %title Avoid going via stack
 	push	hl
 	ld	hl,%1	;const


### PR DESCRIPTION
Code to reproduce bug:
```c
uint8_t t[] = { 0x11 };

int main() {
  uint8_t * ptr = &t;
  uint8_t tmp;

  tmp = ptr[0];

  printByte(ptr[0]);
}
```

This optimization relies that `l_gint` does not modify `DE` register, but there is bunch of i8085-specific optimizations that replaces `l_gint` call with the code, that actually modifies `DE` (https://github.com/z88dk/z88dk/blob/master/lib/arch/8085/8085_rules.1)