### PR TITLE
80cc: First tranche of fixes

### DIFF
--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -671,12 +671,67 @@ void ir_alloc(Func *f)
                 free(cand);
             }
         }
+        /* idx2 STEPPING COUNTER (register-residency phase A): a monotonic
+           width-2 loop counter whose only writes are one LD_IMM init + INC/DEC
+           self-steps, never a deref/step base — held in the spare index reg and
+           stepped with `inc/dec <idx>` (2 bytes, no memory) instead of the TOS
+           `ex(sp),hl;inc;ex(sp),hl` dance. Preferred over the invariant bound
+           for idx2 because it's stepped every iteration. Same call/asm/acc-free
+           gate. IR_NO_IDX2_COUNTER opts out. */
+        int idx2_taken = 0;
+        if (f->idx2_reg != IR_PR_NONE && !f->uses_acc && !f->is_interrupt
+            && !getenv("IR_NO_IDX2_COUNTER")) {
+            int cnt_safe = 1;
+            for (int i = 0; i < f->n_bbs && cnt_safe; i++)
+                for (int j = 0; j < f->bbs[i].n_ops; j++) {
+                    OpKind k = f->bbs[i].ops[j].kind;
+                    if (k == IR_CALL || k == IR_HCALL || k == IR_ASM) { cnt_safe = 0; break; }
+                }
+            size_t nvc = f->n_vregs > 0 ? (size_t)f->n_vregs : 0;
+            int *cbase = calloc(nvc, sizeof(int));   /* deref/step base → not a counter */
+            int *cstep = calloc(nvc, sizeof(int));   /* INC/DEC self-step defs */
+            int *cinit = calloc(nvc, sizeof(int));   /* LD_IMM init defs */
+            int *cother = calloc(nvc, sizeof(int));  /* any other def → disqualify */
+            if (cnt_safe && cbase && cstep && cinit && cother) {
+                for (int i = 0; i < f->n_bbs; i++)
+                    for (int j = 0; j < f->bbs[i].n_ops; j++) {
+                        const Op *o = &f->bbs[i].ops[j];
+                        if ((o->kind == IR_LD_MEM || o->kind == IR_ST_MEM)
+                            && o->mem.kind == IR_MEM_VREG
+                            && o->mem.base >= 0 && o->mem.base < f->n_vregs)
+                            cbase[o->mem.base] = 1;
+                        if (o->kind == IR_POSTSTEP && o->src[0] >= 0
+                            && o->src[0] < f->n_vregs) { cbase[o->src[0]] = 1; }
+                        int d = o->dst;
+                        if (d < 0 || d >= f->n_vregs) continue;
+                        if ((o->kind == IR_INC || o->kind == IR_DEC)
+                            && o->src[0] == d) cstep[d]++;
+                        else if (o->kind == IR_LD_IMM) cinit[d]++;
+                        else cother[d]++;
+                    }
+                int cbest = -1;
+                for (int v = 0; v < f->n_vregs; v++) {
+                    const VReg *vr = &f->vregs[v];
+                    if (vr->width != 2) continue;
+                    if (vr->flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) continue;
+                    if (f->vreg_to_phys[v] != IR_PR_SPILL) continue;
+                    if (cbase[v]) continue;                 /* deref/step base */
+                    if (cstep[v] < 1) continue;             /* actually stepped */
+                    if (cother[v] != 0) continue;           /* only init + steps write it */
+                    if (cinit[v] > 1) continue;             /* one init */
+                    if (use_count[v] < 4) continue;         /* hot, in a loop */
+                    if (cbest < 0 || use_count[v] > use_count[cbest]) cbest = v;
+                }
+                if (cbest >= 0) { f->vreg_to_phys[cbest] = f->idx2_reg; idx2_taken = 1; }
+            }
+            free(cbase); free(cstep); free(cinit); free(cother);
+        }
         /* idx2: ONE width-2 read-only PARAM read inside a loop and still
            spilled — held in the spare index register (f->idx2_reg, opposite
            the frame pointer), read via `push <idx>;pop de` at the compare.
            Gated call/asm/acc-free: those clobber the spare reg (the frame
            reg survives via the prologue push, the spare one doesn't). */
-        if (f->idx2_reg != IR_PR_NONE && !f->uses_acc && !f->is_interrupt) {
+        if (!idx2_taken && f->idx2_reg != IR_PR_NONE && !f->uses_acc && !f->is_interrupt) {
             int idx2_safe = 1;
             for (int i = 0; i < f->n_bbs && idx2_safe; i++)
                 for (int j = 0; j < f->bbs[i].n_ops; j++) {

--- a/src/80cc/ir_build.c
+++ b/src/80cc/ir_build.c
@@ -4732,6 +4732,26 @@ static int build_assign(Builder *b, Node *n)
                 fst->mem.elem = elem_k;
                 return rhs_v;
             }
+            /* Register-float element (`_Float16 a[N]; a[0] = x;` or IEEE-32
+               `float`): convert the RHS to the element's float format — an
+               int RHS becomes the folded float constant, not raw int bits
+               stored as if they were a float. The generic int path below
+               stores the same-width RHS unconverted. */
+            if (is_register_float_kind(elem_k)) {
+                int rhs_v = build_expr(b, n->right);
+                if (rhs_v < 0) return -1;
+                if (node_value_kind(n->right) != elem_k)
+                    rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, elem_k);
+                int faddr = new_temp(b, 2);
+                Op *flea = ir_op_emit(cur_bb(b), IR_LEA);
+                flea->dst = faddr; flea->src[0] = dst_v;
+                Op *fst = ir_op_emit(cur_bb(b), IR_ST_MEM);
+                fst->src[0]   = rhs_v;
+                fst->mem.kind = IR_MEM_VREG;
+                fst->mem.base = faddr;
+                fst->mem.elem = elem_k;
+                return rhs_v;
+            }
             /* Wide long long element (`long long a[N]; a[0] = x;`): widen the
                RHS into the i64 acc and store via IR_ST_MEM's l_i64_store path
                (mirrors the indexed `arr[i] = <long long>` and `*p = <long
@@ -4856,10 +4876,26 @@ static int build_assign(Builder *b, Node *n)
         rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, dst_accum);
         if (rhs_v < 0) return -1;
     }
-    /* Storing an integer into a float lvalue: convert int→float (the
-       front end no longer inserts the cast). No-op for matching kinds. */
-    rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right,
-                n->left->type ? n->left->type->kind : KIND_NONE);
+    /* Storing an integer into a float lvalue: convert int→float (the front
+       end no longer inserts the cast). Derive the destination float kind from
+       the LHS type, unwrapping a folded array/index shape (`f16_arr[0] = 100`
+       leaves n->left->type as KIND_ARRAY, its element in ->ptr) — a deref `*p`
+       already carries the element kind directly. n->type is unreliable here:
+       for a deref store it is the RHS (int) type, which would suppress the
+       conversion and store the raw integer bits. */
+    {
+        Kind ldk = n->left->type ? n->left->type->kind : KIND_NONE;
+        /* Only a folded bare register-float array (`f16_arr[0] = 100` /
+           `f32_arr[0] = 100`, n->left is the bare array var) needs unwrapping
+           to the element here. _Accum / acc-double arrays are already scaled
+           by the dst_accum path above (unwrapping them would double-convert),
+           and a deref `*p` carries its pointee kind with its own store-side
+           conversion. */
+        if (ldk == KIND_ARRAY && n->left->type->ptr
+            && is_register_float_kind(n->left->type->ptr->kind))
+            ldk = n->left->type->ptr->kind;
+        rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, ldk);
+    }
     /* Symmetric: storing a float/double into an integer lvalue
        (`arr[k] = dbl;`, `g = dbl;`). Convert float→long here; the
        per-shape width-coercion below narrows to the element/global width.
@@ -5083,14 +5119,15 @@ static int build_assign(Builder *b, Node *n)
                 op->mem.bank_fn = bf;
                 return rhs_v;
             }
-            /* 4-byte f32 double: a plain 4-byte DEHL value — store all
-               4 bytes. n->type can read back as int for the member
-               shape (elem_w=2 above), which would truncate; force 4.
-               Coerce an INTEGER rhs to f32 (`*p = 5` → 5.0): the raw int
-               vreg stored as 4 bytes is a float denormal (~0), not 5.0.
-               No-op when rhs is already f32. */
-            if (dk == KIND_DOUBLE || dk == KIND_FLOAT) {
-                elem_w = 4;
+            /* Register-float element: a plain 2-byte (f16) or 4-byte (f32)
+               DEHL value — store the whole element. n->type can read back as
+               int for the member shape (elem_w=2 above), which would truncate;
+               force the float width. Coerce an INTEGER rhs to the float format
+               (`*p = 5` → 5.0): the raw int vreg stored as float bits is a
+               denormal (~0) / garbage, not 5.0. No-op when rhs is already that
+               float kind. */
+            if (dk == KIND_DOUBLE || dk == KIND_FLOAT || dk == KIND_FLOAT16) {
+                elem_w = (dk == KIND_FLOAT16) ? 2 : 4;
                 rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, dk);
                 if (rhs_v < 0) return -1;
             }

--- a/src/80cc/ir_build.c
+++ b/src/80cc/ir_build.c
@@ -610,6 +610,7 @@ static const char *float_helper(Kind k, const char *base)
         { "f2ulong", "l_f16_f2ulong", "l_f32_f2ulong" },
         { "ftof16",  NULL,            "l_f32_ftof16"  },
         { "f16tof",  NULL,            "l_f32_f16tof"  },
+        { "invf",    "l_f16_invf",    "l_f32_invf"    },
         { NULL, NULL, NULL }
     };
     int is16 = (k == KIND_FLOAT16);
@@ -946,6 +947,41 @@ static int emit_float_arith(Builder *b, Kind fk, const char *stem,
     HelperInfo *hi = calloc(1, sizeof(HelperInfo));
     hi->name = name; hi->args = args; hi->n_args = 2;
     hi->n_stacked = 1; hi->ret_vreg = dst;
+    op->hcall = hi;
+    return dst;
+}
+
+/* True when `n` is a numeric literal equal to 1 (int `1` or float `1.0`) —
+   the dividend that turns `1.0 / x` into a reciprocal. */
+static int node_is_numeric_one(Node *n)
+{
+    return n && n->ast_type == AST_LITERAL && (double)n->zval == 1.0;
+}
+
+/* Reciprocal-eligible float kinds, mirroring sccz80 zdiv_dconst: the half
+   float and IEEE single ship an inverse helper; the acc-tier 48/64-bit
+   doubles and MBF32 do not, so `1.0/x` stays a full divide there. */
+static int float_reciprocal_ok(Kind fk)
+{
+    if (fk == KIND_FLOAT16) return 1;
+    if (fk == KIND_DOUBLE && c_fp_size == 4 && c_maths_mode == MATHS_IEEE)
+        return 1;
+    return 0;
+}
+
+/* Emit a register-float reciprocal HCALL (l_f{16,32}_invf) computing 1/rv.
+   Unary ABI: operand in HL/DEHL, result in HL/DEHL. Returns the result
+   vreg or -1 if fk has no inverse helper. */
+static int emit_float_reciprocal(Builder *b, Kind fk, int rv)
+{
+    const char *name = float_helper(fk, "invf");
+    if (!name) return -1;
+    int dst = new_temp_kind(b, fk);
+    int *args = calloc(1, sizeof(int)); args[0] = rv;
+    Op *op = ir_op_emit(cur_bb(b), IR_HCALL);
+    op->dst = dst;
+    HelperInfo *hi = calloc(1, sizeof(HelperInfo));
+    hi->name = name; hi->args = args; hi->n_args = 1; hi->ret_vreg = dst;
     op->hcall = hi;
     return dst;
 }
@@ -1672,6 +1708,36 @@ static int build_operand_as_float_reg(Builder *b, Node *node, Kind fk)
     return emit_float_reg_from_int(b, v, fk, uns);
 }
 
+/* Materialise a compile-time float constant (`value`) directly in float kind
+   fk: the FA/IEEE bit pattern as an immediate (f16 / register f32) or a
+   const-pool dload (acc-tier double). Mirrors the AST_LITERAL float path so a
+   CONSTANT int→float conversion folds here instead of a runtime l_f32_sint2f.
+   Returns the vreg, or -1 if fk isn't a register/acc float kind. */
+static int emit_float_const(Builder *b, double value, Kind fk)
+{
+    if (fk == KIND_FLOAT16) {
+        unsigned char fa[8];
+        dofloat(MATHS_IEEE16, value, fa);
+        int fv = new_temp_kind(b, KIND_FLOAT16);
+        ir_emit_ld_imm(cur_bb(b), fv, (int64_t)(((int)fa[1] << 8) | fa[0]));
+        return fv;
+    }
+    if (fk == KIND_DOUBLE) {
+        if (is_register_float_kind(KIND_DOUBLE)) {   /* IEEE-32 / MBF-single */
+            unsigned char fa[8];
+            dofloat(c_maths_mode, value, fa);
+            uint32_t bits = ((uint32_t)fa[3] << 24) | ((uint32_t)fa[2] << 16)
+                          | ((uint32_t)fa[1] << 8)  | (uint32_t)fa[0];
+            int fv = new_temp_kind(b, KIND_DOUBLE);
+            ir_emit_ld_imm(cur_bb(b), fv, (int64_t)bits);
+            return fv;
+        }
+        return emit_pool_load(b, ir_pool_litlab_double((zdouble)value),
+                              c_fp_size, KIND_DOUBLE);   /* 5/6/8-byte double */
+    }
+    return -1;
+}
+
 /* Coerce an already-built value `v` (from `src`) into the float kind `dst_k`
    for an assignment / initialiser / return. Integer source → the right
    int→float conversion (acc or register tier). Same float kind or a
@@ -1684,6 +1750,14 @@ static int coerce_int_to_float_kind(Builder *b, int v, Node *src, Kind dst_k)
     Kind sk = node_value_kind(src);
     if (sk == dst_k) return v;
     int uns = src && src->type && src->type->isunsigned;
+    /* Constant int → register/acc float: fold the conversion at compile time
+       (store the float bit pattern) rather than emit a runtime l_f32_sint2f /
+       int→acc call. `Au[i] = 0` becomes a direct 0.0 store, matching sdcc. */
+    if (src && src->ast_type == AST_LITERAL && kind_is_integer(sk)
+        && (is_register_float_kind(dst_k) || is_acc_float_kind(dst_k))) {
+        int c = emit_float_const(b, (double)src->zval, dst_k);
+        if (c >= 0) return c;
+    }
     if (is_acc_float_kind(dst_k)) {                     /* → 5/6/8-byte double */
         if (sk == KIND_FLOAT16) return emit_acc_from_f16(b, v);
         if (sk == KIND_ACCUM16 || sk == KIND_ACCUM32) return emit_acc_from_accum(b, v, sk);
@@ -1789,9 +1863,19 @@ static int build_float_compound(Builder *b, Node *n, const char *stem)
     Node *lvn = n->left->operand;
     int fw = width_for_kind(fk);
     Kind elem = is_acc ? KIND_DOUBLE : (fw == 2) ? KIND_INT : KIND_LONG;
+    /* For a commutative register-float op (`acc += x`, `acc *= x`) put the
+       rhs — built first, typically a call/mul result — in the STACKED slot
+       so the lowerer can push it to the data stack inline (Lever A), and
+       the freshly-loaded accumulator in the DEHL/reg slot. Matches sccz80's
+       staging; without it the rhs is spilled to a frame slot and reloaded.
+       Acc tier (FA model) keeps lhs-first — it doesn't use the DEHL stack. */
+    int fc_commutative = !is_acc
+        && (!strcmp(stem, "add") || !strcmp(stem, "mul"))
+        && getenv("IR_NO_F32_STACK_ARG") == NULL;
     #define COMPOUND_ARITH(LV) (is_acc \
         ? emit_acc_binop(b, stem, (LV), rv) \
-        : emit_float_arith(b, fk, stem, (LV), rv))
+        : fc_commutative ? emit_float_arith(b, fk, stem, rv, (LV)) \
+                         : emit_float_arith(b, fk, stem, (LV), rv))
 
     int rv = build_expr(b, n->right);
     if (rv < 0) return -1;
@@ -2506,6 +2590,22 @@ static int build_muldiv_float(Builder *b, Node *n, int *handled)
     Kind rk = n->right && n->right->type ? n->right->type->kind : KIND_NONE;
     if (n->ast_type != OP_MULT && n->ast_type != OP_DIV)
         return build_fail("float op %d not yet supported", (int)n->ast_type);
+    /* `1.0 / x` → reciprocal(x): a float divide is reciprocal-then-multiply,
+       so a unit numerator lets us call the inverse helper directly and skip
+       the trailing multiply-by-one (and the 1.0 operand load). Only where a
+       register-float inverse helper exists (see float_reciprocal_ok). */
+    if (n->ast_type == OP_DIV && node_is_numeric_one(n->left)) {
+        Kind rfk = (n->type && kind_is_floating(n->type->kind))
+                     ? n->type->kind
+                 : is_register_float_kind(rk) ? rk : KIND_NONE;
+        if (float_reciprocal_ok(rfk)) {
+            int r = build_operand_as_float_reg(b, n->right, rfk);
+            if (r < 0) return build_fail("reciprocal: divisor not promotable");
+            int dst = emit_float_reciprocal(b, rfk, r);
+            if (dst < 0) return build_fail("reciprocal emit failed");
+            return dst;
+        }
+    }
     /* 5/6-byte double mul/div → wide-accumulator op. */
     if (is_acc_float_kind(lk) && lk == rk) {
         int l = build_expr(b, n->left);
@@ -4587,9 +4687,14 @@ static int build_assign(Builder *b, Node *n)
         && ((Kind)n->left->sym->type == KIND_ACCUM16
          || (Kind)n->left->sym->type == KIND_ACCUM32))
         dst_accum = (Kind)n->left->sym->type;
-    if (n->left->ast_type == OP_DEREF
-        && n->left->type
-        && n->left->type->kind == KIND_PTR
+    /* Any pointer/array-to-_Accum address LHS: `*p` (OP_DEREF), `a[i]`
+       (OP_ADD address, type KIND_PTR) AND a global _Accum array index
+       (type KIND_ARRAY, element in ->ptr). Without these, `acc_arr[i] = 5`
+       built the int literal unscaled (no _Accum hint) and stored the raw
+       integer — reading back ~0. */
+    if (n->left->type
+        && (n->left->type->kind == KIND_PTR
+            || n->left->type->kind == KIND_ARRAY)
         && n->left->type->ptr
         && (n->left->type->ptr->kind == KIND_ACCUM16
          || n->left->type->ptr->kind == KIND_ACCUM32))
@@ -4742,6 +4847,15 @@ static int build_assign(Builder *b, Node *n)
               ? build_expr_hinted(b, n->right, rhs_hint)
               : build_expr(b, n->right);
     if (rhs_v < 0) return -1;
+    /* Non-literal int RHS into an _Accum lvalue (`acc_arr[i] = intvar`):
+       scale it to fixed-point. The hint above only scales LITERALS; a
+       variable needs the runtime int→_Accum conversion, and the coerce
+       below keys off n->left->type (KIND_PTR/ARRAY for an indexed store,
+       not the _Accum kind) so it would miss. No-op if already _Accum. */
+    if (dst_accum != KIND_NONE && rhs_hint < 0) {
+        rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, dst_accum);
+        if (rhs_v < 0) return -1;
+    }
     /* Storing an integer into a float lvalue: convert int→float (the
        front end no longer inserts the cast). No-op for matching kinds. */
     rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right,
@@ -4955,7 +5069,12 @@ static int build_assign(Builder *b, Node *n)
                        && n->left->type->ptr)
                         ? n->left->type->ptr->kind : KIND_NONE;
             if (is_acc_float_kind(dk)) {
-                /* `*p = X` wide double store via dstore. */
+                /* `*p = X` wide double store via dstore. Coerce an INTEGER
+                   rhs to the acc-double (`*p = 5` → 5.0): without it the raw
+                   int vreg is dstore'd as garbage. No-op when already a
+                   double. */
+                rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, dk);
+                if (rhs_v < 0) return -1;
                 Op *op = ir_op_emit(cur_bb(b), IR_ST_MEM);
                 op->src[0]   = rhs_v;
                 op->mem.kind = IR_MEM_VREG;
@@ -4966,9 +5085,15 @@ static int build_assign(Builder *b, Node *n)
             }
             /* 4-byte f32 double: a plain 4-byte DEHL value — store all
                4 bytes. n->type can read back as int for the member
-               shape (elem_w=2 above), which would truncate; force 4. */
-            if (dk == KIND_DOUBLE || dk == KIND_FLOAT)
+               shape (elem_w=2 above), which would truncate; force 4.
+               Coerce an INTEGER rhs to f32 (`*p = 5` → 5.0): the raw int
+               vreg stored as 4 bytes is a float denormal (~0), not 5.0.
+               No-op when rhs is already f32. */
+            if (dk == KIND_DOUBLE || dk == KIND_FLOAT) {
                 elem_w = 4;
+                rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, dk);
+                if (rhs_v < 0) return -1;
+            }
             if (is_acc_int_kind(dk)) {
                 /* `*p = X` wide long long store via l_i64_store. */
                 rhs_v = promote_to_acc_int(b, rhs_v,
@@ -5087,8 +5212,26 @@ static int build_assign(Builder *b, Node *n)
                        && (kind_is_floating(n->left->type->kind)
                            || n->left->type->kind == KIND_LONGLONG))
                         ? n->left->type->kind : KIND_NONE;
+            /* A double/ll *array* lvalue reads back as KIND_ARRAY/KIND_PTR
+               with the element float/ll kind on ->ptr, and n->type can be
+               int (`da[i] = 100`). Follow the pointee so the coercion below
+               fires — else the raw int is stored into the wide slot. */
+            if (vk == KIND_NONE && n->left->type
+                && (n->left->type->kind == KIND_PTR
+                    || n->left->type->kind == KIND_ARRAY)
+                && n->left->type->ptr
+                && (kind_is_floating(n->left->type->ptr->kind)
+                    || n->left->type->ptr->kind == KIND_LONGLONG))
+                vk = n->left->type->ptr->kind;
             if (is_acc_float_kind(vk) || vk == KIND_DOUBLE
                 || vk == KIND_FLOAT) {
+                /* Coerce an INTEGER rhs to the float kind (`o[i] = 0` →
+                   0.0): without it the raw int vreg (width 2) is stored as
+                   the 4-byte value, writing only 2 bytes and leaving the
+                   double's high half stale. No-op when rhs is already that
+                   float kind (`o[i] = 1.0`). */
+                rhs_v = coerce_int_to_float_kind(b, rhs_v, n->right, vk);
+                if (rhs_v < 0) return -1;
                 Op *op = ir_op_emit(cur_bb(b), IR_ST_MEM);
                 op->src[0]   = rhs_v;
                 op->mem.kind = IR_MEM_VREG;

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -686,6 +686,14 @@ static int f32_stack_arg_on;
    ld l,c / ld e,c emit. */
 static int sp_rel_max(const Func *f);
 
+/* Set by lower_func's lookahead (fp-mode only): the trailing `ld bc,hl`
+   cache-maintenance in store_dehl's FP path is dead — the next op clobbers
+   BC and doesn't read this value, so the BC=low invariant can never be used
+   before it's destroyed. store_dehl skips the `ld bc,hl`; store_dehl_cached
+   then leaves the value in its slot (no DEHL-cache claim), so a later read
+   reloads directly via (ix+d). */
+static int cur_store_dehl_bc_dead;
+
 /* Walk a multi-byte slot via (hl), loading/storing one byte and advancing
    to the next — except the final byte (last=1), which is not followed by
    an advance. On gbz80 a non-final byte uses the native post-increment
@@ -1079,8 +1087,11 @@ static void load_to_de(FILE *out, const Func *f, int vreg_id)
        (e.g. a compare result cached in HL with no slot) has
        vreg_spill_slot == -1, and slot_ix_off would then synthesise a bogus
        below-frame offset (`ld de,(ix-9)`). It must fall through to the
-       HL/cache paths below. */
+       HL/cache paths below. Also skip when the value is already live in HL:
+       the ex de,hl path below is a register move, cheaper than the 6-byte
+       (ix±d) slot read — HL-preservation is moot when HL holds this vreg. */
     if (fp_active(f) && f->vregs[vreg_id].width == 2
+        && rs.hl != vreg_id
         && f->vreg_spill_slot && f->vreg_spill_slot[vreg_id] >= 0) {
         /* Deepest slot at TOS: pop de;push de beats synthetic ld de,(ix+d)
            and likewise preserves HL. By-coincidence only. */
@@ -1757,10 +1768,13 @@ static void store_dehl(FILE *out, const Func *f, int vreg_id)
         if (fp_offset_fits(ix_off) && fp_offset_fits(ix_off + 3)) {
             emit(out, "ld\t(%s%+d),hl", frame_reg(), ix_off);
             emit(out, "ld\t(%s%+d),de", frame_reg(), ix_off + 2);
-            /* DEHL cache contract: BC = low half after store_dehl.
-               Subsequent load_to_dehl_adj on a cache hit recovers HL
-               via `ld hl,bc` — needs BC. */
-            emit(out, "ld\tbc,hl");
+            /* DEHL cache contract: BC = low half after store_dehl, so a
+               later load_to_dehl_adj cache hit recovers HL via `ld hl,bc`.
+               Dead when the next op clobbers BC before any such hit —
+               store_dehl_cached then drops the cache claim so reads reload
+               via (ix+d). */
+            if (!cur_store_dehl_bc_dead)
+                emit(out, "ld\tbc,hl");
             return;
         }
     }
@@ -1819,9 +1833,18 @@ static void store_dehl(FILE *out, const Func *f, int vreg_id)
    `ld l,c; ld h,b`. */
 static void store_dehl_cached(FILE *out, const Func *f, int vreg_id)
 {
+    int bc_dead = cur_store_dehl_bc_dead;
     store_dehl(out, f, vreg_id);
     invalidate_hl_cache();
-    cache_dehl(vreg_id);
+    if (bc_dead) {
+        /* store_dehl skipped the `ld bc,hl`, so BC != low — don't claim a
+           DEHL cache that a later hit would recover via `ld hl,bc`. The
+           value is safely in the slot; reads reload via (ix+d). */
+        rs.bc = -1;
+        rs.dehl = -1;
+    } else {
+        cache_dehl(vreg_id);
+    }
 }
 
 /* Forward decl: defined with the rest of the per-op lookahead state.
@@ -8022,6 +8045,19 @@ static int gen_acc_unop(FILE *out, Func *f, const Op *op)
     return 0;
 }
 
+/* True if args[idx]'s vreg is loaded again by a later operand — then its
+   DEHL cache (BC=low) may be recovered via a cache-hit `ld hl,bc`, so the
+   BC-stash must be kept. Otherwise the stash is dead (the call clobbers BC
+   before any re-read). */
+static int hcall_vreg_used_after(const HelperInfo *hi, int idx)
+{
+    int v = hi->args[idx];
+    if (v < 0) return 0;
+    for (int k = idx + 1; k < hi->n_args; k++)
+        if (hi->args[k] == v) return 1;
+    return 0;
+}
+
 static int gen_hcall(FILE *out, Func *f, const Op *op)
 {
     HelperInfo *hi = op->hcall;
@@ -8068,6 +8104,11 @@ static int gen_hcall(FILE *out, Func *f, const Op *op)
             continue;
         }
         if (w == 4) {
+            /* The helper clobbers BC, so this operand's DEHL BC=low stash is
+               dead unless the same vreg is re-loaded as a later operand.
+               (frameix: drops the trailing `ld bc,hl`; sp-mode byte-walk is
+               unaffected — its BC=low is inherent.) */
+            cur_load_to_dehl_no_bc = !hcall_vreg_used_after(hi, i);
             load_to_dehl(out, f, v);
             emit(out, "push\tde");
             emit(out, "push\thl");
@@ -8086,8 +8127,14 @@ static int gen_hcall(FILE *out, Func *f, const Op *op)
     if (n_regs >= 1) {
         int v = hi->args[n_stacked];
         int w = (v >= 0) ? f->vregs[v].width : 2;
-        if (w == 4) load_to_dehl(out, f, v);
-        else        load_to_hl(out, f, v);
+        if (w == 4) {
+            /* Last operand loaded before the call → its BC=low stash is
+               always dead (nothing re-reads it; the call clobbers BC). */
+            cur_load_to_dehl_no_bc = 1;
+            load_to_dehl(out, f, v);
+        } else {
+            load_to_hl(out, f, v);
+        }
     }
     emit(out, "call\t%s", hi->name);
     cur_sp_adjust -= popped_bytes;
@@ -8829,13 +8876,19 @@ static int gen_cmp_eq_ne(FILE *out, Func *f, const Op *op)
             emit(out, "xor\t(hl)");
             emit(out, "or\tc");
         } else {
-            /* RHS already in DEHL cache or FP-mode: load both and
-               XOR through registers. Less common. */
-            load_to_dehl(out, f, op->src[1]);
+            /* Both operands in registers / FP-mode: stage one, load the
+               other, XOR through registers. Push whichever is currently
+               DEHL-cached FIRST — a register-only operand has no coherent
+               slot, so loading the other would clobber it beyond recovery
+               (frameix long-compare of a just-loaded temp vs a slot value).
+               The XOR/OR chain is symmetric, so operand order is irrelevant. */
+            int pushed = dehl_has(op->src[0]) ? op->src[0] : op->src[1];
+            int loaded = (pushed == op->src[0]) ? op->src[1] : op->src[0];
+            load_to_dehl(out, f, pushed);
             emit(out, "push\tde");
             emit(out, "push\thl");
-            load_to_dehl_adj(out, f, op->src[0], 4);
-            emit(out, "pop\tbc");          /* BC = RHS low */
+            load_to_dehl_adj(out, f, loaded, 4);
+            emit(out, "pop\tbc");          /* BC = pushed operand low */
             emit(out, "ld\ta,l");
             emit(out, "xor\tc");
             emit(out, "ld\tc,a");
@@ -9845,6 +9898,11 @@ static int nxt_first_dehl_src(const Op *nxt)
            the push captures DEHL directly, no intermediate slot
            write. */
         return 0;
+    case IR_MOV:
+        /* A width-4 MOV copies src[0] via load_to_dehl (cache hit off the
+           producer). When src is dead here, the producer's store is dead —
+           the MOV does the single store to its own dst. */
+        return 0;
     default:
         return -1;
     }
@@ -10806,6 +10864,36 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
                (`ld l,c; ld h,b`) — no slot read, no register clobber. */
             cur_dehl_dst_dead_safe = 0;
             cur_dehl_dst_no_bc_stash = 0;
+            /* FP-mode: the trailing `ld bc,hl` DEHL-cache maintenance in a
+               width-4 store is dead when, scanning forward in the BB, the
+               value's BC=low invariant is clobbered before any op reads it
+               back — i.e. the first event touching it is a call/hcall/asm
+               (clobbers BC) or another width-4 result (re-caches DEHL, its
+               own `ld bc,hl` overwrites BC), not a read. Eliding is always
+               correct: store_dehl_cached drops the cache claim, so a later
+               read reloads via (ix+d) rather than a stale cache hit. */
+            cur_store_dehl_bc_dead = 0;
+            if (fp_active(f) && op->dst >= 0
+                && f->vregs[op->dst].width == 4) {
+                int V = op->dst;
+                for (int k = j + 1; k < bb->n_ops; k++) {
+                    const Op *ko = &bb->ops[k];
+                    int uses[16];
+                    int nu = ir_op_uses(ko, uses,
+                                (int)(sizeof uses / sizeof uses[0]));
+                    int reads_v = 0;
+                    for (int u = 0; u < nu; u++)
+                        if (uses[u] == V) { reads_v = 1; break; }
+                    if (reads_v) break;           /* read first → maint may hit */
+                    if (ko->kind == IR_CALL || ko->kind == IR_HCALL
+                        || ko->kind == IR_ASM
+                        || (ko->dst >= 0 && ko->dst < f->n_vregs
+                            && f->vregs[ko->dst].width == 4)) {
+                        cur_store_dehl_bc_dead = 1;   /* clobbered before read */
+                        break;
+                    }
+                }
+            }
             /* FP byte-direct chain narrow: when the next op is a long
                binop with dst as either src (commutative byte-direct
                chain picks whichever is in the DEHL cache), the chain
@@ -10833,12 +10921,29 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
                 && f->vregs[op->dst].width == 4
                 && j + 1 < bb->n_ops) {
                 const Op *nxt = &bb->ops[j + 1];
+                /* Unary HCALL consumer (e.g. l_f32_invf reciprocal): its one
+                   width-4 operand is loaded via load_to_dehl → a cache hit off
+                   this dying producer, so the slot store is dead. Kills the
+                   sint2f→invf double-store in `1.0/x`. HCALL operands live in
+                   hi->args, not nxt->src[]. */
+                if (nxt->kind == IR_HCALL && nxt->hcall
+                    && nxt->hcall->n_args == 1 && nxt->hcall->args
+                    && nxt->hcall->args[0] == op->dst) {
+                    cur_dehl_dst_dead_safe = 1;
+                }
                 int pos = nxt_first_dehl_src(nxt);
-                if (pos >= 0 && nxt->src[pos] == op->dst) {
+                if (!cur_dehl_dst_dead_safe && pos >= 0 && nxt->src[pos] == op->dst) {
                     switch (nxt->kind) {
                     case IR_ST_MEM:
                     case IR_NEG: case IR_NOT:
                     case IR_PUSH_DEHL_LONG:
+                        cur_dehl_dst_dead_safe = 1;
+                        break;
+                    case IR_MOV:
+                        /* Copy of a dying width-4 producer: skip the
+                           producer's slot store; the MOV reads it from the
+                           DEHL cache and does the one store (kills the
+                           `acc += x` compound-assign double-store). */
                         cur_dehl_dst_dead_safe = 1;
                         break;
                     case IR_ADD:
@@ -10900,6 +11005,38 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
                         break;
                     default: break;
                     }
+                }
+            }
+            /* HCALL producer → unary HCALL consumer: an HCALL's width-4
+               result whose sole remaining use is the immediately-following
+               unary HCALL (e.g. sint2f→invf in `1.0/x`) stays in the DEHL
+               cache for that consumer, so the result's slot store is dead.
+               The producer's dst lives in hcall->ret_vreg (not op->dst), so
+               the cur_dst_dead paths above never reach it. */
+            if (!cur_dehl_dst_dead_safe
+                && op->kind == IR_HCALL && op->hcall
+                && op->hcall->ret_vreg >= 0
+                && f->vregs[op->hcall->ret_vreg].width == 4
+                && !(f->vregs[op->hcall->ret_vreg].flags
+                     & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE))
+                && j + 1 < bb->n_ops) {
+                int rv = op->hcall->ret_vreg;
+                const Op *nxt = &bb->ops[j + 1];
+                if (nxt->kind == IR_HCALL && nxt->hcall
+                    && nxt->hcall->n_args == 1 && nxt->hcall->args
+                    && nxt->hcall->args[0] == rv
+                    && !(bb->live_out
+                         && ir_bitset_get((const BitSet *)bb->live_out, rv))) {
+                    /* rv must have no other use past the consumer in this BB. */
+                    int used_later = 0;
+                    for (int k = j + 2; k < bb->n_ops && !used_later; k++) {
+                        int uses[16];
+                        int nu = ir_op_uses(&bb->ops[k], uses,
+                                            (int)(sizeof uses / sizeof uses[0]));
+                        for (int u = 0; u < nu; u++)
+                            if (uses[u] == rv) { used_later = 1; break; }
+                    }
+                    if (!used_later) cur_dehl_dst_dead_safe = 1;
                 }
             }
 

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -5498,6 +5498,12 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
         if (src_w == 1) {
             load_byte_to_a(out, f, op->src[0]);
             emit(out, "ld\te,a");           /* stash byte across HL load */
+            /* E (DE's low half) is now the store value, NOT whatever vreg the
+               DE cache believed it held — e.g. an `arr[i]=v` store right after
+               `&arr + i` left i cached in DE. Drop the belief or the next read
+               of that vreg picks up the store value. (gbz80 miscompiled
+               `a[i]=0; b[i]=(char)(i+1)` — the i+1 read `ld a,e` saw 0.) */
+            invalidate_de_cache();
             load_to_hl(out, f, op->mem.base);
             emit_hl_add_offset(out, op->mem.offset, 1);
             emit(out, "ld\t(hl),e");

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -671,6 +671,12 @@ static int cur_dehl_inline_push;         /* vreg pushed inline, -1=none */
 static int cur_dehl_inline_push_base_sp; /* cur_sp_adjust at push time */
 static int cur_dehl_push_to_stack;       /* one-shot flag: set by lookahead */
 
+/* Lever A: push a width-4 call/op result straight to the data stack when
+   its sole use is the stacked operand of a later HCALL (l_f32_mul etc.),
+   instead of spilling to a frame slot and reloading. Off via
+   IR_NO_F32_STACK_ARG. */
+static int f32_stack_arg_on;
+
 /* Load a PR_BC vreg's slot value into BC. Used both by the prologue
    (function entry) and by on-demand reload sites — when a PR_BC vreg
    is read but `rs.bc` holds a different occupant, the reader
@@ -1868,6 +1874,28 @@ static int vreg_is_pr_dehl(const Func *f, int v);
    has determined that the slot write would be dead (cur_dehl_dst_dead
    _safe), we emit the 2-instruction `ld b,h; ld c,l + cache` shape
    instead of the full 11-instruction store_dehl. */
+/* Push a width-4 result (in DEHL) to the data stack instead of a frame
+   slot. `ld bc,hl` stashes the low half so the pushed image is [low][high]
+   (low on top) — identical to a normal stacked-arg push — and the DEHL
+   cache invariant (BC=low) holds after cache_dehl. Records the pending
+   push for the consumer (a long bitop's fused-(hl) path, or gen_hcall's
+   stacked-arg skip). */
+static void emit_dehl_stack_push(FILE *out, int vreg_id)
+{
+    emit(out, "ld\tbc,hl");
+    emit(out, "push\tde");
+    emit(out, "push\tbc");
+    cur_sp_adjust += 4;
+    cur_dehl_inline_push = vreg_id;
+    cur_dehl_inline_push_base_sp = cur_sp_adjust;
+    /* HL was consumed producing the value; any prior tenant claim is
+       stale. Claim HL for OUR low half so the next op doesn't treat the
+       value as an address. */
+    invalidate_hl_cache();
+    hl_about_to_change(vreg_id);
+    cache_dehl(vreg_id);
+}
+
 static void store_dehl_finalize(FILE *out, const Func *f, int vreg_id)
 {
     if (cur_dehl_dst_dead_safe || vreg_is_pr_dehl(f, vreg_id)) {
@@ -1875,25 +1903,7 @@ static void store_dehl_finalize(FILE *out, const Func *f, int vreg_id)
     } else if (cur_dehl_push_to_stack
                && cur_dehl_inline_push < 0
                && cur_stack_long_top < 0) {
-        /* Push to data stack instead of writing to frame slot.
-           Result is in DEHL (D=b3, E=b2, H=b1, L=b0).
-           ld bc,hl stashes the low half into BC so the DEHL cache
-           invariant (BC=low) holds after cache_dehl. */
-        emit(out, "ld\tbc,hl");
-        emit(out, "push\tde");
-        emit(out, "push\tbc");
-        cur_sp_adjust += 4;
-        cur_dehl_inline_push = vreg_id;
-        cur_dehl_inline_push_base_sp = cur_sp_adjust;
-        /* HL was consumed producing the value (e.g. the long
-           indirect-load byte walk ran the BASE pointer through HL) —
-           any prior tenant claim is stale. HL now holds OUR low
-           half; claim it, else the next op's hl_has(base) hit
-           operates on the value as an address (r7: ADD base+4
-           computed value+4 after this push staging). */
-        invalidate_hl_cache();
-        hl_about_to_change(vreg_id);
-        cache_dehl(vreg_id);
+        emit_dehl_stack_push(out, vreg_id);
     } else {
         store_dehl_cached(out, f, vreg_id);
     }
@@ -7699,9 +7709,18 @@ static int gen_call(FILE *out, Func *f, const Op *op)
             emit_acc_store_hl(out, f, ci->ret_vreg);
             invalidate_hl_cache();
             *wide_acc_cell(f, ci->ret_vreg) = ci->ret_vreg;
-        } else if (ret_w == 4)
-            store_dehl_cached(out, f, ci->ret_vreg);
-        else if (ret_w == 1) {
+        } else if (ret_w == 4) {
+            /* Lever A: a width-4 result feeding a later HCALL's stacked
+               arg is pushed straight to the data stack (the lookahead set
+               cur_dehl_push_to_stack) rather than spilled to its slot. */
+            if (cur_dehl_push_to_stack && cur_dehl_inline_push < 0
+                && cur_stack_long_top < 0 && !cur_dehl_dst_dead_safe
+                && !vreg_is_pr_dehl(f, ci->ret_vreg))
+                emit_dehl_stack_push(out, ci->ret_vreg);
+            else
+                store_dehl_cached(out, f, ci->ret_vreg);
+            cur_dehl_push_to_stack = 0;
+        } else if (ret_w == 1) {
             /* Byte return: the value is in HL (low byte in L, char-
                widened by the callee). store_hl writes 2 bytes and would
                overrun a 1-byte slot, so store the low byte via A. */
@@ -8038,6 +8057,17 @@ static int gen_hcall(FILE *out, Func *f, const Op *op)
     for (int i = 0; i < n_stacked; i++) {
         int v = hi->args[i];
         int w = (v >= 0) ? f->vregs[v].width : 2;
+        /* Lever A: this stacked arg was already pushed to the data stack
+           at its production (cur_dehl_inline_push). Its pushed image is
+           [low][high] — exactly a normal stacked arg — and sits topmost
+           (the lookahead barred any intervening push, and !hc_bc_saved).
+           Skip the reload+push; the helper still pops it (popped_bytes). */
+        if (w == 4 && v >= 0 && v == cur_dehl_inline_push && !hc_bc_saved
+            && cur_sp_adjust == cur_dehl_inline_push_base_sp) {
+            cur_dehl_inline_push = -1;
+            popped_bytes += 4;
+            continue;
+        }
         if (w == 4) {
             load_to_dehl(out, f, v);
             emit(out, "push\tde");
@@ -9978,6 +10008,7 @@ int ir_lower_func(FILE *out, Func *f)
        identical-to-pre-lazy-spill lowering for A/B + bisecting). */
     lazy_spill_on = getenv("IR_NO_LAZY_SPILL") == NULL;
     int want_lazy = lazy_spill_on;
+    f32_stack_arg_on = getenv("IR_NO_F32_STACK_ARG") == NULL;
 
     /* No function label here — the surrounding legacy scaffolding
        (declparse.c + codegen.c) already emits `._<name>`. The render
@@ -10923,6 +10954,75 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
                     if (is_bitop && w4 && dst_in_src0
                         && other_at_km1 && other_dies)
                         cur_dehl_push_to_stack = 1;
+                }
+            }
+
+            /* Lever A (f32 stacked-arg residency): a width-4 result whose
+               SOLE in-BB use is the stacked operand of a later HCALL
+               (l_f32_mul etc.) is pushed to the data stack at production
+               (2 instr) instead of a frame-slot spill+reload (~19), and
+               gen_hcall skips its push. Unlike the chain-OR block above —
+               which bails on an intervening call — the target here is the
+               `t=call(); ...; hcall(t, x)` straddle. Gated on no PR_BC
+               (else gen_hcall's bc-save lands atop the staged arg) and no
+               call/hcall/push between (keeps it topmost at a fixed sp). */
+            /* A pending inline push normally blocks a second (one data-stack
+               slot at a time), but CHAINED pushes are fine when THIS op
+               consumes the pending one as its own stacked arg before
+               producing its result — e.g. `p = mul(a,b); s = add(p,c)`:
+               the mul consumes a's push, then its result p is pushed for
+               the add. Allow it when op is that consuming HCALL. */
+            int pending_ok = (cur_dehl_inline_push < 0);
+            if (!pending_ok && op->kind == IR_HCALL && op->hcall
+                && op->hcall->args)
+                for (int a = 0; a < op->hcall->n_stacked; a++)
+                    if (op->hcall->args[a] == cur_dehl_inline_push) {
+                        pending_ok = 1; break;
+                    }
+            if (f32_stack_arg_on
+                && !cur_dehl_push_to_stack
+                && !fp_active(f)
+                && !func_has_pr_bc(f)
+                && !cur_dehl_dst_dead_safe
+                && op->dst >= 0
+                && f->vregs[op->dst].width == 4
+                && !vreg_is_pr_dehl(f, op->dst)
+                && cur_stack_long_top < 0
+                && pending_ok
+                && !(bb->live_out
+                     && ir_bitset_get((const BitSet *)bb->live_out, op->dst))) {
+                int consumer = -1, ok = 1;
+                for (int k = j + 1; k < bb->n_ops && ok; k++) {
+                    const Op *ko = &bb->ops[k];
+                    int uses[16];
+                    int nu = ir_op_uses(ko, uses,
+                                (int)(sizeof uses / sizeof uses[0]));
+                    for (int u = 0; u < nu && ok; u++) {
+                        if (uses[u] != op->dst) continue;
+                        if (consumer >= 0) { ok = 0; break; }
+                        consumer = k;
+                    }
+                    /* Any data-stack push before the consumer would leave
+                       the staged arg no longer topmost. */
+                    if (consumer < 0
+                        && (ko->kind == IR_CALL || ko->kind == IR_HCALL
+                            || ko->kind == IR_PUSH_DEHL_LONG))
+                        ok = 0;
+                }
+                if (ok && consumer >= 0) {
+                    const Op *ko = &bb->ops[consumer];
+                    if (ko->kind == IR_HCALL && ko->hcall
+                        && ko->hcall->n_stacked == 1
+                        && ko->hcall->n_args >= 1
+                        && ko->hcall->args
+                        && ko->hcall->args[0] == op->dst) {
+                        int also_reg = 0;
+                        for (int a = ko->hcall->n_stacked;
+                             a < ko->hcall->n_args; a++)
+                            if (ko->hcall->args[a] == op->dst) also_reg = 1;
+                        if (!also_reg)
+                            cur_dehl_push_to_stack = 1;
+                    }
                 }
             }
 

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -5425,6 +5425,45 @@ static int gen_ld_mem(FILE *out, Func *f, const Op *op)
     return -1;
 }
 
+/* Store a folded constant (const_fold set src[0]=-1) of `w` bytes little-endian
+   at (HL), walking HL to base+w-1 (caller invalidates the HL cache). On gbz80 an
+   all-equal-byte value (e.g. 0 / 0L) loads A once and stores via `ld (hl+),a`
+   (cheaper than repeated `ld (hl),n`). Shared by the MEM_VREG and MEM_SYM folded
+   paths; w is 1/2/4 (long) — never a float/double (const_fold gates elem). */
+static void emit_folded_imm_store(FILE *out, int w, uint32_t v)
+{
+    if (IS_GBZ80() && w >= 2) {
+        int same = 1;
+        for (int i = 1; i < w; i++)
+            if (((v >> (8 * i)) & 0xff) != (v & 0xff)) { same = 0; break; }
+        if (same) {
+            emit(out, "ld\ta,%d", (int)(v & 0xff));
+            for (int i = 0; i < w - 1; i++) emit(out, "ld\t(hl+),a");
+            emit(out, "ld\t(hl),a");
+            invalidate_a_cache();
+            return;
+        }
+    }
+    for (int i = 0; i < w; i++) {
+        emit(out, "ld\t(hl),%d", (int)((v >> (8 * i)) & 0xff));
+        if (i < w - 1) emit(out, "inc\thl");
+    }
+}
+
+/* May ir_opt_const_fold rewrite a constant store of `width` bytes into the
+   immediate form? Byte (`ld (hl),n`) exists and wins on EVERY target (drops the
+   value register — no A/E clobber, no DE-cache invalidation — and is compact),
+   so it always fires. Word (`ld (hl),lo; inc hl; ld (hl),hi`, leaving PR_DE
+   free) is only a win where the register path isn't already cheap: excludes
+   ez80/kc160 (native ld (ix+d),rr + cheap slot reloads), Rabbit, and 8085 (SHLX
+   `ld (de),hl` stores a word in one op). Consulted before the fold, so non-listed
+   targets never see the word imm form (their word-store codegen is unchanged). */
+int ir_cpu_const_store_ok(int width)
+{
+    if (width == 1) return 1;                       /* byte: everywhere */
+    return !IS_RABBIT() && !IS_EZ80() && !IS_KC160() && !IS_8085();
+}
+
 static int gen_st_mem(FILE *out, Func *f, const Op *op)
 {
     emit_ns_switch(out, mem_bank_fn(&op->mem));   /* __addressmod: page in */
@@ -5448,6 +5487,20 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
         return 0;
     }
     if (op->mem.kind == IR_MEM_SYM) {
+        /* Constant value folded into op->imm (const_fold marks src[0]=-1 on a
+           MEM_VREG store; a later pass may fold its &sym+const base into this
+           MEM_SYM form, carrying the marker along). Store the immediate direct
+           — width from mem.elem, NOT the (now absent) value vreg. */
+        if (op->src[0] < 0) {
+            int w = kind_scalar_width(op->mem.elem);
+            const char *s = ir_sym_name(op->mem.sym);
+            int off = op->mem.offset;
+            if (off) emit(out, "ld\thl,_%s+%d", s, off);
+            else     emit(out, "ld\thl,_%s", s);
+            emit_folded_imm_store(out, w, (uint32_t)op->imm);
+            invalidate_hl_cache();
+            return 0;
+        }
         int src_w = (op->src[0] >= 0)
                   ? f->vregs[op->src[0]].width : 2;
         if (src_w == 4) {
@@ -5493,6 +5546,18 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
         return 0;
     }
     if (op->mem.kind == IR_MEM_VREG) {
+        /* Constant value folded into op->imm by ir_opt_const_fold. Store the
+           immediate straight to memory — no value register, no A/E clobber, no
+           DE-cache drop (leaves PR_DE free). Width (1/2/4) from mem.elem. */
+        if (op->src[0] < 0) {
+            int w = kind_scalar_width(op->mem.elem);
+            load_to_hl(out, f, op->mem.base);
+            emit_hl_add_offset(out, op->mem.offset, 1);  /* use BC scratch → keep DE */
+            emit_folded_imm_store(out, w, (uint32_t)op->imm);
+            if (w > 1 || op->mem.offset != 0)
+                invalidate_hl_cache();
+            return 0;
+        }
         /* Indirect store: load value (DE), load address (HL), store. */
         int src_w = f->vregs[op->src[0]].width;
         if (src_w == 1) {

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -1322,6 +1322,12 @@ static int cur_func_ehome = -1; /* this function's PR_E/PR_D vreg, or -1 */
    back-edge). -1 = no such loop in this function. */
 static int cur_home_region_lo = -1;
 static int cur_home_region_hi = -1;
+/* Word DE-home only: the id of a dedicated loop-exit block (reached ONLY from
+   the resident region) at whose entry the home is flushed ONCE — hoisting the
+   flush off the per-iteration header path. -1 = not applicable (multi-target
+   exit, non-fp, or a slot too far for ix-relative store) → fall back to the
+   per-iter header flush. */
+static int cur_home_exit_flush_bb = -1;
 
 /* Load 8-bit value from a vreg's frame slot into A. Cache-aware:
    if A already holds the wanted vreg (set by a prior IR_LD_MEM_VREG
@@ -2060,6 +2066,63 @@ static int cmp_bytewise_ok(const Func *f, const Op *o)
     return cmp_bytewise_shape_ok(f, o);
 }
 
+/* Slot-vs-slot unsigned word compare lowered byte-wise through A
+   (`ld a,(ix+lo0); sub (ix+lo1); ld a,(ix+hi0); sbc a,(ix+hi1)`) instead of two
+   synthetic ix pair-loads + `sbc hl,de`. fp only; 12B/76T vs 15B/95T AND
+   DE/BC/HL-clean, so a word DE-home rides through a mem-vs-mem loop test (the
+   matrix/struct/deref inner-pointer compare `p < end`). ULT/UGE, both operands
+   in ix-addressable slots. The BC-resident LHS case is cmp_bytewise_shape_ok;
+   this is the both-in-frame case. */
+static int cmp_bytewise_mem_shape_ok(const Func *f, const Op *o)
+{
+    if (o->kind != IR_CMP_ULT && o->kind != IR_CMP_UGE) return 0;
+    if (!fp_active(f)) return 0;
+    int s0 = o->src[0], s1 = o->src[1];
+    if (s0 < 0 || s1 < 0 || s0 >= f->n_vregs || s1 >= f->n_vregs) return 0;
+    if (f->vregs[s0].width != 2 || f->vregs[s1].width != 2) return 0;
+    if (!f->vreg_to_phys) return 0;
+    if (f->vreg_to_phys[s0] != IR_PR_SPILL) return 0;   /* both in a slot */
+    if (f->vreg_to_phys[s1] != IR_PR_SPILL) return 0;
+    if (f->vregs[s0].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+    if (f->vregs[s1].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+    int ix0 = slot_ix_off(f, s0), ix1 = slot_ix_off(f, s1);
+    if (!fp_offset_fits(ix0) || !fp_offset_fits(ix0 + 1)) return 0;
+    if (!fp_offset_fits(ix1) || !fp_offset_fits(ix1 + 1)) return 0;
+    return 1;
+}
+
+static int cmp_bytewise_mem_ok(const Func *f, const Op *o)
+{
+    if (cur_branch_test_kind == 0) return 0;
+    return cmp_bytewise_mem_shape_ok(f, o);
+}
+
+/* 8085 slot-vs-slot unsigned compare via DSUB (`sub hl,bc`, CF = unsigned
+   borrow). Load src1 → BC and src0 → HL with LDSI+LHLX (`ld de,sp+N; ld
+   hl,(de)`), committing src1 to BC before the second LDSI reloads DE — so NO
+   push/pop is needed (unlike load_binop_operands, which stages both through HL
+   and must save DE). `sub hl,bc` then folds the whole compare into one byte:
+   9 bytes vs the 13-byte push/pop double-load + byte-wise sub/sbc. sp-mode
+   (8085 has no IX); both operands in LDSI-addressable slots; BC free (else the
+   byte-wise fall-through preserves a live BC). */
+static int cmp_dsub_slot_ok_8085(const Func *f, const Op *o)
+{
+    if (!IS_8085() || fp_active(f)) return 0;
+    if (o->kind != IR_CMP_ULT && o->kind != IR_CMP_UGE) return 0;
+    int s0 = o->src[0], s1 = o->src[1];
+    if (s0 < 0 || s1 < 0 || s0 >= f->n_vregs || s1 >= f->n_vregs) return 0;
+    if (f->vregs[s0].width != 2 || f->vregs[s1].width != 2) return 0;
+    if (!f->vreg_to_phys) return 0;
+    if (f->vreg_to_phys[s0] != IR_PR_SPILL) return 0;   /* both in a slot */
+    if (f->vreg_to_phys[s1] != IR_PR_SPILL) return 0;
+    if (f->vregs[s0].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+    if (f->vregs[s1].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+    int o0 = slot_off(f, s0) + cur_sp_adjust;
+    int o1 = slot_off(f, s1) + cur_sp_adjust;
+    if (o0 < 0 || o0 + 1 > 255 || o1 < 0 || o1 + 1 > 255) return 0;  /* LDSI range */
+    return 1;
+}
+
 /* Is op `o` the word DE-home's accumulate — `home = home OP w` with w a
    vreg? It lowers to `add hl,de; ex de,hl` (try_word_accumulate), which
    re-establishes DE = home, so it preserves the home (DE-clean). Must agree
@@ -2123,6 +2186,15 @@ static int op_de_clean(const Func *f, const Op *o)
             && o->imm >= 1                 /* any stride: emit_pair_add_de_clean */
             && f->vreg_to_phys && f->vreg_to_phys[o->dst] == IR_PR_BC)
             return 1;
+        /* Small const add `dst = src0 + k` (k<=3, any home): gen_add lowers it
+           to `inc hl` chain + the DE-preserving fp slot store — DE-clean, so a
+           slot/HL-resident element pointer stepped inside the loop (`p += 2`)
+           no longer reverts the resident region. fp only (sp commit_hl_word
+           clobbers DE). Mirror gen_add's condition EXACTLY. */
+        if (o->kind == IR_ADD && dw == 2 && o->src[1] < 0 && fp_active(f)
+            && o->dst != cur_func_whome && o->imm >= 1 && o->imm <= 3
+            && !(f->vreg_to_phys && f->vreg_to_phys[o->dst] == IR_PR_BC))
+            return 1;
         /* DE-clean signed loop test (branch-fused). */
         if ((o->kind == IR_CMP_LT || o->kind == IR_CMP_GE)
             && cur_branch_test_kind != 0
@@ -2156,7 +2228,8 @@ static int op_de_clean(const Func *f, const Op *o)
     case IR_LD_MEM:
         return dw == 1;               /* byte deref → A */
     case IR_CMP_ULT: case IR_CMP_UGE:
-        return cmp_bytewise_ok(f, o); /* byte-wise loop test: A-only, DE-clean */
+        /* byte-wise loop test: A-only, DE-clean — BC-vs-slot or slot-vs-slot */
+        return cmp_bytewise_ok(f, o) || cmp_bytewise_mem_ok(f, o);
     default:
         return 0;                     /* assume DE-clobbering */
     }
@@ -2176,7 +2249,7 @@ static int op_de_clean_static(const Func *f, const BB *bb, int j)
         const Op *nxt = &bb->ops[j + 1];
         if ((nxt->kind == IR_BR_ZERO || nxt->kind == IR_BR_COND)
             && nxt->src[0] == o->dst
-            && cmp_bytewise_shape_ok(f, o))
+            && (cmp_bytewise_shape_ok(f, o) || cmp_bytewise_mem_shape_ok(f, o)))
             return 1;
     }
     /* Word DE-home signed loop test (CMP_LT/GE + the branch on its result):
@@ -2193,7 +2266,7 @@ static int op_de_clean_static(const Func *f, const BB *bb, int j)
         const Op *prv = &bb->ops[j - 1];
         if ((prv->kind == IR_CMP_ULT || prv->kind == IR_CMP_UGE)
             && prv->dst == o->src[0]
-            && cmp_bytewise_shape_ok(f, prv))
+            && (cmp_bytewise_shape_ok(f, prv) || cmp_bytewise_mem_shape_ok(f, prv)))
             return 1;
         if ((prv->kind == IR_CMP_LT || prv->kind == IR_CMP_GE)
             && prv->dst == o->src[0]
@@ -2546,6 +2619,23 @@ static void word_home_flush(FILE *out, const Func *f)
     emit(out, "inc\thl");
     emit(out, "ld\t(hl),d");
     cur_byte_home_dirty = 0;
+}
+
+/* Word DE-home region-exit flush — emitted ONCE at the entry of a dedicated
+   loop-exit block (a block reached ONLY from the resident region). Replaces the
+   per-iteration entry flush the region header would otherwise emit. Correct
+   without a reload: compute_home_region proves the home rides physical DE across
+   the whole region and no leaving-edge source redefines it before the branch, so
+   on every region-leaving edge DE = the final accumulator — and a dedicated exit
+   is reached only via those edges. fp-only (the word DE-home forms only in fp). */
+static void word_home_exit_flush(FILE *out, const Func *f)
+{
+    int v = cur_func_whome;
+    if (v < 0 || !fp_active(f)) return;
+    int off = slot_ix_off(f, v);
+    if (!fp_offset_fits(off) || !fp_offset_fits(off + 1)) return;
+    emit(out, "ld\t(%s%+d),e", frame_reg(), off);
+    emit(out, "ld\t(%s%+d),d", frame_reg(), off + 1);
 }
 
 /* Reload the word DE-home into DE from its (coherent) slot, preserving HL —
@@ -3259,6 +3349,11 @@ static int gen_ld_imm(FILE *out, Func *f, const Op *op)
         commit_a_byte(out, f, op->dst);
         return 0;
     }
+    /* idx2 counter init: `ld <idx>,K` (the loop counter's pre-header init). */
+    if (op->dst >= 0 && vreg_in_idx2(f, op->dst)) {
+        emit(out, "ld\t%s,%lld", idx2_reg_name(f), (long long)op->imm);
+        return 0;
+    }
     /* PR_DE dst: emit `ld de,K` directly — no HL detour, spill, or
        swap. The consumer hits load_binop_operands's de_has src[1]. */
     if (op->dst >= 0 && f->vreg_to_phys
@@ -3463,6 +3558,15 @@ static int gen_inc(FILE *out, Func *f, const Op *op)
         commit_a_byte(out, f, op->dst);
         return 0;
     }
+    /* idx2 stepping counter (register residency): the counter lives in the
+       spare index register — step in place with `inc <idx>` (2 bytes, no
+       memory) instead of the TOS ex(sp) dance. */
+    if (op->dst == op->src[0] && vreg_in_idx2(f, op->dst)) {
+        emit(out, "inc\t%s", idx2_reg_name(f));
+        if (hl_has(op->dst)) invalidate_hl_cache();
+        if (de_has(op->dst)) invalidate_de_cache();
+        return 0;
+    }
     if (try_tos_step_xthl(out, f, op, 1)) return 0;
     if (!hl_has(op->src[0]))
         load_to_hl(out, f, op->src[0]);
@@ -3478,6 +3582,12 @@ static int gen_dec(FILE *out, Func *f, const Op *op)
         load_byte_to_a(out, f, op->src[0]);
         emit(out, "dec\ta");
         commit_a_byte(out, f, op->dst);
+        return 0;
+    }
+    if (op->dst == op->src[0] && vreg_in_idx2(f, op->dst)) {
+        emit(out, "dec\t%s", idx2_reg_name(f));
+        if (hl_has(op->dst)) invalidate_hl_cache();
+        if (de_has(op->dst)) invalidate_de_cache();
         return 0;
     }
     if (try_tos_step_xthl(out, f, op, 0)) return 0;
@@ -5858,6 +5968,41 @@ static int gen_add(FILE *out, Func *f, const Op *op)
         commit_hl_result(out, f, op->dst);
         return 0;
     }
+    /* Small positive const add `dst = src0 + k` (k<=3): an `inc hl` chain
+       instead of `ld de,k; add hl,de`. Fewer bytes/T for k<=3, and — the
+       lever — DE-clean, so a word DE-home (a loop accumulator) rides
+       through a stepped element/pointer walk (`sum += *p; p += 2`) instead
+       of the step's `add hl,de` reverting the resident region. Matched in
+       op_de_clean (fp only: the sp-mode commit clobbers DE). Excludes the
+       PR_BC stepped-pointer form (handled above) and z80n (add hl,nn). */
+    if (op->src[1] < 0 && op->imm >= 1 && op->imm <= 3) {
+        load_to_hl(out, f, op->src[0]);
+        for (long i = 0; i < (long)op->imm; i++) emit(out, "inc\thl");
+        commit_hl_result(out, f, op->dst);
+        return 0;
+    }
+    /* Commutative chain (a+b+c+d, field sums): src0 (the running value) is
+       already in HL and src1 sits in a frame slot. load_binop_operands would
+       keep src0 in HL and `push hl; <load src1→DE via HL>; pop hl` (slot
+       addressing needs HL). ADD is commutative, so instead move the running
+       value to DE (`ex de,hl`, 1 byte) and load src1 into the now-free HL —
+       `add hl,de` still yields src0+src1 in HL. Saves the push/pop (1 byte +
+       stack traffic) per chain term. Only where load_to_de_preserve_hl would
+       actually push/pop: needs ex de,hl (not gbz80), and src1 not already
+       cheap-to-DE (BC/DE cache, Rabbit/kc160 native loads). Not inside a word
+       DE-home region (DE is the home there). Skip with a pending HL spill —
+       the normal path resolves it. */
+    if (op->src[1] >= 0 && hl_has(op->src[0]) && pending_spill_v < 0
+        && !cur_home_is_word && !IS_GBZ80() && !IS_RABBIT() && !IS_KC160()
+        && !de_has(op->src[1]) && !bc_has(op->src[1])
+        && !(vreg_in_pr_bc(f, op->src[1]) && fp_active(f))) {
+        emit(out, "ex\tde,hl");            /* DE = src0 (running value) */
+        swap_hl_de_caches();
+        load_to_hl(out, f, op->src[1]);    /* HL = src1 (preserves DE) */
+        emit(out, "add\thl,de");
+        commit_hl_result(out, f, op->dst);
+        return 0;
+    }
     load_binop_operands(out, f, op);
     emit(out, "add\thl,de");
     /* PR_DE dst: move result HL→DE via ex de,hl (+4 T-states).
@@ -8175,6 +8320,25 @@ static int gen_cmp_lt_ge(FILE *out, Func *f, const Op *op)
         cur_skip_next_op = 1;
         return 0;
     }
+    /* Slot-vs-slot unsigned loop test, byte-wise through A (fp). Both operands
+       read from their ix-slots; CF = unsigned borrow (src0 < src1). A-only, so
+       DE (a word home), BC and HL all survive — vs two synthetic ix pair-loads
+       + `sbc hl,de` that clobber DE and HL. Mirrors cmp_bytewise_mem_ok. */
+    if (cmp_bytewise_mem_ok(f, op)) {
+        int s0 = op->src[0], s1 = op->src[1];
+        int ix0 = slot_ix_off(f, s0), ix1 = slot_ix_off(f, s1);
+        emit(out, "ld\ta,(%s%+d)", frame_reg(), ix0);
+        emit(out, "sub\t(%s%+d)", frame_reg(), ix1);
+        emit(out, "ld\ta,(%s%+d)", frame_reg(), ix0 + 1);
+        emit(out, "sbc\ta,(%s%+d)", frame_reg(), ix1 + 1);
+        rs.a = -1;                        /* A clobbered; DE/BC/HL untouched */
+        int br_true = (cur_branch_test_kind == IR_BR_COND);
+        int want_carry = (cf_true_long == br_true);
+        emit(out, "jp\t%s,L_f%d_bb_%d",
+             want_carry ? "c" : "nc", func_emit_idx, cur_branch_test_label);
+        cur_skip_next_op = 1;
+        return 0;
+    }
     /* Word DE-home DE-clean signed loop test (fp): RHS (n) → HL, then subtract
        LHS (i) from it byte-wise reading i from its ix-slot. Uses only A/HL,
        so DE (the resident sum) survives — letting compute_home_region admit
@@ -8197,6 +8361,32 @@ static int gen_cmp_lt_ge(FILE *out, Func *f, const Op *op)
         emit(out, "jp\t%s,L_f%d_bb_%d",
              want_carry ? "c" : "nc", func_emit_idx, cur_branch_test_label);
         rs.a = -1;                         /* A clobbered; HL=n, DE=home kept */
+        cur_skip_next_op = 1;
+        return 0;
+    }
+    /* 8085 slot-vs-slot unsigned compare via DSUB, no push/pop (BC free).
+       LDSI+LHLX load src1→BC then src0→HL, `sub hl,bc` sets CF = unsigned
+       borrow (src0<src1). Mirrors cmp_dsub_slot_ok_8085; must run before
+       load_binop_operands (it loads the operands itself). */
+    if (rs.bc < 0 && cmp_dsub_slot_ok_8085(f, op)) {
+        pending_spill_resolve();                 /* slots coherent before reading */
+        int s0 = op->src[0], s1 = op->src[1];
+        int off1 = slot_off(f, s1) + cur_sp_adjust;
+        int off0 = slot_off(f, s0) + cur_sp_adjust;
+        emit(out, "ld\tde,sp+%d", off1);         /* LDSI: DE = &src1 */
+        emit(out, "ld\thl,(de)");                /* LHLX: HL = src1 */
+        emit(out, "ld\tc,l");
+        emit(out, "ld\tb,h");                    /* BC = src1 */
+        emit(out, "ld\tde,sp+%d", off0);         /* LDSI: DE = &src0 */
+        emit(out, "ld\thl,(de)");                /* LHLX: HL = src0 */
+        emit(out, "sub\thl,bc");                 /* DSUB: CF = uns (src0 < src1) */
+        int br_true = (cur_branch_test_kind == IR_BR_COND);
+        int want_carry = (cf_true_long == br_true);
+        emit(out, "jp\t%s,L_f%d_bb_%d",
+             want_carry ? "c" : "nc", func_emit_idx, cur_branch_test_label);
+        invalidate_hl_cache();      /* HL clobbered by DSUB */
+        invalidate_de_cache();      /* DE holds a raw slot address, not a vreg */
+        invalidate_bc_cache();      /* BC = src1, uncached */
         cur_skip_next_op = 1;
         return 0;
     }
@@ -10003,6 +10193,54 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
     if (cur_func_ehome >= 0 && !getenv("IR_NO_HOME_RESIDENT"))
         compute_home_region(f, cur_func_ehome, bb_alias,
                             &cur_home_region_lo, &cur_home_region_hi);
+    /* Word DE-home exit-flush hoist: if the region leaves to exactly ONE target
+       block that is reached ONLY from the region (every real edge into it comes
+       from within [lo,hi]), flush the home once at that block's entry instead of
+       every iteration at the header. DE = the final accumulator is guaranteed
+       there by the region proof (home rides DE, no leaving-edge redef). Gated on
+       fp + a slot reachable by an ix-relative store. IR_NO_WH_EXIT_HOIST opts
+       out. Byte-home path untouched. */
+    cur_home_exit_flush_bb = -1;
+    if (cur_home_is_word && cur_func_whome >= 0 && fp_active(f)
+        && cur_home_region_lo >= 0 && !getenv("IR_NO_WH_EXIT_HOIST")) {
+        int tgt = -1, ok = 1;
+        for (int b = cur_home_region_lo; b <= cur_home_region_hi && ok; b++) {
+            const BB *sb = &f->bbs[b];
+            int ns = ir_bb_n_succ(sb);
+            for (int s = 0; s < ns; s++) {
+                int sid = ir_bb_succ_at(sb, s);
+                if (sid < 0 || sid >= f->n_bbs) continue;
+                if (bb_alias && bb_alias[sid] >= 0) sid = bb_alias[sid];
+                if (sid >= cur_home_region_lo && sid <= cur_home_region_hi)
+                    continue;                       /* in-region edge */
+                if (tgt < 0) tgt = sid;
+                else if (tgt != sid) { ok = 0; break; }  /* >1 distinct target */
+            }
+        }
+        if (ok && tgt >= 0) {
+            /* tgt reached ONLY from the region: every real (non-trampoline)
+               block with an alias-resolved edge to tgt lies in [lo,hi]. */
+            int all_in = 1;
+            for (int b = 0; b < f->n_bbs && all_in; b++) {
+                if (bb_alias && bb_alias[b] >= 0) continue;   /* trampoline label */
+                const BB *sb = &f->bbs[b];
+                int ns = ir_bb_n_succ(sb);
+                for (int s = 0; s < ns; s++) {
+                    int sid = ir_bb_succ_at(sb, s);
+                    if (sid < 0 || sid >= f->n_bbs) continue;
+                    if (bb_alias && bb_alias[sid] >= 0) sid = bb_alias[sid];
+                    if (sid != tgt) continue;
+                    if (b < cur_home_region_lo || b > cur_home_region_hi) {
+                        all_in = 0; break;
+                    }
+                }
+            }
+            /* the slot must be reachable by the ix-relative store the flush uses */
+            int off = slot_ix_off(f, cur_func_whome);
+            if (all_in && fp_offset_fits(off) && fp_offset_fits(off + 1))
+                cur_home_exit_flush_bb = tgt;
+        }
+    }
     cur_func_uses_params = func_uses_params(f);   /* frame-pointer elision */
     if (bb_byte_out)
         for (int i = 0; i < f->n_bbs; i++) bb_byte_out[i] = -1;
@@ -10086,6 +10324,18 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
         /* No pending spill crosses into a BB yet — the cross-BB inherit
            lands with the defer step. Clear it so nothing leaks. */
         pending_spill_v = -1;
+        /* Word DE-home exit-flush hoist: this block is the region's sole,
+           dedicated exit — physical DE still holds the final accumulator (the
+           region proof; nothing has emitted since the exit branch). Flush it to
+           the slot ONCE here, then drop the belief. The per-iter header flush is
+           suppressed below. Emitted before the cache-carry logic so no ex de,hl
+           can clobber DE first (pending spill already cleared). */
+        if (cur_home_is_word && cur_home_exit_flush_bb >= 0
+            && bb->id == cur_home_exit_flush_bb) {
+            word_home_exit_flush(out, f);
+            cur_byte_home_dirty = 0;
+            cur_byte_home_vreg = -1;
+        }
         /* Carry the HL cache across the BB boundary when ALL
            predecessors have already been lowered AND agree on
            hl_out, AND that vreg is live-in here. This handles both
@@ -10237,9 +10487,12 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
                 }
             }
         }
+        /* The exit-flush is hoisted to the dedicated exit block's entry (once),
+           so suppress the per-iteration header flush when that hoist is active. */
         if (region_exit_here && cur_byte_home_vreg == cur_func_ehome
             && cur_byte_home_dirty
-            && home_is_slotbacked(f, cur_func_ehome))
+            && home_is_slotbacked(f, cur_func_ehome)
+            && !(cur_home_is_word && cur_home_exit_flush_bb >= 0))
             home_flush(out, f);   /* keep belief; slot now coherent */
         for (int j = 0; j < bb->n_ops; j++) {
             const Op *op = &bb->ops[j];

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -1606,6 +1606,11 @@ static void load_to_dehl_adj(FILE *out, const Func *f, int vreg_id, int sp_adj)
 {
     int no_hl = cur_load_to_dehl_no_hl;
     cur_load_to_dehl_no_hl = 0;
+    /* Capture + reset the no-BC-stash request up front: every early return
+       below (incl. the cache-hit) must consume it, else it leaks into the
+       NEXT load_to_dehl and wrongly suppresses that load's BC stash. */
+    int no_bc = cur_load_to_dehl_no_bc;
+    cur_load_to_dehl_no_bc = 0;
     /* The long-load emits below (`ld hl,bc` cache recover, `ld hl,(ix)`,
        the sp-rel slot walk) all clobber HL. Flush a pending width-2
        spill first (dormant for now). The
@@ -1643,11 +1648,17 @@ static void load_to_dehl_adj(FILE *out, const Func *f, int vreg_id, int sp_adj)
             emit(out, "pop\tde");           /* DE = high half (bytes 2-3) */
             emit(out, "push\tde");
             emit(out, "push\thl");
-            if (!cur_load_to_dehl_no_bc)
-                emit(out, "ld\tbc,hl");     /* BC = low half (cache invariant) */
-            cur_load_to_dehl_no_bc = 0;
-            hl_about_to_change(vreg_id);
-            cache_dehl(vreg_id);
+            {
+                int nb = no_bc;
+                if (!nb)
+                    emit(out, "ld\tbc,hl"); /* BC = low half (cache invariant) */
+                hl_about_to_change(vreg_id);
+                /* When the BC=low stash is skipped, BC does NOT back the DEHL
+                   cache — so don't publish the (BC-implying) dehl claim, or a
+                   later cache-hit `ld hl,bc` reads stale BC. */
+                if (nb) rs.dehl = -1;
+                else    cache_dehl(vreg_id);
+            }
             return;
         }
         int ix_off = slot_ix_off(f, vreg_id);
@@ -1662,14 +1673,19 @@ static void load_to_dehl_adj(FILE *out, const Func *f, int vreg_id, int sp_adj)
                when the caller signals it won't read BC — typically a
                byte-direct unary chain (IR_NOT/IR_NEG) that walks
                H/L/E/D through A. */
-            if (!cur_load_to_dehl_no_bc)
-                emit(out, "ld\tbc,hl");
-            cur_load_to_dehl_no_bc = 0;
-            /* HL really does hold the low half here — advertise it
-               so downstream byte-direct chains can read from L/H
-               directly instead of going through BC. */
-            hl_about_to_change(vreg_id);
-            cache_dehl(vreg_id);
+            {
+                int nb = no_bc;
+                if (!nb)
+                    emit(out, "ld\tbc,hl");
+                /* HL really does hold the low half here — advertise it
+                   so downstream byte-direct chains can read from L/H
+                   directly instead of going through BC. */
+                hl_about_to_change(vreg_id);
+                /* BC=low stash skipped ⇒ don't assert the BC-backed dehl
+                   claim (a later cache-hit would `ld hl,bc` stale BC). */
+                if (nb) rs.dehl = -1;
+                else    cache_dehl(vreg_id);
+            }
             return;
         }
     }
@@ -1686,11 +1702,15 @@ static void load_to_dehl_adj(FILE *out, const Func *f, int vreg_id, int sp_adj)
         emit(out, "pop\tde");           /* DE = high half (bytes 2-3) */
         emit(out, "push\tde");
         emit(out, "push\thl");
-        if (!cur_load_to_dehl_no_bc)
-            emit(out, "ld\tbc,hl");     /* BC = low half (cache invariant) */
-        cur_load_to_dehl_no_bc = 0;
-        hl_about_to_change(vreg_id);
-        cache_dehl(vreg_id);
+        {
+            int nb = no_bc;
+            if (!nb)
+                emit(out, "ld\tbc,hl"); /* BC = low half (cache invariant) */
+            hl_about_to_change(vreg_id);
+            /* BC=low stash skipped ⇒ don't assert the BC-backed dehl claim. */
+            if (nb) rs.dehl = -1;
+            else    cache_dehl(vreg_id);
+        }
         return;
     }
     /* Rabbit/kc160 native sp-relative long load. DE=high half (native
@@ -2127,32 +2147,6 @@ static int cmp_bytewise_mem_ok(const Func *f, const Op *o)
 {
     if (cur_branch_test_kind == 0) return 0;
     return cmp_bytewise_mem_shape_ok(f, o);
-}
-
-/* 8085 slot-vs-slot unsigned compare via DSUB (`sub hl,bc`, CF = unsigned
-   borrow). Load src1 → BC and src0 → HL with LDSI+LHLX (`ld de,sp+N; ld
-   hl,(de)`), committing src1 to BC before the second LDSI reloads DE — so NO
-   push/pop is needed (unlike load_binop_operands, which stages both through HL
-   and must save DE). `sub hl,bc` then folds the whole compare into one byte:
-   9 bytes vs the 13-byte push/pop double-load + byte-wise sub/sbc. sp-mode
-   (8085 has no IX); both operands in LDSI-addressable slots; BC free (else the
-   byte-wise fall-through preserves a live BC). */
-static int cmp_dsub_slot_ok_8085(const Func *f, const Op *o)
-{
-    if (!IS_8085() || fp_active(f)) return 0;
-    if (o->kind != IR_CMP_ULT && o->kind != IR_CMP_UGE) return 0;
-    int s0 = o->src[0], s1 = o->src[1];
-    if (s0 < 0 || s1 < 0 || s0 >= f->n_vregs || s1 >= f->n_vregs) return 0;
-    if (f->vregs[s0].width != 2 || f->vregs[s1].width != 2) return 0;
-    if (!f->vreg_to_phys) return 0;
-    if (f->vreg_to_phys[s0] != IR_PR_SPILL) return 0;   /* both in a slot */
-    if (f->vreg_to_phys[s1] != IR_PR_SPILL) return 0;
-    if (f->vregs[s0].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
-    if (f->vregs[s1].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
-    int o0 = slot_off(f, s0) + cur_sp_adjust;
-    int o1 = slot_off(f, s1) + cur_sp_adjust;
-    if (o0 < 0 || o0 + 1 > 255 || o1 < 0 || o1 + 1 > 255) return 0;  /* LDSI range */
-    return 1;
 }
 
 /* Is op `o` the word DE-home's accumulate — `home = home OP w` with w a
@@ -8529,32 +8523,6 @@ static int gen_cmp_lt_ge(FILE *out, Func *f, const Op *op)
         emit(out, "jp\t%s,L_f%d_bb_%d",
              want_carry ? "c" : "nc", func_emit_idx, cur_branch_test_label);
         rs.a = -1;                         /* A clobbered; HL=n, DE=home kept */
-        cur_skip_next_op = 1;
-        return 0;
-    }
-    /* 8085 slot-vs-slot unsigned compare via DSUB, no push/pop (BC free).
-       LDSI+LHLX load src1→BC then src0→HL, `sub hl,bc` sets CF = unsigned
-       borrow (src0<src1). Mirrors cmp_dsub_slot_ok_8085; must run before
-       load_binop_operands (it loads the operands itself). */
-    if (rs.bc < 0 && cmp_dsub_slot_ok_8085(f, op)) {
-        pending_spill_resolve();                 /* slots coherent before reading */
-        int s0 = op->src[0], s1 = op->src[1];
-        int off1 = slot_off(f, s1) + cur_sp_adjust;
-        int off0 = slot_off(f, s0) + cur_sp_adjust;
-        emit(out, "ld\tde,sp+%d", off1);         /* LDSI: DE = &src1 */
-        emit(out, "ld\thl,(de)");                /* LHLX: HL = src1 */
-        emit(out, "ld\tc,l");
-        emit(out, "ld\tb,h");                    /* BC = src1 */
-        emit(out, "ld\tde,sp+%d", off0);         /* LDSI: DE = &src0 */
-        emit(out, "ld\thl,(de)");                /* LHLX: HL = src0 */
-        emit(out, "sub\thl,bc");                 /* DSUB: CF = uns (src0 < src1) */
-        int br_true = (cur_branch_test_kind == IR_BR_COND);
-        int want_carry = (cf_true_long == br_true);
-        emit(out, "jp\t%s,L_f%d_bb_%d",
-             want_carry ? "c" : "nc", func_emit_idx, cur_branch_test_label);
-        invalidate_hl_cache();      /* HL clobbered by DSUB */
-        invalidate_de_cache();      /* DE holds a raw slot address, not a vreg */
-        invalidate_bc_cache();      /* BC = src1, uncached */
         cur_skip_next_op = 1;
         return 0;
     }

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -983,9 +983,8 @@ static void load_to_hl_adj(FILE *out, const Func *f, int vreg_id, int sp_adj)
             emit(out, "ld\thl,%d", off);
             emit(out, "add\thl,sp");
         }
-        emit(out, "ld\ta,(hl)");
-        emit(out, "ld\tl,a");
-        emit(out, "ld\th,0");
+        emit(out, "ld\tl,(hl)");       /* read the byte straight into L … */
+        emit(out, "ld\th,0");          /* … zero-extend; no detour through A */
         hl_about_to_change(vreg_id);   /* HL now holds the value, not the addr */
         return;
     }
@@ -8299,6 +8298,27 @@ static int gen_cmp_lt_ge(FILE *out, Func *f, const Op *op)
        DOES have jp po (parity), which works for these compares, so they stay
        on the jp-po path.) */
     int long_signflip = is_signed && IS_GBZ80();
+    /* Byte compare against a small constant: a width-1 operand is loaded
+       zero-extended (`ld l,(hl); ld h,0`), so the existing widen+16-bit
+       compare is really an UNSIGNED compare of a [0,255] value against a
+       [0,255] constant — identical to a single `cp K`. Emit that directly
+       for the branch-fused `c REL K` (K in a byte): CF = (c < K) unsigned,
+       matching cf_true_long. Removes the widen + the 16-bit sbc machinery.
+       Chiefly the range-narrowed loop counter (`i < 16`). */
+    if (op->src[0] >= 0 && op->src[1] == -1
+        && f->vregs[op->src[0]].width == 1
+        && op->imm >= 0 && op->imm <= 255
+        && cur_branch_test_kind != 0) {
+        load_byte_to_a(out, f, op->src[0]);
+        emit(out, "cp\t%u", (unsigned)(op->imm & 0xff));
+        int br_true = (cur_branch_test_kind == IR_BR_COND);
+        int want_carry = (cf_true_long == br_true);
+        emit(out, "jp\t%s,L_f%d_bb_%d",
+             want_carry ? "c" : "nc", func_emit_idx, cur_branch_test_label);
+        rs.a = -1;                     /* A clobbered; HL/DE/BC untouched */
+        cur_skip_next_op = 1;
+        return 0;
+    }
     /* Long ordered compare: byte-wise sub/sbc chain. Final sbc
        leaves CF = unsigned borrow (a<b) and A = high byte of result.
        Signed gets the S^V correction inline (`jp po ok; xor 0x80;
@@ -9922,6 +9942,9 @@ int ir_lower_func(FILE *out, Func *f)
            byte as width-1 — must run after dce (fewer ops to scan, dead
            producers already gone) and before liveness/slots, which size
            frame slots off the (now-narrowed) widths. */
+        /* Range-narrow bounded loop counters to a byte before narrow_byte
+           and slot sizing (which reads the now-narrowed widths). */
+        int ivnarrow = ir_opt_narrow_iv(f);
         int narrow  = ir_opt_narrow_byte(f);
         /* narrow_byte turns promoting CONV_SX|ZX operands into
            byte-identity copies; propagate them away (else they spill to a
@@ -9952,16 +9975,16 @@ int ir_lower_func(FILE *out, Func *f)
         int pushes  = want_pushes ? ir_opt_insert_long_pushes(f) : 0;
         if ((hoisted > 0 || ivsr > 0 || fwd > 0 || cfold > 0
              || packs > 0 || dce > 0 || early > 0
-             || late > 0 || match > 0 || narrow > 0
+             || late > 0 || match > 0 || narrow > 0 || ivnarrow > 0
              || cse > 0 || pushes > 0 || deadret > 0 || reassoc > 0)
             && getenv("IR_OPT_VERBOSE"))
             fprintf(stderr,
                     "ir_opt: %d licm, %d ivsr, %d early, %d st2ld, %d cfold, "
                     "%d reassoc, %d match, %d cse, "
                     "%d packs, %d late, %d pushes, %d deadret, "
-                    "%d dce, %d narrow in func\n",
+                    "%d dce, %d narrow, %d ivnarrow in func\n",
                     hoisted, ivsr, early, fwd, cfold, reassoc, match,
-                    cse, packs, late, pushes, deadret, dce, narrow);
+                    cse, packs, late, pushes, deadret, dce, narrow, ivnarrow);
     }
 
     /* Drop orphan vregs (abandoned builder temps — in no op slot) before the

--- a/src/80cc/ir_opt.c
+++ b/src/80cc/ir_opt.c
@@ -1341,6 +1341,169 @@ int ir_opt_dce(Func *f)
     return removed;
 }
 
+/* ---- Induction-variable range narrowing (ir_opt_narrow_iv) ----------
+   A loop counter whose value range provably fits [0,256) is retyped to a
+   byte (width 1, KIND_CHAR): the step becomes a byte inc/dec and its slot is
+   one byte, while every int use auto-widens (load_to_hl zero-extends a
+   width-1 vreg). Sound because zero-extending a value proven in [0,256)
+   reproduces its exact int value. Two shapes, both off a single-latch
+   natural loop whose header holds the guard:
+     up:   c=c0 (0..255); header CMP_LT/ULT c,B (B<=255) or LE/ULE (B<=254);
+           exactly one INC c, no DEC.               range [c0, max] <= 255
+     down: c=c0 (0..255); header CMP_GT/GE/NE c,0(/1); exactly one DEC c, no
+           INC (dec runs after the guard, so c stays >= 0). range [0, c0]
+   IR_NO_IV_NARROW opts out. Retype only (no op insertion): the lowerer's
+   width-1 paths do the rest. */
+
+/* Classify every vreg's defs in one function-wide scan (mirrors the idx2
+   counter scan in ir_alloc.c). */
+typedef struct {
+    int n_ldimm, n_inc, n_dec, n_other, is_base;
+    int64_t initval;
+} IvClass;
+
+static int niv_classify(Func *f, IvClass *cl)
+{
+    for (int i = 0; i < f->n_bbs; i++) {
+        BB *bb = &f->bbs[i];
+        for (int j = 0; j < bb->n_ops; j++) {
+            const Op *o = &bb->ops[j];
+            if ((o->kind == IR_LD_MEM || o->kind == IR_ST_MEM)
+                && o->mem.kind == IR_MEM_VREG && o->mem.base >= 0
+                && o->mem.base < f->n_vregs)
+                cl[o->mem.base].is_base = 1;
+            if (o->kind == IR_POSTSTEP && o->src[0] >= 0
+                && o->src[0] < f->n_vregs)
+                cl[o->src[0]].is_base = 1;
+            int d = o->dst;
+            if (d < 0 || d >= f->n_vregs) continue;
+            if (o->kind == IR_LD_IMM)              { cl[d].n_ldimm++; cl[d].initval = o->imm; }
+            else if (o->kind == IR_INC && o->src[0] == d) cl[d].n_inc++;
+            else if (o->kind == IR_DEC && o->src[0] == d) cl[d].n_dec++;
+            else                                    cl[d].n_other++;
+        }
+    }
+    return 1;
+}
+
+/* Is `v` a clean counter (single const init in [0,255], only ±1 self-steps
+   in one direction, no other def, no aliasing) narrowable to a byte? */
+static int niv_counter_ok(Func *f, const IvClass *cl, int v, int *is_down)
+{
+    const VReg *vr = &f->vregs[v];
+    if (vr->width != 2 || !kind_is_integer((int)vr->kind)) return 0;
+    if (vr->flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+    const IvClass *c = &cl[v];
+    if (c->is_base || c->n_other != 0 || c->n_ldimm != 1) return 0;
+    if (c->initval < 0 || c->initval > 255) return 0;
+    if (c->n_inc == 1 && c->n_dec == 0) { *is_down = 0; return 1; }
+    if (c->n_dec == 1 && c->n_inc == 0) { *is_down = 1; return 1; }
+    return 0;
+}
+
+/* Header-guard bound: find a CMP in header `h` that tests counter `c`
+   against a constant and bounds it. Returns 1 and sets *maxval (the largest
+   value c can hold) for the up-counter; for a down-counter it only checks
+   the exit test stops at >= 0 (range [0,c0], caller uses initval). */
+static int niv_up_bound_ok(Func *f, int h, int c, int64_t *maxval)
+{
+    BB *hb = &f->bbs[h];
+    for (int j = 0; j < hb->n_ops; j++) {
+        const Op *o = &hb->ops[j];
+        if (o->src[0] != c || o->src[1] != -1) continue;
+        /* c < B: max value c reaches is B; c <= B: max is B+1. */
+        if (o->kind == IR_CMP_LT || o->kind == IR_CMP_ULT) {
+            if (o->imm >= 0 && o->imm <= 255) { *maxval = o->imm; return 1; }
+        } else if (o->kind == IR_CMP_LE || o->kind == IR_CMP_ULE) {
+            if (o->imm >= 0 && o->imm <= 254) { *maxval = o->imm + 1; return 1; }
+        }
+    }
+    return 0;
+}
+
+static int niv_down_exit_ok(Func *f, int h, int c)
+{
+    BB *hb = &f->bbs[h];
+    for (int j = 0; j < hb->n_ops; j++) {
+        const Op *o = &hb->ops[j];
+        /* while (c) / while (c != 0) / while (c > 0): stops at 0, never neg. */
+        if (o->kind == IR_BR_ZERO && o->src[0] == c) return 1;
+        if (o->src[0] != c || o->src[1] != -1) continue;
+        if ((o->kind == IR_CMP_NE || o->kind == IR_CMP_GT
+             || o->kind == IR_CMP_UGT) && o->imm == 0) return 1;
+        if ((o->kind == IR_CMP_GE || o->kind == IR_CMP_UGE) && o->imm == 1) return 1;
+    }
+    return 0;
+}
+
+int ir_opt_narrow_iv(Func *f)
+{
+    if (!f || f->n_bbs <= 0 || getenv("IR_NO_IV_NARROW")) return 0;
+
+    IvClass *cl = calloc((size_t)(f->n_vregs > 0 ? f->n_vregs : 1), sizeof(IvClass));
+    if (!cl) return 0;
+    niv_classify(f, cl);
+
+    /* Reachability (unreachable back-edges aren't real loops). */
+    int *reach = calloc((size_t)f->n_bbs, sizeof(int));
+    int *stack = calloc((size_t)f->n_bbs, sizeof(int));
+    if (!reach || !stack) { free(cl); free(reach); free(stack); return 0; }
+    int sp = 0; reach[0] = 1; stack[sp++] = 0;
+    while (sp > 0) {
+        BB *cbb = &f->bbs[stack[--sp]];
+        int ns = ir_bb_n_succ(cbb);
+        for (int s = 0; s < ns; s++) {
+            int sid = ir_bb_succ_at(cbb, s);
+            if (sid >= 0 && sid < f->n_bbs && !reach[sid]) { reach[sid] = 1; stack[sp++] = sid; }
+        }
+    }
+    free(stack);
+
+    int narrowed = 0;
+    for (int h = 0; h < f->n_bbs; h++) {
+        if (!reach[h]) continue;
+        /* Single-latch natural loop (mirror ir_opt_ivsr's scan). */
+        int n_entry = 0, n_back = 0;
+        for (int b = 0; b < f->n_bbs; b++) {
+            BB *bb = &f->bbs[b];
+            int ns = ir_bb_n_succ(bb), targets_h = 0;
+            for (int s = 0; s < ns; s++)
+                if (ir_bb_succ_at(bb, s) == h) { targets_h = 1; break; }
+            if (!targets_h) continue;
+            if (b < h) n_entry++;
+            else if (b >= h && reach[b] && licm_reaches(f, h, b)) n_back++;
+        }
+        if (n_entry != 1 || n_back != 1) continue;
+
+        /* Look in the header for a counter-vs-constant guard. */
+        BB *hb = &f->bbs[h];
+        for (int j = 0; j < hb->n_ops; j++) {
+            const Op *o = &hb->ops[j];
+            int c = -1;
+            if ((o->kind >= IR_CMP_EQ && o->kind <= IR_CMP_UGE)
+                && o->src[0] >= 0 && o->src[1] == -1) c = o->src[0];
+            else if (o->kind == IR_BR_ZERO && o->src[0] >= 0) c = o->src[0];
+            if (c < 0 || c >= f->n_vregs) continue;
+            int is_down = 0;
+            if (!niv_counter_ok(f, cl, c, &is_down)) continue;
+            int ok = 0;
+            if (!is_down) {
+                int64_t maxv = 0;
+                ok = niv_up_bound_ok(f, h, c, &maxv) && maxv <= 255;
+            } else {
+                ok = niv_down_exit_ok(f, h, c) && cl[c].initval <= 255;
+            }
+            if (!ok) continue;
+            f->vregs[c].width = 1;
+            f->vregs[c].kind  = KIND_CHAR;
+            narrowed++;
+        }
+    }
+    free(reach);
+    free(cl);
+    return narrowed;
+}
+
 /* ---- Byte-width narrowing (ir_opt_narrow_byte) ----------------------
    C promotes char operands to int, so `crc ^ d[i]`, `x & 0x0f`, `c << 1`
    etc. become width-2 IR ops whose result is immediately truncated back

--- a/src/80cc/ir_opt.c
+++ b/src/80cc/ir_opt.c
@@ -881,8 +881,28 @@ static int ivsr_try_lftr(Func *f, int lo, int hi, int ph,
     for (int t = 0; t < n_cand; t++)
         if (cand[t].iv == iv && cand[t].D > 0 && cand[t].K >= 0) { c = t; break; }
     if (c < 0) return 0;
-    int64_t N;
-    if (!ivsr_const_bound(f, cmp, lo, hi, &N)) return 0;
+    /* The exit bound. Two cases:
+       - a proven-nonnegative COMPILE-TIME CONSTANT: p_end = base + N*scale, a
+         single pre-header ADD (the original, cheapest path);
+       - a loop-invariant VARIABLE bound `n` (e.g. a signed int param, the
+         index_walk shape): the unsigned pointer compare `p < p_end` would turn
+         a 0-trip signed loop (`n <= 0`) into a huge wrapped one if p_end fell
+         below base. Guard it by clamping the bound to max(0,n) when building
+         p_end — branchless, no CFG surgery: p_end = base + max(0,n)*scale >=
+         base always (0-trip when n<=0, no wrap). IR_NO_LFTR_SIGNED opts out. */
+    int64_t N = 0;
+    int bound_v = -1;
+    if (!ivsr_const_bound(f, cmp, lo, hi, &N)) {
+        if (getenv("IR_NO_LFTR_SIGNED")) return 0;
+        int bv = cmp->src[1];
+        if (bv < 0 || bv >= f->n_vregs) return 0;   /* immediate handled above */
+        if (f->vregs[bv].width != 2) return 0;       /* int bound only */
+        if (f->vregs[bv].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+        int bni, bib, bii, bno, bob, boi;
+        ivsr_def_sites(f, bv, lo, hi, &bni, &bib, &bii, &bno, &bob, &boi);
+        if (bni != 0) return 0;                       /* must be loop-invariant */
+        bound_v = bv;
+    }
     /* iv used only by its step + this test, not live-out. */
     if (ivsr_uses_in_loop(f, iv, lo, hi) != 2) return 0;
     if (ivsr_used_outside(f, iv, lo, hi)) return 0;
@@ -890,22 +910,64 @@ static int ivsr_try_lftr(Func *f, int lo, int hi, int ph,
     ivsr_def_sites(f, iv, lo, hi, &s_ni, &s_ib, &s_ii, &s_no, &s_ob, &s_oi);
     if (s_ni != 1 || s_no != 1 || s_ob != ph) return 0;
 
-    int64_t end_off = N * cand[c].scale;
+    int64_t scale = cand[c].scale;
     int base = cand[c].base, p = cand[c].p;
+    /* log2(scale) — scale is 1 or a power of two (from ivsr_iv_term). */
+    int sh = 0; { int64_t sc = scale; while (sc > 1) { sc >>= 1; sh++; } }
+
+    /* Create all vregs up front (ir_vreg_new may realloc f->vregs / f->bbs
+       op arrays — re-fetch the compare op by index afterwards). */
     int pend = ir_vreg_new(f, f->vregs[p].kind, NULL, 0);
     f->vregs[pend].width = f->vregs[p].width;
-    /* Rewrite the test (re-fetch by index — ir_vreg_new may realloc). */
+    int v_b = -1, v_m = -1, v_neff = -1, v_scaled = -1;
+    if (bound_v >= 0) {
+        v_b = ir_vreg_new(f, KIND_INT, NULL, 0); f->vregs[v_b].width = 2;
+        v_m = ir_vreg_new(f, KIND_INT, NULL, 0); f->vregs[v_m].width = 2;
+        v_neff = ir_vreg_new(f, KIND_INT, NULL, 0); f->vregs[v_neff].width = 2;
+        if (sh > 0) {
+            v_scaled = ir_vreg_new(f, KIND_INT, NULL, 0);
+            f->vregs[v_scaled].width = 2;
+        } else {
+            v_scaled = v_neff;
+        }
+    }
+
+    /* Rewrite the test to the unsigned pointer compare. */
     Op *c2 = &f->bbs[cmp_bb].ops[cmp_idx];
     c2->kind = IR_CMP_ULT;
     c2->src[0] = p; c2->src[1] = pend; c2->imm = 0;
     /* Kill the now-dead basic IV (step + init). */
     f->bbs[s_ib].ops[s_ii].kind = IR_NOP;
     f->bbs[s_ob].ops[s_oi].kind = IR_NOP;
-    /* p_end = base + N*scale in the pre-header. */
+
     Op o;
-    if (end_off == 0) { ivsr_init_op(&o, IR_MOV); o.dst = pend; o.src[0] = base; }
-    else { ivsr_init_op(&o, IR_ADD); o.dst = pend; o.src[0] = base; o.imm = end_off; }
-    licm_insert_before_terminator(&f->bbs[ph], &o);
+    if (bound_v < 0) {
+        /* p_end = base + N*scale (constant). */
+        int64_t end_off = N * scale;
+        if (end_off == 0) { ivsr_init_op(&o, IR_MOV); o.dst = pend; o.src[0] = base; }
+        else { ivsr_init_op(&o, IR_ADD); o.dst = pend; o.src[0] = base; o.imm = end_off; }
+        licm_insert_before_terminator(&f->bbs[ph], &o);
+    } else {
+        /* neff = max(0, n), branchlessly and with only reliable ops (80cc has
+           no arithmetic >> — IR_SHR is logical, #289 — and a standalone
+           compare-to-value mis-lowers here):
+             sb   = (unsigned)n >> 15   (0 if n>=0, 1 if n<0)   [logical shift]
+             mask = sb - 1              (0xFFFF if n>=0, 0 if n<0)
+             neff = n & mask            (n if n>=0, 0 if n<0) */
+        ivsr_init_op(&o, IR_SHR); o.dst = v_b; o.src[0] = bound_v; o.imm = 15;
+        licm_insert_before_terminator(&f->bbs[ph], &o);
+        ivsr_init_op(&o, IR_SUB); o.dst = v_m; o.src[0] = v_b; o.imm = 1;
+        licm_insert_before_terminator(&f->bbs[ph], &o);
+        ivsr_init_op(&o, IR_AND); o.dst = v_neff; o.src[0] = bound_v; o.src[1] = v_m;
+        licm_insert_before_terminator(&f->bbs[ph], &o);
+        if (sh > 0) {
+            ivsr_init_op(&o, IR_SHL); o.dst = v_scaled; o.src[0] = v_neff; o.imm = sh;
+            licm_insert_before_terminator(&f->bbs[ph], &o);
+        }
+        /* p_end = base + neff*scale. */
+        ivsr_init_op(&o, IR_ADD); o.dst = pend; o.src[0] = base; o.src[1] = v_scaled;
+        licm_insert_before_terminator(&f->bbs[ph], &o);
+    }
     return 1;
 }
 

--- a/src/80cc/ir_opt.c
+++ b/src/80cc/ir_opt.c
@@ -8,6 +8,11 @@
 #include "ir_opt.h"
 #include "ir_analysis.h"
 
+/* Defined in ir_lower.c (the CPU-lowering layer). Target predicate for the
+   const-store fold — no ccdefs.h dependency, so the decoupling above holds.
+   `width` = store size in bytes (byte folds everywhere; word is gated). */
+extern int ir_cpu_const_store_ok(int width);
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
@@ -500,8 +505,14 @@ static int licm_pre_header(const Func *f, const int *in_loop, int header)
    address), LEA (local frame address). */
 static int licm_eligible_kind(OpKind k)
 {
-    return k == IR_LD_IMM || k == IR_LD_SYM
-        || k == IR_LD_STR || k == IR_LEA;
+    /* LD_IMM (a true constant) is trivially rematerialisable — a 3-byte
+       immediate at each use. Hoisting it only makes the allocator spill it to
+       a slot and reload per iteration (the greedy allocator can't hold it in a
+       register across a body that clobbers HL/DE/BC), which is strictly worse.
+       Leave literals at the use site. LD_SYM (&global) STAYS eligible: hoisting
+       the invariant base is what lets IVSR strength-reduce `base + i` into a
+       register pointer walk (`inc bc`), a real win we must not forgo. */
+    return k == IR_LD_SYM || k == IR_LD_STR || k == IR_LEA;
 }
 
 /* Insert `src_op` into `dst_bb` just BEFORE its last op (the
@@ -1799,6 +1810,34 @@ int ir_opt_const_fold(Func *f)
             }
             if (folded) { op->imm = (op->kind == IR_LD_IMM) ? op->imm : 0; changed++; }
 
+            /* Constant value into an indirect store: fold it into op->imm
+               (src[0]=-1) so the lowerer stores the immediate directly — no
+               value register, no A/E clobber, no DE-cache invalidation (word
+               leaves PR_DE free). Byte and word; require the element-width hint
+               to agree (the lowerer recovers the store width from mem.elem once
+               src[0] is gone — incl. after a &sym+const base folds this into a
+               MEM_SYM store). Byte folds everywhere, word is CPU-gated. Skip
+               volatile / __addressmod (special lowering). */
+            if (op->kind == IR_ST_MEM && op->mem.kind == IR_MEM_VREG
+                && s0 >= 0 && s0 < nv && known[s0]
+                && !op->mem.volatile_ && !op->mem.bank_fn) {
+                int sw = f->vregs[s0].width;
+                /* byte/word: any integer elem of that width (known[] tracks only
+                   integer LD_IMM, so a float const never reaches here). width 4:
+                   KIND_LONG ONLY — NOT KIND_CPTR (3 bytes in memory), nor
+                   KIND_DOUBLE (4-byte float in math32/mbf32, format-dependent
+                   bits, not an integer constant). */
+                int ok = (sw == 1 || sw == 2) ? (kind_scalar_width(op->mem.elem) == sw)
+                       : (sw == 4)            ? (op->mem.elem == KIND_LONG)
+                       : 0;
+                if (ok && ir_cpu_const_store_ok(sw)) {
+                    op->imm = val[s0] & (sw == 1 ? 0xffULL
+                                       : sw == 2 ? 0xffffULL : 0xffffffffULL);
+                    op->src[0] = -1;
+                    changed++;
+                }
+            }
+
             /* Update constant tracking for the (possibly rewritten) op. */
             if (op->kind == IR_POSTSTEP && s0 >= 0 && s0 < nv)
                 known[s0] = 0;          /* steps src[0] in place */
@@ -1809,6 +1848,13 @@ int ir_opt_const_fold(Func *f)
                 } else if (op->kind == IR_MOV && op->src[0] >= 0
                            && op->src[0] < nv && known[op->src[0]]) {
                     known[d] = 1; val[d] = val[op->src[0]];
+                } else if (op->kind == IR_CONV_TRUNC && op->src[0] >= 0
+                           && op->src[0] < nv && known[op->src[0]]) {
+                    /* Narrowing a known constant stays constant (masked to the
+                       dst width) — lets a `(unsigned char)K` store fold to an
+                       immediate (sieve's flags[k]=1). */
+                    known[d] = 1;
+                    val[d] = have_mask ? (val[op->src[0]] & mask) : val[op->src[0]];
                 } else {
                     known[d] = 0;
                 }

--- a/src/80cc/ir_opt.h
+++ b/src/80cc/ir_opt.h
@@ -135,6 +135,11 @@ int ir_opt_dce(Func *f);
  * Returns the number of ops narrowed. */
 int ir_opt_narrow_byte(Func *f);
 
+/* Range-narrow a loop counter proven to fit [0,256) to a byte (width-1):
+ * byte inc/dec step, 1-byte slot, int uses auto-widen. IR_NO_IV_NARROW opts
+ * out. Returns the number of counters narrowed. */
+int ir_opt_narrow_iv(Func *f);
+
 /* Local (per-BB) copy propagation: rewrites src operands reading an
  * identity copy (MOV / same-width CONV_SX|ZX) to read the copy's source,
  * so the copy becomes dead (removed by a following DCE). Pairs with

--- a/test/suites/crcbench/Makefile
+++ b/test/suites/crcbench/Makefile
@@ -1,0 +1,52 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+
+
+
+test.bin: $(SOURCES)
+	$(compile)
+	$(runtest)
+
+test_r2ka.bin: $(SOURCES)
+	$(compile_r2ka)
+	$(runtest_r2ka)
+
+test_r4k.bin: $(SOURCES)
+	$(compile_r4k)
+	$(runtest_r4k)
+
+test_z180.bin: $(SOURCES)
+	$(compile_z180)
+	$(runtest_z180)
+
+test_8080.bin: $(SOURCES)
+	$(compile_8080)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(compile_8085)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(compile_gbz80)
+	$(runtest_gbz80)
+
+test_ez80_z80.bin: $(SOURCES)
+	$(compile_ez80_z80)
+	$(runtest_ez80_z80)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/crcbench/crcbench.c
+++ b/test/suites/crcbench/crcbench.c
@@ -1,0 +1,99 @@
+/*
+ * crcbench.c — long-heavy benchmark for compiler comparison.
+ *
+ * Workload: CRC-32 (zip/ethernet variant, polynomial 0xEDB88320 in
+ * reversed form), bit-by-bit, over a 1 KB deterministic buffer
+ * repeated REPS times. Same buffer fill as intbench / charbench so
+ * cross-bench cache behaviour is comparable.
+ *
+ * CRC-32 is the canonical workload for stressing 32-bit XOR / AND /
+ * right-shift / conditional XOR — the four hot ops in compression,
+ * checksum, and integer hash routines. The inner-loop shape
+ *
+ *     crc = (crc & 1) ? ((crc >> 1) ^ 0xEDB88320) : (crc >> 1);
+ *
+ * exercises walker long shift, long AND with byte literal, and
+ * long XOR with a wide const — exactly the binop family that
+ * dominates md5sum's transform but at narrower kernel granularity.
+ *
+ * Real-world CRC-32 is used in zip/gzip, PNG, Ethernet, SATA,
+ * MPEG-2, POSIX cksum, and many serial protocols.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "test.h"
+
+#define BUF_LEN 1024
+#define REPS    63
+
+static unsigned char buffer[BUF_LEN];
+
+/*
+ * Standard CRC-32, bit-by-bit, reversed-polynomial form. Init
+ * 0xFFFFFFFF, final XOR 0xFFFFFFFF. No table — pure inner-loop
+ * 32-bit arithmetic.
+ */
+static unsigned long crc32(unsigned char *data, unsigned int len)
+{
+    unsigned long crc = 0xFFFFFFFFUL;
+    unsigned char *end = data + len;
+    while (data < end) {
+        crc ^= (unsigned long)*data++;
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+        crc = (crc & 1UL) ? ((crc >> 1) ^ 0xEDB88320UL) : (crc >> 1);
+    }
+    return crc ^ 0xFFFFFFFFUL;
+}
+
+/*
+ * Deterministic 1 KB fill. Same seed/LCG as intbench / charbench
+ * so the input data matches across benches.
+ */
+static void init_data(void)
+{
+    unsigned int i;
+    unsigned int seed = 0xC001U;
+    for (i = 0; i < BUF_LEN; i++) {
+        buffer[i] = (unsigned char)(seed & 0xFFU);
+        seed = (unsigned int)(seed * 25173U + 13849U);
+    }
+}
+
+static void crcbench_run(void)
+{
+    unsigned long crc = 0;
+    unsigned int rep;
+
+    init_data();
+
+    for (rep = 0; rep < REPS; rep++) {
+        crc ^= crc32(buffer, BUF_LEN);
+    }
+
+    /* Expected value computed by host (see comment at the assertEqual
+       below). The XOR-chain over the standard 1 KB buffer × REPS reps
+       is stable across hosts because CRC-32 itself is host-independent
+       and the buffer fill is deterministic. */
+    assertEqual(crc, 0x1C48DD57UL);
+}
+
+int suite_crcbench(void)
+{
+    suite_setup("CRC-32 bench Tests");
+    suite_add_test(crcbench_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    res += suite_crcbench();
+    exit(res);
+}

--- a/test/suites/long_ir/Makefile
+++ b/test/suites/long_ir/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED -lmath48 -lmath16
 # the lib — needed by fastcall AND __sdcccall(1) function-pointer calls.
 JPTH = ../../../libsrc/l/sccz80/9-common/l_jpix.asm ../../../libsrc/l/sccz80/9-common/l_jpiy.asm
 
-all:	test.bin test_gbz80.bin test_8080.bin test_8085.bin irgaps.bin irgaps_gbz80.bin irgaps_8080.bin irgaps_8085.bin structval.bin structval_gbz80.bin structval_8080.bin structval_8085.bin fixed.bin sdcccall.bin sdcccall_kc160.bin wr.bin fp_promote.bin fp_promote_reg.bin fp_promote_f48f16.bin fp_promote_accum.bin aggregate_init.bin fnptr_fastcall.bin faslot.bin libcall_abi.bin const_mult.bin cmp_gt.bin longlong.bin bitfield.bin umaxd.bin fp_to_int.bin
+all:	test.bin test_gbz80.bin test_8080.bin test_8085.bin irgaps.bin irgaps_gbz80.bin irgaps_8080.bin irgaps_8085.bin structval.bin structval_gbz80.bin structval_8080.bin structval_8085.bin fixed.bin sdcccall.bin sdcccall_kc160.bin wr.bin wr_fp.bin fp_promote.bin fp_promote_reg.bin fp_promote_f48f16.bin fp_promote_accum.bin aggregate_init.bin fnptr_fastcall.bin faslot.bin libcall_abi.bin const_mult.bin cmp_gt.bin longlong.bin bitfield.bin umaxd.bin fp_to_int.bin
 
 test.bin: $(SOURCES) long_ir.c
 	$(compile)
@@ -117,6 +117,13 @@ libcall_abi.bin: $(SOURCES) libcall_abi.c
 
 wr.bin: $(SOURCES) word_resident.c
 	$(compile)
+	$(runtest)
+
+# Same word-residency tests in FRAME-POINTER mode. The word DE-home — and its
+# region-exit-flush hoist (the sum stored once at the loop exit, not per iter) —
+# is fp-only, so the sp-built wr.bin above never exercises it. This binary does.
+wr_fp.bin: $(SOURCES) word_resident.c
+	$(call compile,-Cc-frameix)
 	$(runtest)
 
 fp_promote.bin: $(SOURCES) fp_promote.c

--- a/test/suites/long_ir/irgaps.c
+++ b/test/suites/long_ir/irgaps.c
@@ -306,6 +306,24 @@ static void test_const_store_fold(void)
            "const store fold byte+word+long, MEM_VREG + MEM_SYM");
 }
 
+/* IV range-narrowing: a counter proven to fit [0,256) is retyped to a byte
+   (step becomes inc/dec, int uses zero-extend). Must stay value-exact for
+   up-counters, down-counters, post-loop use, and — critically — must NOT
+   narrow a counter that exceeds 255 (would wrap in a byte). */
+static int iv_arr[20];
+static int iv_up(void)   { int s=0,i; for(i=0;i<16;i++) s+=iv_arr[i]; return s; }
+static int iv_down(void) { int s=0,i; for(i=16;i>0;i--) s+=iv_arr[i-1]; return s; }
+static int iv_post(void) { int i; for(i=0;i<16;i++) {} return i; }        /* post = 16 */
+static long iv_big(void) { long s=0; int i; for(i=0;i<300;i++) s+=(i&15); return s; }
+static void test_iv_narrow(void)
+{
+    int i; for (i=0;i<16;i++) iv_arr[i]=i;      /* 0..15, sum 120 */
+    Assert(iv_up()   == 120, "iv narrow: up-counter [0,16)");
+    Assert(iv_down() == 120, "iv narrow: down-counter (16..1]");
+    Assert(iv_post() == 16,  "iv narrow: post-loop counter value");
+    Assert(iv_big()  == 2226, "iv NOT narrowed at >255 (no byte wrap)");
+}
+
 int main(int argc, char *argv[])
 {
     (void)argc; (void)argv;
@@ -324,5 +342,6 @@ int main(int argc, char *argv[])
     suite_add_test(test_ptr_post_inc);
     suite_add_test(test_or_long_zero);
     suite_add_test(test_const_store_fold);
+    suite_add_test(test_iv_narrow);
     return suite_run();
 }

--- a/test/suites/long_ir/irgaps.c
+++ b/test/suites/long_ir/irgaps.c
@@ -275,6 +275,37 @@ static void test_var_long_shift(void)
     Assert(gap_vshl(0x00000001UL, 20) == 0x00100000UL, "var-count long << keeps the count");
 }
 
+/* ---- Constant store folded to an immediate (arr[i]=K) --------------
+ * const_fold rewrites a constant MEM_VREG store to `ld (hl),imm` (byte) /
+ * `ld (hl),lo;inc hl;ld (hl),hi` (word) with src[0]=-1 — no value register.
+ * The word case regressed: a `&sym+const` base folds the store MEM_VREG ->
+ * MEM_SYM, and the MEM_SYM path defaulted the width to 2 and loaded the
+ * (now folded-away) value vreg's dead slot, storing garbage. Covers both
+ * MEM_VREG (variable index) and MEM_SYM (constant index) for byte + word. */
+int csf_w[8];
+unsigned char csf_b[8];
+long csf_l[8];
+static int const_store_fold(void)
+{
+    int i, sum = 0, lok = 1;
+    for (i = 0; i < 8; i++) { csf_w[i] = 1000; csf_b[i] = 0xAB; csf_l[i] = 0x11223344L; }  /* MEM_VREG byte/word/long */
+    csf_w[2] = 2000; csf_b[2] = 0xCD; csf_l[2] = 0x55667788L;    /* const index → MEM_SYM after fold */
+    for (i = 0; i < 8; i++) { sum += csf_w[i]; sum += csf_b[i]; }
+    for (i = 0; i < 8; i++) {
+        long e = (i == 2) ? 0x55667788L : 0x11223344L;
+        if (csf_l[i] != e) lok = 0;
+    }
+    return lok ? sum : -1;
+}
+
+static void test_const_store_fold(void)
+{
+    /* 7*1000 + 2000 = 9000 ; 7*0xAB + 0xCD = 1402 ; total 10402 = 0x28A2.
+       The long stores (0x11223344 / [2]=0x55667788) must round-trip too. */
+    Assert(const_store_fold() == 10402,
+           "const store fold byte+word+long, MEM_VREG + MEM_SYM");
+}
+
 int main(int argc, char *argv[])
 {
     (void)argc; (void)argv;
@@ -292,5 +323,6 @@ int main(int argc, char *argv[])
     suite_add_test(test_postinc_init);
     suite_add_test(test_ptr_post_inc);
     suite_add_test(test_or_long_zero);
+    suite_add_test(test_const_store_fold);
     return suite_run();
 }

--- a/test/suites/long_ir/word_resident.c
+++ b/test/suites/long_ir/word_resident.c
@@ -22,6 +22,7 @@
 int wr_arr[8];
 struct wrec { int a, b, c, d; };
 struct wrec wr_recs[4];
+int wr_mat[4][4];
 
 static int wr_index_walk(int *a, int n)         /* 1 add/iter — index_walk shape */
 {
@@ -57,6 +58,23 @@ static int wr_nested(void)                      /* nested loop — region detect
     return sum;
 }
 
+static int wr_matrix(int m[4][4])               /* `m[i][j]` flat 2D walk — the inner
+                                                   `p < row_end` compare is slot-vs-slot
+                                                   (BC holds the outer row pointer), so it
+                                                   needs the byte-wise-A DE-clean lowering
+                                                   for the DE-home to survive; the `p += 2`
+                                                   element step needs the DE-clean inc-hl
+                                                   chain. A stale/clobbered DE (sum) or a
+                                                   wrong step gives a wrong total. */
+{
+    int i, j, sum;
+    sum = 0;
+    for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
+            sum += m[i][j];
+    return sum;
+}
+
 static int wr_cond_accum(int *a, int n)         /* conditional update — def-dom gate */
 {
     int i, sum;
@@ -86,12 +104,26 @@ static void test_word_resident(void)
         wr_recs[i].a = i + 1; wr_recs[i].b = 0x0100;
         wr_recs[i].c = 0x0010; wr_recs[i].d = 0x1000;
     }
+    {   /* wr_mat[i][j] = (i*4+j+1)*0x80 → 0x80..0x800; running total crosses
+           the high byte repeatedly. Sum = 0x80 * (1+..+16) = 0x80*136 = 0x4400. */
+        int j;
+        for (i = 0; i < 4; i++)
+            for (j = 0; j < 4; j++)
+                wr_mat[i][j] = (i * 4 + j + 1) * 0x80;
+    }
 
     Assert(wr_index_walk(wr_arr, 8) == 0x28EC, "word resident: index walk");
     Assert(wr_ptr_walk(wr_arr, 8)   == 0x28EC, "word resident: ptr walk");
     Assert(wr_index_walk(wr_arr, 0) == 0,      "word resident: zero-trip");
+    /* Signed-bound LFTR clamp: a negative bound is a 0-trip loop. LFTR rewrites
+       `i<n` to a `p<p_end` pointer compare; without clamping p_end to
+       base+max(0,n)*scale a negative n wraps p_end below base and runs a huge
+       loop. Guards that. */
+    Assert(wr_index_walk(wr_arr, -1)    == 0,  "word resident: negative-bound 0-trip");
+    Assert(wr_index_walk(wr_arr, -1000) == 0,  "word resident: large-negative-bound 0-trip");
     Assert(wr_field_sum(wr_recs, 4) == 0x444A, "word resident: field sum");
     Assert(wr_nested()              == 0x48C0, "word resident: nested");
+    Assert(wr_matrix(wr_mat)        == 0x4400, "word resident: matrix m[i][j] (slot-vs-slot DE-clean cmp)");
     Assert(wr_cond_accum(wr_arr, 8) == 0x1230, "word resident: conditional accum");
     /* i=-30000,-20000,-10000,0 → sum -60000 → (int16) 0x15A0. First compare
        -30000<10000 has i-hi=-40000 (int16 overflow): guards the signed test's

--- a/test/suites/math/fixmath.c
+++ b/test/suites/math/fixmath.c
@@ -120,6 +120,22 @@ void test_pow()
     run_pow(FIX16_FROM_FLOAT(2.0), FIX16_FROM_FLOAT(0.5), FIX16_FROM_FLOAT(1.42));
 }
 
+/* Storing an INTEGER into an _Accum lvalue via an index / pointer deref must
+   scale int→fixed-point (`fa[i] = 5` → 5.0, not the raw bits 5). The
+   indexed/deref store paths skipped the scaling, storing the unshifted int. */
+static FIX itf_a[4];
+static FIX *itf_p;
+static int itf_seed = 7;
+static int seven(void) { return itf_seed; }   /* opaque: no const-fold to a literal */
+void test_int_to_accum_store()
+{
+    int i;
+    for (i = 0; i < 4; i++) itf_a[i] = 5;         /* int literal -> _Accum (array) */
+    Assert(FIX16_TO_INT(itf_a[0]) == 5, "int lit -> accum arr");
+    itf_p = &itf_a[2]; *itf_p = seven();          /* int var -> _Accum (deref) */
+    Assert(FIX16_TO_INT(itf_a[2]) == 7, "int var -> accum deref");
+}
+
 int suite_math()
 {
     suite_setup(MATH_LIBRARY " Tests");
@@ -127,6 +143,7 @@ int suite_math()
     suite_add_test(test_comparison);
     suite_add_test(test_integer_constant_operations);
     suite_add_test(test_approx_equal);
+    suite_add_test(test_int_to_accum_store);
     suite_add_test(test_sqrt);
     suite_add_test(test_pow);
     return suite_run();

--- a/test/suites/math/math.c
+++ b/test/suites/math/math.c
@@ -281,6 +281,38 @@ void test_fmax()
 
 #endif
 
+/* Storing an INTEGER into a float lvalue via an index / pointer deref must
+   convert int→float (`fa[i] = 5` → 5.0), not store the raw integer. The
+   indexed/deref store paths skipped the conversion, storing an int-width
+   value into the float slot: for a 4-byte double (math32/mbf32) `fa[i]=0`
+   left the high 2 bytes stale, so a prior value leaked. */
+static FLOAT itf_a[4];
+static FLOAT *itf_p;
+void test_int_to_float_store()
+{
+    int i, five = 5;
+    for (i = 0; i < 4; i++) itf_a[i] = 100;      /* int literal → float (array) */
+    Assert(approx_equal(itf_a[0], 100.0, EPSILON), "int lit -> float arr");
+    itf_p = &itf_a[2]; *itf_p = five;            /* int var → float (deref) */
+    Assert(approx_equal(itf_a[2], 5.0, EPSILON), "int var -> float deref");
+    for (i = 0; i < 4; i++) itf_a[i] = 0;         /* int 0 → float: clear ALL bytes */
+    Assert(approx_equal(itf_a[0], 0.0, EPSILON), "int 0 -> float arr (no stale high bytes)");
+    Assert(approx_equal(itf_a[1], 0.0, EPSILON), "int 0 -> float arr [1]");
+}
+
+/* `1.0 / x` is lowered to the reciprocal helper (l_f32_invf / l_f16_invf)
+   on IEEE-f32 and f16, and stays a full divide elsewhere — either way the
+   result must match. The divisor comes from a runtime-written global so the
+   quotient can't const-fold away. */
+static FLOAT recip_in[3];
+void test_reciprocal()
+{
+    recip_in[0] = 4.0; recip_in[1] = 0.5; recip_in[2] = 8.0;
+    Assert(approx_equal(1.0 / recip_in[0], 0.25,  EPSILON), "1/4 = 0.25");
+    Assert(approx_equal(1.0 / recip_in[1], 2.0,   EPSILON), "1/0.5 = 2");
+    Assert(approx_equal(1.0 / recip_in[2], 0.125, EPSILON), "1/8 = 0.125");
+}
+
 int suite_math()
 {
     suite_setup(MATH_LIBRARY " Tests");
@@ -293,6 +325,8 @@ int suite_math()
     suite_add_test(test_post_incdecrement);
     suite_add_test(test_pre_incdecrement);
     suite_add_test(test_approx_equal);
+    suite_add_test(test_int_to_float_store);
+    suite_add_test(test_reciprocal);
     suite_add_test(test_sqrt);
     suite_add_test(test_pow);
 #ifndef MATH16

--- a/test/suites/math/math.c
+++ b/test/suites/math/math.c
@@ -305,12 +305,18 @@ void test_int_to_float_store()
    result must match. The divisor comes from a runtime-written global so the
    quotient can't const-fold away. */
 static FLOAT recip_in[3];
+static int   recip_den[2];
 void test_reciprocal()
 {
     recip_in[0] = 4.0; recip_in[1] = 0.5; recip_in[2] = 8.0;
     Assert(approx_equal(1.0 / recip_in[0], 0.25,  EPSILON), "1/4 = 0.25");
     Assert(approx_equal(1.0 / recip_in[1], 2.0,   EPSILON), "1/0.5 = 2");
     Assert(approx_equal(1.0 / recip_in[2], 0.125, EPSILON), "1/8 = 0.125");
+    /* int reciprocal: sint2f feeds invf directly (the eval_A shape) — the
+       int-to-float result must survive in the DEHL cache for invf. */
+    recip_den[0] = 4; recip_den[1] = 8;
+    Assert(approx_equal(1.0 / recip_den[0], 0.25,  EPSILON), "1/int4 = 0.25");
+    Assert(approx_equal(1.0 / recip_den[1], 0.125, EPSILON), "1/int8 = 0.125");
 }
 
 int suite_math()

--- a/test/suites/sieve/Makefile
+++ b/test/suites/sieve/Makefile
@@ -1,0 +1,52 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+
+
+
+test.bin: $(SOURCES)
+	$(compile)
+	$(runtest)
+
+test_r2ka.bin: $(SOURCES)
+	$(compile_r2ka)
+	$(runtest_r2ka)
+
+test_r4k.bin: $(SOURCES)
+	$(compile_r4k)
+	$(runtest_r4k)
+
+test_z180.bin: $(SOURCES)
+	$(compile_z180)
+	$(runtest_z180)
+
+test_8080.bin: $(SOURCES)
+	$(compile_8080)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(compile_8085)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(compile_gbz80)
+	$(runtest_gbz80)
+
+test_ez80_z80.bin: $(SOURCES)
+	$(compile_ez80_z80)
+	$(runtest_ez80_z80)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/sieve/sieve.c
+++ b/test/suites/sieve/sieve.c
@@ -1,0 +1,65 @@
+/*
+ * sieve.c — Sieve of Eratosthenes prime count, compiler comparison bench.
+ *
+ * Classic BYTE-magazine sieve: mark composites in a byte flag array over
+ * [2, SIZE) and count the primes that survive. The hot inner loop is pure
+ * unsigned-int arithmetic + a strided byte-array walk (flags[k] with
+ * k += i), so it exercises int add/compare, the `!flags[k]` byte load and
+ * the flags[k]=1 byte store — a good foil for pointer/index codegen.
+ *
+ * Uses the (n+1)^2 = n^2 + 2n + 1 recurrence to advance the square bound
+ * without a multiply, keeping the outer test a plain 16-bit compare.
+ *
+ * SIZE and the expected prime count are host-verified: primes in [2,7999].
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "test.h"
+
+#define SIZE 8000
+
+static unsigned char flags[SIZE];
+
+/* Count primes in [2, SIZE-1]. `count` starts at every candidate and is
+   decremented once per composite the sieve reaches. */
+static unsigned int sieve_count(void)
+{
+    unsigned int i, i_sq, k, count;
+
+    memset(flags, 0, SIZE);
+
+    count = SIZE - 2;
+    i_sq = 4;
+    for (i = 2; i_sq < SIZE; ++i) {
+        if (!flags[i]) {
+            for (k = i_sq; k < SIZE; k += i) {
+                count   -= !flags[k];
+                flags[k] = 1;
+            }
+        }
+        i_sq += i + i + 1;      /* (n+1)^2 = n^2 + 2n + 1 */
+    }
+    return count;
+}
+
+static void sieve_run(void)
+{
+    assertEqual(sieve_count(), 1007U);   /* primes in [2,7999], host-verified */
+}
+
+int suite_sieve(void)
+{
+    suite_setup("Sieve Tests");
+    suite_add_test(sieve_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    (void)argc; (void)argv;
+    res += suite_sieve();
+    exit(res);
+}

--- a/test/suites/spectralnorm/Makefile
+++ b/test/suites/spectralnorm/Makefile
@@ -1,0 +1,35 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+# Floating-point bench: z80 uses IEEE math32 (matches sdcc's 32-bit double,
+# so cross-compiler comparison is apples-to-apples); the index-register-less
+# CPUs (8080/8085/gbz80 — the strategic sp-mode targets) use the 32-bit MBF
+# library, mirroring the math suite.
+all:	test.bin test_8080.bin test_8085.bin test_gbz80.bin
+
+
+test.bin: $(SOURCES)
+	$(call compile,-DMATH32 -D__MATH_MATH32 -fp-mode=ieee,-lmath32)
+	$(runtest)
+
+test_8080.bin: $(SOURCES)
+	$(call compile_8080,--math-mbf32)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(call compile_8085,--math-mbf32)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(call compile_gbz80,--math-mbf32)
+	$(runtest_gbz80)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/spectralnorm/spectralnorm.c
+++ b/test/suites/spectralnorm/spectralnorm.c
@@ -1,0 +1,98 @@
+/*
+ * spectralnorm.c — spectral-norm (Computer Language Benchmarks Game),
+ * adapted as a floating-point compiler-comparison bench.
+ *
+ * Approximates the largest singular value of the infinite matrix
+ * A[i][j] = 1/((i+j)(i+j+1)/2 + i+1) by 10 rounds of power iteration on
+ * A^T·A applied to a length-NUM vector, then sqrt(vBv/vv). The hot work is
+ * double multiply-accumulate in the NUM×NUM inner loops (eval_A_times_u /
+ * eval_At_times_u) plus a double divide per eval_A — a dense workout of the
+ * software float ABI and codegen.
+ *
+ * NUM=16 (not the canonical 100) keeps the emulated-double workload inside
+ * a sensible simulator budget while still exercising every float path. The
+ * result is checked with a tolerance (approx_equal) because the exact bits
+ * differ across float formats (math32 vs mbf32). Host-verified value below.
+ *
+ * Contributed originally by Sebastien Loisel.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "test.h"
+
+#define NUM 16
+
+/* Absolute-tolerance compare — the exact low bits differ between the 48-bit
+   and 32-bit (MBF) float libraries, so an == would be wrong. */
+static int approx_equal(double a, double b, double eps)
+{
+    double d = a - b;
+    if (d < 0.0) d = -d;
+    return d < eps;
+}
+
+static double eval_A(int i, int j)
+{
+    return 1.0 / ((i + j) * (i + j + 1) / 2 + i + 1);
+}
+
+static void eval_A_times_u(const double u[], double Au[])
+{
+    int i, j;
+    for (i = 0; i < NUM; i++) {
+        Au[i] = 0;
+        for (j = 0; j < NUM; j++) Au[i] += eval_A(i, j) * u[j];
+    }
+}
+
+static void eval_At_times_u(const double u[], double Au[])
+{
+    int i, j;
+    for (i = 0; i < NUM; i++) {
+        Au[i] = 0;
+        for (j = 0; j < NUM; j++) Au[i] += eval_A(j, i) * u[j];
+    }
+}
+
+static void eval_AtA_times_u(const double u[], double AtAu[])
+{
+    static double v[NUM];
+    eval_A_times_u(u, v);
+    eval_At_times_u(v, AtAu);
+}
+
+static void spectralnorm_run(void)
+{
+    static double u[NUM], v[NUM];
+    double vBv, vv, r;
+    int i;
+
+    for (i = 0; i < NUM; i++) u[i] = 1;
+    for (i = 0; i < 10; i++) {
+        eval_AtA_times_u(u, v);
+        eval_AtA_times_u(v, u);
+    }
+    vBv = vv = 0;
+    for (i = 0; i < NUM; i++) { vBv += u[i] * v[i]; vv += v[i] * v[i]; }
+    r = sqrt(vBv / vv);
+
+    /* NUM=16 converges to 1.273525215 (host, IEEE double). */
+    Assert(approx_equal(r, 1.273525215, 0.005), "spectral norm ~= 1.27353");
+}
+
+int suite_spectralnorm(void)
+{
+    suite_setup("Spectral-norm Tests");
+    suite_add_test(spectralnorm_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    (void)argc; (void)argv;
+    res += suite_spectralnorm();
+    exit(res);
+}


### PR DESCRIPTION
[sitting here whilst it builds]

This has a tranche and fixes and codegen changes:

* Demote an int loop into a uchar loop if limits are suitable. This reduces the increment to a inc (ix+d)/inc(hl)
* Other loop tweaks to speed up and free up registers
* Stop hoisting of a true constant - loading from the slot is more expensive than a direct load
* Tighten up codegen to avoid some register shuffling
* Copy sccz80's 1/x floating point optimisation
* A lot of missing float const conversion issues
* Add some more benchmarks in to cover different scenarios