### PR TITLE
(xcc) Add support for XCC compiler

### DIFF
--- a/lib/xcc_rules.1
+++ b/lib/xcc_rules.1
@@ -1,0 +1,11 @@
+%title Rename xcc __divsint call to xcc-specific alias (avoid stack-based sdcc symbol clash)
+	call	__divsint
+=
+	EXTERN	__xcc_divsint
+	call	__xcc_divsint
+
+%title Rename xcc __divuint call to xcc-specific alias
+	call	__divuint
+=
+	EXTERN	__xcc_divuint
+	call	__xcc_divuint

--- a/libsrc/l/l_z80.lst
+++ b/libsrc/l/l_z80.lst
@@ -1,3 +1,4 @@
 @${NEWLIB_ROOT}l/sccz80/z80.lst
 @${NEWLIB_ROOT}l/util/z80.lst
+@${NEWLIB_ROOT}l/xcc.lst
 @${NEWLIB_ROOT}l/sdcc.lst

--- a/libsrc/l/xcc.lst
+++ b/libsrc/l/xcc.lst
@@ -1,0 +1,10 @@
+${NEWLIB_ROOT}l/xcc/__mulint
+${NEWLIB_ROOT}l/xcc/__divuint
+${NEWLIB_ROOT}l/xcc/__divsint
+${NEWLIB_ROOT}l/xcc/__moduint
+${NEWLIB_ROOT}l/xcc/__smod16
+${NEWLIB_ROOT}l/xcc/__mullong
+${NEWLIB_ROOT}l/xcc/__divulong
+${NEWLIB_ROOT}l/xcc/__divslong
+${NEWLIB_ROOT}l/xcc/__modulong
+${NEWLIB_ROOT}l/xcc/__smod32

--- a/libsrc/l/xcc/__divsint.asm
+++ b/libsrc/l/xcc/__divsint.asm
@@ -1,0 +1,22 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __sdiv16
+PUBLIC __xcc_divsint
+
+EXTERN l_divs_16_16x16
+
+; 16-bit signed division (xcc sdcccall(1) runtime ABI).
+; Exposed as __sdiv16 (xcc's own name) and __xcc_divsint (renamed via
+; lib/xcc_rules.1 to sidestep sdcc's stack-based __divsint in the same crt0
+; archive).
+;
+; enter : hl = dividend, de = divisor
+; exit  : de = quotient, hl = remainder (sign of dividend)
+; uses  : af, bc, de, hl
+
+__sdiv16:
+__xcc_divsint:
+   call l_divs_16_16x16    ; hl = quotient, de = remainder
+   ex de,hl                ; xcc returns de = quotient, hl = remainder
+   ret

--- a/libsrc/l/xcc/__divslong.asm
+++ b/libsrc/l/xcc/__divslong.asm
@@ -1,0 +1,36 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __sdiv32
+PUBLIC __divslong
+
+EXTERN l_divs_32_32x32
+
+; 32-bit signed division (xcc sdcccall(1) runtime ABI). See __divulong for
+; the bank-shuffle rationale — signed differs only in the underlying core.
+
+__sdiv32:
+__divslong:
+   push ix
+   ld ix,0
+   add ix,sp
+
+   ex de,hl
+   exx
+
+   ld l,(ix+4)
+   ld h,(ix+5)
+   ld e,(ix+6)
+   ld d,(ix+7)
+
+   call l_divs_32_32x32
+
+   ex de,hl
+   push hl
+   push de
+   exx
+   pop de
+   pop hl
+
+   pop ix
+   ret

--- a/libsrc/l/xcc/__divuint.asm
+++ b/libsrc/l/xcc/__divuint.asm
@@ -1,0 +1,22 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __div16
+PUBLIC __xcc_divuint
+
+EXTERN l_divu_16_16x16
+
+; 16-bit unsigned division (xcc sdcccall(1) runtime ABI).
+; Exposed as __div16 and __xcc_divuint — call sites emitted as __divuint are
+; renamed via lib/xcc_rules.1 to sidestep sdcc's stack-based __divuint in the
+; same crt0 archive.
+;
+; enter : hl = dividend, de = divisor
+; exit  : de = quotient, hl = remainder
+; uses  : af, bc, de, hl
+
+__div16:
+__xcc_divuint:
+   call l_divu_16_16x16    ; hl = quotient, de = remainder
+   ex de,hl                ; xcc returns de = quotient, hl = remainder
+   ret

--- a/libsrc/l/xcc/__divulong.asm
+++ b/libsrc/l/xcc/__divulong.asm
@@ -1,0 +1,43 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __div32
+PUBLIC __divulong
+
+EXTERN l_divu_32_32x32
+
+; 32-bit unsigned division (xcc sdcccall(1) runtime ABI).
+;
+; enter : de:hl = x  (dividend, DE=low16, HL=high16)
+;         y at 4(ix)..7(ix) (divisor, lsb..msb)
+; exit  : de:hl = quotient (DE=low16, HL=high16)
+; uses  : af, bc, de, hl, ix, alt regs
+;
+; z88dk l_divu_32_32x32 spec: dehl (main) = divisor, dehl' (shadow) = dividend
+;                             exit dehl = quotient, dehl' = remainder.
+
+__div32:
+__divulong:
+   push ix
+   ld ix,0
+   add ix,sp
+
+   ex de,hl                    ; bank A: DE=hi(x), HL=lo(x)  — z88dk dividend
+   exx                         ; park dividend in shadow; bank B active
+
+   ld l,(ix+4)
+   ld h,(ix+5)                 ; HL = y_low_word
+   ld e,(ix+6)
+   ld d,(ix+7)                 ; DE = y_high_word — bank B holds divisor (z88dk)
+
+   call l_divu_32_32x32        ; bank B = quotient, bank A (shadow) = remainder
+
+   ex de,hl                    ; bank B: xcc order quotient
+   push hl
+   push de
+   exx                         ; bank A active
+   pop de
+   pop hl                      ; bank A = xcc order quotient
+
+   pop ix
+   ret

--- a/libsrc/l/xcc/__moduint.asm
+++ b/libsrc/l/xcc/__moduint.asm
@@ -1,0 +1,17 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __mod16
+PUBLIC __moduint
+
+EXTERN l_divu_16_16x16
+
+; 16-bit unsigned modulus (xcc sdcccall(1) runtime ABI)
+;
+; enter : hl = dividend, de = divisor
+; exit  : de = dividend % divisor
+; uses  : af, bc, de, hl
+
+__mod16:
+__moduint:
+   jp l_divu_16_16x16      ; hl = quotient, de = remainder — xcc wants de = remainder

--- a/libsrc/l/xcc/__modulong.asm
+++ b/libsrc/l/xcc/__modulong.asm
@@ -1,0 +1,33 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __mod32
+PUBLIC __modulong
+
+EXTERN l_divu_32_32x32
+
+; 32-bit unsigned modulus (xcc sdcccall(1) runtime ABI).
+; After l_divu_32_32x32, shadow bank already holds the remainder — one exx
+; brings it home; then ex de,hl to xcc order.
+
+__mod32:
+__modulong:
+   push ix
+   ld ix,0
+   add ix,sp
+
+   ex de,hl                    ; bank A: z88dk dividend
+   exx                         ; park dividend in shadow
+
+   ld l,(ix+4)
+   ld h,(ix+5)
+   ld e,(ix+6)
+   ld d,(ix+7)                 ; bank B: z88dk divisor
+
+   call l_divu_32_32x32        ; bank B = quotient, bank A = remainder
+
+   exx                         ; bank A active with z88dk remainder
+   ex de,hl                    ; xcc order
+
+   pop ix
+   ret

--- a/libsrc/l/xcc/__mulint.asm
+++ b/libsrc/l/xcc/__mulint.asm
@@ -1,0 +1,19 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __mul16
+PUBLIC __mulint
+
+EXTERN l_mulu_16_16x16
+
+; 16-bit multiplication (xcc sdcccall(1) runtime ABI)
+;
+; enter : hl = multiplicand, de = multiplier
+; exit  : de = product (low 16)
+; uses  : af, bc, de, hl
+
+__mul16:
+__mulint:
+   call l_mulu_16_16x16    ; hl = hl * de
+   ex de,hl                ; xcc returns product in de
+   ret

--- a/libsrc/l/xcc/__mullong.asm
+++ b/libsrc/l/xcc/__mullong.asm
@@ -1,0 +1,49 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __mul32
+PUBLIC __mullong
+
+EXTERN l_mulu_32_32x32
+
+; 32-bit multiplication (xcc sdcccall(1) runtime ABI).
+;
+; enter : de:hl = x  (DE = low16, HL = high16 — xcc convention)
+;         y at 4(ix)..7(ix) after `push ix; ld ix, sp` (lsb..msb)
+; exit  : de:hl = product low 32 (DE = low16, HL = high16)
+; uses  : af, bc, de, hl, ix, alt regs
+;
+; z88dk l_mulu_32_32x32 uses DE = high16, HL = low16, second op in DEHL' shadow.
+; Wrapper flow:
+;   1. ex de,hl        : convert x to z88dk order in bank A
+;   2. exx             : x now in shadow bank; caller's "other" bank (B) is active
+;   3. load y from stack into active bank in z88dk order
+;   4. call l_mulu_32_32x32   : main (B) = mcand, shadow (A) = mplier → main (B) = product
+;   5. ex de,hl        : convert product to xcc order
+;   6. push/exx/pop    : shuttle product back to bank A so caller sees it in original main
+
+__mul32:
+__mullong:
+   push ix
+   ld ix,0
+   add ix,sp                   ; ix = sp; 4(ix)..7(ix) = y bytes (lsb..msb)
+
+   ex de,hl                    ; bank A: DE=hi(x), HL=lo(x)  — z88dk order
+   exx                         ; bank B now active; x parked in shadow
+
+   ld l,(ix+4)
+   ld h,(ix+5)                 ; HL = y_low_word
+   ld e,(ix+6)
+   ld d,(ix+7)                 ; DE = y_high_word — bank B in z88dk order
+
+   call l_mulu_32_32x32        ; bank B = product (z88dk)
+
+   ex de,hl                    ; bank B: DE=lo, HL=hi  — xcc order
+   push hl
+   push de
+   exx                         ; back to bank A (clobbered by mul; product on stack)
+   pop de
+   pop hl                      ; bank A = product (xcc order)
+
+   pop ix
+   ret

--- a/libsrc/l/xcc/__smod16.asm
+++ b/libsrc/l/xcc/__smod16.asm
@@ -1,0 +1,18 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __smod16
+PUBLIC __modsint
+
+EXTERN l_divs_16_16x16
+
+; 16-bit signed modulus (xcc sdcccall(1) runtime ABI, C11 semantics)
+; l_divs_16_16x16 leaves remainder in de with the sign of the dividend.
+;
+; enter : hl = dividend, de = divisor
+; exit  : de = dividend % divisor
+; uses  : af, bc, de, hl
+
+__smod16:
+__modsint:
+   jp l_divs_16_16x16

--- a/libsrc/l/xcc/__smod32.asm
+++ b/libsrc/l/xcc/__smod32.asm
@@ -1,0 +1,33 @@
+SECTION code_clib
+SECTION code_l_xcc
+
+PUBLIC __smod32
+PUBLIC __modslong
+
+EXTERN l_divs_32_32x32
+
+; 32-bit signed modulus (xcc sdcccall(1) runtime ABI, C11: sign of dividend).
+; l_divs_32_32x32 leaves the remainder in the shadow bank with the sign of
+; the dividend, matching xcc's expected semantic.
+
+__smod32:
+__modslong:
+   push ix
+   ld ix,0
+   add ix,sp
+
+   ex de,hl
+   exx
+
+   ld l,(ix+4)
+   ld h,(ix+5)
+   ld e,(ix+6)
+   ld d,(ix+7)
+
+   call l_divs_32_32x32
+
+   exx
+   ex de,hl
+
+   pop ix
+   ret

--- a/src/zcc/zcc.c
+++ b/src/zcc/zcc.c
@@ -315,6 +315,8 @@ static enum iostyle    compiler_style = outimplied;
 #define CC_SDCC      1
 #define CC_EZ80CLANG 2
 #define CC_80CC      3
+#define CC_XCC       4
+
 static char           *c_compiler_type = "sccz80";
 static int             compiler_type = CC_SCCZ80;
 
@@ -366,6 +368,7 @@ static char  *c_coptrules_target = NULL;
 static char  *coptrules_cpu = NULL;
 static char  *c_ez80clang_opt = NULL;
 static char  *c_80cc_opt = NULL;
+static char  *c_xcc_opt = NULL;
 static char  *c_sdccopt1 = NULL;
 static char  *c_sdccopt2 = NULL;
 static char  *c_sdccopt3 = NULL;
@@ -442,6 +445,7 @@ static arg_t  config[] = {
     { "COPTRULESTARGET", 0, SetStringConfig, &c_coptrules_target, NULL, "Optimisation file for target specific operations",NULL },
     { "EZ80CLANGRULES", 0, SetStringConfig, &c_ez80clang_opt, NULL, "Rules for ez80 clang", "DESTDIR/lib/clang_rules.1"},
     { "80CCRULES", 0, SetStringConfig, &c_80cc_opt, NULL, "Options for 80cc", "DESTDIR/lib/80cc_rules.1"},
+    { "XCCRULES", 0, SetStringConfig, &c_xcc_opt, NULL, "Options for xcc", "DESTDIR/lib/xcc_rules.1"},
     { "SDCCOPT1", 0, SetStringConfig, &c_sdccopt1, NULL, "", "\"DESTDIR/lib/sdcc/sdcc_opt.1\"" },
     { "SDCCOPT2", 0, SetStringConfig, &c_sdccopt2, NULL, "", "\"DESTDIR/lib/sdcc/sdcc_opt.2\"" },
     { "SDCCOPT3", 0, SetStringConfig, &c_sdccopt3, NULL, "", "\"DESTDIR/lib/sdcc/sdcc_opt.3\"" },
@@ -1473,6 +1477,14 @@ int main(int argc, char **argv)
                 int    num_rules = 0;
 
                 rules[num_rules++] = c_ez80clang_opt;
+
+                apply_copt_rules(i, num_rules, rules, ".opt", ".op1", ".asm");
+            } else if (compiler_type == CC_XCC) {
+                char  *rules[MAX_COPT_RULE_FILES];
+                int    num_rules = 0;
+                rules[num_rules++] = c_sdccopt1;
+                rules[num_rules++] = c_sdccopt9;
+                rules[num_rules++] = c_xcc_opt;
 
                 apply_copt_rules(i, num_rules, rules, ".opt", ".op1", ".asm");
 
@@ -3116,6 +3128,16 @@ static void configure_compiler(void)
         compiler_style = filter_outspecified_flag;
         BuildOptions(&asmargs, "-D__SDCC");
         BuildOptions(&linkargs, "-D__SDCC");
+    } else if (strcmp(c_compiler_type,"xcc") == 0 ) {
+        compiler_type = CC_XCC;
+        preprocarg = " -D__XCC";
+        BuildOptions(&cpparg, preprocarg);
+        c_compiler = "xcc";
+        add_option_to_compiler("-S -O2 --sdcccall 0 --c1mode");
+        c_cpp_exe = c_sdcc_preproc_exe;
+        compiler_style = filter_outspecified_flag;
+        BuildOptions(&asmargs, "-D__XCC");
+        BuildOptions(&linkargs, "-D__XCC");
     } else if (strcmp(c_compiler_type,"sccz80") == 0 ) {
         preprocarg = " -DSCCZ80 -DSMALL_C -D__SCCZ80";
         BuildOptions(&cpparg, preprocarg);


### PR DESCRIPTION
It's not often you add support for 2 compilers in one week. This is that week!

* Add support for -compiler=xcc from https://github.com/retro-vault/xyz
* Minimal support routines have been added that can link some functions..

Not usable yet against classic due to a symbol prefix issue in xcc.

