### PR TITLE
ucpp: fix lexer excessive newline generation

### DIFF
--- a/.github/workflows/build-on-windows-msbuild-x64.yml
+++ b/.github/workflows/build-on-windows-msbuild-x64.yml
@@ -59,3 +59,9 @@ jobs:
         set PATH=%RUNNER_WORKSPACE%\z88dk\bin;%PATH%
         set ZCCCFG=%RUNNER_WORKSPACE%\z88dk\lib\config
         perl -S prove t\*.t
+    - name: Run ucpp tests
+      run: |
+        cd src\ucpp
+        set PATH=%RUNNER_WORKSPACE%\z88dk\bin;%PATH%
+        set ZCCCFG=%RUNNER_WORKSPACE%\z88dk\lib\config
+        perl -S prove t\*.t

--- a/.github/workflows/build-on-windows-msbuild-x86.yml
+++ b/.github/workflows/build-on-windows-msbuild-x86.yml
@@ -59,3 +59,9 @@ jobs:
         set PATH=%RUNNER_WORKSPACE%\z88dk\bin;%PATH%
         set ZCCCFG=%RUNNER_WORKSPACE%\z88dk\lib\config
         perl -S prove t\*.t
+    - name: Run ucpp tests
+      run: |
+        cd src\ucpp
+        set PATH=%RUNNER_WORKSPACE%\z88dk\bin;%PATH%
+        set ZCCCFG=%RUNNER_WORKSPACE%\z88dk\lib\config
+        perl -S prove t\*.t

--- a/.github/workflows/test-macos-latest.yml
+++ b/.github/workflows/test-macos-latest.yml
@@ -31,3 +31,10 @@ jobs:
         export PATH=$RUNNER_WORKSPACE/z88dk/osx-latest/z88dk/bin:$PATH
         export ZCCCFG=$RUNNER_WORKSPACE/z88dk/osx-latest/z88dk/lib/config
         perl -S prove t/*.t
+    - name: Run ucpp tests
+      run: |
+        set -x
+        cd osx-latest/z88dk/src/ucpp
+        export PATH=$RUNNER_WORKSPACE/z88dk/osx-latest/z88dk/bin:$PATH
+        export ZCCCFG=$RUNNER_WORKSPACE/z88dk/osx-latest/z88dk/lib/config
+        perl -S prove t/*.t

--- a/.github/workflows/test-win32-latest.yml
+++ b/.github/workflows/test-win32-latest.yml
@@ -32,3 +32,9 @@ jobs:
         set PATH=%RUNNER_WORKSPACE%\z88dk\win32-latest\z88dk\bin;%PATH%
         set ZCCCFG=%RUNNER_WORKSPACE%\z88dk\win32-latest\z88dk\lib\config
         perl -S prove t\*.t
+    - name: Run ucpp tests
+      run: |
+        cd win32-latest\z88dk\src\ucpp
+        set PATH=%RUNNER_WORKSPACE%\z88dk\win32-latest\z88dk\bin;%PATH%
+        set ZCCCFG=%RUNNER_WORKSPACE%\z88dk\win32-latest\z88dk\lib\config
+        perl -S prove t\*.t

--- a/src/ucpp/cpp.c
+++ b/src/ucpp/cpp.c
@@ -545,7 +545,7 @@ void free_lexer_state(struct lexer_state *ls)
 /*
  * Print line information.
  */
-static void print_line_info(struct lexer_state *ls, unsigned long flags)
+void print_line_info(struct lexer_state *ls, unsigned long flags)
 {
 	char *fn = current_long_filename ?
 		current_long_filename : current_filename;

--- a/src/ucpp/cpp.h
+++ b/src/ucpp/cpp.h
@@ -262,6 +262,8 @@ int check_cpp_errors(struct lexer_state *);
 void add_incpath(char *);
 void init_tables(int);
 int enter_file(struct lexer_state *, unsigned long);
+void print_line_info(struct lexer_state *, unsigned long);
+void yield_newlines(struct lexer_state *);
 int cpp(struct lexer_state *);
 void set_identifier_char(int c);
 void unset_identifier_char(int c);

--- a/src/ucpp/lexer.c
+++ b/src/ucpp/lexer.c
@@ -810,8 +810,6 @@ static inline int read_token(struct lexer_state *ls)
 		utf8 = ls->utf8;
 		shift_state = 0;
 	}
-	if (!(ls->flags & LEXER) && (ls->flags & KEEP_OUTPUT))
-		for (; ls->line > ls->oline;) put_char(ls,'\n');
 	do {
 		c = next_char(ls);
 		if (c < 0) {
@@ -938,15 +936,20 @@ static inline int read_token(struct lexer_state *ls)
 					outc = -2;
 				} else {
 					if (outc < 0) {
+				        yield_newlines(ls);
 						put_char(ls, '%');
 						put_char(ls, ':');
 						if (outc == -2)
 							put_char(ls, '%');
 						outc = 0;
 					} else if (outc) {
+				        yield_newlines(ls);
 						put_char(ls, outc);
 						outc = 0;
 					}
+				    if (c != '\n') {
+				        yield_newlines(ls);
+				    }
 					put_char(ls, c);
 				}
 			}
@@ -998,6 +1001,7 @@ int next_token(struct lexer_state *ls)
 	if (ls->flags & READ_AGAIN) {
 		ls->flags &= ~READ_AGAIN;
 		if (!(ls->flags & LEXER)) {
+			yield_newlines(ls);
 			char *c = S_TOKEN(ls->ctok->type) ?
 				ls->ctok->name : token_name(ls->ctok);
 			if (ls->ctok->type == OPT_NONE) {

--- a/src/ucpp/t/issue_2731.t
+++ b/src/ucpp/t/issue_2731.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+
+# Test https://github.com/z88dk/z88dk/issues/2731
+# ucpp: Excessive blank lines generated when there are large line number gaps
+# from conditional compilation or #include files
+
+unlink_testfiles;
+
+# Create a test file with conditional compilation that causes large gaps
+spew("${test}.c", <<END);
+int main( void ) {
+
+#if TEST
+/*
+    *
+    * here comes a long comment
+    *
+    */
+#endif
+
+    int test = TEST;
+    int a = 12 /*  <--- this is an error in line 12 */
+    char b = 13;
+
+/*
+    *
+    * here comes another long comment - but if'ed out
+    *
+    */
+
+    int x = 21 /* <--- this is an eror in line 21 */
+    char y = 22;
+    return 23;
+}
+END
+
+# Run ucpp with TEST=0
+run_ok("z88dk-ucpp -DTEST=0 ${test}.c -o ${test}-a.i 2> ${test}-a.err");
+
+# Run ucpp with TEST=1
+run_ok("z88dk-ucpp -DTEST=1 ${test}.c -o ${test}-b.i 2> ${test}-b.err");
+
+# Check that output files were created
+ok -f "${test}-a.i", "${test}-a.i created";
+ok -f "${test}-b.i", "${test}-b.i created";
+
+# Find line numbers for "int a" and "int x"
+sub find_line_number {
+    my($file, $pattern) = @_;
+    open(my $fh, "<", $file) or die "Cannot open $file: $!";
+    my $line_num = 0;
+    while (<$fh>) {
+        $line_num++;
+        if (/$pattern/) {
+            close($fh);
+            return $line_num;
+        }
+    }
+    close($fh);
+    return undef;
+}
+
+# Check "int a" is at the same line in both outputs (consistency check)
+my $line_a_a = find_line_number("${test}-a.i", qr/^\s*int\s+a\s*=/);
+my $line_a_b = find_line_number("${test}-b.i", qr/^\s*int\s+a\s*=/);
+
+ok defined($line_a_a), "found 'int a' in ${test}-a.i";
+ok defined($line_a_b), "found 'int a' in ${test}-b.i";
+is $line_a_a, $line_a_b, "'int a' at same line in both outputs (line $line_a_a)";
+
+# Check "int x" is at the same line in both outputs (consistency check)
+my $line_x_a = find_line_number("${test}-a.i", qr/^\s*int\s+x\s*=/);
+my $line_x_b = find_line_number("${test}-b.i", qr/^\s*int\s+x\s*=/);
+
+ok defined($line_x_a), "found 'int x' in ${test}-a.i";
+ok defined($line_x_b), "found 'int x' in ${test}-b.i";
+is $line_x_a, $line_x_b, "'int x' at same line in both outputs (line $line_x_a)";
+
+unlink_testfiles;
+done_testing;
+

--- a/src/ucpp/t/issue_2831_huge_file.t
+++ b/src/ucpp/t/issue_2831_huge_file.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+use File::Copy;
+
+# Test https://github.com/z88dk/z88dk/issues/2831
+# ucpp: Test with large file (test_t_issue_2831.c) to ensure no excessive blank lines
+# are generated when processing files with many conditional compilation blocks
+
+unlink_testfiles;
+
+# Copy the test file
+my $test_file = "${test}.c";
+my $source_file = "t/test_t_issue_2831.c";
+# If running from parent directory, adjust path
+$source_file = "test_t_issue_2831.c" if -f "test_t_issue_2831.c" && !-f $source_file;
+copy($source_file, $test_file) or die "Cannot copy $source_file to $test_file: $!";
+
+# Run ucpp on the test file
+run_ok("z88dk-ucpp -d $test_file -o ${test}.i 2> ${test}.err");
+
+# Check that output file was created
+ok -f "${test}.i", "${test}.i created";
+
+# Check max consecutive blank lines (should be reasonable, < 10)
+sub count_max_consecutive_blank_lines {
+    my($file) = @_;
+    my $max = 0;
+    my $count = 0;
+    open(my $fh, "<", $file) or die "Cannot open $file: $!";
+    while (<$fh>) {
+        if (/^\s*$/) {
+            $count++;
+            $max = $count if $count > $max;
+        } else {
+            $count = 0;
+        }
+    }
+    close($fh);
+    return $max;
+}
+
+my $max_blanks = count_max_consecutive_blank_lines("${test}.i");
+cmp_ok($max_blanks, '<', 10, "max consecutive blank lines is reasonable ($max_blanks)");
+
+# Check file size is reasonable (not millions of lines)
+my $size = -s "${test}.i";
+my $line_count = `wc -l < ${test}.i`;
+chomp $line_count;
+
+cmp_ok($size, '<', 10000, "output file size is reasonable ($size bytes)");
+cmp_ok($line_count, '<', 500, "output file line count is reasonable ($line_count lines)");
+
+unlink_testfiles;
+done_testing;
+

--- a/src/ucpp/t/issue_2831_semicolon.t
+++ b/src/ucpp/t/issue_2831_semicolon.t
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+use File::Copy;
+
+# Test https://github.com/z88dk/z88dk/issues/2831
+# ucpp: Ensure comments after #line directives are on separate lines
+# Expected: 
+
+# #line 246 "t/test_t_fgetc.c"
+# ; Check for value of -1
+
+unlink_testfiles;
+
+# Copy the test file
+my $test_file = "${test}.c";
+my $source_file = "t/test_t_fgetc.c";
+# If running from parent directory, adjust path
+$source_file = "test_t_fgetc.c" if -f "test_t_fgetc.c" && !-f $source_file;
+copy($source_file, $test_file) or die "Cannot copy $source_file to $test_file: $!";
+
+# Run ucpp on the test file (may fail on missing headers, but should still produce output)
+system("z88dk-ucpp -d $test_file -o ${test}.i 2> ${test}.err");
+
+# Check that output file was created
+ok -f "${test}.i", "${test}.i created";
+
+# Check that #line directive is followed by newline, then "; Check for value of -1"
+my $content = slurp("${test}.i");
+like $content, qr/#line\s+\d+\s+"[^"]+"\s*\n\s*;\s*Check for value of -1/s, 
+    "#line directive followed by newline, then '; Check for value of -1'";
+
+unlink_testfiles;
+done_testing;
+

--- a/src/ucpp/t/test_t_fgetc.c
+++ b/src/ucpp/t/test_t_fgetc.c
@@ -1,0 +1,260 @@
+/*
+ *	  New stdio functions for Small C+
+ *
+ *	  djm 4/5/99
+ *
+ * --------
+ * $Id: fgetc.c,v 1.13 2016-03-06 21:36:52 dom Exp $
+ */
+
+#define ANSI_STDIO
+#define STDIO_ASM
+
+/*
+ *	struct fp {
+ *		union xx {
+ *			int fd;
+ *			char *str;
+ *		} desc;
+ *		u8_t error;
+ *		u8_t flags;
+ *		u8_t ungetc;
+ */
+
+int fgetc(FILE *fp)
+{
+#asm
+IF __CPU_INTEL__ || __CPU_GBZ80__
+    pop     bc
+    pop     de  ;fp
+    push    de
+    push    bc
+    ld      hl,-1	;EOF
+    inc     de	
+    inc     de
+    ld      a,(de)	;de = &fp_flags get flags
+    ld      b,a
+    and     a
+  IF __CPU_GBZ80__
+    jr      z,fgetc_assign_ret
+  ELSE
+    ret     z
+  ENDIF
+    and     _IOEOF	;check we`re not write/EOF
+  IF __CPU_GBZ80__
+    jr      nz,fgetc_assign_ret
+  ELSE
+    ret     nz
+  ENDIF
+    ld      a,b         ;flags
+    and     _IOUNGETC
+    jr      z,no_ungetc
+    ld      a,b         ;reset ungotc flag
+    and     ~(_IOUNGETC)
+    ld      (de),a
+    inc     de          ;de=&fp_ungetc
+    ld      a,(de)	    ;Pick up ungot character
+    ld      l,a
+    ld      h,0
+  IF __CPU_GBZ80__
+fgetc_assign_ret:
+    ld      d,h
+    ld      e,l
+  ENDIF
+    ret
+.no_ungetc
+; Now do strings
+    ld      a,(de)
+    and     _IOSTRING
+    jr      z,no_string	;not a string
+    ex      de,hl
+    dec     hl		;fp_desc+1
+    ld      d,(hl)
+    dec     hl		;fp_desc
+    ld      e,(hl)
+    ld      a,(de)
+    inc     de
+    ld      (hl),e		
+    inc     hl		;fp_desc+1
+    ld      (hl),d
+    ex      de,hl
+    ld      hl,-1	;EOF
+    and     a	;test for zero
+  IF __CPU_GBZ80__
+    jr      z,fgetc_assign_ret
+  ENDIF
+    ret     z	;return EOF if so
+    ld      l,a	;else return character
+    ld      h,0
+  IF __CPU_GBZ80__
+    jr      fgetc_assign_ret
+  ELSE
+    ret
+  ENDIF
+.no_string
+    dec     de	;fp_desc+1
+    dec     de	;fp_desc
+    push    de	;preserve fp
+    call    fchkstd	;check for stdin (stdout/err have failed already)
+    pop     de	;ix back
+    jr      c,no_stdin
+    call    fgetc_cons  ;get from console
+    ret	                ;always succeeds - never EOF
+.no_stdin
+    ex      de,hl
+    ld      e,(hl)
+    inc     hl      ;fp_desc+1
+    ld      d,(hl)
+    dec     hl      ;fp_desc
+    ex      de,hl
+    push    de
+    call    readbyte    ;readbyte sorts out stack (fastcall)
+    pop     de          ;get fp back
+  IF __CPU_GBZ80__
+    jr      nc,fgetc_assign_ret
+  ELSE
+#ifdef __STDIO_BINARY
+    push    de
+    inc     de
+    inc     de          ;de = &flags
+    ld      a,(de)
+    pop     de  
+    and     _IOTEXT     ;check for text mode
+    jr      z,not_text_fp
+    ld      a,l
+#ifdef __STDIO_EOFMARKER
+    cp      __STDIO_EOFMARKER	;compare with the EOF marker
+    jp      z,seteof
+#endif
+#ifdef __STDIO_CRLF
+    cp      13
+    jr      z,no_stdin		; Read again
+#endif
+#endif
+not_text_fp:
+    ld      a,h
+    inc     a
+    ret     nz
+  ENDIF
+.seteof
+    ld      hl,-1
+    inc     de	
+    inc     de		;fp_flags
+    ld      a,(de)
+    or      _IOEOF
+    ld      (de),a	;set EOF, return with EOF
+  IF __CPU_GBZ80__
+    jr      fgetc_assign_ret
+  ENDIF
+ELSE
+
+  ;;z80 family here, can use ix
+  IF __CPU_RABBIT__
+    ld      hl,(sp + 2)
+    push    ix		;save callers ix
+    ld      ix,hl
+  ELSE
+    pop     bc
+    pop     hl	; fp
+    push    hl
+    push    bc
+    push    ix	; callers ix
+    push    hl
+    pop     ix
+  ENDIF
+
+    ld      a,(ix+fp_flags)	;get flags
+    and     a
+    jp      z, is_eof
+	;	Check removed to allow READ+WRITE streams
+    bit     3,a     ;_IOEOF
+    jp      nz, is_eof
+    bit     0,a     ;_IOUNGETC
+    jr      z,no_ungetc
+    res     0,(ix+fp_flags)     ;reset _IOUNGETC
+    ld      l,(ix+fp_ungetc)
+    ld      h,0
+    jp      fgetc_end
+.no_ungetc
+    ; Now check for strings
+    bit     7,a                 ;_IOSTRING
+    jr      z,no_string	        ;
+    ;; It is a string
+    ld      hl,(ix+fp_extra)	; Check to see if there is any string left
+    ld      a,h
+    or      l
+    jp      z,is_eof
+    dec     hl
+    ld      (ix+fp_extra),hl
+
+    ld      hl,(ix+fp_desc)
+    ld      a,(hl)
+    inc     hl
+    ld      (ix+fp_desc),hl
+    and     a		            ;test for end of string
+    jr      z,is_eof	        ;return EOF if so
+    ld      l,a		            ;else return character
+    ld      h,0
+    jr      fgetc_end
+.no_string
+    bit     5,a                 ;_IOEXTRA
+    and     _IOEXTRA
+    jr      z,not_extra_fp
+    ld      hl,(ix + fp_extra)
+    ld      a,__STDIO_MSG_GETC
+    call	l_jphl
+    jr      nc, fgetc_end
+    jr      seteof		;EOF reached (sock closed?)
+.not_extra_fp
+    push    ix		;preserve fp
+    call	fchkstd		;check for stdin (stdout/err have failed already)
+    pop     ix		;ix back
+    jr      c,no_stdin
+    call	fgetc_cons	;get from console
+#ifdef __STDIO_EOFMARKER
+    ld      a,l
+    cp	__STDIO_EOFMARKER
+    jr      z,is_eof
+#endif
+    push    hl
+    call	fputc_cons
+    pop     hl
+    jr      fgetc_end	; always succeeds - never EOF when EOF has not been defined.
+.no_stdin
+    ld      hl,(ix+fp_desc)
+    push    ix
+    call	readbyte	; readbyte sorts out stack (fastcall)
+    			; hl = byte read
+    			; c = EOF
+    			; nc = good
+    pop     ix		; get fp back
+#ifdef __STDIO_BINARY
+    ld      a,_IOTEXT	;check for text mode
+    and     (ix+fp_flags)
+    jr      z,not_text_fp
+    ld      a,l
+#ifdef __STDIO_EOFMARKER
+    cp	__STDIO_EOFMARKER	;compare with the EOF marker
+    jr      z,is_eof
+#endif
+#ifdef __STDIO_CRLF
+    cp      13
+    jr      z,no_stdin		; Read again
+#endif
+.not_text_fp
+#endif
+    ; Check for value of -1
+    ld      a,h
+    inc     a
+    jr      nz,fgetc_end
+.is_eof
+    ld      hl,-1		;signify EOF
+.seteof
+    ld      a,(ix+fp_flags)
+    or      _IOEOF
+    ld      (ix+fp_flags),a	;set EOF, return with EOF
+.fgetc_end
+    pop      ix
+ENDIF
+#endasm
+}

--- a/src/ucpp/t/test_t_issue_2831.c
+++ b/src/ucpp/t/test_t_issue_2831.c
@@ -1,0 +1,6911 @@
+void ____CIDR_command() {
+#define ___CIDR_FEATURES_START
+#if defined(__STDC_VERSION__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_LANGUAGE_STANDARD, ____CIDR_command_STANDARD_C = ((void) __STDC_VERSION__, 0); }
+#endif
+#if defined(__cplusplus)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_LANGUAGE_STANDARD, ____CIDR_command_STANDARD_CPP = ((void) __cplusplus, 0); }
+#endif
+#ifdef __FILE_NAME__
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_macro__FILE_NAME__ = ((void) "_file_name_short_", 0); }
+#endif
+#if defined(__has_builtin)
+#define __CIDR_HELPER_DEFINE_0
+#endif
+#if defined(__CIDR_HELPER_DEFINE_0)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_BUILTIN = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_BUILTIN = ((void) 0, 0); }
+#endif
+#if defined(__has_feature)
+#define __CIDR_HELPER_DEFINE_1
+#endif
+#if defined(__CIDR_HELPER_DEFINE_1)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_FEATURE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_FEATURE = ((void) 0, 0); }
+#endif
+#if defined(__has_extension)
+#define __CIDR_HELPER_DEFINE_2
+#endif
+#if defined(__CIDR_HELPER_DEFINE_2)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_EXTENSION = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_EXTENSION = ((void) 0, 0); }
+#endif
+#if defined(__has_include_next)
+#define __CIDR_HELPER_DEFINE_3
+#endif
+#if defined(__CIDR_HELPER_DEFINE_3)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_HAS_INCLUDE_NEXT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_HAS_INCLUDE_NEXT = ((void) 0, 0); }
+#endif
+#if defined(__has_include)
+#define __CIDR_HELPER_DEFINE_4
+#endif
+#if defined(__CIDR_HELPER_DEFINE_4)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_include = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_include = ((void) 0, 0); }
+#endif
+#if defined(__has_cpp_attribute)
+#define __CIDR_HELPER_DEFINE_5
+#endif
+#if defined(__CIDR_HELPER_DEFINE_5)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_cpp_attribute = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_cpp_attribute = ((void) 0, 0); }
+#endif
+#if !defined(__cplusplus) && __STDC_VERSION__ <= 199409L
+#define __CIDR_HELPER_DEFINE_6
+#endif
+#if defined(__CIDR_HELPER_DEFINE_6)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_VARIABLE_DECLARATION_RULES_ARE_C89_COMPATIBLE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_VARIABLE_DECLARATION_RULES_ARE_C89_COMPATIBLE = ((void) 0, 0); }
+#endif
+#if __clang__
+#if !(defined (__has_extension)) && defined(__has_feature)
+  #define __has_extension __has_feature
+#endif
+#if !defined(__has_attribute)
+  #define __has_attribute(x) 0
+#endif
+#if !defined(__has_builtin)
+  #define __has_builtin(x) 0
+#endif
+#if !defined(__is_identifier)
+  #define __is_identifier(x) 1
+#endif
+#if !__has_builtin(__is_target_arch)
+  #define __is_target_arch(x) 0
+#endif
+#if !__has_builtin(__is_target_vendor)
+  #define __is_target_vendor(x) 0
+#endif
+#if !__has_builtin(__is_target_os)
+  #define __is_target_os(x) 0
+#endif
+#if !__has_builtin(__is_target_variant_os)
+  #define __is_target_variant_os(x) 0
+#endif
+#if !__has_builtin(__is_target_environment)
+  #define __is_target_environment(x) 0
+#endif
+#if !__has_builtin(__is_target_variant_environment)
+  #define __is_target_variant_environment(x) 0
+#endif
+#if !defined(speculative_load_hardening)
+#if __has_feature(speculative_load_hardening)
+#define __CIDR_HELPER_DEFINE_7
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_7)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_speculative_load_hardening = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_speculative_load_hardening = ((void) 0, 0); }
+#endif
+#if !defined(speculative_load_hardening)
+#if __has_extension(speculative_load_hardening)
+#define __CIDR_HELPER_DEFINE_8
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_8)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_speculative_load_hardening = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_speculative_load_hardening = ((void) 0, 0); }
+#endif
+#if !defined(address_sanitizer)
+#if __has_feature(address_sanitizer)
+#define __CIDR_HELPER_DEFINE_9
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_9)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_address_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_address_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(address_sanitizer)
+#if __has_extension(address_sanitizer)
+#define __CIDR_HELPER_DEFINE_10
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_10)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_address_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_address_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(leak_sanitizer)
+#if __has_feature(leak_sanitizer)
+#define __CIDR_HELPER_DEFINE_11
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_11)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_leak_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_leak_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(leak_sanitizer)
+#if __has_extension(leak_sanitizer)
+#define __CIDR_HELPER_DEFINE_12
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_12)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_leak_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_leak_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(hwaddress_sanitizer)
+#if __has_feature(hwaddress_sanitizer)
+#define __CIDR_HELPER_DEFINE_13
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_13)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_hwaddress_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_hwaddress_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(hwaddress_sanitizer)
+#if __has_extension(hwaddress_sanitizer)
+#define __CIDR_HELPER_DEFINE_14
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_14)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_hwaddress_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_hwaddress_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(memtag_stack)
+#if __has_feature(memtag_stack)
+#define __CIDR_HELPER_DEFINE_15
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_15)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memtag_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memtag_stack = ((void) 0, 0); }
+#endif
+#if !defined(memtag_stack)
+#if __has_extension(memtag_stack)
+#define __CIDR_HELPER_DEFINE_16
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_16)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memtag_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memtag_stack = ((void) 0, 0); }
+#endif
+#if !defined(memtag_heap)
+#if __has_feature(memtag_heap)
+#define __CIDR_HELPER_DEFINE_17
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_17)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memtag_heap = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memtag_heap = ((void) 0, 0); }
+#endif
+#if !defined(memtag_heap)
+#if __has_extension(memtag_heap)
+#define __CIDR_HELPER_DEFINE_18
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_18)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memtag_heap = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memtag_heap = ((void) 0, 0); }
+#endif
+#if !defined(memtag_globals)
+#if __has_feature(memtag_globals)
+#define __CIDR_HELPER_DEFINE_19
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_19)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memtag_globals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memtag_globals = ((void) 0, 0); }
+#endif
+#if !defined(memtag_globals)
+#if __has_extension(memtag_globals)
+#define __CIDR_HELPER_DEFINE_20
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_20)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memtag_globals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memtag_globals = ((void) 0, 0); }
+#endif
+#if !defined(xray_instrument)
+#if __has_feature(xray_instrument)
+#define __CIDR_HELPER_DEFINE_21
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_21)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_xray_instrument = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_xray_instrument = ((void) 0, 0); }
+#endif
+#if !defined(xray_instrument)
+#if __has_extension(xray_instrument)
+#define __CIDR_HELPER_DEFINE_22
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_22)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_xray_instrument = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_xray_instrument = ((void) 0, 0); }
+#endif
+#if !defined(undefined_behavior_sanitizer)
+#if __has_feature(undefined_behavior_sanitizer)
+#define __CIDR_HELPER_DEFINE_23
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_23)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_undefined_behavior_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_undefined_behavior_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(undefined_behavior_sanitizer)
+#if __has_extension(undefined_behavior_sanitizer)
+#define __CIDR_HELPER_DEFINE_24
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_24)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_undefined_behavior_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_undefined_behavior_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(realtime_sanitizer)
+#if __has_feature(realtime_sanitizer)
+#define __CIDR_HELPER_DEFINE_25
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_25)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_realtime_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_realtime_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(realtime_sanitizer)
+#if __has_extension(realtime_sanitizer)
+#define __CIDR_HELPER_DEFINE_26
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_26)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_realtime_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_realtime_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(coverage_sanitizer)
+#if __has_feature(coverage_sanitizer)
+#define __CIDR_HELPER_DEFINE_27
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_27)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_coverage_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_coverage_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(coverage_sanitizer)
+#if __has_extension(coverage_sanitizer)
+#define __CIDR_HELPER_DEFINE_28
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_28)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_coverage_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_coverage_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(assume_nonnull)
+#if __has_feature(assume_nonnull)
+#define __CIDR_HELPER_DEFINE_29
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_29)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_assume_nonnull = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_assume_nonnull = ((void) 0, 0); }
+#endif
+#if !defined(assume_nonnull)
+#if __has_extension(assume_nonnull)
+#define __CIDR_HELPER_DEFINE_30
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_30)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_assume_nonnull = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_assume_nonnull = ((void) 0, 0); }
+#endif
+#if !defined(attribute_analyzer_noreturn)
+#if __has_feature(attribute_analyzer_noreturn)
+#define __CIDR_HELPER_DEFINE_31
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_31)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_analyzer_noreturn = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_analyzer_noreturn = ((void) 0, 0); }
+#endif
+#if !defined(attribute_analyzer_noreturn)
+#if __has_extension(attribute_analyzer_noreturn)
+#define __CIDR_HELPER_DEFINE_32
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_32)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_analyzer_noreturn = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_analyzer_noreturn = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability)
+#if __has_feature(attribute_availability)
+#define __CIDR_HELPER_DEFINE_33
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_33)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability)
+#if __has_extension(attribute_availability)
+#define __CIDR_HELPER_DEFINE_34
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_34)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_message)
+#if __has_feature(attribute_availability_with_message)
+#define __CIDR_HELPER_DEFINE_35
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_35)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_message = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_message = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_message)
+#if __has_extension(attribute_availability_with_message)
+#define __CIDR_HELPER_DEFINE_36
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_36)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_message = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_message = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_app_extension)
+#if __has_feature(attribute_availability_app_extension)
+#define __CIDR_HELPER_DEFINE_37
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_37)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_app_extension = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_app_extension = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_app_extension)
+#if __has_extension(attribute_availability_app_extension)
+#define __CIDR_HELPER_DEFINE_38
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_38)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_app_extension = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_app_extension = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_version_underscores)
+#if __has_feature(attribute_availability_with_version_underscores)
+#define __CIDR_HELPER_DEFINE_39
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_39)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_version_underscores = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_version_underscores = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_version_underscores)
+#if __has_extension(attribute_availability_with_version_underscores)
+#define __CIDR_HELPER_DEFINE_40
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_40)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_version_underscores = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_version_underscores = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_tvos)
+#if __has_feature(attribute_availability_tvos)
+#define __CIDR_HELPER_DEFINE_41
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_41)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_tvos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_tvos = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_tvos)
+#if __has_extension(attribute_availability_tvos)
+#define __CIDR_HELPER_DEFINE_42
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_42)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_tvos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_tvos = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_watchos)
+#if __has_feature(attribute_availability_watchos)
+#define __CIDR_HELPER_DEFINE_43
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_43)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_watchos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_watchos = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_watchos)
+#if __has_extension(attribute_availability_watchos)
+#define __CIDR_HELPER_DEFINE_44
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_44)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_watchos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_watchos = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_driverkit)
+#if __has_feature(attribute_availability_driverkit)
+#define __CIDR_HELPER_DEFINE_45
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_45)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_driverkit = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_driverkit = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_driverkit)
+#if __has_extension(attribute_availability_driverkit)
+#define __CIDR_HELPER_DEFINE_46
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_46)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_driverkit = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_driverkit = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_strict)
+#if __has_feature(attribute_availability_with_strict)
+#define __CIDR_HELPER_DEFINE_47
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_47)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_strict = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_strict = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_strict)
+#if __has_extension(attribute_availability_with_strict)
+#define __CIDR_HELPER_DEFINE_48
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_48)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_strict = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_strict = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_replacement)
+#if __has_feature(attribute_availability_with_replacement)
+#define __CIDR_HELPER_DEFINE_49
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_49)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_replacement = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_with_replacement = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_with_replacement)
+#if __has_extension(attribute_availability_with_replacement)
+#define __CIDR_HELPER_DEFINE_50
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_50)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_replacement = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_with_replacement = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_in_templates)
+#if __has_feature(attribute_availability_in_templates)
+#define __CIDR_HELPER_DEFINE_51
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_51)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_in_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_in_templates = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_in_templates)
+#if __has_extension(attribute_availability_in_templates)
+#define __CIDR_HELPER_DEFINE_52
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_52)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_in_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_in_templates = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_swift)
+#if __has_feature(attribute_availability_swift)
+#define __CIDR_HELPER_DEFINE_53
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_53)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_swift = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_availability_swift = ((void) 0, 0); }
+#endif
+#if !defined(attribute_availability_swift)
+#if __has_extension(attribute_availability_swift)
+#define __CIDR_HELPER_DEFINE_54
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_54)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_swift = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_availability_swift = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_returns_not_retained)
+#if __has_feature(attribute_cf_returns_not_retained)
+#define __CIDR_HELPER_DEFINE_55
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_55)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_returns_not_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_returns_not_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_returns_not_retained)
+#if __has_extension(attribute_cf_returns_not_retained)
+#define __CIDR_HELPER_DEFINE_56
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_56)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_returns_not_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_returns_not_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_returns_retained)
+#if __has_feature(attribute_cf_returns_retained)
+#define __CIDR_HELPER_DEFINE_57
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_57)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_returns_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_returns_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_returns_retained)
+#if __has_extension(attribute_cf_returns_retained)
+#define __CIDR_HELPER_DEFINE_58
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_58)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_returns_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_returns_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_returns_on_parameters)
+#if __has_feature(attribute_cf_returns_on_parameters)
+#define __CIDR_HELPER_DEFINE_59
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_59)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_returns_on_parameters = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_returns_on_parameters = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_returns_on_parameters)
+#if __has_extension(attribute_cf_returns_on_parameters)
+#define __CIDR_HELPER_DEFINE_60
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_60)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_returns_on_parameters = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_returns_on_parameters = ((void) 0, 0); }
+#endif
+#if !defined(attribute_deprecated_with_message)
+#if __has_feature(attribute_deprecated_with_message)
+#define __CIDR_HELPER_DEFINE_61
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_61)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_deprecated_with_message = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_deprecated_with_message = ((void) 0, 0); }
+#endif
+#if !defined(attribute_deprecated_with_message)
+#if __has_extension(attribute_deprecated_with_message)
+#define __CIDR_HELPER_DEFINE_62
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_62)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_deprecated_with_message = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_deprecated_with_message = ((void) 0, 0); }
+#endif
+#if !defined(attribute_deprecated_with_replacement)
+#if __has_feature(attribute_deprecated_with_replacement)
+#define __CIDR_HELPER_DEFINE_63
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_63)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_deprecated_with_replacement = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_deprecated_with_replacement = ((void) 0, 0); }
+#endif
+#if !defined(attribute_deprecated_with_replacement)
+#if __has_extension(attribute_deprecated_with_replacement)
+#define __CIDR_HELPER_DEFINE_64
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_64)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_deprecated_with_replacement = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_deprecated_with_replacement = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ext_vector_type)
+#if __has_feature(attribute_ext_vector_type)
+#define __CIDR_HELPER_DEFINE_65
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_65)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ext_vector_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ext_vector_type = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ext_vector_type)
+#if __has_extension(attribute_ext_vector_type)
+#define __CIDR_HELPER_DEFINE_66
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_66)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ext_vector_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ext_vector_type = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_returns_not_retained)
+#if __has_feature(attribute_ns_returns_not_retained)
+#define __CIDR_HELPER_DEFINE_67
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_67)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_returns_not_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_returns_not_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_returns_not_retained)
+#if __has_extension(attribute_ns_returns_not_retained)
+#define __CIDR_HELPER_DEFINE_68
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_68)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_returns_not_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_returns_not_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_returns_retained)
+#if __has_feature(attribute_ns_returns_retained)
+#define __CIDR_HELPER_DEFINE_69
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_69)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_returns_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_returns_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_returns_retained)
+#if __has_extension(attribute_ns_returns_retained)
+#define __CIDR_HELPER_DEFINE_70
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_70)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_returns_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_returns_retained = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_consumes_self)
+#if __has_feature(attribute_ns_consumes_self)
+#define __CIDR_HELPER_DEFINE_71
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_71)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_consumes_self = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_consumes_self = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_consumes_self)
+#if __has_extension(attribute_ns_consumes_self)
+#define __CIDR_HELPER_DEFINE_72
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_72)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_consumes_self = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_consumes_self = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_consumed)
+#if __has_feature(attribute_ns_consumed)
+#define __CIDR_HELPER_DEFINE_73
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_73)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_consumed = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_ns_consumed = ((void) 0, 0); }
+#endif
+#if !defined(attribute_ns_consumed)
+#if __has_extension(attribute_ns_consumed)
+#define __CIDR_HELPER_DEFINE_74
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_74)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_consumed = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_ns_consumed = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_consumed)
+#if __has_feature(attribute_cf_consumed)
+#define __CIDR_HELPER_DEFINE_75
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_75)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_consumed = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_cf_consumed = ((void) 0, 0); }
+#endif
+#if !defined(attribute_cf_consumed)
+#if __has_extension(attribute_cf_consumed)
+#define __CIDR_HELPER_DEFINE_76
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_76)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_consumed = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_cf_consumed = ((void) 0, 0); }
+#endif
+#if !defined(attribute_objc_ivar_unused)
+#if __has_feature(attribute_objc_ivar_unused)
+#define __CIDR_HELPER_DEFINE_77
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_77)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_objc_ivar_unused = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_objc_ivar_unused = ((void) 0, 0); }
+#endif
+#if !defined(attribute_objc_ivar_unused)
+#if __has_extension(attribute_objc_ivar_unused)
+#define __CIDR_HELPER_DEFINE_78
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_78)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_objc_ivar_unused = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_objc_ivar_unused = ((void) 0, 0); }
+#endif
+#if !defined(attribute_objc_method_family)
+#if __has_feature(attribute_objc_method_family)
+#define __CIDR_HELPER_DEFINE_79
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_79)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_objc_method_family = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_objc_method_family = ((void) 0, 0); }
+#endif
+#if !defined(attribute_objc_method_family)
+#if __has_extension(attribute_objc_method_family)
+#define __CIDR_HELPER_DEFINE_80
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_80)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_objc_method_family = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_objc_method_family = ((void) 0, 0); }
+#endif
+#if !defined(attribute_overloadable)
+#if __has_feature(attribute_overloadable)
+#define __CIDR_HELPER_DEFINE_81
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_81)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_overloadable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_overloadable = ((void) 0, 0); }
+#endif
+#if !defined(attribute_overloadable)
+#if __has_extension(attribute_overloadable)
+#define __CIDR_HELPER_DEFINE_82
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_82)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_overloadable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_overloadable = ((void) 0, 0); }
+#endif
+#if !defined(attribute_unavailable_with_message)
+#if __has_feature(attribute_unavailable_with_message)
+#define __CIDR_HELPER_DEFINE_83
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_83)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_unavailable_with_message = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_unavailable_with_message = ((void) 0, 0); }
+#endif
+#if !defined(attribute_unavailable_with_message)
+#if __has_extension(attribute_unavailable_with_message)
+#define __CIDR_HELPER_DEFINE_84
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_84)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_unavailable_with_message = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_unavailable_with_message = ((void) 0, 0); }
+#endif
+#if !defined(attribute_unused_on_fields)
+#if __has_feature(attribute_unused_on_fields)
+#define __CIDR_HELPER_DEFINE_85
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_85)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_unused_on_fields = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_unused_on_fields = ((void) 0, 0); }
+#endif
+#if !defined(attribute_unused_on_fields)
+#if __has_extension(attribute_unused_on_fields)
+#define __CIDR_HELPER_DEFINE_86
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_86)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_unused_on_fields = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_unused_on_fields = ((void) 0, 0); }
+#endif
+#if !defined(attribute_diagnose_if_objc)
+#if __has_feature(attribute_diagnose_if_objc)
+#define __CIDR_HELPER_DEFINE_87
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_87)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_diagnose_if_objc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_attribute_diagnose_if_objc = ((void) 0, 0); }
+#endif
+#if !defined(attribute_diagnose_if_objc)
+#if __has_extension(attribute_diagnose_if_objc)
+#define __CIDR_HELPER_DEFINE_88
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_88)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_diagnose_if_objc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_attribute_diagnose_if_objc = ((void) 0, 0); }
+#endif
+#if !defined(blocks)
+#if __has_feature(blocks)
+#define __CIDR_HELPER_DEFINE_89
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_89)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_blocks = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_blocks = ((void) 0, 0); }
+#endif
+#if !defined(blocks)
+#if __has_extension(blocks)
+#define __CIDR_HELPER_DEFINE_90
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_90)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_blocks = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_blocks = ((void) 0, 0); }
+#endif
+#if !defined(c_thread_safety_attributes)
+#if __has_feature(c_thread_safety_attributes)
+#define __CIDR_HELPER_DEFINE_91
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_91)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_thread_safety_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_thread_safety_attributes = ((void) 0, 0); }
+#endif
+#if !defined(c_thread_safety_attributes)
+#if __has_extension(c_thread_safety_attributes)
+#define __CIDR_HELPER_DEFINE_92
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_92)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_thread_safety_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_thread_safety_attributes = ((void) 0, 0); }
+#endif
+#if !defined(cxx_exceptions)
+#if __has_feature(cxx_exceptions)
+#define __CIDR_HELPER_DEFINE_93
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_93)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_exceptions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_exceptions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_exceptions)
+#if __has_extension(cxx_exceptions)
+#define __CIDR_HELPER_DEFINE_94
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_94)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_exceptions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_exceptions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_exceptions)
+#if __has_feature(cxx_exceptions) || __has_extension(cxx_exceptions)
+#define __CIDR_HELPER_DEFINE_95
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_95)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXCEPTIONS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXCEPTIONS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_rtti)
+#if __has_feature(cxx_rtti)
+#define __CIDR_HELPER_DEFINE_96
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_96)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_rtti = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_rtti = ((void) 0, 0); }
+#endif
+#if !defined(cxx_rtti)
+#if __has_extension(cxx_rtti)
+#define __CIDR_HELPER_DEFINE_97
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_97)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_rtti = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_rtti = ((void) 0, 0); }
+#endif
+#if !defined(define_target_os_macros)
+#if __has_feature(define_target_os_macros)
+#define __CIDR_HELPER_DEFINE_98
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_98)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_define_target_os_macros = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_define_target_os_macros = ((void) 0, 0); }
+#endif
+#if !defined(define_target_os_macros)
+#if __has_extension(define_target_os_macros)
+#define __CIDR_HELPER_DEFINE_99
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_99)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_define_target_os_macros = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_define_target_os_macros = ((void) 0, 0); }
+#endif
+#if !defined(enumerator_attributes)
+#if __has_feature(enumerator_attributes)
+#define __CIDR_HELPER_DEFINE_100
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_100)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_enumerator_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_enumerator_attributes = ((void) 0, 0); }
+#endif
+#if !defined(enumerator_attributes)
+#if __has_extension(enumerator_attributes)
+#define __CIDR_HELPER_DEFINE_101
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_101)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_enumerator_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_enumerator_attributes = ((void) 0, 0); }
+#endif
+#if !defined(nullability)
+#if __has_feature(nullability)
+#define __CIDR_HELPER_DEFINE_102
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_102)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability = ((void) 0, 0); }
+#endif
+#if !defined(nullability)
+#if __has_extension(nullability)
+#define __CIDR_HELPER_DEFINE_103
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_103)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability = ((void) 0, 0); }
+#endif
+#if !defined(nullability)
+#if __has_feature(nullability) || __has_extension(nullability)
+#define __CIDR_HELPER_DEFINE_104
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_104)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_NULLABILITY = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_NULLABILITY = ((void) 0, 0); }
+#endif
+#if !defined(nullability_on_arrays)
+#if __has_feature(nullability_on_arrays)
+#define __CIDR_HELPER_DEFINE_105
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_105)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability_on_arrays = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability_on_arrays = ((void) 0, 0); }
+#endif
+#if !defined(nullability_on_arrays)
+#if __has_extension(nullability_on_arrays)
+#define __CIDR_HELPER_DEFINE_106
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_106)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability_on_arrays = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability_on_arrays = ((void) 0, 0); }
+#endif
+#if !defined(nullability_on_classes)
+#if __has_feature(nullability_on_classes)
+#define __CIDR_HELPER_DEFINE_107
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_107)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability_on_classes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability_on_classes = ((void) 0, 0); }
+#endif
+#if !defined(nullability_on_classes)
+#if __has_extension(nullability_on_classes)
+#define __CIDR_HELPER_DEFINE_108
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_108)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability_on_classes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability_on_classes = ((void) 0, 0); }
+#endif
+#if !defined(nullability_nullable_result)
+#if __has_feature(nullability_nullable_result)
+#define __CIDR_HELPER_DEFINE_109
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_109)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability_nullable_result = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_nullability_nullable_result = ((void) 0, 0); }
+#endif
+#if !defined(nullability_nullable_result)
+#if __has_extension(nullability_nullable_result)
+#define __CIDR_HELPER_DEFINE_110
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_110)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability_nullable_result = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_nullability_nullable_result = ((void) 0, 0); }
+#endif
+#if !defined(nullability_nullable_result)
+#if __has_feature(nullability_nullable_result) || __has_extension(nullability_nullable_result)
+#define __CIDR_HELPER_DEFINE_111
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_111)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_NULLABILITY_NULLABLE_RESULT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_NULLABILITY_NULLABLE_RESULT = ((void) 0, 0); }
+#endif
+#if !defined(numerical_stability_sanitizer)
+#if __has_feature(numerical_stability_sanitizer)
+#define __CIDR_HELPER_DEFINE_112
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_112)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_numerical_stability_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_numerical_stability_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(numerical_stability_sanitizer)
+#if __has_extension(numerical_stability_sanitizer)
+#define __CIDR_HELPER_DEFINE_113
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_113)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_numerical_stability_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_numerical_stability_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(memory_sanitizer)
+#if __has_feature(memory_sanitizer)
+#define __CIDR_HELPER_DEFINE_114
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_114)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memory_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_memory_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(memory_sanitizer)
+#if __has_extension(memory_sanitizer)
+#define __CIDR_HELPER_DEFINE_115
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_115)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memory_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_memory_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(thread_sanitizer)
+#if __has_feature(thread_sanitizer)
+#define __CIDR_HELPER_DEFINE_116
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_116)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_thread_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_thread_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(thread_sanitizer)
+#if __has_extension(thread_sanitizer)
+#define __CIDR_HELPER_DEFINE_117
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_117)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_thread_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_thread_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(dataflow_sanitizer)
+#if __has_feature(dataflow_sanitizer)
+#define __CIDR_HELPER_DEFINE_118
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_118)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_dataflow_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_dataflow_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(dataflow_sanitizer)
+#if __has_extension(dataflow_sanitizer)
+#define __CIDR_HELPER_DEFINE_119
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_119)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_dataflow_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_dataflow_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(scudo)
+#if __has_feature(scudo)
+#define __CIDR_HELPER_DEFINE_120
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_120)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_scudo = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_scudo = ((void) 0, 0); }
+#endif
+#if !defined(scudo)
+#if __has_extension(scudo)
+#define __CIDR_HELPER_DEFINE_121
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_121)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_scudo = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_scudo = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_intrinsics)
+#if __has_feature(ptrauth_intrinsics)
+#define __CIDR_HELPER_DEFINE_122
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_122)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_intrinsics = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_intrinsics = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_intrinsics)
+#if __has_extension(ptrauth_intrinsics)
+#define __CIDR_HELPER_DEFINE_123
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_123)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_intrinsics = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_intrinsics = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_qualifier)
+#if __has_feature(ptrauth_qualifier)
+#define __CIDR_HELPER_DEFINE_124
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_124)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_qualifier = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_qualifier = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_qualifier)
+#if __has_extension(ptrauth_qualifier)
+#define __CIDR_HELPER_DEFINE_125
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_125)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_qualifier = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_qualifier = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_calls)
+#if __has_feature(ptrauth_calls)
+#define __CIDR_HELPER_DEFINE_126
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_126)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_calls = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_calls = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_calls)
+#if __has_extension(ptrauth_calls)
+#define __CIDR_HELPER_DEFINE_127
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_127)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_calls = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_calls = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_returns)
+#if __has_feature(ptrauth_returns)
+#define __CIDR_HELPER_DEFINE_128
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_128)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_returns = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_returns = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_returns)
+#if __has_extension(ptrauth_returns)
+#define __CIDR_HELPER_DEFINE_129
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_129)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_returns = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_returns = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_vtable_pointer_address_discrimination)
+#if __has_feature(ptrauth_vtable_pointer_address_discrimination)
+#define __CIDR_HELPER_DEFINE_130
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_130)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_vtable_pointer_address_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_vtable_pointer_address_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_vtable_pointer_address_discrimination)
+#if __has_extension(ptrauth_vtable_pointer_address_discrimination)
+#define __CIDR_HELPER_DEFINE_131
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_131)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_vtable_pointer_address_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_vtable_pointer_address_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_vtable_pointer_type_discrimination)
+#if __has_feature(ptrauth_vtable_pointer_type_discrimination)
+#define __CIDR_HELPER_DEFINE_132
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_132)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_vtable_pointer_type_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_vtable_pointer_type_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_vtable_pointer_type_discrimination)
+#if __has_extension(ptrauth_vtable_pointer_type_discrimination)
+#define __CIDR_HELPER_DEFINE_133
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_133)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_vtable_pointer_type_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_vtable_pointer_type_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_type_info_vtable_pointer_discrimination)
+#if __has_feature(ptrauth_type_info_vtable_pointer_discrimination)
+#define __CIDR_HELPER_DEFINE_134
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_134)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_type_info_vtable_pointer_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_type_info_vtable_pointer_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_type_info_vtable_pointer_discrimination)
+#if __has_extension(ptrauth_type_info_vtable_pointer_discrimination)
+#define __CIDR_HELPER_DEFINE_135
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_135)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_type_info_vtable_pointer_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_type_info_vtable_pointer_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_member_function_pointer_type_discrimination)
+#if __has_feature(ptrauth_member_function_pointer_type_discrimination)
+#define __CIDR_HELPER_DEFINE_136
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_136)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_member_function_pointer_type_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_member_function_pointer_type_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_member_function_pointer_type_discrimination)
+#if __has_extension(ptrauth_member_function_pointer_type_discrimination)
+#define __CIDR_HELPER_DEFINE_137
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_137)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_member_function_pointer_type_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_member_function_pointer_type_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_function_pointer_type_discrimination)
+#if __has_feature(ptrauth_function_pointer_type_discrimination)
+#define __CIDR_HELPER_DEFINE_138
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_138)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_function_pointer_type_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_function_pointer_type_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_function_pointer_type_discrimination)
+#if __has_extension(ptrauth_function_pointer_type_discrimination)
+#define __CIDR_HELPER_DEFINE_139
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_139)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_function_pointer_type_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_function_pointer_type_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_indirect_gotos)
+#if __has_feature(ptrauth_indirect_gotos)
+#define __CIDR_HELPER_DEFINE_140
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_140)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_indirect_gotos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_indirect_gotos = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_indirect_gotos)
+#if __has_extension(ptrauth_indirect_gotos)
+#define __CIDR_HELPER_DEFINE_141
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_141)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_indirect_gotos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_indirect_gotos = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_init_fini)
+#if __has_feature(ptrauth_init_fini)
+#define __CIDR_HELPER_DEFINE_142
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_142)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_init_fini = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_init_fini = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_init_fini)
+#if __has_extension(ptrauth_init_fini)
+#define __CIDR_HELPER_DEFINE_143
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_143)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_init_fini = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_init_fini = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_init_fini_address_discrimination)
+#if __has_feature(ptrauth_init_fini_address_discrimination)
+#define __CIDR_HELPER_DEFINE_144
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_144)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_init_fini_address_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_init_fini_address_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_init_fini_address_discrimination)
+#if __has_extension(ptrauth_init_fini_address_discrimination)
+#define __CIDR_HELPER_DEFINE_145
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_145)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_init_fini_address_discrimination = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_init_fini_address_discrimination = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_elf_got)
+#if __has_feature(ptrauth_elf_got)
+#define __CIDR_HELPER_DEFINE_146
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_146)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_elf_got = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ptrauth_elf_got = ((void) 0, 0); }
+#endif
+#if !defined(ptrauth_elf_got)
+#if __has_extension(ptrauth_elf_got)
+#define __CIDR_HELPER_DEFINE_147
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_147)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_elf_got = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ptrauth_elf_got = ((void) 0, 0); }
+#endif
+#if !defined(swiftcc)
+#if __has_feature(swiftcc)
+#define __CIDR_HELPER_DEFINE_148
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_148)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_swiftcc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_swiftcc = ((void) 0, 0); }
+#endif
+#if !defined(swiftcc)
+#if __has_extension(swiftcc)
+#define __CIDR_HELPER_DEFINE_149
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_149)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_swiftcc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_swiftcc = ((void) 0, 0); }
+#endif
+#if !defined(swiftasynccc)
+#if __has_feature(swiftasynccc)
+#define __CIDR_HELPER_DEFINE_150
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_150)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_swiftasynccc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_swiftasynccc = ((void) 0, 0); }
+#endif
+#if !defined(swiftasynccc)
+#if __has_extension(swiftasynccc)
+#define __CIDR_HELPER_DEFINE_151
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_151)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_swiftasynccc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_swiftasynccc = ((void) 0, 0); }
+#endif
+#if !defined(pragma_stdc_cx_limited_range)
+#if __has_feature(pragma_stdc_cx_limited_range)
+#define __CIDR_HELPER_DEFINE_152
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_152)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_pragma_stdc_cx_limited_range = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_pragma_stdc_cx_limited_range = ((void) 0, 0); }
+#endif
+#if !defined(pragma_stdc_cx_limited_range)
+#if __has_extension(pragma_stdc_cx_limited_range)
+#define __CIDR_HELPER_DEFINE_153
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_153)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_pragma_stdc_cx_limited_range = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_pragma_stdc_cx_limited_range = ((void) 0, 0); }
+#endif
+#if !defined(efficiency_sanitizer)
+#if __has_feature(efficiency_sanitizer)
+#define __CIDR_HELPER_DEFINE_154
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_154)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_efficiency_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_efficiency_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(efficiency_sanitizer)
+#if __has_extension(efficiency_sanitizer)
+#define __CIDR_HELPER_DEFINE_155
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_155)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_efficiency_sanitizer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_efficiency_sanitizer = ((void) 0, 0); }
+#endif
+#if !defined(objc_arr)
+#if __has_feature(objc_arr)
+#define __CIDR_HELPER_DEFINE_156
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_156)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arr = ((void) 0, 0); }
+#endif
+#if !defined(objc_arr)
+#if __has_extension(objc_arr)
+#define __CIDR_HELPER_DEFINE_157
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_157)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arr = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc)
+#if __has_feature(objc_arc)
+#define __CIDR_HELPER_DEFINE_158
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_158)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arc = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc)
+#if __has_extension(objc_arc)
+#define __CIDR_HELPER_DEFINE_159
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_159)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arc = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc)
+#if __has_feature(objc_arc) || __has_extension(objc_arc)
+#define __CIDR_HELPER_DEFINE_160
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_160)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_ARC = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_ARC = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc_fields)
+#if __has_feature(objc_arc_fields)
+#define __CIDR_HELPER_DEFINE_161
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_161)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arc_fields = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arc_fields = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc_fields)
+#if __has_extension(objc_arc_fields)
+#define __CIDR_HELPER_DEFINE_162
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_162)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arc_fields = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arc_fields = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc_weak)
+#if __has_feature(objc_arc_weak)
+#define __CIDR_HELPER_DEFINE_163
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_163)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arc_weak = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_arc_weak = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc_weak)
+#if __has_extension(objc_arc_weak)
+#define __CIDR_HELPER_DEFINE_164
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_164)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arc_weak = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_arc_weak = ((void) 0, 0); }
+#endif
+#if !defined(objc_default_synthesize_properties)
+#if __has_feature(objc_default_synthesize_properties)
+#define __CIDR_HELPER_DEFINE_165
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_165)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_default_synthesize_properties = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_default_synthesize_properties = ((void) 0, 0); }
+#endif
+#if !defined(objc_default_synthesize_properties)
+#if __has_extension(objc_default_synthesize_properties)
+#define __CIDR_HELPER_DEFINE_166
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_166)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_default_synthesize_properties = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_default_synthesize_properties = ((void) 0, 0); }
+#endif
+#if !defined(objc_default_synthesize_properties)
+#if __has_feature(objc_default_synthesize_properties) || __has_extension(objc_default_synthesize_properties)
+#define __CIDR_HELPER_DEFINE_167
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_167)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_DEFAULT_SYNTHESIZE_PROPERTIES = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_DEFAULT_SYNTHESIZE_PROPERTIES = ((void) 0, 0); }
+#endif
+#if !defined(objc_fixed_enum)
+#if __has_feature(objc_fixed_enum)
+#define __CIDR_HELPER_DEFINE_168
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_168)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_fixed_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_fixed_enum = ((void) 0, 0); }
+#endif
+#if !defined(objc_fixed_enum)
+#if __has_extension(objc_fixed_enum)
+#define __CIDR_HELPER_DEFINE_169
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_169)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_fixed_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_fixed_enum = ((void) 0, 0); }
+#endif
+#if !defined(objc_instancetype)
+#if __has_feature(objc_instancetype)
+#define __CIDR_HELPER_DEFINE_170
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_170)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_instancetype = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_instancetype = ((void) 0, 0); }
+#endif
+#if !defined(objc_instancetype)
+#if __has_extension(objc_instancetype)
+#define __CIDR_HELPER_DEFINE_171
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_171)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_instancetype = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_instancetype = ((void) 0, 0); }
+#endif
+#if !defined(objc_instancetype)
+#if __has_feature(objc_instancetype) || __has_extension(objc_instancetype)
+#define __CIDR_HELPER_DEFINE_172
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_172)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_INSTANCETYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_INSTANCETYPE = ((void) 0, 0); }
+#endif
+#if !defined(objc_kindof)
+#if __has_feature(objc_kindof)
+#define __CIDR_HELPER_DEFINE_173
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_173)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_kindof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_kindof = ((void) 0, 0); }
+#endif
+#if !defined(objc_kindof)
+#if __has_extension(objc_kindof)
+#define __CIDR_HELPER_DEFINE_174
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_174)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_kindof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_kindof = ((void) 0, 0); }
+#endif
+#if !defined(objc_modules)
+#if __has_feature(objc_modules)
+#define __CIDR_HELPER_DEFINE_175
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_175)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_modules = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_modules = ((void) 0, 0); }
+#endif
+#if !defined(objc_modules)
+#if __has_extension(objc_modules)
+#define __CIDR_HELPER_DEFINE_176
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_176)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_modules = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_modules = ((void) 0, 0); }
+#endif
+#if !defined(objc_nonfragile_abi)
+#if __has_feature(objc_nonfragile_abi)
+#define __CIDR_HELPER_DEFINE_177
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_177)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_nonfragile_abi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_nonfragile_abi = ((void) 0, 0); }
+#endif
+#if !defined(objc_nonfragile_abi)
+#if __has_extension(objc_nonfragile_abi)
+#define __CIDR_HELPER_DEFINE_178
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_178)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_nonfragile_abi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_nonfragile_abi = ((void) 0, 0); }
+#endif
+#if !defined(objc_property_explicit_atomic)
+#if __has_feature(objc_property_explicit_atomic)
+#define __CIDR_HELPER_DEFINE_179
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_179)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_property_explicit_atomic = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_property_explicit_atomic = ((void) 0, 0); }
+#endif
+#if !defined(objc_property_explicit_atomic)
+#if __has_extension(objc_property_explicit_atomic)
+#define __CIDR_HELPER_DEFINE_180
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_180)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_property_explicit_atomic = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_property_explicit_atomic = ((void) 0, 0); }
+#endif
+#if !defined(objc_property_explicit_atomic)
+#if __has_feature(objc_property_explicit_atomic) || __has_extension(objc_property_explicit_atomic)
+#define __CIDR_HELPER_DEFINE_181
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_181)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_PROPERTY_EXPLICIT_ATOMIC = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_PROPERTY_EXPLICIT_ATOMIC = ((void) 0, 0); }
+#endif
+#if !defined(objc_protocol_qualifier_mangling)
+#if __has_feature(objc_protocol_qualifier_mangling)
+#define __CIDR_HELPER_DEFINE_182
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_182)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_protocol_qualifier_mangling = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_protocol_qualifier_mangling = ((void) 0, 0); }
+#endif
+#if !defined(objc_protocol_qualifier_mangling)
+#if __has_extension(objc_protocol_qualifier_mangling)
+#define __CIDR_HELPER_DEFINE_183
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_183)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_protocol_qualifier_mangling = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_protocol_qualifier_mangling = ((void) 0, 0); }
+#endif
+#if !defined(objc_weak_class)
+#if __has_feature(objc_weak_class)
+#define __CIDR_HELPER_DEFINE_184
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_184)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_weak_class = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_weak_class = ((void) 0, 0); }
+#endif
+#if !defined(objc_weak_class)
+#if __has_extension(objc_weak_class)
+#define __CIDR_HELPER_DEFINE_185
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_185)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_weak_class = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_weak_class = ((void) 0, 0); }
+#endif
+#if !defined(ownership_holds)
+#if __has_feature(ownership_holds)
+#define __CIDR_HELPER_DEFINE_186
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_186)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ownership_holds = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ownership_holds = ((void) 0, 0); }
+#endif
+#if !defined(ownership_holds)
+#if __has_extension(ownership_holds)
+#define __CIDR_HELPER_DEFINE_187
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_187)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ownership_holds = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ownership_holds = ((void) 0, 0); }
+#endif
+#if !defined(ownership_returns)
+#if __has_feature(ownership_returns)
+#define __CIDR_HELPER_DEFINE_188
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_188)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ownership_returns = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ownership_returns = ((void) 0, 0); }
+#endif
+#if !defined(ownership_returns)
+#if __has_extension(ownership_returns)
+#define __CIDR_HELPER_DEFINE_189
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_189)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ownership_returns = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ownership_returns = ((void) 0, 0); }
+#endif
+#if !defined(ownership_takes)
+#if __has_feature(ownership_takes)
+#define __CIDR_HELPER_DEFINE_190
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_190)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ownership_takes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_ownership_takes = ((void) 0, 0); }
+#endif
+#if !defined(ownership_takes)
+#if __has_extension(ownership_takes)
+#define __CIDR_HELPER_DEFINE_191
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_191)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ownership_takes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_ownership_takes = ((void) 0, 0); }
+#endif
+#if !defined(objc_bool)
+#if __has_feature(objc_bool)
+#define __CIDR_HELPER_DEFINE_192
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_192)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_bool = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_bool = ((void) 0, 0); }
+#endif
+#if !defined(objc_bool)
+#if __has_extension(objc_bool)
+#define __CIDR_HELPER_DEFINE_193
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_193)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_bool = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_bool = ((void) 0, 0); }
+#endif
+#if !defined(objc_bool)
+#if __has_feature(objc_bool) || __has_extension(objc_bool)
+#define __CIDR_HELPER_DEFINE_194
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_194)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_BOOL = ((void) 1, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___objc_no = ((void) "((BOOL)0)", 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___objc_yes = ((void) "((BOOL)1)", 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_BOOL = ((void) 0, 0); }
+#endif
+#if !defined(objc_subscripting)
+#if __has_feature(objc_subscripting)
+#define __CIDR_HELPER_DEFINE_195
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_195)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_subscripting = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_subscripting = ((void) 0, 0); }
+#endif
+#if !defined(objc_subscripting)
+#if __has_extension(objc_subscripting)
+#define __CIDR_HELPER_DEFINE_196
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_196)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_subscripting = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_subscripting = ((void) 0, 0); }
+#endif
+#if !defined(objc_subscripting)
+#if __has_feature(objc_subscripting) || __has_extension(objc_subscripting)
+#define __CIDR_HELPER_DEFINE_197
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_197)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_SUBSCRIPTING = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_SUBSCRIPTING = ((void) 0, 0); }
+#endif
+#if !defined(objc_array_literals)
+#if __has_feature(objc_array_literals)
+#define __CIDR_HELPER_DEFINE_198
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_198)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_array_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_array_literals = ((void) 0, 0); }
+#endif
+#if !defined(objc_array_literals)
+#if __has_extension(objc_array_literals)
+#define __CIDR_HELPER_DEFINE_199
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_199)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_array_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_array_literals = ((void) 0, 0); }
+#endif
+#if !defined(objc_array_literals)
+#if __has_feature(objc_array_literals) || __has_extension(objc_array_literals)
+#define __CIDR_HELPER_DEFINE_200
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_200)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_ARRAY_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_ARRAY_LITERALS = ((void) 0, 0); }
+#endif
+#if !defined(objc_dictionary_literals)
+#if __has_feature(objc_dictionary_literals)
+#define __CIDR_HELPER_DEFINE_201
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_201)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_dictionary_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_dictionary_literals = ((void) 0, 0); }
+#endif
+#if !defined(objc_dictionary_literals)
+#if __has_extension(objc_dictionary_literals)
+#define __CIDR_HELPER_DEFINE_202
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_202)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_dictionary_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_dictionary_literals = ((void) 0, 0); }
+#endif
+#if !defined(objc_dictionary_literals)
+#if __has_feature(objc_dictionary_literals) || __has_extension(objc_dictionary_literals)
+#define __CIDR_HELPER_DEFINE_203
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_203)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_DICTIONARY_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_DICTIONARY_LITERALS = ((void) 0, 0); }
+#endif
+#if !defined(objc_boxed_expressions)
+#if __has_feature(objc_boxed_expressions)
+#define __CIDR_HELPER_DEFINE_204
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_204)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_boxed_expressions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_boxed_expressions = ((void) 0, 0); }
+#endif
+#if !defined(objc_boxed_expressions)
+#if __has_extension(objc_boxed_expressions)
+#define __CIDR_HELPER_DEFINE_205
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_205)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_boxed_expressions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_boxed_expressions = ((void) 0, 0); }
+#endif
+#if !defined(objc_boxed_nsvalue_expressions)
+#if __has_feature(objc_boxed_nsvalue_expressions)
+#define __CIDR_HELPER_DEFINE_206
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_206)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_boxed_nsvalue_expressions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_boxed_nsvalue_expressions = ((void) 0, 0); }
+#endif
+#if !defined(objc_boxed_nsvalue_expressions)
+#if __has_extension(objc_boxed_nsvalue_expressions)
+#define __CIDR_HELPER_DEFINE_207
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_207)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_boxed_nsvalue_expressions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_boxed_nsvalue_expressions = ((void) 0, 0); }
+#endif
+#if !defined(arc_cf_code_audited)
+#if __has_feature(arc_cf_code_audited)
+#define __CIDR_HELPER_DEFINE_208
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_208)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_arc_cf_code_audited = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_arc_cf_code_audited = ((void) 0, 0); }
+#endif
+#if !defined(arc_cf_code_audited)
+#if __has_extension(arc_cf_code_audited)
+#define __CIDR_HELPER_DEFINE_209
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_209)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_arc_cf_code_audited = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_arc_cf_code_audited = ((void) 0, 0); }
+#endif
+#if !defined(objc_bridge_id)
+#if __has_feature(objc_bridge_id)
+#define __CIDR_HELPER_DEFINE_210
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_210)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_bridge_id = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_bridge_id = ((void) 0, 0); }
+#endif
+#if !defined(objc_bridge_id)
+#if __has_extension(objc_bridge_id)
+#define __CIDR_HELPER_DEFINE_211
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_211)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_bridge_id = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_bridge_id = ((void) 0, 0); }
+#endif
+#if !defined(objc_bridge_id_on_typedefs)
+#if __has_feature(objc_bridge_id_on_typedefs)
+#define __CIDR_HELPER_DEFINE_212
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_212)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_bridge_id_on_typedefs = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_bridge_id_on_typedefs = ((void) 0, 0); }
+#endif
+#if !defined(objc_bridge_id_on_typedefs)
+#if __has_extension(objc_bridge_id_on_typedefs)
+#define __CIDR_HELPER_DEFINE_213
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_213)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_bridge_id_on_typedefs = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_bridge_id_on_typedefs = ((void) 0, 0); }
+#endif
+#if !defined(objc_generics)
+#if __has_feature(objc_generics)
+#define __CIDR_HELPER_DEFINE_214
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_214)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_generics = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_generics = ((void) 0, 0); }
+#endif
+#if !defined(objc_generics)
+#if __has_extension(objc_generics)
+#define __CIDR_HELPER_DEFINE_215
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_215)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_generics = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_generics = ((void) 0, 0); }
+#endif
+#if !defined(objc_generics_variance)
+#if __has_feature(objc_generics_variance)
+#define __CIDR_HELPER_DEFINE_216
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_216)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_generics_variance = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_generics_variance = ((void) 0, 0); }
+#endif
+#if !defined(objc_generics_variance)
+#if __has_extension(objc_generics_variance)
+#define __CIDR_HELPER_DEFINE_217
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_217)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_generics_variance = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_generics_variance = ((void) 0, 0); }
+#endif
+#if !defined(objc_class_property)
+#if __has_feature(objc_class_property)
+#define __CIDR_HELPER_DEFINE_218
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_218)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_class_property = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_class_property = ((void) 0, 0); }
+#endif
+#if !defined(objc_class_property)
+#if __has_extension(objc_class_property)
+#define __CIDR_HELPER_DEFINE_219
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_219)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_class_property = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_class_property = ((void) 0, 0); }
+#endif
+#if !defined(objc_class_property)
+#if __has_feature(objc_class_property) || __has_extension(objc_class_property)
+#define __CIDR_HELPER_DEFINE_220
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_220)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_CLASS_PROPERTY = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_OBJC_CLASS_PROPERTY = ((void) 0, 0); }
+#endif
+#if !defined(objc_c_static_assert)
+#if __has_feature(objc_c_static_assert)
+#define __CIDR_HELPER_DEFINE_221
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_221)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_c_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_c_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(objc_c_static_assert)
+#if __has_extension(objc_c_static_assert)
+#define __CIDR_HELPER_DEFINE_222
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_222)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_c_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_c_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(objc_cxx_static_assert)
+#if __has_feature(objc_cxx_static_assert)
+#define __CIDR_HELPER_DEFINE_223
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_223)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_cxx_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_objc_cxx_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(objc_cxx_static_assert)
+#if __has_extension(objc_cxx_static_assert)
+#define __CIDR_HELPER_DEFINE_224
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_224)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_cxx_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_objc_cxx_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(c_alignas)
+#if __has_feature(c_alignas)
+#define __CIDR_HELPER_DEFINE_225
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_225)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_alignas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_alignas = ((void) 0, 0); }
+#endif
+#if !defined(c_alignas)
+#if __has_extension(c_alignas)
+#define __CIDR_HELPER_DEFINE_226
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_226)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_alignas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_alignas = ((void) 0, 0); }
+#endif
+#if !defined(c_alignof)
+#if __has_feature(c_alignof)
+#define __CIDR_HELPER_DEFINE_227
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_227)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_alignof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_alignof = ((void) 0, 0); }
+#endif
+#if !defined(c_alignof)
+#if __has_extension(c_alignof)
+#define __CIDR_HELPER_DEFINE_228
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_228)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_alignof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_alignof = ((void) 0, 0); }
+#endif
+#if !defined(c_atomic)
+#if __has_feature(c_atomic)
+#define __CIDR_HELPER_DEFINE_229
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_229)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_atomic = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_atomic = ((void) 0, 0); }
+#endif
+#if !defined(c_atomic)
+#if __has_extension(c_atomic)
+#define __CIDR_HELPER_DEFINE_230
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_230)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_atomic = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_atomic = ((void) 0, 0); }
+#endif
+#if !defined(c_generic_selections)
+#if __has_feature(c_generic_selections)
+#define __CIDR_HELPER_DEFINE_231
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_231)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_generic_selections = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_generic_selections = ((void) 0, 0); }
+#endif
+#if !defined(c_generic_selections)
+#if __has_extension(c_generic_selections)
+#define __CIDR_HELPER_DEFINE_232
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_232)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_generic_selections = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_generic_selections = ((void) 0, 0); }
+#endif
+#if !defined(c_static_assert)
+#if __has_feature(c_static_assert)
+#define __CIDR_HELPER_DEFINE_233
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_233)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(c_static_assert)
+#if __has_extension(c_static_assert)
+#define __CIDR_HELPER_DEFINE_234
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_234)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(c_static_assert)
+#if __has_feature(c_static_assert) || __has_extension(c_static_assert)
+#define __CIDR_HELPER_DEFINE_235
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_235)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_STATIC_ASSERT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_STATIC_ASSERT = ((void) 0, 0); }
+#endif
+#if !defined(c_thread_local)
+#if __has_feature(c_thread_local)
+#define __CIDR_HELPER_DEFINE_236
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_236)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_thread_local = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_thread_local = ((void) 0, 0); }
+#endif
+#if !defined(c_thread_local)
+#if __has_extension(c_thread_local)
+#define __CIDR_HELPER_DEFINE_237
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_237)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_thread_local = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_thread_local = ((void) 0, 0); }
+#endif
+#if !defined(cxx_access_control_sfinae)
+#if __has_feature(cxx_access_control_sfinae)
+#define __CIDR_HELPER_DEFINE_238
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_238)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_access_control_sfinae = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_access_control_sfinae = ((void) 0, 0); }
+#endif
+#if !defined(cxx_access_control_sfinae)
+#if __has_extension(cxx_access_control_sfinae)
+#define __CIDR_HELPER_DEFINE_239
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_239)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_access_control_sfinae = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_access_control_sfinae = ((void) 0, 0); }
+#endif
+#if !defined(cxx_alias_templates)
+#if __has_feature(cxx_alias_templates)
+#define __CIDR_HELPER_DEFINE_240
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_240)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_alias_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_alias_templates = ((void) 0, 0); }
+#endif
+#if !defined(cxx_alias_templates)
+#if __has_extension(cxx_alias_templates)
+#define __CIDR_HELPER_DEFINE_241
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_241)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_alias_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_alias_templates = ((void) 0, 0); }
+#endif
+#if !defined(cxx_alignas)
+#if __has_feature(cxx_alignas)
+#define __CIDR_HELPER_DEFINE_242
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_242)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_alignas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_alignas = ((void) 0, 0); }
+#endif
+#if !defined(cxx_alignas)
+#if __has_extension(cxx_alignas)
+#define __CIDR_HELPER_DEFINE_243
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_243)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_alignas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_alignas = ((void) 0, 0); }
+#endif
+#if !defined(cxx_alignof)
+#if __has_feature(cxx_alignof)
+#define __CIDR_HELPER_DEFINE_244
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_244)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_alignof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_alignof = ((void) 0, 0); }
+#endif
+#if !defined(cxx_alignof)
+#if __has_extension(cxx_alignof)
+#define __CIDR_HELPER_DEFINE_245
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_245)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_alignof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_alignof = ((void) 0, 0); }
+#endif
+#if !defined(cxx_atomic)
+#if __has_feature(cxx_atomic)
+#define __CIDR_HELPER_DEFINE_246
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_246)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_atomic = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_atomic = ((void) 0, 0); }
+#endif
+#if !defined(cxx_atomic)
+#if __has_extension(cxx_atomic)
+#define __CIDR_HELPER_DEFINE_247
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_247)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_atomic = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_atomic = ((void) 0, 0); }
+#endif
+#if !defined(cxx_attributes)
+#if __has_feature(cxx_attributes)
+#define __CIDR_HELPER_DEFINE_248
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_248)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_attributes = ((void) 0, 0); }
+#endif
+#if !defined(cxx_attributes)
+#if __has_extension(cxx_attributes)
+#define __CIDR_HELPER_DEFINE_249
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_249)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_attributes = ((void) 0, 0); }
+#endif
+#if !defined(cxx_attributes)
+#if __has_feature(cxx_attributes) || __has_extension(cxx_attributes)
+#define __CIDR_HELPER_DEFINE_250
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_250)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_ATTRIBUTES = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_ATTRIBUTES = ((void) 0, 0); }
+#endif
+#if !defined(cxx_auto_type)
+#if __has_feature(cxx_auto_type)
+#define __CIDR_HELPER_DEFINE_251
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_251)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_auto_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_auto_type = ((void) 0, 0); }
+#endif
+#if !defined(cxx_auto_type)
+#if __has_extension(cxx_auto_type)
+#define __CIDR_HELPER_DEFINE_252
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_252)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_auto_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_auto_type = ((void) 0, 0); }
+#endif
+#if !defined(cxx_auto_type)
+#if __has_feature(cxx_auto_type) || __has_extension(cxx_auto_type)
+#define __CIDR_HELPER_DEFINE_253
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_253)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_AUTO_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_AUTO_TYPE = ((void) 0, 0); }
+#endif
+#if !defined(cxx_constexpr)
+#if __has_feature(cxx_constexpr)
+#define __CIDR_HELPER_DEFINE_254
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_254)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_constexpr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_constexpr = ((void) 0, 0); }
+#endif
+#if !defined(cxx_constexpr)
+#if __has_extension(cxx_constexpr)
+#define __CIDR_HELPER_DEFINE_255
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_255)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_constexpr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_constexpr = ((void) 0, 0); }
+#endif
+#if !defined(cxx_constexpr)
+#if __has_feature(cxx_constexpr) || __has_extension(cxx_constexpr)
+#define __CIDR_HELPER_DEFINE_256
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_256)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR = ((void) 0, 0); }
+#endif
+#if !defined(cxx_constexpr_string_builtins)
+#if __has_feature(cxx_constexpr_string_builtins)
+#define __CIDR_HELPER_DEFINE_257
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_257)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_constexpr_string_builtins = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_constexpr_string_builtins = ((void) 0, 0); }
+#endif
+#if !defined(cxx_constexpr_string_builtins)
+#if __has_extension(cxx_constexpr_string_builtins)
+#define __CIDR_HELPER_DEFINE_258
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_258)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_constexpr_string_builtins = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_constexpr_string_builtins = ((void) 0, 0); }
+#endif
+#if !defined(cxx_decltype)
+#if __has_feature(cxx_decltype)
+#define __CIDR_HELPER_DEFINE_259
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_259)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_decltype = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_decltype = ((void) 0, 0); }
+#endif
+#if !defined(cxx_decltype)
+#if __has_extension(cxx_decltype)
+#define __CIDR_HELPER_DEFINE_260
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_260)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_decltype = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_decltype = ((void) 0, 0); }
+#endif
+#if !defined(cxx_decltype_incomplete_return_types)
+#if __has_feature(cxx_decltype_incomplete_return_types)
+#define __CIDR_HELPER_DEFINE_261
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_261)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_decltype_incomplete_return_types = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_decltype_incomplete_return_types = ((void) 0, 0); }
+#endif
+#if !defined(cxx_decltype_incomplete_return_types)
+#if __has_extension(cxx_decltype_incomplete_return_types)
+#define __CIDR_HELPER_DEFINE_262
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_262)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_decltype_incomplete_return_types = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_decltype_incomplete_return_types = ((void) 0, 0); }
+#endif
+#if !defined(cxx_default_function_template_args)
+#if __has_feature(cxx_default_function_template_args)
+#define __CIDR_HELPER_DEFINE_263
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_263)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_default_function_template_args = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_default_function_template_args = ((void) 0, 0); }
+#endif
+#if !defined(cxx_default_function_template_args)
+#if __has_extension(cxx_default_function_template_args)
+#define __CIDR_HELPER_DEFINE_264
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_264)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_default_function_template_args = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_default_function_template_args = ((void) 0, 0); }
+#endif
+#if !defined(cxx_defaulted_functions)
+#if __has_feature(cxx_defaulted_functions)
+#define __CIDR_HELPER_DEFINE_265
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_265)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_defaulted_functions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_defaulted_functions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_defaulted_functions)
+#if __has_extension(cxx_defaulted_functions)
+#define __CIDR_HELPER_DEFINE_266
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_266)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_defaulted_functions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_defaulted_functions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_delegating_constructors)
+#if __has_feature(cxx_delegating_constructors)
+#define __CIDR_HELPER_DEFINE_267
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_267)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_delegating_constructors = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_delegating_constructors = ((void) 0, 0); }
+#endif
+#if !defined(cxx_delegating_constructors)
+#if __has_extension(cxx_delegating_constructors)
+#define __CIDR_HELPER_DEFINE_268
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_268)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_delegating_constructors = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_delegating_constructors = ((void) 0, 0); }
+#endif
+#if !defined(cxx_deleted_functions)
+#if __has_feature(cxx_deleted_functions)
+#define __CIDR_HELPER_DEFINE_269
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_269)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_deleted_functions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_deleted_functions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_deleted_functions)
+#if __has_extension(cxx_deleted_functions)
+#define __CIDR_HELPER_DEFINE_270
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_270)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_deleted_functions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_deleted_functions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_explicit_conversions)
+#if __has_feature(cxx_explicit_conversions)
+#define __CIDR_HELPER_DEFINE_271
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_271)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_explicit_conversions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_explicit_conversions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_explicit_conversions)
+#if __has_extension(cxx_explicit_conversions)
+#define __CIDR_HELPER_DEFINE_272
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_272)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_explicit_conversions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_explicit_conversions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generalized_initializers)
+#if __has_feature(cxx_generalized_initializers)
+#define __CIDR_HELPER_DEFINE_273
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_273)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_generalized_initializers = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_generalized_initializers = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generalized_initializers)
+#if __has_extension(cxx_generalized_initializers)
+#define __CIDR_HELPER_DEFINE_274
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_274)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_generalized_initializers = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_generalized_initializers = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generalized_initializers)
+#if __has_feature(cxx_generalized_initializers) || __has_extension(cxx_generalized_initializers)
+#define __CIDR_HELPER_DEFINE_275
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_275)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERALIZED_INITIALIZERS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERALIZED_INITIALIZERS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_implicit_moves)
+#if __has_feature(cxx_implicit_moves)
+#define __CIDR_HELPER_DEFINE_276
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_276)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_implicit_moves = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_implicit_moves = ((void) 0, 0); }
+#endif
+#if !defined(cxx_implicit_moves)
+#if __has_extension(cxx_implicit_moves)
+#define __CIDR_HELPER_DEFINE_277
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_277)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_implicit_moves = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_implicit_moves = ((void) 0, 0); }
+#endif
+#if !defined(cxx_inheriting_constructors)
+#if __has_feature(cxx_inheriting_constructors)
+#define __CIDR_HELPER_DEFINE_278
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_278)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_inheriting_constructors = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_inheriting_constructors = ((void) 0, 0); }
+#endif
+#if !defined(cxx_inheriting_constructors)
+#if __has_extension(cxx_inheriting_constructors)
+#define __CIDR_HELPER_DEFINE_279
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_279)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_inheriting_constructors = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_inheriting_constructors = ((void) 0, 0); }
+#endif
+#if !defined(cxx_inline_namespaces)
+#if __has_feature(cxx_inline_namespaces)
+#define __CIDR_HELPER_DEFINE_280
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_280)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_inline_namespaces = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_inline_namespaces = ((void) 0, 0); }
+#endif
+#if !defined(cxx_inline_namespaces)
+#if __has_extension(cxx_inline_namespaces)
+#define __CIDR_HELPER_DEFINE_281
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_281)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_inline_namespaces = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_inline_namespaces = ((void) 0, 0); }
+#endif
+#if !defined(cxx_lambdas)
+#if __has_feature(cxx_lambdas)
+#define __CIDR_HELPER_DEFINE_282
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_282)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_lambdas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_lambdas = ((void) 0, 0); }
+#endif
+#if !defined(cxx_lambdas)
+#if __has_extension(cxx_lambdas)
+#define __CIDR_HELPER_DEFINE_283
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_283)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_lambdas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_lambdas = ((void) 0, 0); }
+#endif
+#if !defined(cxx_lambdas)
+#if __has_feature(cxx_lambdas) || __has_extension(cxx_lambdas)
+#define __CIDR_HELPER_DEFINE_284
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_284)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_LAMBDAS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_LAMBDAS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_local_type_template_args)
+#if __has_feature(cxx_local_type_template_args)
+#define __CIDR_HELPER_DEFINE_285
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_285)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_local_type_template_args = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_local_type_template_args = ((void) 0, 0); }
+#endif
+#if !defined(cxx_local_type_template_args)
+#if __has_extension(cxx_local_type_template_args)
+#define __CIDR_HELPER_DEFINE_286
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_286)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_local_type_template_args = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_local_type_template_args = ((void) 0, 0); }
+#endif
+#if !defined(cxx_nonstatic_member_init)
+#if __has_feature(cxx_nonstatic_member_init)
+#define __CIDR_HELPER_DEFINE_287
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_287)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_nonstatic_member_init = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_nonstatic_member_init = ((void) 0, 0); }
+#endif
+#if !defined(cxx_nonstatic_member_init)
+#if __has_extension(cxx_nonstatic_member_init)
+#define __CIDR_HELPER_DEFINE_288
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_288)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_nonstatic_member_init = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_nonstatic_member_init = ((void) 0, 0); }
+#endif
+#if !defined(cxx_nonstatic_member_init)
+#if __has_feature(cxx_nonstatic_member_init) || __has_extension(cxx_nonstatic_member_init)
+#define __CIDR_HELPER_DEFINE_289
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_289)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NONSTATIC_MEMBER_INIT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NONSTATIC_MEMBER_INIT = ((void) 0, 0); }
+#endif
+#if !defined(cxx_noexcept)
+#if __has_feature(cxx_noexcept)
+#define __CIDR_HELPER_DEFINE_290
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_290)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_noexcept = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_noexcept = ((void) 0, 0); }
+#endif
+#if !defined(cxx_noexcept)
+#if __has_extension(cxx_noexcept)
+#define __CIDR_HELPER_DEFINE_291
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_291)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_noexcept = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_noexcept = ((void) 0, 0); }
+#endif
+#if !defined(cxx_nullptr)
+#if __has_feature(cxx_nullptr)
+#define __CIDR_HELPER_DEFINE_292
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_292)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_nullptr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_nullptr = ((void) 0, 0); }
+#endif
+#if !defined(cxx_nullptr)
+#if __has_extension(cxx_nullptr)
+#define __CIDR_HELPER_DEFINE_293
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_293)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_nullptr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_nullptr = ((void) 0, 0); }
+#endif
+#if !defined(cxx_nullptr)
+#if __has_feature(cxx_nullptr) || __has_extension(cxx_nullptr)
+#define __CIDR_HELPER_DEFINE_294
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_294)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NULLPTR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NULLPTR = ((void) 0, 0); }
+#endif
+#if !defined(cxx_override_control)
+#if __has_feature(cxx_override_control)
+#define __CIDR_HELPER_DEFINE_295
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_295)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_override_control = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_override_control = ((void) 0, 0); }
+#endif
+#if !defined(cxx_override_control)
+#if __has_extension(cxx_override_control)
+#define __CIDR_HELPER_DEFINE_296
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_296)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_override_control = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_override_control = ((void) 0, 0); }
+#endif
+#if !defined(cxx_override_control)
+#if __has_feature(cxx_override_control) || __has_extension(cxx_override_control)
+#define __CIDR_HELPER_DEFINE_297
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_297)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_OVERRIDE_CONTROL = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_OVERRIDE_CONTROL = ((void) 0, 0); }
+#endif
+#if !defined(cxx_range_for)
+#if __has_feature(cxx_range_for)
+#define __CIDR_HELPER_DEFINE_298
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_298)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_range_for = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_range_for = ((void) 0, 0); }
+#endif
+#if !defined(cxx_range_for)
+#if __has_extension(cxx_range_for)
+#define __CIDR_HELPER_DEFINE_299
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_299)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_range_for = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_range_for = ((void) 0, 0); }
+#endif
+#if !defined(cxx_raw_string_literals)
+#if __has_feature(cxx_raw_string_literals)
+#define __CIDR_HELPER_DEFINE_300
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_300)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_raw_string_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_raw_string_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_raw_string_literals)
+#if __has_extension(cxx_raw_string_literals)
+#define __CIDR_HELPER_DEFINE_301
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_301)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_raw_string_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_raw_string_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_raw_string_literals)
+#if __has_feature(cxx_raw_string_literals) || __has_extension(cxx_raw_string_literals)
+#define __CIDR_HELPER_DEFINE_302
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_302)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RAW_STRING_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RAW_STRING_LITERALS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_reference_qualified_functions)
+#if __has_feature(cxx_reference_qualified_functions)
+#define __CIDR_HELPER_DEFINE_303
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_303)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_reference_qualified_functions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_reference_qualified_functions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_reference_qualified_functions)
+#if __has_extension(cxx_reference_qualified_functions)
+#define __CIDR_HELPER_DEFINE_304
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_304)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_reference_qualified_functions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_reference_qualified_functions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_rvalue_references)
+#if __has_feature(cxx_rvalue_references)
+#define __CIDR_HELPER_DEFINE_305
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_305)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_rvalue_references = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_rvalue_references = ((void) 0, 0); }
+#endif
+#if !defined(cxx_rvalue_references)
+#if __has_extension(cxx_rvalue_references)
+#define __CIDR_HELPER_DEFINE_306
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_306)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_rvalue_references = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_rvalue_references = ((void) 0, 0); }
+#endif
+#if !defined(cxx_strong_enums)
+#if __has_feature(cxx_strong_enums)
+#define __CIDR_HELPER_DEFINE_307
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_307)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_strong_enums = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_strong_enums = ((void) 0, 0); }
+#endif
+#if !defined(cxx_strong_enums)
+#if __has_extension(cxx_strong_enums)
+#define __CIDR_HELPER_DEFINE_308
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_308)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_strong_enums = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_strong_enums = ((void) 0, 0); }
+#endif
+#if !defined(cxx_static_assert)
+#if __has_feature(cxx_static_assert)
+#define __CIDR_HELPER_DEFINE_309
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_309)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(cxx_static_assert)
+#if __has_extension(cxx_static_assert)
+#define __CIDR_HELPER_DEFINE_310
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_310)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_static_assert = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_static_assert = ((void) 0, 0); }
+#endif
+#if !defined(cxx_thread_local)
+#if __has_feature(cxx_thread_local)
+#define __CIDR_HELPER_DEFINE_311
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_311)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_thread_local = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_thread_local = ((void) 0, 0); }
+#endif
+#if !defined(cxx_thread_local)
+#if __has_extension(cxx_thread_local)
+#define __CIDR_HELPER_DEFINE_312
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_312)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_thread_local = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_thread_local = ((void) 0, 0); }
+#endif
+#if !defined(cxx_trailing_return)
+#if __has_feature(cxx_trailing_return)
+#define __CIDR_HELPER_DEFINE_313
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_313)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_trailing_return = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_trailing_return = ((void) 0, 0); }
+#endif
+#if !defined(cxx_trailing_return)
+#if __has_extension(cxx_trailing_return)
+#define __CIDR_HELPER_DEFINE_314
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_314)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_trailing_return = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_trailing_return = ((void) 0, 0); }
+#endif
+#if !defined(cxx_unicode_literals)
+#if __has_feature(cxx_unicode_literals)
+#define __CIDR_HELPER_DEFINE_315
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_315)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_unicode_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_unicode_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_unicode_literals)
+#if __has_extension(cxx_unicode_literals)
+#define __CIDR_HELPER_DEFINE_316
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_316)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_unicode_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_unicode_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_unrestricted_unions)
+#if __has_feature(cxx_unrestricted_unions)
+#define __CIDR_HELPER_DEFINE_317
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_317)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_unrestricted_unions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_unrestricted_unions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_unrestricted_unions)
+#if __has_extension(cxx_unrestricted_unions)
+#define __CIDR_HELPER_DEFINE_318
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_318)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_unrestricted_unions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_unrestricted_unions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_user_literals)
+#if __has_feature(cxx_user_literals)
+#define __CIDR_HELPER_DEFINE_319
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_319)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_user_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_user_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_user_literals)
+#if __has_extension(cxx_user_literals)
+#define __CIDR_HELPER_DEFINE_320
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_320)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_user_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_user_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_user_literals)
+#if __has_feature(cxx_user_literals) || __has_extension(cxx_user_literals)
+#define __CIDR_HELPER_DEFINE_321
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_321)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_USER_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_USER_LITERALS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_variadic_templates)
+#if __has_feature(cxx_variadic_templates)
+#define __CIDR_HELPER_DEFINE_322
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_322)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_variadic_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_variadic_templates = ((void) 0, 0); }
+#endif
+#if !defined(cxx_variadic_templates)
+#if __has_extension(cxx_variadic_templates)
+#define __CIDR_HELPER_DEFINE_323
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_323)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_variadic_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_variadic_templates = ((void) 0, 0); }
+#endif
+#if !defined(cxx_aggregate_nsdmi)
+#if __has_feature(cxx_aggregate_nsdmi)
+#define __CIDR_HELPER_DEFINE_324
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_324)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_aggregate_nsdmi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_aggregate_nsdmi = ((void) 0, 0); }
+#endif
+#if !defined(cxx_aggregate_nsdmi)
+#if __has_extension(cxx_aggregate_nsdmi)
+#define __CIDR_HELPER_DEFINE_325
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_325)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_aggregate_nsdmi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_aggregate_nsdmi = ((void) 0, 0); }
+#endif
+#if !defined(cxx_binary_literals)
+#if __has_feature(cxx_binary_literals)
+#define __CIDR_HELPER_DEFINE_326
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_326)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_binary_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_binary_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_binary_literals)
+#if __has_extension(cxx_binary_literals)
+#define __CIDR_HELPER_DEFINE_327
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_327)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_binary_literals = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_binary_literals = ((void) 0, 0); }
+#endif
+#if !defined(cxx_binary_literals)
+#if __has_feature(cxx_binary_literals) || __has_extension(cxx_binary_literals)
+#define __CIDR_HELPER_DEFINE_328
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_328)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BINARY_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BINARY_LITERALS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_contextual_conversions)
+#if __has_feature(cxx_contextual_conversions)
+#define __CIDR_HELPER_DEFINE_329
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_329)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_contextual_conversions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_contextual_conversions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_contextual_conversions)
+#if __has_extension(cxx_contextual_conversions)
+#define __CIDR_HELPER_DEFINE_330
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_330)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_contextual_conversions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_contextual_conversions = ((void) 0, 0); }
+#endif
+#if !defined(cxx_decltype_auto)
+#if __has_feature(cxx_decltype_auto)
+#define __CIDR_HELPER_DEFINE_331
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_331)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_decltype_auto = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_decltype_auto = ((void) 0, 0); }
+#endif
+#if !defined(cxx_decltype_auto)
+#if __has_extension(cxx_decltype_auto)
+#define __CIDR_HELPER_DEFINE_332
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_332)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_decltype_auto = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_decltype_auto = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generic_lambdas)
+#if __has_feature(cxx_generic_lambdas)
+#define __CIDR_HELPER_DEFINE_333
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_333)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_generic_lambdas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_generic_lambdas = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generic_lambdas)
+#if __has_extension(cxx_generic_lambdas)
+#define __CIDR_HELPER_DEFINE_334
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_334)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_generic_lambdas = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_generic_lambdas = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generic_lambdas)
+#if __has_feature(cxx_generic_lambdas) || __has_extension(cxx_generic_lambdas)
+#define __CIDR_HELPER_DEFINE_335
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_335)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERIC_LAMBDAS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERIC_LAMBDAS = ((void) 0, 0); }
+#endif
+#if !defined(cxx_init_captures)
+#if __has_feature(cxx_init_captures)
+#define __CIDR_HELPER_DEFINE_336
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_336)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_init_captures = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_init_captures = ((void) 0, 0); }
+#endif
+#if !defined(cxx_init_captures)
+#if __has_extension(cxx_init_captures)
+#define __CIDR_HELPER_DEFINE_337
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_337)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_init_captures = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_init_captures = ((void) 0, 0); }
+#endif
+#if !defined(cxx_relaxed_constexpr)
+#if __has_feature(cxx_relaxed_constexpr)
+#define __CIDR_HELPER_DEFINE_338
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_338)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_relaxed_constexpr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_relaxed_constexpr = ((void) 0, 0); }
+#endif
+#if !defined(cxx_relaxed_constexpr)
+#if __has_extension(cxx_relaxed_constexpr)
+#define __CIDR_HELPER_DEFINE_339
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_339)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_relaxed_constexpr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_relaxed_constexpr = ((void) 0, 0); }
+#endif
+#if !defined(cxx_relaxed_constexpr)
+#if __has_feature(cxx_relaxed_constexpr) || __has_extension(cxx_relaxed_constexpr)
+#define __CIDR_HELPER_DEFINE_340
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_340)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RELAXED_CONSTEXPR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RELAXED_CONSTEXPR = ((void) 0, 0); }
+#endif
+#if !defined(cxx_return_type_deduction)
+#if __has_feature(cxx_return_type_deduction)
+#define __CIDR_HELPER_DEFINE_341
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_341)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_return_type_deduction = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_return_type_deduction = ((void) 0, 0); }
+#endif
+#if !defined(cxx_return_type_deduction)
+#if __has_extension(cxx_return_type_deduction)
+#define __CIDR_HELPER_DEFINE_342
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_342)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_return_type_deduction = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_return_type_deduction = ((void) 0, 0); }
+#endif
+#if !defined(cxx_return_type_deduction)
+#if __has_feature(cxx_return_type_deduction) || __has_extension(cxx_return_type_deduction)
+#define __CIDR_HELPER_DEFINE_343
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_343)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RETURN_TYPE_DEDUCTION = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RETURN_TYPE_DEDUCTION = ((void) 0, 0); }
+#endif
+#if !defined(cxx_variable_templates)
+#if __has_feature(cxx_variable_templates)
+#define __CIDR_HELPER_DEFINE_344
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_344)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_variable_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_variable_templates = ((void) 0, 0); }
+#endif
+#if !defined(cxx_variable_templates)
+#if __has_extension(cxx_variable_templates)
+#define __CIDR_HELPER_DEFINE_345
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_345)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_variable_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_variable_templates = ((void) 0, 0); }
+#endif
+#if !defined(cxx_runtime_arrays)
+#if __has_feature(cxx_runtime_arrays)
+#define __CIDR_HELPER_DEFINE_346
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_346)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_runtime_arrays = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_runtime_arrays = ((void) 0, 0); }
+#endif
+#if !defined(cxx_runtime_arrays)
+#if __has_extension(cxx_runtime_arrays)
+#define __CIDR_HELPER_DEFINE_347
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_347)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_runtime_arrays = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_runtime_arrays = ((void) 0, 0); }
+#endif
+#if !defined(cxx_concepts)
+#if __has_feature(cxx_concepts)
+#define __CIDR_HELPER_DEFINE_348
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_348)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_concepts = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_concepts = ((void) 0, 0); }
+#endif
+#if !defined(cxx_concepts)
+#if __has_extension(cxx_concepts)
+#define __CIDR_HELPER_DEFINE_349
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_349)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_concepts = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_concepts = ((void) 0, 0); }
+#endif
+#if !defined(raw_invocation_type)
+#if __has_feature(raw_invocation_type)
+#define __CIDR_HELPER_DEFINE_350
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_350)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_raw_invocation_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_raw_invocation_type = ((void) 0, 0); }
+#endif
+#if !defined(raw_invocation_type)
+#if __has_extension(raw_invocation_type)
+#define __CIDR_HELPER_DEFINE_351
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_351)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_raw_invocation_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_raw_invocation_type = ((void) 0, 0); }
+#endif
+#if !defined(c_attributes)
+#if __has_feature(c_attributes)
+#define __CIDR_HELPER_DEFINE_352
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_352)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_c_attributes = ((void) 0, 0); }
+#endif
+#if !defined(c_attributes)
+#if __has_extension(c_attributes)
+#define __CIDR_HELPER_DEFINE_353
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_353)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_c_attributes = ((void) 0, 0); }
+#endif
+#if !defined(cxx_fixed_enum)
+#if __has_feature(cxx_fixed_enum)
+#define __CIDR_HELPER_DEFINE_354
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_354)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_fixed_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_fixed_enum = ((void) 0, 0); }
+#endif
+#if !defined(cxx_fixed_enum)
+#if __has_extension(cxx_fixed_enum)
+#define __CIDR_HELPER_DEFINE_355
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_355)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_fixed_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_fixed_enum = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generalized_nttp)
+#if __has_feature(cxx_generalized_nttp)
+#define __CIDR_HELPER_DEFINE_356
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_356)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_generalized_nttp = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_generalized_nttp = ((void) 0, 0); }
+#endif
+#if !defined(cxx_generalized_nttp)
+#if __has_extension(cxx_generalized_nttp)
+#define __CIDR_HELPER_DEFINE_357
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_357)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_generalized_nttp = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_generalized_nttp = ((void) 0, 0); }
+#endif
+#if !defined(cxx_explicit_this_parameter)
+#if __has_feature(cxx_explicit_this_parameter)
+#define __CIDR_HELPER_DEFINE_358
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_358)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_explicit_this_parameter = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_explicit_this_parameter = ((void) 0, 0); }
+#endif
+#if !defined(cxx_explicit_this_parameter)
+#if __has_extension(cxx_explicit_this_parameter)
+#define __CIDR_HELPER_DEFINE_359
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_359)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_explicit_this_parameter = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_explicit_this_parameter = ((void) 0, 0); }
+#endif
+#if !defined(cxx_explicit_this_parameter)
+#if __has_feature(cxx_explicit_this_parameter) || __has_extension(cxx_explicit_this_parameter)
+#define __CIDR_HELPER_DEFINE_360
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_360)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXPLICIT_THIS_PARAMETER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXPLICIT_THIS_PARAMETER = ((void) 0, 0); }
+#endif
+#if !defined(overloadable_unmarked)
+#if __has_feature(overloadable_unmarked)
+#define __CIDR_HELPER_DEFINE_361
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_361)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_overloadable_unmarked = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_overloadable_unmarked = ((void) 0, 0); }
+#endif
+#if !defined(overloadable_unmarked)
+#if __has_extension(overloadable_unmarked)
+#define __CIDR_HELPER_DEFINE_362
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_362)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_overloadable_unmarked = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_overloadable_unmarked = ((void) 0, 0); }
+#endif
+#if !defined(pragma_clang_attribute_namespaces)
+#if __has_feature(pragma_clang_attribute_namespaces)
+#define __CIDR_HELPER_DEFINE_363
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_363)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_pragma_clang_attribute_namespaces = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_pragma_clang_attribute_namespaces = ((void) 0, 0); }
+#endif
+#if !defined(pragma_clang_attribute_namespaces)
+#if __has_extension(pragma_clang_attribute_namespaces)
+#define __CIDR_HELPER_DEFINE_364
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_364)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_pragma_clang_attribute_namespaces = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_pragma_clang_attribute_namespaces = ((void) 0, 0); }
+#endif
+#if !defined(pragma_clang_attribute_external_declaration)
+#if __has_feature(pragma_clang_attribute_external_declaration)
+#define __CIDR_HELPER_DEFINE_365
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_365)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_pragma_clang_attribute_external_declaration = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_pragma_clang_attribute_external_declaration = ((void) 0, 0); }
+#endif
+#if !defined(pragma_clang_attribute_external_declaration)
+#if __has_extension(pragma_clang_attribute_external_declaration)
+#define __CIDR_HELPER_DEFINE_366
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_366)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_pragma_clang_attribute_external_declaration = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_pragma_clang_attribute_external_declaration = ((void) 0, 0); }
+#endif
+#if !defined(statement_attributes_with_gnu_syntax)
+#if __has_feature(statement_attributes_with_gnu_syntax)
+#define __CIDR_HELPER_DEFINE_367
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_367)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_statement_attributes_with_gnu_syntax = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_statement_attributes_with_gnu_syntax = ((void) 0, 0); }
+#endif
+#if !defined(statement_attributes_with_gnu_syntax)
+#if __has_extension(statement_attributes_with_gnu_syntax)
+#define __CIDR_HELPER_DEFINE_368
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_368)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_statement_attributes_with_gnu_syntax = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_statement_attributes_with_gnu_syntax = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm)
+#if __has_feature(gnu_asm)
+#define __CIDR_HELPER_DEFINE_369
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_369)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm)
+#if __has_extension(gnu_asm)
+#define __CIDR_HELPER_DEFINE_370
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_370)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm_goto_with_outputs)
+#if __has_feature(gnu_asm_goto_with_outputs)
+#define __CIDR_HELPER_DEFINE_371
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_371)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm_goto_with_outputs = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm_goto_with_outputs = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm_goto_with_outputs)
+#if __has_extension(gnu_asm_goto_with_outputs)
+#define __CIDR_HELPER_DEFINE_372
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_372)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm_goto_with_outputs = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm_goto_with_outputs = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm_goto_with_outputs_full)
+#if __has_feature(gnu_asm_goto_with_outputs_full)
+#define __CIDR_HELPER_DEFINE_373
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_373)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm_goto_with_outputs_full = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm_goto_with_outputs_full = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm_goto_with_outputs_full)
+#if __has_extension(gnu_asm_goto_with_outputs_full)
+#define __CIDR_HELPER_DEFINE_374
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_374)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm_goto_with_outputs_full = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm_goto_with_outputs_full = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm_constexpr_strings)
+#if __has_feature(gnu_asm_constexpr_strings)
+#define __CIDR_HELPER_DEFINE_375
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_375)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm_constexpr_strings = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_gnu_asm_constexpr_strings = ((void) 0, 0); }
+#endif
+#if !defined(gnu_asm_constexpr_strings)
+#if __has_extension(gnu_asm_constexpr_strings)
+#define __CIDR_HELPER_DEFINE_376
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_376)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm_constexpr_strings = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_gnu_asm_constexpr_strings = ((void) 0, 0); }
+#endif
+#if !defined(matrix_types)
+#if __has_feature(matrix_types)
+#define __CIDR_HELPER_DEFINE_377
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_377)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_matrix_types = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_matrix_types = ((void) 0, 0); }
+#endif
+#if !defined(matrix_types)
+#if __has_extension(matrix_types)
+#define __CIDR_HELPER_DEFINE_378
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_378)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_matrix_types = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_matrix_types = ((void) 0, 0); }
+#endif
+#if !defined(matrix_types_scalar_division)
+#if __has_feature(matrix_types_scalar_division)
+#define __CIDR_HELPER_DEFINE_379
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_379)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_matrix_types_scalar_division = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_matrix_types_scalar_division = ((void) 0, 0); }
+#endif
+#if !defined(matrix_types_scalar_division)
+#if __has_extension(matrix_types_scalar_division)
+#define __CIDR_HELPER_DEFINE_380
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_380)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_matrix_types_scalar_division = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_matrix_types_scalar_division = ((void) 0, 0); }
+#endif
+#if !defined(cxx_attributes_on_using_declarations)
+#if __has_feature(cxx_attributes_on_using_declarations)
+#define __CIDR_HELPER_DEFINE_381
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_381)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_attributes_on_using_declarations = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_attributes_on_using_declarations = ((void) 0, 0); }
+#endif
+#if !defined(cxx_attributes_on_using_declarations)
+#if __has_extension(cxx_attributes_on_using_declarations)
+#define __CIDR_HELPER_DEFINE_382
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_382)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_attributes_on_using_declarations = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_attributes_on_using_declarations = ((void) 0, 0); }
+#endif
+#if !defined(datasizeof)
+#if __has_feature(datasizeof)
+#define __CIDR_HELPER_DEFINE_383
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_383)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_datasizeof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_datasizeof = ((void) 0, 0); }
+#endif
+#if !defined(datasizeof)
+#if __has_extension(datasizeof)
+#define __CIDR_HELPER_DEFINE_384
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_384)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_datasizeof = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_datasizeof = ((void) 0, 0); }
+#endif
+#if !defined(cxx_abi_relative_vtable)
+#if __has_feature(cxx_abi_relative_vtable)
+#define __CIDR_HELPER_DEFINE_385
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_385)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_abi_relative_vtable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cxx_abi_relative_vtable = ((void) 0, 0); }
+#endif
+#if !defined(cxx_abi_relative_vtable)
+#if __has_extension(cxx_abi_relative_vtable)
+#define __CIDR_HELPER_DEFINE_386
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_386)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_abi_relative_vtable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cxx_abi_relative_vtable = ((void) 0, 0); }
+#endif
+#if !defined(clang_atomic_attributes)
+#if __has_feature(clang_atomic_attributes)
+#define __CIDR_HELPER_DEFINE_387
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_387)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_clang_atomic_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_clang_atomic_attributes = ((void) 0, 0); }
+#endif
+#if !defined(clang_atomic_attributes)
+#if __has_extension(clang_atomic_attributes)
+#define __CIDR_HELPER_DEFINE_388
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_388)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_clang_atomic_attributes = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_clang_atomic_attributes = ((void) 0, 0); }
+#endif
+#if !defined(cuda_noinline_keyword)
+#if __has_feature(cuda_noinline_keyword)
+#define __CIDR_HELPER_DEFINE_389
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_389)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cuda_noinline_keyword = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cuda_noinline_keyword = ((void) 0, 0); }
+#endif
+#if !defined(cuda_noinline_keyword)
+#if __has_extension(cuda_noinline_keyword)
+#define __CIDR_HELPER_DEFINE_390
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_390)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cuda_noinline_keyword = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cuda_noinline_keyword = ((void) 0, 0); }
+#endif
+#if !defined(cuda_implicit_host_device_templates)
+#if __has_feature(cuda_implicit_host_device_templates)
+#define __CIDR_HELPER_DEFINE_391
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_391)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cuda_implicit_host_device_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_cuda_implicit_host_device_templates = ((void) 0, 0); }
+#endif
+#if !defined(cuda_implicit_host_device_templates)
+#if __has_extension(cuda_implicit_host_device_templates)
+#define __CIDR_HELPER_DEFINE_392
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_392)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cuda_implicit_host_device_templates = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_cuda_implicit_host_device_templates = ((void) 0, 0); }
+#endif
+#if !defined(kcfi)
+#if __has_feature(kcfi)
+#define __CIDR_HELPER_DEFINE_393
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_393)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_kcfi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_kcfi = ((void) 0, 0); }
+#endif
+#if !defined(kcfi)
+#if __has_extension(kcfi)
+#define __CIDR_HELPER_DEFINE_394
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_394)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_kcfi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_kcfi = ((void) 0, 0); }
+#endif
+#if !defined(kcfi_arity)
+#if __has_feature(kcfi_arity)
+#define __CIDR_HELPER_DEFINE_395
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_395)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_kcfi_arity = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_kcfi_arity = ((void) 0, 0); }
+#endif
+#if !defined(kcfi_arity)
+#if __has_extension(kcfi_arity)
+#define __CIDR_HELPER_DEFINE_396
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_396)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_kcfi_arity = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_kcfi_arity = ((void) 0, 0); }
+#endif
+#if !defined(modules)
+#if __has_feature(modules)
+#define __CIDR_HELPER_DEFINE_397
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_397)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_modules = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_modules = ((void) 0, 0); }
+#endif
+#if !defined(modules)
+#if __has_extension(modules)
+#define __CIDR_HELPER_DEFINE_398
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_398)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_modules = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_modules = ((void) 0, 0); }
+#endif
+#if !defined(safe_stack)
+#if __has_feature(safe_stack)
+#define __CIDR_HELPER_DEFINE_399
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_399)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_safe_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_safe_stack = ((void) 0, 0); }
+#endif
+#if !defined(safe_stack)
+#if __has_extension(safe_stack)
+#define __CIDR_HELPER_DEFINE_400
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_400)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_safe_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_safe_stack = ((void) 0, 0); }
+#endif
+#if !defined(shadow_call_stack)
+#if __has_feature(shadow_call_stack)
+#define __CIDR_HELPER_DEFINE_401
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_401)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_shadow_call_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_shadow_call_stack = ((void) 0, 0); }
+#endif
+#if !defined(shadow_call_stack)
+#if __has_extension(shadow_call_stack)
+#define __CIDR_HELPER_DEFINE_402
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_402)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_shadow_call_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_shadow_call_stack = ((void) 0, 0); }
+#endif
+#if !defined(tls)
+#if __has_feature(tls)
+#define __CIDR_HELPER_DEFINE_403
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_403)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_tls = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_tls = ((void) 0, 0); }
+#endif
+#if !defined(tls)
+#if __has_extension(tls)
+#define __CIDR_HELPER_DEFINE_404
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_404)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_tls = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_tls = ((void) 0, 0); }
+#endif
+#if !defined(experimental_library)
+#if __has_feature(experimental_library)
+#define __CIDR_HELPER_DEFINE_405
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_405)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_experimental_library = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_experimental_library = ((void) 0, 0); }
+#endif
+#if !defined(experimental_library)
+#if __has_extension(experimental_library)
+#define __CIDR_HELPER_DEFINE_406
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_406)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_experimental_library = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_experimental_library = ((void) 0, 0); }
+#endif
+#if !defined(experimental_library)
+#if __has_feature(experimental_library) || __has_extension(experimental_library)
+#define __CIDR_HELPER_DEFINE_407
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_407)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_EXPERIMENTAL_LIBRARY = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_EXPERIMENTAL_LIBRARY = ((void) 0, 0); }
+#endif
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_nothrow_assign = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_nothrow_assign = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_nothrow_copy = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_nothrow_copy = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_nothrow_constructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_nothrow_constructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_trivial_assign = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_trivial_assign = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_trivial_copy = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_trivial_copy = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_trivial_constructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_trivial_constructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_trivial_destructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_trivial_destructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_has_virtual_destructor = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_has_virtual_destructor = ((void) 0, 0); }
+#if !defined(is_abstract)
+#if __has_feature(is_abstract)
+#define __CIDR_HELPER_DEFINE_408
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_408)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_abstract = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_abstract = ((void) 0, 0); }
+#endif
+#if !defined(is_abstract)
+#if __has_extension(is_abstract)
+#define __CIDR_HELPER_DEFINE_409
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_409)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_abstract = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_abstract = ((void) 0, 0); }
+#endif
+#if !defined(is_base_of)
+#if __has_feature(is_base_of)
+#define __CIDR_HELPER_DEFINE_410
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_410)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_base_of = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_base_of = ((void) 0, 0); }
+#endif
+#if !defined(is_base_of)
+#if __has_extension(is_base_of)
+#define __CIDR_HELPER_DEFINE_411
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_411)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_base_of = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_base_of = ((void) 0, 0); }
+#endif
+#if !defined(is_base_of)
+#if __has_feature(is_base_of) || __has_extension(is_base_of)
+#define __CIDR_HELPER_DEFINE_412
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_412)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_BASE_OF = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_BASE_OF = ((void) 0, 0); }
+#endif
+#if !defined(is_class)
+#if __has_feature(is_class)
+#define __CIDR_HELPER_DEFINE_413
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_413)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_class = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_class = ((void) 0, 0); }
+#endif
+#if !defined(is_class)
+#if __has_extension(is_class)
+#define __CIDR_HELPER_DEFINE_414
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_414)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_class = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_class = ((void) 0, 0); }
+#endif
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_constructible = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_constructible = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_convertible_to = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_convertible_to = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_empty = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_empty = ((void) 0, 0); }
+#if !defined(is_enum)
+#if __has_feature(is_enum)
+#define __CIDR_HELPER_DEFINE_415
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_415)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_enum = ((void) 0, 0); }
+#endif
+#if !defined(is_enum)
+#if __has_extension(is_enum)
+#define __CIDR_HELPER_DEFINE_416
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_416)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_enum = ((void) 0, 0); }
+#endif
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_final = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_final = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_literal = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_literal = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_standard_layout = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_standard_layout = ((void) 0, 0); }
+#if !defined(is_pod)
+#if __has_feature(is_pod)
+#define __CIDR_HELPER_DEFINE_417
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_417)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_pod = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_pod = ((void) 0, 0); }
+#endif
+#if !defined(is_pod)
+#if __has_extension(is_pod)
+#define __CIDR_HELPER_DEFINE_418
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_418)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_pod = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_pod = ((void) 0, 0); }
+#endif
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_polymorphic = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_polymorphic = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_sealed = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_sealed = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_trivial = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_trivial = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_trivially_assignable = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_trivially_assignable = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_trivially_constructible = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_trivially_constructible = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_trivially_copyable = ((void) 0, 0); }
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_trivially_copyable = ((void) 0, 0); }
+#if !defined(is_union)
+#if __has_feature(is_union)
+#define __CIDR_HELPER_DEFINE_419
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_419)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_union = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_is_union = ((void) 0, 0); }
+#endif
+#if !defined(is_union)
+#if __has_extension(is_union)
+#define __CIDR_HELPER_DEFINE_420
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_420)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_union = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_is_union = ((void) 0, 0); }
+#endif
+#if !defined(underlying_type)
+#if __has_feature(underlying_type)
+#define __CIDR_HELPER_DEFINE_421
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_421)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_underlying_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_feature_underlying_type = ((void) 0, 0); }
+#endif
+#if !defined(underlying_type)
+#if __has_extension(underlying_type)
+#define __CIDR_HELPER_DEFINE_422
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_422)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_underlying_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_extension_underlying_type = ((void) 0, 0); }
+#endif
+#if !defined(underlying_type)
+#if __has_feature(underlying_type) || __has_extension(underlying_type)
+#define __CIDR_HELPER_DEFINE_423
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_423)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_UNDERLYING_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_UNDERLYING_TYPE = ((void) 0, 0); }
+#endif
+#if __has_builtin(__builtin_available)
+#define __CIDR_HELPER_DEFINE_424
+#endif
+#if defined(__CIDR_HELPER_DEFINE_424)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___builtin_available = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___builtin_available = ((void) 0, 0); }
+#endif
+#if __has_builtin(__builtin_available)
+#define __CIDR_HELPER_DEFINE_425
+#endif
+#if defined(__CIDR_HELPER_DEFINE_425)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_AVAILABLE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_AVAILABLE = ((void) 0, 0); }
+#endif
+#if __has_builtin(__builtin_bit_cast)
+#define __CIDR_HELPER_DEFINE_426
+#endif
+#if defined(__CIDR_HELPER_DEFINE_426)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___builtin_bit_cast = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___builtin_bit_cast = ((void) 0, 0); }
+#endif
+#if __has_builtin(__builtin_bit_cast)
+#define __CIDR_HELPER_DEFINE_427
+#endif
+#if defined(__CIDR_HELPER_DEFINE_427)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_BIT_CAST = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_BIT_CAST = ((void) 0, 0); }
+#endif
+#if __has_builtin(__builtin_source_location)
+#define __CIDR_HELPER_DEFINE_428
+#endif
+#if defined(__CIDR_HELPER_DEFINE_428)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___builtin_source_location = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___builtin_source_location = ((void) 0, 0); }
+#endif
+#if __has_builtin(__builtin_source_location)
+#define __CIDR_HELPER_DEFINE_429
+#endif
+#if defined(__CIDR_HELPER_DEFINE_429)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_SOURCE_LOCATION = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_SOURCE_LOCATION = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_arch)
+#define __CIDR_HELPER_DEFINE_430
+#endif
+#if defined(__CIDR_HELPER_DEFINE_430)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_arch = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_arch = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_arch)
+#define __CIDR_HELPER_DEFINE_431
+#endif
+#if defined(__CIDR_HELPER_DEFINE_431)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_ARCH = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_ARCH = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_vendor)
+#define __CIDR_HELPER_DEFINE_432
+#endif
+#if defined(__CIDR_HELPER_DEFINE_432)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_vendor = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_vendor = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_vendor)
+#define __CIDR_HELPER_DEFINE_433
+#endif
+#if defined(__CIDR_HELPER_DEFINE_433)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_VENDOR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_VENDOR = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_os)
+#define __CIDR_HELPER_DEFINE_434
+#endif
+#if defined(__CIDR_HELPER_DEFINE_434)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_os = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_os = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_os)
+#define __CIDR_HELPER_DEFINE_435
+#endif
+#if defined(__CIDR_HELPER_DEFINE_435)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_OS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_OS = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_environment)
+#define __CIDR_HELPER_DEFINE_436
+#endif
+#if defined(__CIDR_HELPER_DEFINE_436)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_environment = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_environment = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_environment)
+#define __CIDR_HELPER_DEFINE_437
+#endif
+#if defined(__CIDR_HELPER_DEFINE_437)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_ENVIRONMENT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_ENVIRONMENT = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_variant_os)
+#define __CIDR_HELPER_DEFINE_438
+#endif
+#if defined(__CIDR_HELPER_DEFINE_438)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_variant_os = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_variant_os = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_variant_os)
+#define __CIDR_HELPER_DEFINE_439
+#endif
+#if defined(__CIDR_HELPER_DEFINE_439)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_VARIANT_OS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_VARIANT_OS = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_variant_environment)
+#define __CIDR_HELPER_DEFINE_440
+#endif
+#if defined(__CIDR_HELPER_DEFINE_440)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_variant_environment = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_builtin___is_target_variant_environment = ((void) 0, 0); }
+#endif
+#if __has_builtin(__is_target_variant_environment)
+#define __CIDR_HELPER_DEFINE_441
+#endif
+#if defined(__CIDR_HELPER_DEFINE_441)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_VARIANT_ENVIRONMENT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_IS_TARGET_VARIANT_ENVIRONMENT = ((void) 0, 0); }
+#endif
+#if !defined(objc_boxable)
+#if __has_attribute(objc_boxable)
+#define __CIDR_HELPER_DEFINE_442
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_442)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_boxable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_boxable = ((void) 0, 0); }
+#endif
+#if !defined(objc_method_family)
+#if __has_attribute(objc_method_family)
+#define __CIDR_HELPER_DEFINE_443
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_443)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_method_family = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_method_family = ((void) 0, 0); }
+#endif
+#if !defined(objc_requires_super)
+#if __has_attribute(objc_requires_super)
+#define __CIDR_HELPER_DEFINE_444
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_444)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_requires_super = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_requires_super = ((void) 0, 0); }
+#endif
+#if !defined(objc_runtime_name)
+#if __has_attribute(objc_runtime_name)
+#define __CIDR_HELPER_DEFINE_445
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_445)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_runtime_name = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_runtime_name = ((void) 0, 0); }
+#endif
+#if !defined(objc_arc_weak_reference_unavailable)
+#if __has_attribute(objc_arc_weak_reference_unavailable)
+#define __CIDR_HELPER_DEFINE_446
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_446)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_arc_weak_reference_unavailable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_arc_weak_reference_unavailable = ((void) 0, 0); }
+#endif
+#if !defined(objc_bridge)
+#if __has_attribute(objc_bridge)
+#define __CIDR_HELPER_DEFINE_447
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_447)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_bridge = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_bridge = ((void) 0, 0); }
+#endif
+#if !defined(objc_designated_initializer)
+#if __has_attribute(objc_designated_initializer)
+#define __CIDR_HELPER_DEFINE_448
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_448)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_designated_initializer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_designated_initializer = ((void) 0, 0); }
+#endif
+#if !defined(objc_ownership)
+#if __has_attribute(objc_ownership)
+#define __CIDR_HELPER_DEFINE_449
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_449)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_ownership = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_ownership = ((void) 0, 0); }
+#endif
+#if !defined(objc_precise_lifetime)
+#if __has_attribute(objc_precise_lifetime)
+#define __CIDR_HELPER_DEFINE_450
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_450)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_precise_lifetime = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_precise_lifetime = ((void) 0, 0); }
+#endif
+#if !defined(objc_protocol_requires_explicit_implementation)
+#if __has_attribute(objc_protocol_requires_explicit_implementation)
+#define __CIDR_HELPER_DEFINE_451
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_451)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_protocol_requires_explicit_implementation = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_protocol_requires_explicit_implementation = ((void) 0, 0); }
+#endif
+#if !defined(objc_requires_property_definitions)
+#if __has_attribute(objc_requires_property_definitions)
+#define __CIDR_HELPER_DEFINE_452
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_452)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_requires_property_definitions = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_requires_property_definitions = ((void) 0, 0); }
+#endif
+#if !defined(objc_returns_inner_pointer)
+#if __has_attribute(objc_returns_inner_pointer)
+#define __CIDR_HELPER_DEFINE_453
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_453)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_returns_inner_pointer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_returns_inner_pointer = ((void) 0, 0); }
+#endif
+#if !defined(objc_root_class)
+#if __has_attribute(objc_root_class)
+#define __CIDR_HELPER_DEFINE_454
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_454)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_root_class = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_objc_root_class = ((void) 0, 0); }
+#endif
+#if !defined(ibaction)
+#if __has_attribute(ibaction)
+#define __CIDR_HELPER_DEFINE_455
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_455)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ibaction = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ibaction = ((void) 0, 0); }
+#endif
+#if !defined(iboutlet)
+#if __has_attribute(iboutlet)
+#define __CIDR_HELPER_DEFINE_456
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_456)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_iboutlet = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_iboutlet = ((void) 0, 0); }
+#endif
+#if !defined(iboutletcollection)
+#if __has_attribute(iboutletcollection)
+#define __CIDR_HELPER_DEFINE_457
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_457)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_iboutletcollection = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_iboutletcollection = ((void) 0, 0); }
+#endif
+#if !defined(ns_consumed)
+#if __has_attribute(ns_consumed)
+#define __CIDR_HELPER_DEFINE_458
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_458)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_consumed = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_consumed = ((void) 0, 0); }
+#endif
+#if !defined(ns_consumed_self)
+#if __has_attribute(ns_consumed_self)
+#define __CIDR_HELPER_DEFINE_459
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_459)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_consumed_self = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_consumed_self = ((void) 0, 0); }
+#endif
+#if !defined(ns_returns_not_retained)
+#if __has_attribute(ns_returns_not_retained)
+#define __CIDR_HELPER_DEFINE_460
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_460)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_returns_not_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_returns_not_retained = ((void) 0, 0); }
+#endif
+#if !defined(ns_returns_retained)
+#if __has_attribute(ns_returns_retained)
+#define __CIDR_HELPER_DEFINE_461
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_461)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_returns_retained = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ns_returns_retained = ((void) 0, 0); }
+#endif
+#if !defined(swift_error)
+#if __has_attribute(swift_error)
+#define __CIDR_HELPER_DEFINE_462
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_462)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_error = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_error = ((void) 0, 0); }
+#endif
+#if !defined(swift_name)
+#if __has_attribute(swift_name)
+#define __CIDR_HELPER_DEFINE_463
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_463)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_name = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_name = ((void) 0, 0); }
+#endif
+#if !defined(swift_private)
+#if __has_attribute(swift_private)
+#define __CIDR_HELPER_DEFINE_464
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_464)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_private = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_private = ((void) 0, 0); }
+#endif
+#if !defined(swift_wrapper)
+#if __has_attribute(swift_wrapper)
+#define __CIDR_HELPER_DEFINE_465
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_465)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_wrapper = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_swift_wrapper = ((void) 0, 0); }
+#endif
+#if !defined(amdgpu_num_sgpr)
+#if __has_attribute(amdgpu_num_sgpr)
+#define __CIDR_HELPER_DEFINE_466
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_466)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_amdgpu_num_sgpr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_amdgpu_num_sgpr = ((void) 0, 0); }
+#endif
+#if !defined(amdgpu_num_vgpr)
+#if __has_attribute(amdgpu_num_vgpr)
+#define __CIDR_HELPER_DEFINE_467
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_467)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_amdgpu_num_vgpr = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_amdgpu_num_vgpr = ((void) 0, 0); }
+#endif
+#if !defined(interrupt)
+#if __has_attribute(interrupt)
+#define __CIDR_HELPER_DEFINE_468
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_468)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_interrupt = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_interrupt = ((void) 0, 0); }
+#endif
+#if !defined(acquire_capability)
+#if __has_attribute(acquire_capability)
+#define __CIDR_HELPER_DEFINE_469
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_469)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_acquire_capability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_acquire_capability = ((void) 0, 0); }
+#endif
+#if !defined(acquire_shared_capability)
+#if __has_attribute(acquire_shared_capability)
+#define __CIDR_HELPER_DEFINE_470
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_470)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_acquire_shared_capability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_acquire_shared_capability = ((void) 0, 0); }
+#endif
+#if !defined(assume_aligned)
+#if __has_attribute(assume_aligned)
+#define __CIDR_HELPER_DEFINE_471
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_471)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_assume_aligned = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_assume_aligned = ((void) 0, 0); }
+#endif
+#if !defined(availability)
+#if __has_attribute(availability)
+#define __CIDR_HELPER_DEFINE_472
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_472)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_availability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_availability = ((void) 0, 0); }
+#endif
+#if !defined(noreturn)
+#if __has_attribute(noreturn)
+#define __CIDR_HELPER_DEFINE_473
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_473)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noreturn = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noreturn = ((void) 0, 0); }
+#endif
+#if !defined(carries_dependency)
+#if __has_attribute(carries_dependency)
+#define __CIDR_HELPER_DEFINE_474
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_474)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_carries_dependency = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_carries_dependency = ((void) 0, 0); }
+#endif
+#if !defined(enable_if)
+#if __has_attribute(enable_if)
+#define __CIDR_HELPER_DEFINE_475
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_475)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_enable_if = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_enable_if = ((void) 0, 0); }
+#endif
+#if !defined(flatten)
+#if __has_attribute(flatten)
+#define __CIDR_HELPER_DEFINE_476
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_476)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_flatten = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_flatten = ((void) 0, 0); }
+#endif
+#if !defined(format)
+#if __has_attribute(format)
+#define __CIDR_HELPER_DEFINE_477
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_477)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_format = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_format = ((void) 0, 0); }
+#endif
+#if !defined(internal_linkage)
+#if __has_attribute(internal_linkage)
+#define __CIDR_HELPER_DEFINE_478
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_478)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_internal_linkage = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_internal_linkage = ((void) 0, 0); }
+#endif
+#if !defined(noduplicate)
+#if __has_attribute(noduplicate)
+#define __CIDR_HELPER_DEFINE_479
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_479)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noduplicate = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noduplicate = ((void) 0, 0); }
+#endif
+#if !defined(no_sanitize)
+#if __has_attribute(no_sanitize)
+#define __CIDR_HELPER_DEFINE_480
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_480)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize = ((void) 0, 0); }
+#endif
+#if !defined(no_sanitize_address)
+#if __has_attribute(no_sanitize_address)
+#define __CIDR_HELPER_DEFINE_481
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_481)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_address = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_address = ((void) 0, 0); }
+#endif
+#if !defined(no_address_safety_analysis)
+#if __has_attribute(no_address_safety_analysis)
+#define __CIDR_HELPER_DEFINE_482
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_482)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_address_safety_analysis = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_address_safety_analysis = ((void) 0, 0); }
+#endif
+#if !defined(no_sanitize_thread)
+#if __has_attribute(no_sanitize_thread)
+#define __CIDR_HELPER_DEFINE_483
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_483)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_thread = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_thread = ((void) 0, 0); }
+#endif
+#if !defined(no_sanitize_memory)
+#if __has_attribute(no_sanitize_memory)
+#define __CIDR_HELPER_DEFINE_484
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_484)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_memory = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_memory = ((void) 0, 0); }
+#endif
+#if !defined(no_split_stack)
+#if __has_attribute(no_split_stack)
+#define __CIDR_HELPER_DEFINE_485
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_485)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_split_stack = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_split_stack = ((void) 0, 0); }
+#endif
+#if !defined(optnone)
+#if __has_attribute(optnone)
+#define __CIDR_HELPER_DEFINE_486
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_486)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_optnone = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_optnone = ((void) 0, 0); }
+#endif
+#if !defined(overloadable)
+#if __has_attribute(overloadable)
+#define __CIDR_HELPER_DEFINE_487
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_487)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_overloadable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_overloadable = ((void) 0, 0); }
+#endif
+#if __has_attribute(__overloadable__)
+#define __CIDR_HELPER_DEFINE_488
+#endif
+#if defined(__CIDR_HELPER_DEFINE_488)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute___overloadable__ = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute___overloadable__ = ((void) 0, 0); }
+#endif
+#if !defined(release_capability)
+#if __has_attribute(release_capability)
+#define __CIDR_HELPER_DEFINE_489
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_489)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_release_capability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_release_capability = ((void) 0, 0); }
+#endif
+#if !defined(release_shared_capability)
+#if __has_attribute(release_shared_capability)
+#define __CIDR_HELPER_DEFINE_490
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_490)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_release_shared_capability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_release_shared_capability = ((void) 0, 0); }
+#endif
+#if !defined(target)
+#if __has_attribute(target)
+#define __CIDR_HELPER_DEFINE_491
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_491)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_target = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_target = ((void) 0, 0); }
+#endif
+#if !defined(try_acquire_capability)
+#if __has_attribute(try_acquire_capability)
+#define __CIDR_HELPER_DEFINE_492
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_492)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_try_acquire_capability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_try_acquire_capability = ((void) 0, 0); }
+#endif
+#if !defined(try_acquire_shared_capability)
+#if __has_attribute(try_acquire_shared_capability)
+#define __CIDR_HELPER_DEFINE_493
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_493)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_try_acquire_shared_capability = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_try_acquire_shared_capability = ((void) 0, 0); }
+#endif
+#if !defined(section)
+#if __has_attribute(section)
+#define __CIDR_HELPER_DEFINE_494
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_494)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_section = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_section = ((void) 0, 0); }
+#endif
+#if !defined(tls_model)
+#if __has_attribute(tls_model)
+#define __CIDR_HELPER_DEFINE_495
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_495)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_tls_model = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_tls_model = ((void) 0, 0); }
+#endif
+#if !defined(align_value)
+#if __has_attribute(align_value)
+#define __CIDR_HELPER_DEFINE_496
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_496)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_align_value = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_align_value = ((void) 0, 0); }
+#endif
+#if !defined(flag_enum)
+#if __has_attribute(flag_enum)
+#define __CIDR_HELPER_DEFINE_497
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_497)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_flag_enum = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_flag_enum = ((void) 0, 0); }
+#endif
+#if !defined(fastcall)
+#if __has_attribute(fastcall)
+#define __CIDR_HELPER_DEFINE_498
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_498)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_fastcall = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_fastcall = ((void) 0, 0); }
+#endif
+#if !defined(ms_abi)
+#if __has_attribute(ms_abi)
+#define __CIDR_HELPER_DEFINE_499
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_499)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ms_abi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ms_abi = ((void) 0, 0); }
+#endif
+#if !defined(pcs)
+#if __has_attribute(pcs)
+#define __CIDR_HELPER_DEFINE_500
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_500)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_pcs = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_pcs = ((void) 0, 0); }
+#endif
+#if !defined(regparm)
+#if __has_attribute(regparm)
+#define __CIDR_HELPER_DEFINE_501
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_501)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_regparm = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_regparm = ((void) 0, 0); }
+#endif
+#if !defined(stdcall)
+#if __has_attribute(stdcall)
+#define __CIDR_HELPER_DEFINE_502
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_502)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_stdcall = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_stdcall = ((void) 0, 0); }
+#endif
+#if !defined(thiscall)
+#if __has_attribute(thiscall)
+#define __CIDR_HELPER_DEFINE_503
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_503)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_thiscall = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_thiscall = ((void) 0, 0); }
+#endif
+#if !defined(vectorcall)
+#if __has_attribute(vectorcall)
+#define __CIDR_HELPER_DEFINE_504
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_504)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_vectorcall = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_vectorcall = ((void) 0, 0); }
+#endif
+#if !defined(callable_when)
+#if __has_attribute(callable_when)
+#define __CIDR_HELPER_DEFINE_505
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_505)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_callable_when = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_callable_when = ((void) 0, 0); }
+#endif
+#if !defined(consumable)
+#if __has_attribute(consumable)
+#define __CIDR_HELPER_DEFINE_506
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_506)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_consumable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_consumable = ((void) 0, 0); }
+#endif
+#if !defined(param_typestate)
+#if __has_attribute(param_typestate)
+#define __CIDR_HELPER_DEFINE_507
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_507)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_param_typestate = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_param_typestate = ((void) 0, 0); }
+#endif
+#if !defined(return_typestate)
+#if __has_attribute(return_typestate)
+#define __CIDR_HELPER_DEFINE_508
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_508)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_return_typestate = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_return_typestate = ((void) 0, 0); }
+#endif
+#if !defined(set_typestate)
+#if __has_attribute(set_typestate)
+#define __CIDR_HELPER_DEFINE_509
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_509)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_set_typestate = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_set_typestate = ((void) 0, 0); }
+#endif
+#if !defined(test_typestate)
+#if __has_attribute(test_typestate)
+#define __CIDR_HELPER_DEFINE_510
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_510)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_test_typestate = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_test_typestate = ((void) 0, 0); }
+#endif
+#if !defined(argument_with_type_tag)
+#if __has_attribute(argument_with_type_tag)
+#define __CIDR_HELPER_DEFINE_511
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_511)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_argument_with_type_tag = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_argument_with_type_tag = ((void) 0, 0); }
+#endif
+#if !defined(pointer_with_type_tag)
+#if __has_attribute(pointer_with_type_tag)
+#define __CIDR_HELPER_DEFINE_512
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_512)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_pointer_with_type_tag = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_pointer_with_type_tag = ((void) 0, 0); }
+#endif
+#if !defined(type_tag_for_datatype)
+#if __has_attribute(type_tag_for_datatype)
+#define __CIDR_HELPER_DEFINE_513
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_513)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_type_tag_for_datatype = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_type_tag_for_datatype = ((void) 0, 0); }
+#endif
+#if !defined(nonnull)
+#if __has_attribute(nonnull)
+#define __CIDR_HELPER_DEFINE_514
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_514)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_nonnull = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_nonnull = ((void) 0, 0); }
+#endif
+#if !defined(returns_nonnull)
+#if __has_attribute(returns_nonnull)
+#define __CIDR_HELPER_DEFINE_515
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_515)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_returns_nonnull = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_returns_nonnull = ((void) 0, 0); }
+#endif
+#if !defined(aligned)
+#if __has_attribute(aligned)
+#define __CIDR_HELPER_DEFINE_516
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_516)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_aligned = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_aligned = ((void) 0, 0); }
+#endif
+#if !defined(deprecated)
+#if __has_attribute(deprecated)
+#define __CIDR_HELPER_DEFINE_517
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_517)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_deprecated = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_deprecated = ((void) 0, 0); }
+#endif
+#if !defined(unused)
+#if __has_attribute(unused)
+#define __CIDR_HELPER_DEFINE_518
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_518)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_unused = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_unused = ((void) 0, 0); }
+#endif
+#if !defined(used)
+#if __has_attribute(used)
+#define __CIDR_HELPER_DEFINE_519
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_519)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_used = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_used = ((void) 0, 0); }
+#endif
+#if !defined(hot)
+#if __has_attribute(hot)
+#define __CIDR_HELPER_DEFINE_520
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_520)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_hot = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_hot = ((void) 0, 0); }
+#endif
+#if !defined(cold)
+#if __has_attribute(cold)
+#define __CIDR_HELPER_DEFINE_521
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_521)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_cold = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_cold = ((void) 0, 0); }
+#endif
+#if !defined(weak)
+#if __has_attribute(weak)
+#define __CIDR_HELPER_DEFINE_522
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_522)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_weak = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_weak = ((void) 0, 0); }
+#endif
+#if !defined(packed)
+#if __has_attribute(packed)
+#define __CIDR_HELPER_DEFINE_523
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_523)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_packed = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_packed = ((void) 0, 0); }
+#endif
+#if !defined(dllexport)
+#if __has_attribute(dllexport)
+#define __CIDR_HELPER_DEFINE_524
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_524)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_dllexport = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_dllexport = ((void) 0, 0); }
+#endif
+#if !defined(dllimport)
+#if __has_attribute(dllimport)
+#define __CIDR_HELPER_DEFINE_525
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_525)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_dllimport = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_dllimport = ((void) 0, 0); }
+#endif
+#if !defined(selectany)
+#if __has_attribute(selectany)
+#define __CIDR_HELPER_DEFINE_526
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_526)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_selectany = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_selectany = ((void) 0, 0); }
+#endif
+#if !defined(shared)
+#if __has_attribute(shared)
+#define __CIDR_HELPER_DEFINE_527
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_527)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_shared = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_shared = ((void) 0, 0); }
+#endif
+#if !defined(ms_struct)
+#if __has_attribute(ms_struct)
+#define __CIDR_HELPER_DEFINE_528
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_528)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ms_struct = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ms_struct = ((void) 0, 0); }
+#endif
+#if !defined(gcc_struct)
+#if __has_attribute(gcc_struct)
+#define __CIDR_HELPER_DEFINE_529
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_529)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_gcc_struct = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_gcc_struct = ((void) 0, 0); }
+#endif
+#if !defined(cdecl)
+#if __has_attribute(cdecl)
+#define __CIDR_HELPER_DEFINE_530
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_530)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_cdecl = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_cdecl = ((void) 0, 0); }
+#endif
+#if !defined(sysv_abi)
+#if __has_attribute(sysv_abi)
+#define __CIDR_HELPER_DEFINE_531
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_531)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_sysv_abi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_sysv_abi = ((void) 0, 0); }
+#endif
+#if !defined(callee_pop_aggregate_return)
+#if __has_attribute(callee_pop_aggregate_return)
+#define __CIDR_HELPER_DEFINE_532
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_532)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_callee_pop_aggregate_return = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_callee_pop_aggregate_return = ((void) 0, 0); }
+#endif
+#if !defined(ms_hook_prologue)
+#if __has_attribute(ms_hook_prologue)
+#define __CIDR_HELPER_DEFINE_533
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_533)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ms_hook_prologue = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ms_hook_prologue = ((void) 0, 0); }
+#endif
+#if !defined(sseregparm)
+#if __has_attribute(sseregparm)
+#define __CIDR_HELPER_DEFINE_534
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_534)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_sseregparm = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_sseregparm = ((void) 0, 0); }
+#endif
+#if !defined(force_align_arg_pointer)
+#if __has_attribute(force_align_arg_pointer)
+#define __CIDR_HELPER_DEFINE_535
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_535)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_force_align_arg_pointer = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_force_align_arg_pointer = ((void) 0, 0); }
+#endif
+#if !defined(alias)
+#if __has_attribute(alias)
+#define __CIDR_HELPER_DEFINE_536
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_536)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_alias = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_alias = ((void) 0, 0); }
+#endif
+#if !defined(alloc_align)
+#if __has_attribute(alloc_align)
+#define __CIDR_HELPER_DEFINE_537
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_537)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_alloc_align = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_alloc_align = ((void) 0, 0); }
+#endif
+#if !defined(alloc_size)
+#if __has_attribute(alloc_size)
+#define __CIDR_HELPER_DEFINE_538
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_538)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_alloc_size = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_alloc_size = ((void) 0, 0); }
+#endif
+#if !defined(always_inline)
+#if __has_attribute(always_inline)
+#define __CIDR_HELPER_DEFINE_539
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_539)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_always_inline = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_always_inline = ((void) 0, 0); }
+#endif
+#if !defined(artificial)
+#if __has_attribute(artificial)
+#define __CIDR_HELPER_DEFINE_540
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_540)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_artificial = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_artificial = ((void) 0, 0); }
+#endif
+#if !defined(bnd_instrument)
+#if __has_attribute(bnd_instrument)
+#define __CIDR_HELPER_DEFINE_541
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_541)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_bnd_instrument = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_bnd_instrument = ((void) 0, 0); }
+#endif
+#if !defined(bnd_legacy)
+#if __has_attribute(bnd_legacy)
+#define __CIDR_HELPER_DEFINE_542
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_542)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_bnd_legacy = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_bnd_legacy = ((void) 0, 0); }
+#endif
+#if !defined(const)
+#if __has_attribute(const)
+#define __CIDR_HELPER_DEFINE_543
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_543)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_const = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_const = ((void) 0, 0); }
+#endif
+#if !defined(constructor)
+#if __has_attribute(constructor)
+#define __CIDR_HELPER_DEFINE_544
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_544)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_constructor = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_constructor = ((void) 0, 0); }
+#endif
+#if !defined(destructor)
+#if __has_attribute(destructor)
+#define __CIDR_HELPER_DEFINE_545
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_545)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_destructor = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_destructor = ((void) 0, 0); }
+#endif
+#if !defined(error)
+#if __has_attribute(error)
+#define __CIDR_HELPER_DEFINE_546
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_546)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_error = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_error = ((void) 0, 0); }
+#endif
+#if !defined(warning)
+#if __has_attribute(warning)
+#define __CIDR_HELPER_DEFINE_547
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_547)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_warning = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_warning = ((void) 0, 0); }
+#endif
+#if !defined(externally_visible)
+#if __has_attribute(externally_visible)
+#define __CIDR_HELPER_DEFINE_548
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_548)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_externally_visible = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_externally_visible = ((void) 0, 0); }
+#endif
+#if !defined(format_arg)
+#if __has_attribute(format_arg)
+#define __CIDR_HELPER_DEFINE_549
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_549)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_format_arg = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_format_arg = ((void) 0, 0); }
+#endif
+#if !defined(gnu_inline)
+#if __has_attribute(gnu_inline)
+#define __CIDR_HELPER_DEFINE_550
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_550)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_gnu_inline = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_gnu_inline = ((void) 0, 0); }
+#endif
+#if !defined(ifunc)
+#if __has_attribute(ifunc)
+#define __CIDR_HELPER_DEFINE_551
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_551)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ifunc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ifunc = ((void) 0, 0); }
+#endif
+#if !defined(interrupt_handler)
+#if __has_attribute(interrupt_handler)
+#define __CIDR_HELPER_DEFINE_552
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_552)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_interrupt_handler = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_interrupt_handler = ((void) 0, 0); }
+#endif
+#if !defined(leaf)
+#if __has_attribute(leaf)
+#define __CIDR_HELPER_DEFINE_553
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_553)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_leaf = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_leaf = ((void) 0, 0); }
+#endif
+#if !defined(malloc)
+#if __has_attribute(malloc)
+#define __CIDR_HELPER_DEFINE_554
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_554)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_malloc = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_malloc = ((void) 0, 0); }
+#endif
+#if !defined(no_icf)
+#if __has_attribute(no_icf)
+#define __CIDR_HELPER_DEFINE_555
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_555)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_icf = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_icf = ((void) 0, 0); }
+#endif
+#if !defined(no_instrument_function)
+#if __has_attribute(no_instrument_function)
+#define __CIDR_HELPER_DEFINE_556
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_556)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_instrument_function = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_instrument_function = ((void) 0, 0); }
+#endif
+#if !defined(no_reorder)
+#if __has_attribute(no_reorder)
+#define __CIDR_HELPER_DEFINE_557
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_557)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_reorder = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_reorder = ((void) 0, 0); }
+#endif
+#if !defined(no_sanitize_undefined)
+#if __has_attribute(no_sanitize_undefined)
+#define __CIDR_HELPER_DEFINE_558
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_558)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_undefined = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_no_sanitize_undefined = ((void) 0, 0); }
+#endif
+#if !defined(noclone)
+#if __has_attribute(noclone)
+#define __CIDR_HELPER_DEFINE_559
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_559)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noclone = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noclone = ((void) 0, 0); }
+#endif
+#if !defined(noinline)
+#if __has_attribute(noinline)
+#define __CIDR_HELPER_DEFINE_560
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_560)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noinline = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noinline = ((void) 0, 0); }
+#endif
+#if !defined(nothrow)
+#if __has_attribute(nothrow)
+#define __CIDR_HELPER_DEFINE_561
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_561)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_nothrow = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_nothrow = ((void) 0, 0); }
+#endif
+#if !defined(noplt)
+#if __has_attribute(noplt)
+#define __CIDR_HELPER_DEFINE_562
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_562)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noplt = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_noplt = ((void) 0, 0); }
+#endif
+#if !defined(optimize)
+#if __has_attribute(optimize)
+#define __CIDR_HELPER_DEFINE_563
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_563)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_optimize = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_optimize = ((void) 0, 0); }
+#endif
+#if !defined(pure)
+#if __has_attribute(pure)
+#define __CIDR_HELPER_DEFINE_564
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_564)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_pure = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_pure = ((void) 0, 0); }
+#endif
+#if !defined(returns_twice)
+#if __has_attribute(returns_twice)
+#define __CIDR_HELPER_DEFINE_565
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_565)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_returns_twice = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_returns_twice = ((void) 0, 0); }
+#endif
+#if !defined(sentinel)
+#if __has_attribute(sentinel)
+#define __CIDR_HELPER_DEFINE_566
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_566)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_sentinel = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_sentinel = ((void) 0, 0); }
+#endif
+#if !defined(stack_protect)
+#if __has_attribute(stack_protect)
+#define __CIDR_HELPER_DEFINE_567
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_567)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_stack_protect = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_stack_protect = ((void) 0, 0); }
+#endif
+#if !defined(target_clones)
+#if __has_attribute(target_clones)
+#define __CIDR_HELPER_DEFINE_568
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_568)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_target_clones = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_target_clones = ((void) 0, 0); }
+#endif
+#if !defined(visibility)
+#if __has_attribute(visibility)
+#define __CIDR_HELPER_DEFINE_569
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_569)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_visibility = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_visibility = ((void) 0, 0); }
+#endif
+#if !defined(warn_unused_result)
+#if __has_attribute(warn_unused_result)
+#define __CIDR_HELPER_DEFINE_570
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_570)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_warn_unused_result = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_warn_unused_result = ((void) 0, 0); }
+#endif
+#if !defined(weakref)
+#if __has_attribute(weakref)
+#define __CIDR_HELPER_DEFINE_571
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_571)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_weakref = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_weakref = ((void) 0, 0); }
+#endif
+#if !defined(lower)
+#if __has_attribute(lower)
+#define __CIDR_HELPER_DEFINE_572
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_572)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_lower = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_lower = ((void) 0, 0); }
+#endif
+#if !defined(upper)
+#if __has_attribute(upper)
+#define __CIDR_HELPER_DEFINE_573
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_573)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_upper = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_upper = ((void) 0, 0); }
+#endif
+#if !defined(either)
+#if __has_attribute(either)
+#define __CIDR_HELPER_DEFINE_574
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_574)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_either = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_either = ((void) 0, 0); }
+#endif
+#if !defined(reentrant)
+#if __has_attribute(reentrant)
+#define __CIDR_HELPER_DEFINE_575
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_575)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_reentrant = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_reentrant = ((void) 0, 0); }
+#endif
+#if !defined(critical)
+#if __has_attribute(critical)
+#define __CIDR_HELPER_DEFINE_576
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_576)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_critical = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_critical = ((void) 0, 0); }
+#endif
+#if !defined(wakeup)
+#if __has_attribute(wakeup)
+#define __CIDR_HELPER_DEFINE_577
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_577)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_wakeup = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_wakeup = ((void) 0, 0); }
+#endif
+#if !defined(cleanup)
+#if __has_attribute(cleanup)
+#define __CIDR_HELPER_DEFINE_578
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_578)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_cleanup = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_cleanup = ((void) 0, 0); }
+#endif
+#if !defined(common)
+#if __has_attribute(common)
+#define __CIDR_HELPER_DEFINE_579
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_579)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_common = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_common = ((void) 0, 0); }
+#endif
+#if !defined(nocommon)
+#if __has_attribute(nocommon)
+#define __CIDR_HELPER_DEFINE_580
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_580)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_nocommon = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_nocommon = ((void) 0, 0); }
+#endif
+#if !defined(mode)
+#if __has_attribute(mode)
+#define __CIDR_HELPER_DEFINE_581
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_581)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_mode = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_mode = ((void) 0, 0); }
+#endif
+#if !defined(vector_size)
+#if __has_attribute(vector_size)
+#define __CIDR_HELPER_DEFINE_582
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_582)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_vector_size = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_vector_size = ((void) 0, 0); }
+#endif
+#if !defined(bnd_variable_size)
+#if __has_attribute(bnd_variable_size)
+#define __CIDR_HELPER_DEFINE_583
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_583)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_bnd_variable_size = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_bnd_variable_size = ((void) 0, 0); }
+#endif
+#if !defined(designated_init)
+#if __has_attribute(designated_init)
+#define __CIDR_HELPER_DEFINE_584
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_584)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_designated_init = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_designated_init = ((void) 0, 0); }
+#endif
+#if !defined(may_alias)
+#if __has_attribute(may_alias)
+#define __CIDR_HELPER_DEFINE_585
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_585)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_may_alias = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_may_alias = ((void) 0, 0); }
+#endif
+#if !defined(scalar_storage_order)
+#if __has_attribute(scalar_storage_order)
+#define __CIDR_HELPER_DEFINE_586
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_586)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_scalar_storage_order = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_scalar_storage_order = ((void) 0, 0); }
+#endif
+#if !defined(transparent_union)
+#if __has_attribute(transparent_union)
+#define __CIDR_HELPER_DEFINE_587
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_587)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_transparent_union = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_transparent_union = ((void) 0, 0); }
+#endif
+#if !defined(ext_vector_type)
+#if __has_attribute(ext_vector_type)
+#define __CIDR_HELPER_DEFINE_588
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_588)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ext_vector_type = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_ext_vector_type = ((void) 0, 0); }
+#endif
+#if __has_attribute(__ext_vector_type__)
+#define __CIDR_HELPER_DEFINE_589
+#endif
+#if defined(__CIDR_HELPER_DEFINE_589)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute___ext_vector_type__ = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute___ext_vector_type__ = ((void) 0, 0); }
+#endif
+#if !defined(type_visibility)
+#if __has_attribute(type_visibility)
+#define __CIDR_HELPER_DEFINE_590
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_590)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_type_visibility = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_type_visibility = ((void) 0, 0); }
+#endif
+#if !defined(unavailable)
+#if __has_attribute(unavailable)
+#define __CIDR_HELPER_DEFINE_591
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_591)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_unavailable = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__has_attribute_unavailable = ((void) 0, 0); }
+#endif
+#if !defined(x86_64)
+#if __is_target_arch(x86_64)
+#define __CIDR_HELPER_DEFINE_592
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_592)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_arch_x86_64 = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_arch_x86_64 = ((void) 0, 0); }
+#endif
+#if !defined(arm64)
+#if __is_target_arch(arm64)
+#define __CIDR_HELPER_DEFINE_593
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_593)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_arch_arm64 = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_arch_arm64 = ((void) 0, 0); }
+#endif
+#if !defined(arm64e)
+#if __is_target_arch(arm64e)
+#define __CIDR_HELPER_DEFINE_594
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_594)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_arch_arm64e = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_arch_arm64e = ((void) 0, 0); }
+#endif
+#if !defined(apple)
+#if __is_target_vendor(apple)
+#define __CIDR_HELPER_DEFINE_595
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_595)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_vendor_apple = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_vendor_apple = ((void) 0, 0); }
+#endif
+#if !defined(ios)
+#if __is_target_os(ios)
+#define __CIDR_HELPER_DEFINE_596
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_596)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_ios = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_ios = ((void) 0, 0); }
+#endif
+#if !defined(ios)
+#if __is_target_variant_os(ios)
+#define __CIDR_HELPER_DEFINE_597
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_597)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_ios = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_ios = ((void) 0, 0); }
+#endif
+#if !defined(macos)
+#if __is_target_os(macos)
+#define __CIDR_HELPER_DEFINE_598
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_598)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_macos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_macos = ((void) 0, 0); }
+#endif
+#if !defined(macos)
+#if __is_target_variant_os(macos)
+#define __CIDR_HELPER_DEFINE_599
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_599)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_macos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_macos = ((void) 0, 0); }
+#endif
+#if !defined(macosx)
+#if __is_target_os(macosx)
+#define __CIDR_HELPER_DEFINE_600
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_600)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_macosx = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_macosx = ((void) 0, 0); }
+#endif
+#if !defined(macosx)
+#if __is_target_variant_os(macosx)
+#define __CIDR_HELPER_DEFINE_601
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_601)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_macosx = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_macosx = ((void) 0, 0); }
+#endif
+#if !defined(tvos)
+#if __is_target_os(tvos)
+#define __CIDR_HELPER_DEFINE_602
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_602)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_tvos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_tvos = ((void) 0, 0); }
+#endif
+#if !defined(tvos)
+#if __is_target_variant_os(tvos)
+#define __CIDR_HELPER_DEFINE_603
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_603)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_tvos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_tvos = ((void) 0, 0); }
+#endif
+#if !defined(watchos)
+#if __is_target_os(watchos)
+#define __CIDR_HELPER_DEFINE_604
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_604)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_watchos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_watchos = ((void) 0, 0); }
+#endif
+#if !defined(watchos)
+#if __is_target_variant_os(watchos)
+#define __CIDR_HELPER_DEFINE_605
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_605)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_watchos = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_watchos = ((void) 0, 0); }
+#endif
+#if !defined(driverkit)
+#if __is_target_os(driverkit)
+#define __CIDR_HELPER_DEFINE_606
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_606)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_driverkit = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_os_driverkit = ((void) 0, 0); }
+#endif
+#if !defined(driverkit)
+#if __is_target_variant_os(driverkit)
+#define __CIDR_HELPER_DEFINE_607
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_607)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_driverkit = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_os_driverkit = ((void) 0, 0); }
+#endif
+#if !defined(simulator)
+#if __is_target_environment(simulator)
+#define __CIDR_HELPER_DEFINE_608
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_608)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_environment_simulator = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_environment_simulator = ((void) 0, 0); }
+#endif
+#if !defined(simulator)
+#if __is_target_variant_environment(simulator)
+#define __CIDR_HELPER_DEFINE_609
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_609)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_environment_simulator = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_environment_simulator = ((void) 0, 0); }
+#endif
+#if !defined(macabi)
+#if __is_target_environment(macabi)
+#define __CIDR_HELPER_DEFINE_610
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_610)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_environment_macabi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_environment_macabi = ((void) 0, 0); }
+#endif
+#if !defined(macabi)
+#if __is_target_variant_environment(macabi)
+#define __CIDR_HELPER_DEFINE_611
+#endif
+#endif
+#if defined(__CIDR_HELPER_DEFINE_611)
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_environment_macabi = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_clang__is_target_variant_environment_macabi = ((void) 0, 0); }
+#endif
+#if !__is_identifier(__auto_type)
+#define __CIDR_HELPER_DEFINE_612
+#endif
+#if defined(__CIDR_HELPER_DEFINE_612)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_GCC_AUTO_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_GCC_AUTO_TYPE = ((void) 0, 0); }
+#endif
+#if defined(__cpp_concepts)
+#define __CIDR_HELPER_DEFINE_613
+#endif
+#if defined(__CIDR_HELPER_DEFINE_613)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONCEPTS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONCEPTS = ((void) 0, 0); }
+#endif
+#else
+#define __CIDR_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if !defined(__cplusplus) && __CIDR_GCC_VERSION >= 40900
+#define __CIDR_HELPER_DEFINE_614
+#endif
+#if defined(__CIDR_HELPER_DEFINE_614)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_GCC_AUTO_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_GCC_AUTO_TYPE = ((void) 0, 0); }
+#endif
+#if !defined(__cplusplus) && __STDC_VERSION__ >= 201112L && __CIDR_GCC_VERSION >= 40600
+#define __CIDR_HELPER_DEFINE_615
+#endif
+#if defined(__CIDR_HELPER_DEFINE_615)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_STATIC_ASSERT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_STATIC_ASSERT = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40400
+#define __CIDR_HELPER_DEFINE_616
+#endif
+#if defined(__CIDR_HELPER_DEFINE_616)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_AUTO_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_AUTO_TYPE = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40700
+#define __CIDR_HELPER_DEFINE_617
+#endif
+#if defined(__CIDR_HELPER_DEFINE_617)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_OVERRIDE_CONTROL = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_OVERRIDE_CONTROL = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40400
+#define __CIDR_HELPER_DEFINE_618
+#endif
+#if defined(__CIDR_HELPER_DEFINE_618)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERALIZED_INITIALIZERS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERALIZED_INITIALIZERS = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40600
+#define __CIDR_HELPER_DEFINE_619
+#endif
+#if defined(__CIDR_HELPER_DEFINE_619)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NULLPTR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NULLPTR = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40700
+#define __CIDR_HELPER_DEFINE_620
+#endif
+#if defined(__CIDR_HELPER_DEFINE_620)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NONSTATIC_MEMBER_INIT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NONSTATIC_MEMBER_INIT = ((void) 0, 0); }
+#endif
+#if defined(__cplusplus) && __EXCEPTIONS
+#define __CIDR_HELPER_DEFINE_621
+#endif
+#if defined(__CIDR_HELPER_DEFINE_621)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXCEPTIONS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXCEPTIONS = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40600
+#define __CIDR_HELPER_DEFINE_622
+#endif
+#if defined(__CIDR_HELPER_DEFINE_622)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40500
+#define __CIDR_HELPER_DEFINE_623
+#endif
+#if defined(__CIDR_HELPER_DEFINE_623)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RAW_STRING_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RAW_STRING_LITERALS = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40700
+#define __CIDR_HELPER_DEFINE_624
+#endif
+#if defined(__CIDR_HELPER_DEFINE_624)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_USER_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_USER_LITERALS = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 40700
+#define __CIDR_HELPER_DEFINE_625
+#endif
+#if defined(__CIDR_HELPER_DEFINE_625)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_ATTRIBUTES = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_ATTRIBUTES = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201402 && __CIDR_GCC_VERSION >= 40900
+#define __CIDR_HELPER_DEFINE_626
+#endif
+#if defined(__CIDR_HELPER_DEFINE_626)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BINARY_LITERALS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BINARY_LITERALS = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201402 && __CIDR_GCC_VERSION >= 40900
+#define __CIDR_HELPER_DEFINE_627
+#endif
+#if defined(__CIDR_HELPER_DEFINE_627)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RETURN_TYPE_DEDUCTION = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RETURN_TYPE_DEDUCTION = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 201402 && __CIDR_GCC_VERSION >= 40900
+#define __CIDR_HELPER_DEFINE_628
+#endif
+#if defined(__CIDR_HELPER_DEFINE_628)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERIC_LAMBDAS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERIC_LAMBDAS = ((void) 0, 0); }
+#endif
+#if defined(__cpp_explicit_this_parameter)
+#define __CIDR_HELPER_DEFINE_629
+#endif
+#if defined(__CIDR_HELPER_DEFINE_629)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXPLICIT_THIS_PARAMETER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXPLICIT_THIS_PARAMETER = ((void) 0, 0); }
+#endif
+#if !defined(__cplusplus) && __STDC_VERSION__ > 201710L && __CIDR_GCC_VERSION >= 130100
+#define __CIDR_HELPER_DEFINE_630
+#endif
+#if defined(__CIDR_HELPER_DEFINE_630)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_NULLPTR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_NULLPTR = ((void) 0, 0); }
+#endif
+#if !defined(__cplusplus) && __STDC_VERSION__ > 201710L && __CIDR_GCC_VERSION >= 130100
+#define __CIDR_HELPER_DEFINE_631
+#endif
+#if defined(__CIDR_HELPER_DEFINE_631)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_AUTO_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_AUTO_TYPE = ((void) 0, 0); }
+#endif
+#if !defined(__cplusplus) && __STDC_VERSION__ > 201710L && __CIDR_GCC_VERSION >= 130100
+#define __CIDR_HELPER_DEFINE_632
+#endif
+#if defined(__CIDR_HELPER_DEFINE_632)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_CONSTEXPR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_CONSTEXPR = ((void) 0, 0); }
+#endif
+#if __cplusplus >= 202402L || __CIDR_GCC_VERSION >= 130100 || __cpp_constexpr >= 201304L
+#define __CIDR_HELPER_DEFINE_633
+#endif
+#if defined(__CIDR_HELPER_DEFINE_633)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR_VOID = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR_VOID = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_bit_cast)
+#define __CIDR_HELPER_DEFINE_634
+#endif
+#if defined(__CIDR_HELPER_DEFINE_634)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_BIT_CAST = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_BIT_CAST = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_source_location)
+#define __CIDR_HELPER_DEFINE_635
+#endif
+#if defined(__CIDR_HELPER_DEFINE_635)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_SOURCE_LOCATION = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_BUILTIN_SOURCE_LOCATION = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_is_constant_evaluated)
+#define __CIDR_HELPER_DEFINE_636
+#endif
+#if defined(__CIDR_HELPER_DEFINE_636)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BUILTIN_IS_CONSTANT_EVALUATED = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BUILTIN_IS_CONSTANT_EVALUATED = ((void) 0, 0); }
+#endif
+#else
+#if __CIDR_GCC_VERSION >= 90100
+#define __CIDR_HELPER_DEFINE_637
+#endif
+#if defined(__CIDR_HELPER_DEFINE_637)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BUILTIN_IS_CONSTANT_EVALUATED = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BUILTIN_IS_CONSTANT_EVALUATED = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__SIZEOF_WCHAR_T__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_WCHAR_T = ((void) __SIZEOF_WCHAR_T__, 0); }
+#endif
+#if defined(__SIZEOF_SHORT__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_SHORT = ((void) __SIZEOF_SHORT__, 0); }
+#endif
+#if defined(__SIZEOF_INT__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_INT = ((void) __SIZEOF_INT__, 0); }
+#endif
+#if defined(__SIZEOF_LONG__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_LONG = ((void) __SIZEOF_LONG__, 0); }
+#endif
+#if defined(__SIZEOF_POINTER__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_POINTER = ((void) __SIZEOF_POINTER__, 0); }
+#endif
+#if defined(__SIZEOF_LONG_LONG__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_LONG_LONG = ((void) __SIZEOF_LONG_LONG__, 0); }
+#endif
+#if defined(__SIZEOF_INT128__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_INT128_T = ((void) __SIZEOF_INT128__, 0); }
+#endif
+#if defined(__SIZEOF_FLOAT__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_FLOAT = ((void) __SIZEOF_FLOAT__, 0); }
+#endif
+#if defined(__SIZEOF_DOUBLE__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_DOUBLE = ((void) __SIZEOF_DOUBLE__, 0); }
+#endif
+#if defined(__SIZEOF_LONG_DOUBLE__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_LONG_DOUBLE = ((void) __SIZEOF_LONG_DOUBLE__, 0); }
+#endif
+#if defined(__SIZEOF_SIZE_T__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_SIZE_T = ((void) __SIZEOF_SIZE_T__, 0); }
+#endif
+#if defined(__SIZEOF_PTRDIFF_T__)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_PTRDIFF_T = ((void) __SIZEOF_PTRDIFF_T__, 0); }
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_array)
+#define __CIDR_HELPER_DEFINE_638
+#endif
+#if defined(__CIDR_HELPER_DEFINE_638)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_ARRAY = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_ARRAY = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_unbounded_array)
+#define __CIDR_HELPER_DEFINE_639
+#endif
+#if defined(__CIDR_HELPER_DEFINE_639)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_UNBOUNDED_ARRAY = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_UNBOUNDED_ARRAY = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_function)
+#define __CIDR_HELPER_DEFINE_640
+#endif
+#if defined(__CIDR_HELPER_DEFINE_640)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_FUNCTION = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_FUNCTION = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_object)
+#define __CIDR_HELPER_DEFINE_641
+#endif
+#if defined(__CIDR_HELPER_DEFINE_641)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_OBJECT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_OBJECT = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_literal)
+#define __CIDR_HELPER_DEFINE_642
+#endif
+#if defined(__CIDR_HELPER_DEFINE_642)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_LITERAL = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_LITERAL = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_pointer)
+#define __CIDR_HELPER_DEFINE_643
+#endif
+#if defined(__CIDR_HELPER_DEFINE_643)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_POINTER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_POINTER = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_member_pointer)
+#define __CIDR_HELPER_DEFINE_644
+#endif
+#if defined(__CIDR_HELPER_DEFINE_644)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_MEMBER_POINTER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_MEMBER_POINTER = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_member_function_pointer)
+#define __CIDR_HELPER_DEFINE_645
+#endif
+#if defined(__CIDR_HELPER_DEFINE_645)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_MEMBER_FUNCTION_POINTER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_MEMBER_FUNCTION_POINTER = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_member_object_pointer)
+#define __CIDR_HELPER_DEFINE_646
+#endif
+#if defined(__CIDR_HELPER_DEFINE_646)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_MEMBER_OBJECT_POINTER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_MEMBER_OBJECT_POINTER = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_reference)
+#define __CIDR_HELPER_DEFINE_647
+#endif
+#if defined(__CIDR_HELPER_DEFINE_647)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_REFERENCE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_REFERENCE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_lvalue_reference)
+#define __CIDR_HELPER_DEFINE_648
+#endif
+#if defined(__CIDR_HELPER_DEFINE_648)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_LVALUE_REFERENCE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_LVALUE_REFERENCE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_rvalue_reference)
+#define __CIDR_HELPER_DEFINE_649
+#endif
+#if defined(__CIDR_HELPER_DEFINE_649)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_RVALUE_REFERENCE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_RVALUE_REFERENCE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_const)
+#define __CIDR_HELPER_DEFINE_650
+#endif
+#if defined(__CIDR_HELPER_DEFINE_650)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONST = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONST = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_volatile)
+#define __CIDR_HELPER_DEFINE_651
+#endif
+#if defined(__CIDR_HELPER_DEFINE_651)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_VOLATILE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_VOLATILE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_nullptr)
+#define __CIDR_HELPER_DEFINE_652
+#endif
+#if defined(__CIDR_HELPER_DEFINE_652)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NULLPTR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NULLPTR = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_scalar)
+#define __CIDR_HELPER_DEFINE_653
+#endif
+#if defined(__CIDR_HELPER_DEFINE_653)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SCALAR = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SCALAR = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_arithmetic)
+#define __CIDR_HELPER_DEFINE_654
+#endif
+#if defined(__CIDR_HELPER_DEFINE_654)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_ARITHMETIC = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_ARITHMETIC = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_compound)
+#define __CIDR_HELPER_DEFINE_655
+#endif
+#if defined(__CIDR_HELPER_DEFINE_655)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_COMPOUND = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_COMPOUND = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_fundamental)
+#define __CIDR_HELPER_DEFINE_656
+#endif
+#if defined(__CIDR_HELPER_DEFINE_656)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_FUNDAMENTAL = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_FUNDAMENTAL = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_complete_type)
+#define __CIDR_HELPER_DEFINE_657
+#endif
+#if defined(__CIDR_HELPER_DEFINE_657)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_COMPLETE_TYPE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_COMPLETE_TYPE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_signed)
+#define __CIDR_HELPER_DEFINE_658
+#endif
+#if defined(__CIDR_HELPER_DEFINE_658)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SIGNED = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SIGNED = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_unsigned)
+#define __CIDR_HELPER_DEFINE_659
+#endif
+#if defined(__CIDR_HELPER_DEFINE_659)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_UNSIGNED = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_UNSIGNED = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_void)
+#define __CIDR_HELPER_DEFINE_660
+#endif
+#if defined(__CIDR_HELPER_DEFINE_660)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_VOID = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_VOID = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_integral)
+#define __CIDR_HELPER_DEFINE_661
+#endif
+#if defined(__CIDR_HELPER_DEFINE_661)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_INTEGRAL = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_INTEGRAL = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_floating_point)
+#define __CIDR_HELPER_DEFINE_662
+#endif
+#if defined(__CIDR_HELPER_DEFINE_662)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_FLOATING_POINT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_FLOATING_POINT = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__add_pointer)
+#define __CIDR_HELPER_DEFINE_663
+#endif
+#if defined(__CIDR_HELPER_DEFINE_663)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_ADD_POINTER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_ADD_POINTER = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__add_lvalue_reference)
+#define __CIDR_HELPER_DEFINE_664
+#endif
+#if defined(__CIDR_HELPER_DEFINE_664)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_ADD_LVALUE_REFERENCE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_ADD_LVALUE_REFERENCE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__add_rvalue_reference)
+#define __CIDR_HELPER_DEFINE_665
+#endif
+#if defined(__CIDR_HELPER_DEFINE_665)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_ADD_RVALUE_REFERENCE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_ADD_RVALUE_REFERENCE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__decay)
+#define __CIDR_HELPER_DEFINE_666
+#endif
+#if defined(__CIDR_HELPER_DEFINE_666)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_DECAY = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_DECAY = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__make_signed)
+#define __CIDR_HELPER_DEFINE_667
+#endif
+#if defined(__CIDR_HELPER_DEFINE_667)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_MAKE_SIGNED = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_MAKE_SIGNED = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__make_unsigned)
+#define __CIDR_HELPER_DEFINE_668
+#endif
+#if defined(__CIDR_HELPER_DEFINE_668)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_MAKE_UNSIGNED = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_MAKE_UNSIGNED = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_const)
+#define __CIDR_HELPER_DEFINE_669
+#endif
+#if defined(__CIDR_HELPER_DEFINE_669)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_CONST = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_CONST = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_volatile)
+#define __CIDR_HELPER_DEFINE_670
+#endif
+#if defined(__CIDR_HELPER_DEFINE_670)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_VOLATILE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_VOLATILE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_cv)
+#define __CIDR_HELPER_DEFINE_671
+#endif
+#if defined(__CIDR_HELPER_DEFINE_671)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_CV = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_CV = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_cvref)
+#define __CIDR_HELPER_DEFINE_672
+#endif
+#if defined(__CIDR_HELPER_DEFINE_672)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_CVREF = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_CVREF = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_reference)
+#define __CIDR_HELPER_DEFINE_673
+#endif
+#if defined(__CIDR_HELPER_DEFINE_673)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_REFERENCE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_REFERENCE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_reference_t)
+#define __CIDR_HELPER_DEFINE_674
+#endif
+#if defined(__CIDR_HELPER_DEFINE_674)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_REFERENCE_T = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_REFERENCE_T = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_pointer)
+#define __CIDR_HELPER_DEFINE_675
+#endif
+#if defined(__CIDR_HELPER_DEFINE_675)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_POINTER = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_POINTER = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_extent)
+#define __CIDR_HELPER_DEFINE_676
+#endif
+#if defined(__CIDR_HELPER_DEFINE_676)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_EXTENT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_EXTENT = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__remove_all_extents)
+#define __CIDR_HELPER_DEFINE_677
+#endif
+#if defined(__CIDR_HELPER_DEFINE_677)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_ALL_EXTENTS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_REMOVE_ALL_EXTENTS = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_convertible)
+#define __CIDR_HELPER_DEFINE_678
+#endif
+#if defined(__CIDR_HELPER_DEFINE_678)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONVERTIBLE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONVERTIBLE = ((void) 0, 0); }
+#endif
+#else
+#if defined(__cplusplus) && __CIDR_GCC_VERSION >= 130100
+#define __CIDR_HELPER_DEFINE_679
+#endif
+#if defined(__CIDR_HELPER_DEFINE_679)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONVERTIBLE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONVERTIBLE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_nothrow_convertible)
+#define __CIDR_HELPER_DEFINE_680
+#endif
+#if defined(__CIDR_HELPER_DEFINE_680)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NOTHROW_CONVERTIBLE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NOTHROW_CONVERTIBLE = ((void) 0, 0); }
+#endif
+#else
+#if defined(__cplusplus) && __CIDR_GCC_VERSION >= 130100
+#define __CIDR_HELPER_DEFINE_681
+#endif
+#if defined(__CIDR_HELPER_DEFINE_681)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NOTHROW_CONVERTIBLE = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NOTHROW_CONVERTIBLE = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_same)
+#define __CIDR_HELPER_DEFINE_682
+#endif
+#if defined(__CIDR_HELPER_DEFINE_682)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME = ((void) 0, 0); }
+#endif
+#else
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 100100
+#define __CIDR_HELPER_DEFINE_683
+#endif
+#if defined(__CIDR_HELPER_DEFINE_683)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__is_same_as)
+#define __CIDR_HELPER_DEFINE_684
+#endif
+#if defined(__CIDR_HELPER_DEFINE_684)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME_AS = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME_AS = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__make_integer_seq)
+#define __CIDR_HELPER_DEFINE_685
+#endif
+#if defined(__CIDR_HELPER_DEFINE_685)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_MAKE_INTEGER_SEQ = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_MAKE_INTEGER_SEQ = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__type_pack_element)
+#define __CIDR_HELPER_DEFINE_686
+#endif
+#if defined(__CIDR_HELPER_DEFINE_686)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_TYPE_PACK_ELEMENT = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_TYPE_PACK_ELEMENT = ((void) 0, 0); }
+#endif
+#endif
+#if defined(__has_builtin)
+#if __has_builtin(__integer_pack)
+#define __CIDR_HELPER_DEFINE_687
+#endif
+#if defined(__CIDR_HELPER_DEFINE_687)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_INTEGER_PACK = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_INTEGER_PACK = ((void) 0, 0); }
+#endif
+#else
+#if __cplusplus >= 201103 && __CIDR_GCC_VERSION >= 80100
+#define __CIDR_HELPER_DEFINE_688
+#endif
+#if defined(__CIDR_HELPER_DEFINE_688)
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_INTEGER_PACK = ((void) 1, 0); }
+#else
+{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_INTEGER_PACK = ((void) 0, 0); }
+#endif
+#endif
+} /* ____CIDR_command() */

--- a/src/ucpp/t/testlib.pl
+++ b/src/ucpp/t/testlib.pl
@@ -1,0 +1,940 @@
+#!/usr/bin/env perl
+
+use Modern::Perl;
+use Test::More;
+use Test::HexDifferences;
+use Config;
+use Capture::Tiny 'capture_merged';
+use Path::Tiny;
+use Text::Diff;
+
+$ENV{PATH} = join($Config{path_sep}, 
+			".",
+			"../../bin",
+			$ENV{PATH});
+
+my $OBJ_FILE_VERSION = "18";
+
+use vars '$test', '$null', '@CPUS';
+$test = "test_".(($0 =~ s/\.t$//r) =~ s/[\.\/\\]/_/gr);
+$null = ($^O eq 'MSWin32') ? 'nul' : '/dev/null';
+@CPUS = qw( z80 		z80_strict 
+			z80n 		z80n_strict
+			z180 		z180_strict 
+			ez80 		ez80_strict
+			ez80_z80 	ez80_z80_strict
+			r800 		r800_strict
+			r2ka		r2ka_strict
+			r3k			r3k_strict
+			r4k 		r4k_strict 
+			r5k 		r5k_strict
+			r6k 		r6k_strict
+			8080 8085 
+			gbz80 		gbz80_strict 
+			kc160		kc160_strict
+			kc160_z80	kc160_z80_strict
+);
+
+unlink_testfiles();
+
+#------------------------------------------------------------------------------
+sub check_bin_file {
+    my($got_file, $exp_bin) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    
+	my $got_bin = slurp($got_file);
+	eq_or_dump_diff($got_bin, $exp_bin, "bin file $got_file ok");
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub check_text_file {
+    my($got_file, $exp_text) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    
+	(my $got_text = slurp($got_file)) =~ s/\r\n/\n/g;
+	$exp_text =~ s/\r\n/\n/g;
+	
+	my $diff = diff(\$exp_text, \$got_text, {STYLE => 'Table'});
+	is $diff, "", "text file $got_file ok";
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub z80asm_ok {
+    my($options, $files, $exp_warn, @pairs_asm_bin) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    
+    # build $asm and $bin
+    my($asm, $bin) = ("","");
+    while (my($a, $b) = splice(@pairs_asm_bin, 0, 2)) {
+        $asm .= "$a\n";
+        $bin .= $b;
+    }
+    
+    # save asm file
+    my $asm_file = "${test}.asm";
+    my $bin_file = "${test}.bin";
+    spew($asm_file, $asm);
+    unlink($bin_file);
+    
+    # assemble
+    $options ||= "-b";
+    $files ||= $asm_file;
+
+    run_ok("z88dk-z80asm $options $files 2> ${test}.stderr");
+    check_bin_file($bin_file, $bin);
+    check_text_file("${test}.stderr", $exp_warn) if $exp_warn;
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub z80asm_nok {
+    my($options, $files, $asm, $exp_err) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    
+    # save asm file
+    my $asm_file = "${test}.asm";
+	spew($asm_file, $asm);
+    
+    # assemble
+    $options ||= "-b";
+    $files ||= $asm_file;
+
+    capture_nok("z88dk-z80asm $options $files", $exp_err);
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub ticks {
+	my($source, $options) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	spew("$test.asm", $source);
+	run_ok("z88dk-z80asm $options -b -l -m $test.asm");
+	
+	(Test::More->builder->is_passing) or die;
+
+	my $cpu = ($options =~ /(?:-m=?)(\S+)/) ? $1 : "z80";
+	run_ok("z88dk-ticks -z80asm-tests -m$cpu $test.bin -output $test.out");
+
+	(Test::More->builder->is_passing) or die;
+
+	my $bin = slurp("$test.out");
+	my $mem = substr($bin, 0, 0x10000); $mem =~ s/\0+$//;
+	my @mem = map {ord} split //, $mem;
+	my @regs = map {ord} split //, substr($bin, 0x10000);
+	my $ret = {
+		mem 	=> \@mem, 
+	};
+	$ret->{F} = shift @regs;	$ret->{F_S}  = ($ret->{F} & 0x80) ? 1 : 0;
+								$ret->{F_Z}  = ($ret->{F} & 0x40) ? 1 : 0;
+								$ret->{F_H}  = ($ret->{F} & 0x10) ? 1 : 0;
+								$ret->{F_PV} = ($ret->{F} & 0x04) ? 1 : 0;
+								$ret->{F_N}  = ($ret->{F} & 0x02) ? 1 : 0;
+								$ret->{F_C}  = ($ret->{F} & 0x01) ? 1 : 0;
+	$ret->{A} = shift @regs;
+	$ret->{C} = shift @regs;
+	$ret->{B} = shift @regs;	$ret->{BC} = ($ret->{B} << 8) | $ret->{C};
+	$ret->{L} = shift @regs;
+	$ret->{H} = shift @regs;	$ret->{HL} = ($ret->{H} << 8) | $ret->{L};
+	my $PCl = shift @regs;
+	my $PCh = shift @regs;		$ret->{PC} = ($PCh << 8) | $PCl;
+	my $SPl = shift @regs;
+	my $SPh = shift @regs;		$ret->{SP} = ($SPh << 8) | $SPl;
+	$ret->{I} = shift @regs;
+	$ret->{R} = shift @regs;
+	$ret->{E} = shift @regs;
+	$ret->{D} = shift @regs;	$ret->{DE} = ($ret->{D} << 8) | $ret->{E};
+	$ret->{C_} = shift @regs;
+	$ret->{B_} = shift @regs;	$ret->{BC_} = ($ret->{B_} << 8) | $ret->{C_};
+	$ret->{E_} = shift @regs;
+	$ret->{D_} = shift @regs;	$ret->{DE_} = ($ret->{D_} << 8) | $ret->{E_};
+	$ret->{L_} = shift @regs;
+	$ret->{H_} = shift @regs;	$ret->{HL_} = ($ret->{H_} << 8) | $ret->{L_};
+	$ret->{F_} = shift @regs;	$ret->{F__S}  = ($ret->{F_} & 0x80) ? 1 : 0;
+								$ret->{F__Z}  = ($ret->{F_} & 0x40) ? 1 : 0;
+								$ret->{F__H}  = ($ret->{F_} & 0x10) ? 1 : 0;
+								$ret->{F__PV} = ($ret->{F_} & 0x04) ? 1 : 0;
+								$ret->{F__N}  = ($ret->{F_} & 0x02) ? 1 : 0;
+								$ret->{F__C}  = ($ret->{F_} & 0x01) ? 1 : 0;
+	$ret->{A_} = shift @regs;
+	my $IYl = shift @regs;
+	my $IYh = shift @regs;		$ret->{IY} = ($IYh << 8) | $IYl;
+	my $IXl = shift @regs;
+	my $IXh = shift @regs;		$ret->{IX} = ($IXh << 8) | $IXl;
+	$ret->{IFF} = shift @regs;
+	$ret->{IM} = shift @regs;
+	my $MPl = shift @regs;
+	my $MPh = shift @regs;		$ret->{MP} = ($MPh << 8) | $MPl;
+	@regs == 8 or die;
+		
+	(Test::More->builder->is_passing) or die;
+
+	return $ret;
+}
+
+sub parity {
+	my($a) = @_;
+	my $bits = 0;
+	$bits++ if $a & 0x80;
+	$bits++ if $a & 0x40;
+	$bits++ if $a & 0x20;
+	$bits++ if $a & 0x10;
+	$bits++ if $a & 0x08;
+	$bits++ if $a & 0x04;
+	$bits++ if $a & 0x02;
+	$bits++ if $a & 0x01;
+	return ($bits & 1) == 0 ? 1 : 0;
+}
+
+#------------------------------------------------------------------------------
+sub capture_ok {
+    my($cmd, $exp_out) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    
+    run_ok($cmd." > ${test}.stdout");
+    check_text_file("${test}.stdout", $exp_out);
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub capture_nok {
+    my($cmd, $exp_err) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    run_nok($cmd." 2> ${test}.stderr");
+    check_text_file("${test}.stderr", $exp_err);
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub run_ok {
+    my($cmd) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+	
+	ok 1, "Running: $cmd";
+    ok 0==system($cmd), $cmd;
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+sub run_nok {
+    my($cmd) = @_;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+	
+	ok 1, "Running: $cmd";
+    ok 0!=system($cmd), $cmd;
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+# string table
+{
+	package ST;
+	use Object::Tiny::RW qw( hash list );
+	
+	sub new {
+		my($class) = shift;
+		return bless {
+			hash => {"" => 0},
+			list => [""] }, $class;
+	}
+	
+	sub add {
+		my($self, $str) = @_;
+		return $self->hash->{$str} if exists $self->hash->{$str};
+		my $id = $self->count;
+		$self->hash->{$str} = $id;
+		push @{$self->list}, $str;
+		return $id;
+	}
+	
+	sub lookup {
+		my($self, $id) = @_;
+		return $self->list->[$id];
+	}
+	
+	sub count {
+		my($self) = @_;
+		return scalar @{$self->list};
+	}
+	
+	sub store {
+		my($self) = @_;
+		
+		# build list of strings and indexes
+		my $strings = "";
+		my @index;
+		for my $id (0 .. $self->count - 1) {
+			push @index, length($strings);
+			$strings .= $self->lookup($id) . pack("C", 0);
+		}
+		my $aligned = (length($strings)+3) & ~3;
+		$strings .= pack("C*", (0) x ($aligned - length($strings)));
+		
+		# write sizes
+		my $o = pack("VV", $self->count, length($strings));
+		
+		# write indexes
+		$o .= pack("V*", @index);
+		
+		# write strings
+		$o .= $strings;
+		
+		return $o;
+	}
+}	
+
+#------------------------------------------------------------------------------
+sub bytes { return pack("C*", map {$_ & 0xff} @_); }
+sub words { return pack("v*", @_); }
+sub words_be { return pack("n*", @_); }
+sub pointers { return join('', map {pack("vC", $_ & 0xFFFF, ($_ >> 16) & 0xFF)} @_); }
+sub dwords { return pack("V*", @_); }
+
+sub unlink_testfiles {
+	my(@additional) = @_;
+    unlink(<${test}*>, @additional) 
+        if Test::More->builder->is_passing;
+}
+
+# return object file binary representation
+sub objfile {
+	my(%args) = @_;
+
+	my $st = ST->new;				# string table
+
+	exists($args{ORG}) and die;
+
+	my $o = "Z80RMF".$OBJ_FILE_VERSION;
+
+	# store CPU and -IXIY
+	$o .= pack("VV", $args{CPU}//1, $args{SWAP_IXIY}//0);
+	
+	# store empty pointers; mark position for later
+	my $name_addr	 = length($o); $o .= pack("V", -1);
+	my $expr_addr	 = length($o); $o .= pack("V", -1);
+	my $symbols_addr = length($o); $o .= pack("V", -1);
+	my $lib_addr	 = length($o); $o .= pack("V", -1);
+	my $code_addr	 = length($o); $o .= pack("V", -1);
+	my $st_addr		 = length($o); $o .= pack("V", -1);
+	
+	# store expressions
+	if ($args{EXPRS}) {
+		store_ptr(\$o, $expr_addr);
+		for (@{$args{EXPRS}}) {
+			@$_ == 9 or die;
+			my($type, $filename, $line_nr, $section, $asmptr, $ptr, $opcode_size, 
+			   $target_name, $text) = @$_;
+
+			my %TYPES = ( 	"J"=>1, "U"=>2, "S"=>3, 
+							"W"=>4, "C"=>4, # was C until v17, after is W
+							"B"=>5, "L"=>6, "u"=>7, "s"=>8, 
+							"P"=>9, "H"=>10, "="=>11 );
+			die "invalid type $type" unless exists $TYPES{$type};
+
+			$o .= pack("V", $TYPES{$type});
+			$o .= pack("V", $st->add($filename)) . pack("V", $line_nr);
+			$o .= pack("V", $st->add($section));
+			$o .= pack("VVV", $asmptr, $ptr, $opcode_size);
+			$o .= pack("V", $st->add($target_name));
+			$o .= pack("V", $st->add($text));
+		}
+		$o .= pack("V", 0);
+	}
+
+	# store symbols
+	if ($args{SYMBOLS}) {
+		store_ptr(\$o, $symbols_addr);
+		for (@{$args{SYMBOLS}}) {
+			@$_ == 7 or die;
+			my($scope, $type, $section, $value, $name, $def_filename, $line_nr) = @$_;
+			
+			my %SCOPES = ("L"=>1, "G"=>2);
+			die "invalid scope $scope" unless exists $SCOPES{$scope};
+
+			my %TYPES = ("C"=>1, "A"=>2, "="=>3);
+			die "invalid scope $type" unless exists $TYPES{$type};
+
+			$o .= pack("V", $SCOPES{$scope});
+			$o .= pack("V", $TYPES{$type});
+			$o .= pack("V", $st->add($section));
+			$o .= pack("V", $value);
+			$o .= pack("V", $st->add($name));
+			$o .= pack("V", $st->add($def_filename)) . pack("V", $line_nr);
+		}
+		$o .= pack("V", 0);
+	}
+
+	# store library
+	if ($args{EXTERNS}) {
+		store_ptr(\$o, $lib_addr);
+		for my $name (@{$args{EXTERNS}}) {
+			$o .= pack("V", $st->add($name));
+		}
+		$o .= pack("V", $st->add(""));		# end marker
+	}
+
+	# store name
+	store_ptr(\$o, $name_addr);
+	$o .= pack("V", $st->add($args{NAME}//"test"));
+
+	# store code
+	if ( $args{CODE} ) {
+		ref($args{CODE}) eq 'ARRAY' or die;
+		store_ptr(\$o, $code_addr);
+		for (@{$args{CODE}}) {
+			@$_ == 4 or die;
+			my($section, $org, $align, $code) = @$_;
+			$o .= pack("V", length($code));
+			$o .= pack("V", $st->add($section));
+			$o .= pack("VV", $org, $align);
+			$o .= $code;
+			
+			my $aligned_size = (length($code) + 3) & ~3;
+			my $extra_bytes = $aligned_size - length($code);
+			$o .= pack("C*", (0) x $extra_bytes);
+		}
+		$o .= pack("V", -1);
+	}
+
+	# store string table
+	store_ptr(\$o, $st_addr);
+	$o .= $st->store;
+	
+	return $o;
+}
+
+#------------------------------------------------------------------------------
+# store a pointer to the end of the binary object at the given address
+sub store_ptr {
+	my($robj, $addr) = @_;
+	my $ptr = length($$robj);
+	my $packed_ptr = pack("V", $ptr);
+	substr($$robj, $addr, length($packed_ptr)) = $packed_ptr;
+}
+
+#------------------------------------------------------------------------------
+sub pack_lstring {
+	my($string) = @_;
+	return pack("v", length($string)).$string;
+}
+
+#------------------------------------------------------------------------------
+# return library file binary representation
+sub libfile {
+	my($o_files, $public) = @_;
+
+	my $o = "Z80LMF".$OBJ_FILE_VERSION;
+	
+	# string table pointer
+	my $st_addr	= length($o); 
+	$o .= pack("V", -1);
+
+	for my $i (0 .. $#$o_files) {
+		my $o_file = $o_files->[$i];
+		my $next_ptr = length($o) + 4 + 4 + length($o_file);
+
+		$o .= pack("V", $next_ptr);
+		$o .= pack("V", length($o_file));
+		$o .= $o_file;
+	}
+	$o .= pack("V", -1);	# next
+	$o .= pack("V", 0);	# length = deleted
+
+	# store string table
+	my $st = ST->new();
+	for (@$public) {
+		$st->add($_);
+	}
+
+	store_ptr(\$o, $st_addr);
+	$o .= $st->store;
+
+	return $o;
+}
+
+#------------------------------------------------------------------------------
+# quote command line argument with "" on Windows, '' otherwise
+sub quote_os {
+	my($txt) = @_;
+	if ($^O eq 'MSWin32') {
+		return '"\''.$txt.'\'"';
+	}
+	else {
+		return "'\"".$txt."\"'";
+	}
+}
+
+sub os_quoted {
+	my($txt) = @_;
+	if ($^O eq 'MSWin32') {
+		return "'".$txt."'";
+	}
+	else {
+		return '"'.$txt.'"';
+	}
+}
+
+#------------------------------------------------------------------------------
+# path()->spew fails sometimes on Windows (race condition?) with 
+# Error rename on 'test_t_ALIGN.asm37032647357911' -> 'test_t_ALIGN.asm': Permission denied
+# replace by a simpler spew without renames
+sub spew {
+	my($file, @data) = @_;
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	my $open_ok = open(my $fh, ">:raw", $file);
+	ok $open_ok, "write $file"; 
+	
+	if ($open_ok) {
+		print $fh join('', @data);
+	}
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+# and for simetry
+sub slurp {
+	my($file) = @_;
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	my $open_ok = open(my $fh, "<:raw", $file);
+	ok $open_ok, "read $file";
+	
+	if ($open_ok) {
+		read($fh, my $data, -s $file);
+		return $data;
+	}
+	else {
+		return "";
+	}
+	
+	(Test::More->builder->is_passing) or die;
+}
+
+#------------------------------------------------------------------------------
+# read map file, retun map of symbols to values
+sub read_map_file {
+	my($file) = @_;
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	my $open_ok = open(my $fh, "<:raw", $file);
+	ok $open_ok, "read $file";
+
+	my %map;	
+	if ($open_ok) {
+		while (<$fh>) {
+			chomp;
+			if (/^(\w+)\s*=\s*\$([0-9a-f]+)/i) {
+				$map{$1} = hex($2);
+			}
+			else {
+				ok 0, "cannot parse $_";
+			}
+		}
+	}
+
+	(Test::More->builder->is_passing) or die;
+
+	return %map;
+}
+
+#------------------------------------------------------------------------------
+sub cpu_compatible {
+	my($code_cpu, $lib_cpu) = @_;
+	
+	# unstrictify CPU
+	for ($code_cpu, $lib_cpu) {
+		s/_strict$//;
+	}
+	
+	if ($code_cpu eq $lib_cpu) {
+		return 1;
+	}
+	elsif ($code_cpu eq "z80" && $lib_cpu eq "8080") {
+		return 1;
+	}
+	elsif ($code_cpu eq "z180" && $lib_cpu eq "8080") {
+		return 1;
+	}
+	elsif ($code_cpu eq "ez80") {
+		return 0;
+	}
+	elsif ($code_cpu eq "ez80_z80") {
+		return 0;
+	}
+	elsif ($code_cpu eq "z80n" && ($lib_cpu eq "8080" || $lib_cpu eq "z80")) {
+		return 1;
+	}
+	elsif ($code_cpu eq "r2ka") {
+		return 0;
+	}
+	elsif ($code_cpu eq "r3k" && $lib_cpu eq "r2ka") {
+		return 1;
+	}
+	elsif ($code_cpu eq "r4k") {
+		return 0;
+	}
+	elsif ($code_cpu eq "r5k" && $lib_cpu eq "r4k") {
+		return 1;
+	}
+	elsif ($code_cpu eq "r6k" && ($lib_cpu eq "r4k" || $lib_cpu eq "r5k")) {
+		return 1;
+	}
+	elsif ($code_cpu eq "gbz80") {
+		return 0;
+	}
+	elsif ($code_cpu eq "8080") {
+		return 0;
+	}
+	elsif ($code_cpu eq "8085" && $lib_cpu eq "8080") {
+		return 1;
+	}
+	elsif ($code_cpu eq "r800" && $lib_cpu eq "8080") {
+		return 1;
+	}
+	elsif ($code_cpu eq "kc160") {
+		return 0;
+	}
+	elsif ($code_cpu eq "kc160_z80" && $lib_cpu eq "8080") {
+		return 1;
+	}
+	else {
+		return 0;
+	}
+}
+
+#------------------------------------------------------------------------------
+sub ixiy_compatible {
+	my($code_ixiy, $lib_ixiy) = @_;
+	if ($code_ixiy eq $lib_ixiy) {
+		return 1;
+	}
+	elsif ($code_ixiy eq "" && $lib_ixiy eq "-IXIY-soft") {
+		return 1;
+	}
+	elsif ($code_ixiy eq "-IXIY-soft" && $lib_ixiy eq "") {
+		return 1;
+	}
+	else {
+		return 0;
+	}
+}
+
+#------------------------------------------------------------------------------
+# Ticks: prepare tests and run all in one go
+{
+	package Ticks;
+	use Object::Tiny::RW qw( test_nr res_addr asm tests );
+	use Test::More;
+	
+	sub new {
+		my($class) = @_;
+		return bless {test_nr=>0, 
+					  res_addr=>0,
+					  asm=>[], 
+					  tests=>[]}, $class;
+	}
+	
+	sub add {
+		my($self, $asm, %checks) = @_;
+		
+		my $test_nr = ++$self->{test_nr};
+		
+		# localize all labels
+		my %labels;
+		while ($asm =~ /^ \s* (?| \. \s* ([a-z_]\w*) | ([a-z_]\w*) \s* : ) /mixg) {
+			$labels{$1}++;
+		}
+		for my $label (keys %labels) {
+			$asm =~ s/ \b $label \b /L${test_nr}_${label}/ixg;
+		}
+		
+		# add reset code
+		my $reset_code = "xor a\n";
+		for my $reg (qw( bc de hl )) {
+			$reset_code .= "ld $reg, 0\n";
+		}
+		$reset_code .= "IF !__CPU_INTEL__ && !__CPU_GBZ80__\n";
+		$reset_code .= "exx\n";
+		for my $reg (qw( bc de hl )) {
+			$reset_code .= "ld $reg, 0\n";
+		}
+		$reset_code .= "exx\n";
+		$reset_code .= "ENDIF\n";
+		$reset_code .= "IF !__CPU_INTEL__ && !__CPU_GBZ80__\nld ix, 0\nld iy, 0\nENDIF\n";
+		
+		# add test code
+		my $test_code = "";
+		for my $k (sort keys %checks) {
+			my $v = $checks{$k};
+			
+			if    ($k =~ /^F_S/) { $test_code .= $self->test_flag_code($test_nr, $k, 0x80, $v); }
+			elsif ($k =~ /^F_Z/) { $test_code .= $self->test_flag_code($test_nr, $k, 0x40, $v); }
+			elsif ($k =~ /^F_H/) { $test_code .= $self->test_flag_code($test_nr, $k, 0x10, $v); }
+			elsif ($k =~ /^F_PV/){ $test_code .= $self->test_flag_code($test_nr, $k, 0x04, $v); }
+			elsif ($k =~ /^F_N/) { $test_code .= $self->test_flag_code($test_nr, $k, 0x02, $v); }
+			elsif ($k =~ /^F_C/) { $test_code .= $self->test_flag_code($test_nr, $k, 0x01, $v); }
+			elsif ($k =~ /^(BC|DE|HL|SP|IX|IY)$/) {
+				$test_code .= $self->test_dd_code($test_nr, $k, $v);
+			}
+			elsif ($k =~ /^(BC|DE|HL)_$/) {
+				$test_code .= $self->test_dd1_code($test_nr, $k, $v);
+			}
+			elsif ($k =~ /^(B|C|D|E|H|L|A)$/) {
+				$test_code .= $self->test_r_code($test_nr, $k, $v);
+			}
+			elsif ($k =~ /^(B|C|D|E|H|L|A)_$/) {
+				$test_code .= $self->test_r1_code($test_nr, $k, $v);
+			}
+			else {
+				die "cannot parse $k";
+			}
+		}
+		
+		push @{$self->asm}, $reset_code, $asm, $test_code;
+		
+	}
+	
+	sub _alloc_addr {
+		my($self, $n) = @_;
+		
+		my $res_addr = $self->{res_addr};
+		$self->{res_addr} += $n;
+		return $res_addr;
+	}
+	
+	sub _tick_plain_regs {
+		my($self, $reg) = @_;
+		
+		my $reg_tick  = $reg =~ s/_/'/r;
+		my $reg_plain = $reg =~ s/_//r;
+		return ($reg_tick, $reg_plain);
+	}
+	
+	sub _eval_value {
+		my($self, $value, @args) = @_;
+		
+		if (ref($value) eq 'CODE') {
+			$value = $value->(@args);
+		}
+		return $value;
+	}
+	
+	sub _check_value {
+		my($self, $test_nr, $t, $reg, $res_addr, $size, $mask, $value) = @_;
+		local $Test::Builder::Level = $Test::Builder::Level + 1;
+		
+		my $got;
+		if ($size == 1) {
+			$got = $t->{mem}[$res_addr] & ($mask ? $mask : 0xFF);
+			if ($mask) {
+				$got = $got ? 1 : 0;
+			}
+		}
+		elsif ($size == 2) {
+			$got = ($t->{mem}[$res_addr] + ($t->{mem}[$res_addr+1] << 8))
+					& ($mask ? $mask : 0xFFFF);
+		}
+		else {
+			die;
+		}
+		
+		$value = $self->_eval_value($value, $t);
+		if ($size == 1) {
+			$value &= 0xFF;
+		}
+		elsif ($size == 2) {
+			$value &= 0xFFFF;
+		}
+		else {
+			die;
+		}
+		
+		is $got, $value, "Test $test_nr addr=$res_addr $reg=$value";
+	}
+			
+	sub test_flag_code {
+		my($self, $test_nr, $flag, $mask, $value) = @_;
+		
+		my $res_addr = $self->_alloc_addr(1);
+		push @{$self->tests}, sub {
+			my($t) = @_;
+			local $Test::Builder::Level = $Test::Builder::Level + 1;
+			SKIP: {
+				skip "8085 does not have the N flag" if $t->{cpu} eq '8085' && $flag eq 'F_N';
+				$self->_check_value($test_nr, $t, $flag, $res_addr, 1, $mask, $value);
+			}
+		};
+		return <<END;
+							push af
+							ex (sp), hl
+							ld ($res_addr), hl
+							ex (sp), hl
+							pop af
+END
+	}
+	
+	sub test_dd_code {
+		my($self, $test_nr, $dd, $value) = @_;
+		
+		my $res_addr = $self->_alloc_addr(2);
+		push @{$self->tests}, sub {
+			my($t) = @_;
+			local $Test::Builder::Level = $Test::Builder::Level + 1;
+			$self->_check_value($test_nr, $t, $dd, $res_addr, 2, 0, $value);
+		};
+
+		my $cond = ($dd =~ /IX|IY/i) ? "!__CPU_INTEL__ && !__CPU_GBZ80__" : "1";
+		return <<END;
+						IF $cond
+								ld ($res_addr), $dd
+						ELSE
+								push hl
+								ld hl, 0
+								ld ($res_addr), hl
+								pop hl
+						ENDIF
+END
+	}
+	
+	sub test_dd1_code {
+		my($self, $test_nr, $dd, $value) = @_;
+
+		my($dd_tick, $dd_plain) = $self->_tick_plain_regs($dd);
+		my $res_addr = $self->_alloc_addr(2);
+		push @{$self->tests}, sub {
+			my($t) = @_;
+			local $Test::Builder::Level = $Test::Builder::Level + 1;
+			$self->_check_value($test_nr, $t, $dd_tick, $res_addr, 2, 0, $value);
+		};
+		return <<END;
+						IF !__CPU_INTEL__ && !__CPU_GBZ80__
+							exx
+						ENDIF
+							ld ($res_addr), $dd_plain
+						IF !__CPU_INTEL__ && !__CPU_GBZ80__
+							exx
+						ENDIF
+END
+	}
+	
+	sub test_r_code {
+		my($self, $test_nr, $r, $value) = @_;
+		
+		my $res_addr = $self->_alloc_addr(1);
+		push @{$self->tests}, sub {
+			my($t) = @_;
+			local $Test::Builder::Level = $Test::Builder::Level + 1;
+			$self->_check_value($test_nr, $t, $r, $res_addr, 1, 0, $value);
+		};
+		if ($r eq 'A') {
+			return <<END;
+							ld ($res_addr), a
+END
+		}
+		else {
+			return <<END;
+							push af
+							ld a, $r
+							ld ($res_addr), a
+							pop af
+END
+		}
+	}
+	
+	sub test_r1_code {
+		my($self, $test_nr, $r, $value) = @_;
+		
+		my($r_tick, $r_plain) = $self->_tick_plain_regs($r);
+		my $res_addr = $self->_alloc_addr(1);
+		push @{$self->tests}, sub {
+			my($t) = @_;
+			local $Test::Builder::Level = $Test::Builder::Level + 1;
+			$self->_check_value($test_nr, $t, $r_tick, $res_addr, 1, 0, $value);
+		};
+		if ($r =~ /A_/) {
+			return <<END;
+							ex af, af'
+							ld ($res_addr), a
+							ex af, af'
+END
+		}
+		else {
+			return <<END;
+							push af
+						IF !__CPU_INTEL__ && !__CPU_GBZ80__
+							exx
+						ENDIF
+							ld a, $r_plain
+							ld ($res_addr), a
+						IF !__CPU_INTEL__ && !__CPU_GBZ80__
+							exx
+						ENDIF
+							pop af
+END
+		}
+	}
+	
+	sub run {
+		my($self, @opts) = @_;
+		local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+		my $save_bytes = $self->res_addr;
+		
+		unshift @{$self->asm}, <<END;
+			IF __CPU_R4K__ || __CPU_R5K__ || __CPU_R6K__
+				;; Enable R4K instruction mode on the R4K
+				ld      a,0xC0
+				ioi ld  (0x0420),a      ;EDMR register (p299 in R4000UM.pdf)
+			ENDIF			
+				jp 		start
+				defs 	$save_bytes		;save bytes for results
+			start:
+END
+		push @{$self->asm}, <<END;
+				jp 0
+END
+		push @opts, "" if @opts==0;
+		for my $cpu (@::CPUS) {
+			SKIP: {
+				skip "$cpu not supported by ticks" if $cpu =~ /^ez80$/;
+				skip "$cpu not supported" if $cpu =~ /_strict/;
+				
+				for my $opts (@opts) {
+					# run ticks
+					my $t = ::ticks(join("\n", "; $cpu $opts\n", @{$self->asm}), "-m$cpu $opts");
+					
+					# collect labels
+					open(my $f, "<", "$::test.map") or die "open $::test.map: $!";
+					while (<$f>) {
+						if (/^(\w+)\s*=\s*\$([0-9a-f]+)/i) {
+							$t->{labels}{$1} = hex($2);
+						}
+					}
+					$t->{cpu} = $cpu;
+					
+					# check results
+					for (@{$self->tests}) {
+						$_->($t);
+
+						(Test::More->builder->is_passing) or die;
+					}
+				}
+			}
+		}
+	}
+}
+
+1;


### PR DESCRIPTION
Take a look at this file, this is generated by CLion

[ucpp-test.c](https://github.com/user-attachments/files/24015217/ucpp-test.c)

Essentially it generates #ifdef checks like this one

```c
#if defined(__CIDR_HELPER_DEFINE_1)
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_FEATURE = ((void) 1, 0); }
#else
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_FEATURE = ((void) 0, 0); }
#endif
```

to detect compiler (preprocessor) behavior.

So, do

```bash
z88dk-ucpp -iquote"." -D__SPECTRUM -DSPECTRUM -D__SPECTRUM__ -D__Z80 -DZ80 -D___CIDR_DEFINITIONS_END -D__Z88DK  -DSCCZ80 -DSMALL_C -D__SCCZ80 -I"/Users/desert/Documents/Work/spectranext/sdk/z88dk/lib/config/../..//include/arch/zx" -isystem"/Users/desert/Documents/Work/spectranext/sdk/z88dk/lib/config/../..//include"   -d  "ucpp-test.c" -o ucpp-test-out.i
```

Note ucpp-test-out.i contains thousands of newlines, as much as 7000 in one place.

This leads to CLion crashing and not producing syntax highlighting.

With this fix it produces clean

```c
#line 1 "ucpp-test.c"
void ____CIDR_command() {
{ int __attribute__ ((unused)) ____CIDR_command_SET_LANGUAGE_STANDARD, ____CIDR_command_STANDARD_C = ((void)  199901L , 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_BUILTIN = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_FEATURE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_EXTENSION = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_HAS_HAS_INCLUDE_NEXT = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_include = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_ADD_DEFINITION, ____CIDR_command___CIDR_builtin__has_cpp_attribute = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_VARIABLE_DECLARATION_RULES_ARE_C89_COMPATIBLE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_GCC_AUTO_TYPE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_STATIC_ASSERT = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_AUTO_TYPE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_OVERRIDE_CONTROL = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERALIZED_INITIALIZERS = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NULLPTR = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_NONSTATIC_MEMBER_INIT = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXCEPTIONS = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RAW_STRING_LITERALS = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_USER_LITERALS = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_ATTRIBUTES = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BINARY_LITERALS = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_RETURN_TYPE_DEDUCTION = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_GENERIC_LAMBDAS = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_EXPLICIT_THIS_PARAMETER = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_NULLPTR = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_AUTO_TYPE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_C_CONSTEXPR = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_CONSTEXPR_VOID = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_FEATURE, ____CIDR_command_CXX_BUILTIN_IS_CONSTANT_EVALUATED = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_SIZE, ____CIDR_command_SIZE_T = ((void)  2 , 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_CONVERTIBLE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_NOTHROW_CONVERTIBLE = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_IS_SAME = ((void) 0, 0); }
{ int __attribute__ ((unused)) ____CIDR_command_SET_TYPE_TRAIT, ____CIDR_command_INTEGER_PACK = ((void) 0, 0); }
}  
```