### PR TITLE
Check length in read() before trying to read data

### DIFF
--- a/libsrc/target/aquarius/fcntl/read.c
+++ b/libsrc/target/aquarius/fcntl/read.c
@@ -43,13 +43,15 @@ not_failed:
     ld      l,a
     ; And fill buffer for offered length
 loop:
+    ld      a, b
+    or      c
+    jr      z, read_done
     call    __esp_read_byte
     ld      (hl),a
     inc     hl
     dec     bc
-    ld      a,b
-    or      c
-    jr      nz,loop
+    jr      loop
+read_done:
     pop     hl      ;amount read
     ret
 #endasm


### PR DESCRIPTION
When the ESP reaches the end of the file, it returns an offered length of 0. In the current implementation this causes the code to hang trying to read a byte which never comes. I’ve updated the logic to check for a zero length before attempting to read any bytes.