### PR TITLE
Issue #2858 fix preprocessor lines

### DIFF
--- a/src/sccz80/codegen.c
+++ b/src/sccz80/codegen.c
@@ -150,7 +150,7 @@ static const char *map_library_routine(const char *wanted, Kind to)
 /* Output a comment line for the assembler */
 void gen_comment(const char *message)
 {
-    outfmt(";%s\n",message);
+    outfmt(";%s:%d: %s\n",Filename, lineno, message);
 }
 
 /* Put out assembler info before any code is generated */

--- a/src/sccz80/preproc.c
+++ b/src/sccz80/preproc.c
@@ -85,13 +85,14 @@ void vinline(void)
             unit = input;
         clear();
         while ((k = getc(unit)) > 0) {
-            if (k == '\n' || k == '\r' || lptr >= LINEMAX)
+            if (k == '\r') continue;
+            if (k == '\n' ||lptr >= LINEMAX)
                 break;
             line[lptr++] = k;
         }
         line[lptr] = 0; /* append null */
-        if (k != '\r')
-            ++lineno; /* read one more line */
+        ++lineno; 
+
         if (k <= 0) {
             fclose(unit);
             if (inpt2 != NULL)
@@ -102,14 +103,14 @@ void vinline(void)
             }
         }
         if (lptr) {
-            if (c_intermix_ccode && cmode) {
+            if (c_intermix_ccode && cmode && pstack == NULL) {
                 gen_comment(line);
             }
             if (c_cline_directive || c_intermix_ccode) {
                 while ( lptr-- ) {
                     if ( !isspace(lptr)) break;
                 }
-                if ( lptr ) 
+                if ( lptr && pstack == NULL) 
                     gen_emit_line(lineno);
             }
             lptr = 0;
@@ -191,7 +192,7 @@ void ifline(void)
                 string[0] = 0;
                 sscanf(line + lptr, "%d %s", &num, string);
                 if (num)
-                    lineno = --num;
+                    lineno = num - 1;
 
                 if (strlen(string)) {
                     if ( strcmp(Filename, string)) {

--- a/src/ucpp/lexer.c
+++ b/src/ucpp/lexer.c
@@ -477,7 +477,20 @@ static inline void write_char(struct lexer_state *ls, unsigned char c)
  */
 void put_char(struct lexer_state *ls, unsigned char c)
 {
-	if (ls->flags & KEEP_OUTPUT) write_char(ls, c);
+	if (ls->flags & KEEP_OUTPUT) {
+        if ( c == '\n' ) {
+        } else if (c ) {
+            yield_newlines(ls);
+            write_char(ls, c);
+        }
+    }
+}
+
+void put_char_direct(struct lexer_state *ls, unsigned char c)
+{
+	if (ls->flags & KEEP_OUTPUT) {
+        write_char(ls, c);
+    }
 }
 
 /*
@@ -810,6 +823,8 @@ static inline int read_token(struct lexer_state *ls)
 		utf8 = ls->utf8;
 		shift_state = 0;
 	}
+    // if (!(ls->flags & LEXER) && (ls->flags & KEEP_OUTPUT))
+    //     yield_newlines(ls);
 	do {
 		c = next_char(ls);
 		if (c < 0) {
@@ -936,20 +951,15 @@ static inline int read_token(struct lexer_state *ls)
 					outc = -2;
 				} else {
 					if (outc < 0) {
-				        yield_newlines(ls);
 						put_char(ls, '%');
 						put_char(ls, ':');
 						if (outc == -2)
 							put_char(ls, '%');
 						outc = 0;
 					} else if (outc) {
-				        yield_newlines(ls);
 						put_char(ls, outc);
 						outc = 0;
 					}
-				    if (c != '\n') {
-				        yield_newlines(ls);
-				    }
 					put_char(ls, c);
 				}
 			}
@@ -1001,7 +1011,6 @@ int next_token(struct lexer_state *ls)
 	if (ls->flags & READ_AGAIN) {
 		ls->flags &= ~READ_AGAIN;
 		if (!(ls->flags & LEXER)) {
-			yield_newlines(ls);
 			char *c = S_TOKEN(ls->ctok->type) ?
 				ls->ctok->name : token_name(ls->ctok);
 			if (ls->ctok->type == OPT_NONE) {

--- a/src/ucpp/macro.c
+++ b/src/ucpp/macro.c
@@ -327,13 +327,23 @@ static void print_token_nailed(struct lexer_state *ls, struct token *t,
 	long nail_line)
 {
 	char *x = t->name;
+    int line_offs = 0;
 
+    // If this macro is at the end of the line, then we've incremented linecount
+    // To avoid printing a newline before this macro, decrement line count and then
+    // increment after printing
+    if ( ls->tknl ) {
+        ls->line--;
+        line_offs = 1;
+    }
 	if (ls->flags & LEXER) {
 		print_token(ls, t, 0);
+        if ( line_offs) ls->line++;
 		return;
 	}
 	if (!S_TOKEN(t->type)) x = operators_name[t->type];
 	for (; *x; x ++) put_char(ls, *x);
+    if ( line_offs) ls->line++;
 }
 
 /*

--- a/src/ucpp/macro.c
+++ b/src/ucpp/macro.c
@@ -284,12 +284,13 @@ void yield_newlines(struct lexer_state *ls)
 	if (!(ls->flags & KEEP_OUTPUT)) {
 		return;
 	}
-
 	if (ls->line > ls->oline + 10) {
 	    print_line_info(ls, ls->flags);
 	    ls->oline = ls->line;
 	} else {
-	    for (; ls->line > ls->oline;) put_char(ls,'\n');
+        while ( ls->oline < ls->line ) {
+            put_char_direct(ls, '\n');
+        }
 	}
 }
 
@@ -314,7 +315,6 @@ void print_token(struct lexer_state *ls, struct token *t, long uz_line)
 			TOKEN_LIST_MEMG);
 		return;
 	}
-    yield_newlines(ls);
 	if (!S_TOKEN(t->type)) x = operators_name[t->type];
 	for (; *x; x ++) put_char(ls, *x);
 }
@@ -331,9 +331,6 @@ static void print_token_nailed(struct lexer_state *ls, struct token *t,
 	if (ls->flags & LEXER) {
 		print_token(ls, t, 0);
 		return;
-	}
-	if (ls->flags & KEEP_OUTPUT) {
-		for (; ls->oline < nail_line;) put_char(ls, '\n');
 	}
 	if (!S_TOKEN(t->type)) x = operators_name[t->type];
 	for (; *x; x ++) put_char(ls, *x);

--- a/src/ucpp/t/Issue_2858_macro_no_args.c
+++ b/src/ucpp/t/Issue_2858_macro_no_args.c
@@ -1,0 +1,39 @@
+#define STDIO_ASM
+#define malloc(a) mymalloc(a)
+
+#asm
+    SECTION code_clib
+    PUBLIC    funopen
+    PUBLIC    _funopen
+
+; FILE  *funopen(const void    *cookie, int (*readfn)(void *, char *, int),
+;     int (*writefn)(void *,    const char *, int),
+;     fpos_t    (*seekfn)(void *, fpos_t, int),    int (*closefn)(void *));
+
+DEFVARS 0 {
+    fu_readfn        ds.w    1
+    fu_writefn        ds.w    1
+    fu_seekfn        ds.w    1
+    fu_closefn        ds.w    1
+}
+
+
+funopen:
+_funopen:
+IF __CPU_INTEL__ | __CPU_GBZ80__
+    ld      hl,0
+    ret
+ELSE
+    ; Allocate some memory first of all
+    push    ix          ;save callers ix
+
+    ld      ix,4
+    add    ix,sp        ;points to closefn
+
+    ld      hl, +(fp_extra + 2) + ( fu_closefn + 2)
+    push    hl
+    call    malloc
+    pop     bc
+    push    hl          ;Keep for later
+
+#endasm

--- a/src/ucpp/t/Issue_2858_macro_no_args.t
+++ b/src/ucpp/t/Issue_2858_macro_no_args.t
@@ -9,9 +9,9 @@ unlink_testfiles;
 
 # Copy the test file
 my $test_file = "${test}.c";
-my $source_file = "t/Issue_2858_world.c";
+my $source_file = "t/Issue_2858_macro_no_args.c";
 # If running from parent directory, adjust path
-$source_file = "t/Issue_2858_world.c" if -f "t/Issue_2858_world.c" && !-f $source_file;
+$source_file = "t/Issue_2858_macro_no_args.c" if -f "t/Issue_2858_macro_no_args.c" && !-f $source_file;
 copy($source_file, $test_file) or die "Cannot copy $source_file to $test_file: $!";
 
 # Run ucpp on the test file (may fail on missing headers, but should still produce output)
@@ -22,7 +22,7 @@ ok -f "${test}.i", "${test}.i created";
 
 # Check that #line directive is followed by newline, then "; Check for value of -1"
 my $content = slurp("${test}.i");
-like $content, qr/#line\s8\s"[^"]*"(\r)?\nint main/s, 
+like $content, qr/call     malloc(\r)?\n/s, 
     "#line [file]:8 directive followed by newline, then 'main";
 
 unlink_testfiles;

--- a/src/ucpp/t/Issue_2858_world.c
+++ b/src/ucpp/t/Issue_2858_world.c
@@ -1,0 +1,19 @@
+/*
+ *      Hello World
+ */
+
+#include <stdio.h>
+#include <features.h>
+#include <conio.h>
+int main()
+{
+        int i;
+        for ( i = 1; i < 10; i++ )
+                ;;
+        printf("Hello world!\n");
+        printf("Again %d",1);
+        for ( i = 1; i < 10; i++ ) {
+                printf("Here we go\n");
+        }
+        while(1) {}
+}

--- a/src/ucpp/t/Issue_2858_world.t
+++ b/src/ucpp/t/Issue_2858_world.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+use File::Copy;
+
+unlink_testfiles;
+
+# Copy the test file
+my $test_file = "${test}.c";
+my $source_file = "t/Issue_2858_world.c";
+# If running from parent directory, adjust path
+$source_file = "t/Issue_2858_world.c" if -f "t/Issue_2858_world.c" && !-f $source_file;
+copy($source_file, $test_file) or die "Cannot copy $source_file to $test_file: $!";
+
+# Run ucpp on the test file (may fail on missing headers, but should still produce output)
+system("z88dk-ucpp -I../../include -I../../../include -d $test_file -o ${test}.i 2> ${test}.err");
+
+# Check that output file was created
+ok -f "${test}.i", "${test}.i created";
+
+# Check that #line directive is followed by newline, then "; Check for value of -1"
+my $content = slurp("${test}.i");
+like $content, qr/#line\s8\s"[^"]*"\nint main/s, 
+    "#line [file]:8 directive followed by newline, then 'main";
+
+unlink_testfiles;
+done_testing;
+

--- a/src/ucpp/ucppi.h
+++ b/src/ucpp/ucppi.h
@@ -73,6 +73,7 @@ struct comp_token_fifo {
 
 void init_cppm(void);
 void put_char(struct lexer_state *, unsigned char);
+void put_char_direct(struct lexer_state *, unsigned char);
 void discard_char(struct lexer_state *);
 int next_token(struct lexer_state *);
 int grap_char(struct lexer_state *);

--- a/src/z80asm/t/issue_0341.t
+++ b/src/z80asm/t/issue_0341.t
@@ -40,7 +40,7 @@ check_text_file("${test}1.map", <<END);
 __ASM_LINE_2_${test_expanded}1_2easm = \$0000 ; addr, local, , ${test}1_asm, , ${test}1.asm:2
 __C_LINE_0_${test_expanded}_2ec = \$0000 ; addr, local, , ${test}_c, , ${test}.c:0
 __C_LINE_10_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0194 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:10
-__C_LINE_11_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$0194 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:11
+__C_LINE_11_${test_expanded}_2ec_3a_3amain_3a_3a1_3a_3a3 = \$01A5 ; addr, local, , ${test}_c, code_compiler, ${test}.c::main::1::3:11
 __C_LINE_1_${test_expanded}_2ec = \$0000 ; addr, local, , ${test}_c, , ${test}.c:1
 __C_LINE_2_${test_expanded}_2ec_3a_3aadd_3a_3a0_3a_3a0 = \$0180 ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::0::0:2
 __C_LINE_3_${test_expanded}_2ec_3a_3aadd_3a_3a1_3a_3a1 = \$0180 ; addr, local, , ${test}_c, code_compiler, ${test}.c::add::1::1:3


### PR DESCRIPTION
* The `#line` collapsing created a few issues where line numbers could be off in certain cases
* Match more closely `--c-code-in-asm` across sccz80 and sdcc - remove parameter C_LINE entries and quoted bits

Reformat of ucpp to follow since it's got tab/space/indent crazy
