### PR TITLE
Updated perl paths in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,6 @@ parts:
       - libyaml-tiny-perl
       - libgmp3-dev
       - pkg-config
-      - strict
     stage-packages:
       - libregexp-common-perl
       - libcapture-tiny-perl
@@ -136,12 +135,12 @@ apps:
     plugs: [home, removable-media]
   z88dk-asmpp:
     environment:
-      PERL5LIB: "$SNAP/perl5/lib/perl5:$SNAP/usr/share/perl5:$SNAP/usr/share/perl/5.30:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.30"
+      PERL5LIB: "$SNAP/perl5/lib/perl5:$SNAP/usr/share/perl5:$SNAP/usr/share/perl/5.38:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.38"
     command: bin/z88dk-asmpp
     plugs: [home, removable-media]
   z88dk-asmstyle:
     environment:
-      PERL5LIB: "$SNAP/perl5/lib/perl5:$SNAP/usr/share/perl/5.30:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.30"
+      PERL5LIB: "$SNAP/perl5/lib/perl5:$SNAP/usr/share/perl/5.38:$SNAP/usr/lib/x86_64-linux-gnu/perl/5.38"
     command: bin/z88dk-asmstyle
     plugs: [home, removable-media]
 


### PR DESCRIPTION
Updated perl paths for snapcraft build to point to perl 5.38 instead of 5.30 to resolve the following error when running asmstyle.

Can't locate strict.pm in @INC (you may need to install the strict module) (@INC entries checked: /snap/z88dk/8961/perl5/lib/perl5/5.38.2/x86_64-linux-gnu-thread-multi /snap/z88dk/8961/perl5/lib/perl5/5.38.2 /snap/z88dk/8961/perl5/lib/perl5/x86_64-linux-gnu-thread-multi /snap/z88dk/8961/perl5/lib/perl5 /snap/z88dk/8961/usr/share/perl/5.30 /snap/z88dk/8961/usr/lib/x86_64-linux-gnu/perl/5.30 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at /snap/z88dk/8961/perl5/lib/perl5/Modern/Perl.pm line 6.
BEGIN failed--compilation aborted at /snap/z88dk/8961/perl5/lib/perl5/Modern/Perl.pm line 6.
Compilation failed in require at /snap/z88dk/8961/bin/z88dk-asmstyle line 10.
BEGIN failed--compilation aborted at /snap/z88dk/8961/bin/z88dk-asmstyle line 10.