### PR TITLE
Issue #2858: Handle another line miscount case

### DIFF
--- a/src/ucpp/cpp.c
+++ b/src/ucpp/cpp.c
@@ -429,7 +429,7 @@ static void close_input(struct lexer_state *ls)
 #endif
 	if (ls->input) {
 		fclose(ls->input);
-		ls->input = 0;
+		ls->input = NULL;
 	}
 }
 
@@ -1432,6 +1432,7 @@ do_include_next:
 		}
 		/* file was found, but it is useless to include it again */
 		freemem(fname);
+		ls->oline++;
 		return 0;
 	}
 #ifdef UCPP_MMAP
@@ -2056,7 +2057,7 @@ int cpp(struct lexer_state *ls)
 				/* We found a guardian but an old one. */
 				freemem(protect_detect.macro);
 			}
-			protect_detect.macro = 0;
+			protect_detect.macro = NULL;
 		}
 		if (ls->ifnest) {
 			error(ls->line, "unterminated #if construction "
@@ -2128,7 +2129,6 @@ int cpp(struct lexer_state *ls)
 	if (ls->ctok->type == NEWLINE) ls->ltwnl = 1; 
 	else if (!ttWHI(ls->ctok->type)) ls->ltwnl = 0;
 
-    //yield_newlines(ls); // Gets line numbers right, but doesn't collapse multiple newlines.
 	return r ? r : -1;
 }
 

--- a/src/ucpp/t/Issue_2858_duplicate_include.c
+++ b/src/ucpp/t/Issue_2858_duplicate_include.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+int main()
+{
+   bah0;
+}

--- a/src/ucpp/t/Issue_2858_duplicate_include.t
+++ b/src/ucpp/t/Issue_2858_duplicate_include.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+BEGIN { use lib 't'; require 'testlib.pl'; }
+
+use Modern::Perl;
+use File::Copy;
+
+unlink_testfiles;
+
+# Copy the test file
+my $test_file = "${test}.c";
+my $source_file = "t/Issue_2858_duplicate_include.c";
+# If running from parent directory, adjust path
+$source_file = "t/Issue_2858_duplicate_include.c" if -f "t/Issue_2858_duplicate_include.c" && !-f $source_file;
+copy($source_file, $test_file) or die "Cannot copy $source_file to $test_file: $!";
+
+# Run ucpp on the test file (may fail on missing headers, but should still produce output)
+system("z88dk-ucpp -I../../include -I../../../include -d $test_file -o ${test}.i 2> ${test}.err");
+
+# Check that output file was created
+ok -f "${test}.i", "${test}.i created";
+
+# Check that #line directive is followed by newline, then "; Check for value of -1"
+my $content = slurp("${test}.i");
+like $content, qr/#line\s4\s"[^"]*"(\r)?\n(\r)?\nint main/s, 
+    "#line [file]:8 directive followed by newline, then 'main";
+
+unlink_testfiles;
+done_testing;
+


### PR DESCRIPTION
This copes with double inclusion of header files with a guardian.