### PR TITLE
80cc: More optimisations and benches - register residency

### DIFF
--- a/src/80cc/ir.c
+++ b/src/80cc/ir.c
@@ -240,6 +240,7 @@ Func *ir_func_new(SYMBOL *fn)
     f->has_setjmp = 0;
     f->ns = NULL;
     f->word_home_vreg = -1;
+    f->de_home_general = 0;
     f->vreg_to_phys = NULL;
     f->vreg_spill_slot = NULL;
     f->live_ranges = NULL;

--- a/src/80cc/ir.c
+++ b/src/80cc/ir.c
@@ -187,6 +187,10 @@ const char *ir_phys_name(PhysReg pr)
     case IR_PR_BC:     return "BC";
     case IR_PR_IX:     return "IX";
     case IR_PR_IY:     return "IY";
+    case IR_PR_IXL:    return "IXL";
+    case IR_PR_IXH:    return "IXH";
+    case IR_PR_IYL:    return "IYL";
+    case IR_PR_IYH:    return "IYH";
     case IR_PR_DEHL:   return "DEHL";
     case IR_PR_AF_ALT: return "AF'";
     case IR_PR_HL_ALT: return "HL'";

--- a/src/80cc/ir.h
+++ b/src/80cc/ir.h
@@ -546,6 +546,14 @@ typedef struct {
        IR_PR_DE). Set by ir_alloc, read by ir_lower. */
     int        word_home_vreg;
 
+    /* DE-home co-design (opt-in IR_DE_HOME): set when word_home_vreg is a
+       GENERAL (non-reduction) loop-carried width-2 vreg (e.g. searchbench
+       `hi`) rather than a reduction accumulator. The lowerer keeps DE clean
+       across the region via the (ix+d) compare/ALU folds + a push/pop-de deref,
+       and commits a general home-def to DE. 0 = reduction accumulator (the
+       existing try_word_accumulate path). */
+    int        de_home_general;
+
     /* Function attributes — pulled from the symbol's ctype flags but
        hoisted here for the lowerer's convenience. */
     IrAbi      abi;

--- a/src/80cc/ir.h
+++ b/src/80cc/ir.h
@@ -67,6 +67,12 @@ typedef enum {
     IR_PR_B,           /* width-1 byte home: high half of BC (headroom) */
     IR_PR_IX,
     IR_PR_IY,
+    /* width-1 byte homes in index-register halves (z80/z80n/ez80 only —
+       ld a,iyl / ld iyl,a / add a,iyl etc.). SLOTLESS and clobber-free in a
+       no-call region (the operand loader never stages in an index reg), so
+       unlike PR_E/PR_D they need no backing slot, lazy-spill, or cross-BB carry:
+       the value rides the half from its def for the whole region. */
+    IR_PR_IXL, IR_PR_IXH, IR_PR_IYL, IR_PR_IYH,
     IR_PR_DEHL,        /* 32-bit pair occupying DE and HL together */
     IR_PR_AF_ALT,
     IR_PR_HL_ALT,

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -230,6 +230,51 @@ static int pr_bc_propose(const Func *f,
     return n;
 }
 
+/* z80/z80n/z180: a stepping counter homed in idx2 (IX/IY) is only cheap if its
+   reads are index-half-friendly — its own step (`inc iy`) and, on z80/z80n only,
+   branch-fused int compares (`ld a,iyl; sub …` — the (ix+d) fold reads the halves
+   in place). Any OTHER read (address arithmetic `arr[i]`, general ALU `n - i`, a
+   move to a gp pair) needs a `push iy; pop hl` every iteration, which usually
+   costs more than the frame slot the idx2 home saved. Returns 1 if v has such a
+   "hostile" use → the caller skips the idx2 counter home, letting v fall to BC/a
+   slot.
+   z180 has NO usable index halves (`sub iyl` traps the undocumented opcode), so
+   there the compare exemption does NOT apply — a counter's exit test would itself
+   push/pop, so any counter with a compare use is hostile (effectively disabling
+   the idx2 counter home on z180, which is right). ez80/kc160/rabbit read index
+   registers cheaply (lea / native ops), so they keep the counter — gate is
+   z80/z80n/z180 only. */
+static int idx2_counter_hostile_use(const Func *f, int v)
+{
+    int halves_ok = (c_cpu == CPU_Z80 || IS_Z80N());   /* NOT z180 */
+    if (!(halves_ok || c_cpu == CPU_Z180)) return 0;
+    int hostile = 0;
+    for (int i = 0; i < f->n_bbs; i++)
+        for (int j = 0; j < f->bbs[i].n_ops; j++) {
+            const Op *o = &f->bbs[i].ops[j];
+            int u[16];
+            int nu = ir_op_uses(o, u, (int)(sizeof u / sizeof u[0]));
+            int uses_v = 0;
+            for (int k = 0; k < nu; k++) if (u[k] == v) { uses_v = 1; break; }
+            if (!uses_v) continue;
+            /* The counter's own self-step (inc/dec iy, or add iy,rr) — fine. */
+            if (o->dst == v && (o->kind == IR_INC || o->kind == IR_DEC
+                                || o->kind == IR_ADD || o->kind == IR_SUB))
+                continue;
+            /* Branch-fused int compare reads iyl/iyh in place — z80/z80n only
+               (z180 traps the index-half opcodes, so its compare push/pops too). */
+            if (halves_ok
+                && (o->kind == IR_CMP_LT || o->kind == IR_CMP_LE
+                 || o->kind == IR_CMP_GT || o->kind == IR_CMP_GE
+                 || o->kind == IR_CMP_ULT || o->kind == IR_CMP_ULE
+                 || o->kind == IR_CMP_UGT || o->kind == IR_CMP_UGE
+                 || o->kind == IR_CMP_EQ || o->kind == IR_CMP_NE))
+                continue;
+            hostile++;   /* address/ALU/move (or any z180 non-step) use */
+        }
+    return hostile;
+}
+
 /* idx2 proposer: the two candidate classes for the spare index register
    (f->idx2_reg) — a hot stepping COUNTER (LD_IMM init + INC/DEC self-steps,
    never a deref/step base) and a hot read-only PARAM bound. Both need the
@@ -285,8 +330,11 @@ static int idx2_propose(const Func *f, const int *use_count,
             if (is_base[v]) continue;
             if (use_count[v] < 4) continue;
             unsigned fl = 0;
-            /* Stepping counter: only-init(<=1) + steps write it. */
-            if (!counter_off && cstep[v] >= 1 && cother[v] == 0 && cinit[v] <= 1)
+            /* Stepping counter: only-init(<=1) + steps write it. On z80/z80n/z180
+               skip the idx2 home when the counter feeds address/ALU work that
+               would push iy;pop hl every iteration (idx2_counter_hostile_use). */
+            if (!counter_off && cstep[v] >= 1 && cother[v] == 0 && cinit[v] <= 1
+                && idx2_counter_hostile_use(f, v) == 0)
                 fl = CF_IDX2_COUNTER;
             /* Read-only invariant param. */
             else if ((vr->flags & IR_VREG_PARAM) && write_count[v] == 0)

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -130,6 +130,7 @@ enum {
     CF_IDX2_PARAM     = 1u << 1,   /* idx2: a read-only invariant param */
     CF_BYTE_SINGLE_BB = 1u << 2,   /* byte: confined to one BB → slotless PR_C ok */
     CF_SPECULATIVE    = 1u << 3,   /* IV-residency candidate (Phase 2) */
+    CF_DE_GENERAL     = 1u << 4,   /* DE-home: a general (non-accumulate) home */
 };
 /* Cost-model per-access weights (relative T-state savings of reg vs slot; the
    orchestrator's benefit = Σ depth-weighted access weights). A DEREF of a base
@@ -410,6 +411,101 @@ static int word_acc_propose(const Func *f, const int *use_count,
     return n;
 }
 
+/* DE-home GENERAL proposer (default-on; IR_NO_DE_HOME opts out): a hot loop-
+   carried width-2 vreg that is NOT a reduction accumulator — searchbench's `hi`
+   (init in bb0, updated `hi = mid - 1` in-loop). It rides DE across the loop; the
+   (ix+d) compare/ALU folds keep the region DE-clean and the indexed deref recomputes
+   from BC. Distinct from word_acc_propose (which requires `v = v OP w`). Same
+   domination + hotness gates; additionally the vreg must be DEFINED inside a loop
+   (loop-carried) and not be a memory base. Tagged CF_DE_GENERAL so the arbiter sets
+   f->de_home_general. The pick is speculative (the lowerer reverts to the baseline
+   allocation if no DE-clean region forms), so a false candidate never regresses.
+   Fills out[] (sized f->n_vregs), returns the count. */
+static int de_home_general_propose(const Func *f, const int *use_count,
+                                   const int *write_count, const int *bb_in_loop,
+                                   const int *first_use, const int *last_use,
+                                   Cand *out)
+{
+    if (getenv("IR_NO_DE_HOME")) return 0;
+    for (int i = 0; i < f->n_bbs; i++)
+        for (int j = 0; j < f->bbs[i].n_ops; j++) {
+            OpKind k = f->bbs[i].ops[j].kind;
+            if (k == IR_CALL || k == IR_HCALL || k == IR_ASM) return 0;
+        }
+    for (int v = 0; v < f->n_vregs; v++)
+        if (f->vreg_to_phys[v] == IR_PR_E || f->vreg_to_phys[v] == IR_PR_D)
+            return 0;   /* DE low half already a byte E/D home */
+    size_t nv = f->n_vregs > 0 ? (size_t)f->n_vregs : 0;
+    int *wd_def  = calloc(nv, sizeof(int));
+    int *wd_read = calloc(nv, sizeof(int));
+    int *wd_base = calloc(nv, sizeof(int));
+    int *wd_acc  = calloc(nv, sizeof(int));   /* exclude reduction accumulators */
+    int *wd_ldef = calloc(nv, sizeof(int));   /* defined inside a loop bb */
+    int n = 0;
+    if (wd_def && wd_read && wd_base && wd_acc && wd_ldef) {
+        for (int v = 0; v < f->n_vregs; v++) { wd_def[v] = INT_MAX; wd_read[v] = INT_MAX; }
+        int g = 0;
+        for (int i = 0; i < f->n_bbs; i++) {
+            const BB *bb = &f->bbs[i];
+            for (int j = 0; j < bb->n_ops; j++, g++) {
+                const Op *o = &bb->ops[j];
+                int u[16];
+                int nu = ir_op_uses(o, u, (int)(sizeof u/sizeof u[0]));
+                for (int k = 0; k < nu; k++)
+                    if (u[k] >= 0 && u[k] < f->n_vregs && g < wd_read[u[k]])
+                        wd_read[u[k]] = g;
+                if (o->dst >= 0 && o->dst < f->n_vregs) {
+                    if (g < wd_def[o->dst]) wd_def[o->dst] = g;
+                    if (bb_in_loop[i]) wd_ldef[o->dst] = 1;
+                }
+                if (o->kind == IR_POSTSTEP && o->src[0] >= 0
+                    && o->src[0] < f->n_vregs && g < wd_def[o->src[0]])
+                    wd_def[o->src[0]] = g;
+                if ((o->kind == IR_LD_MEM || o->kind == IR_ST_MEM)
+                    && o->mem.kind == IR_MEM_VREG
+                    && o->mem.base >= 0 && o->mem.base < f->n_vregs)
+                    wd_base[o->mem.base] = 1;
+                if (o->kind == IR_POSTSTEP && o->src[0] >= 0
+                    && o->src[0] < f->n_vregs)
+                    wd_base[o->src[0]] = 1;
+                switch (o->kind) {
+                case IR_ADD: case IR_SUB: case IR_RSUB:
+                case IR_AND: case IR_OR:  case IR_XOR:
+                    if (o->dst >= 0 && o->dst < f->n_vregs
+                        && o->src[1] >= 0 && bb_in_loop[i]
+                        && (o->src[0] == o->dst || o->src[1] == o->dst))
+                        wd_acc[o->dst] = 1;
+                    break;
+                default: break;
+                }
+            }
+        }
+        for (int v = 0; v < f->n_vregs; v++) {
+            const VReg *vr = &f->vregs[v];
+            if (vr->width != 2) continue;
+            if (vr->flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE
+                             | IR_VREG_PARAM)) continue;
+            if (f->vreg_to_phys[v] != IR_PR_SPILL) continue;
+            if (wd_base[v]) continue;                     /* not a deref base */
+            if (wd_acc[v]) continue;                      /* accumulators → word_acc */
+            if (!wd_ldef[v]) continue;                    /* must be loop-carried */
+            if (use_count[v] < 4) continue;
+            if (write_count[v] < 2) continue;
+            if (wd_def[v] >= f->bbs[0].n_ops) continue;   /* init def in entry bb0 */
+            if (wd_def[v] >= wd_read[v]) continue;        /* def-first */
+            out[n].vreg = v;
+            out[n].benefit = use_count[v];
+            out[n].lo = first_use[v];
+            out[n].hi = last_use[v];
+            out[n].allowed = RC_DE_ACC;
+            out[n].flags = CF_DE_GENERAL;
+            n++;
+        }
+    }
+    free(wd_def); free(wd_read); free(wd_base); free(wd_acc); free(wd_ldef);
+    return n;
+}
+
 /* Word DE-home arbiter: single occupant, highest benefit (first on tie). The
    winner OWNS DE — every other PR_DE tenant is demoted to SPILL (its def can't
    clobber the home; it reloads through HL at the accumulate). Saves the pre-pick
@@ -601,6 +697,7 @@ static void unified_arbitrate(Func *f, Cand *pool, int n)
     }
     int idx2_taken = 0, byte_reg = 0;    /* 0 / 'C' / 'E' */
     int de_acc_vreg = -1;                /* DE-acc winner, APPLIED after the loop */
+    int de_acc_general = 0;              /* winner is a general (non-acc) home */
     /* Whole-function occupancy predicates, recomputed cheaply from
        vreg_to_phys as assignments land. */
     for (int i = 0; i < n; i++) {
@@ -632,11 +729,22 @@ static void unified_arbitrate(Func *f, Cand *pool, int n)
         }
 
         if (c->allowed & RC_DE_ACC) {
+            /* GENERAL DE-home candidates are handled in a SEPARATE phase after
+               this loop (see below): they are speculative (revert if no region
+               forms), so they must be overlaid on the finished BC/idx2/byte
+               baseline — reserving DE here would let an inferior vreg grab the
+               BC the home vacated, and a revert would restore THAT perturbed
+               state, not the true baseline. The reduction word-acc (non-general)
+               keeps the in-loop reservation (present in every build). */
+            if (c->flags & CF_DE_GENERAL) continue;
             /* RESERVE DE (E aliases it, so a later byte can't take E); the
                eviction + prepick snapshot + assign happen AFTER the loop, so
                the prepick captures the full BC/idx2/byte baseline the lowerer
                reverts to — matching the sequential picker (word-acc runs last). */
-            if (de_acc_vreg < 0 && byte_reg != 'E') de_acc_vreg = v;
+            if (de_acc_vreg < 0 && byte_reg != 'E') {
+                de_acc_vreg = v;
+                de_acc_general = 0;
+            }
             continue;
         }
 
@@ -681,6 +789,45 @@ static void unified_arbitrate(Func *f, Cand *pool, int n)
                 f->vreg_to_phys[j] = IR_PR_SPILL;
         f->vreg_to_phys[de_acc_vreg] = IR_PR_DE;
         f->word_home_vreg = de_acc_vreg;
+        f->de_home_general = de_acc_general;
+    }
+
+    /* GENERAL DE-home phase (opt-in, speculative). Only if no reduction word-acc
+       claimed DE and no byte E/D-home took DE's low half. The pick is OVERLAID on
+       the finished BC/idx2/byte/word-acc baseline: snapshot that baseline as the
+       revert target FIRST, then promote the winner to DE (from BC or spill),
+       evicting any other DE tenant. Because the snapshot is the true baseline,
+       a revert (no region forms) restores codegen exactly — no BC perturbation. */
+    if (f->word_home_vreg < 0) {
+        int gbest = -1;
+        for (int i = 0; i < n; i++) {
+            const Cand *c = &pool[i];
+            if (!(c->allowed & RC_DE_ACC) || !(c->flags & CF_DE_GENERAL)) continue;
+            int v = c->vreg;
+            int ph = f->vreg_to_phys[v];
+            if (ph != IR_PR_SPILL && ph != IR_PR_BC) continue;  /* promotable only */
+            if (gbest < 0 || c->benefit > pool[gbest].benefit) gbest = i;
+        }
+        /* A byte home in E/D forbids a word DE-home (shared low half). */
+        int e_taken = 0;
+        for (int j = 0; j < f->n_vregs; j++)
+            if (f->vreg_to_phys[j] == IR_PR_E || f->vreg_to_phys[j] == IR_PR_D) {
+                e_taken = 1; break;
+            }
+        if (gbest >= 0 && !e_taken) {
+            int v = pool[gbest].vreg;
+            free(word_home_prepick);
+            word_home_prepick = malloc((size_t)f->n_vregs * sizeof(int));
+            if (word_home_prepick)
+                memcpy(word_home_prepick, f->vreg_to_phys,
+                       (size_t)f->n_vregs * sizeof(int));
+            for (int j = 0; j < f->n_vregs; j++)
+                if (j != v && f->vreg_to_phys[j] == IR_PR_DE)
+                    f->vreg_to_phys[j] = IR_PR_SPILL;
+            f->vreg_to_phys[v] = IR_PR_DE;   /* promote (from BC or spill) to DE */
+            f->word_home_vreg = v;
+            f->de_home_general = 1;
+        }
     }
 }
 
@@ -1308,6 +1455,12 @@ void ir_alloc(Func *f)
                 if (c_word_resident && !getenv("IR_NO_WORD_RESIDENT"))
                     np += word_acc_propose(f, use_count, write_count, bb_in_loop,
                                            first_use, last_use, pool + np);
+                /* DE-home co-design: a general loop-carried width-2 vreg (opt-in
+                   IR_DE_HOME). Same RC_DE_ACC class → the arbiter's DE reservation
+                   + prepick revert apply; tagged CF_DE_GENERAL so the lowerer uses
+                   the general home-def path, not try_word_accumulate. */
+                np += de_home_general_propose(f, use_count, write_count, bb_in_loop,
+                                              first_use, last_use, pool + np);
                 /* Phase 2: hot loop-carried int IVs. IR_NO_IV_RESIDENT opts out. */
                 if (!getenv("IR_NO_IV_RESIDENT"))
                     np += iv_propose(f, use_count, write_count, all_defs_ok,

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -1173,16 +1173,24 @@ void ir_alloc(Func *f)
         BB *bb = &f->bbs[i];
         for (int j = 0; j < bb->n_ops; j++) {
             const Op *o = &bb->ops[j];
-            /* IR_ST_MEM byte/int with IR_MEM_VREG base + nonzero offset
-               emits `ld bc,N; add hl,bc` for the offset add (DE holds
-               the value being stored, so can't be used for the add).
-               Conservative: any IR_ST_MEM IR_MEM_VREG with offset is a
-               BC clobber. Stores with offset==0 don't emit the add and
-               are safe. */
-            if (o->kind == IR_ST_MEM
-                && o->mem.kind == IR_MEM_VREG
-                && o->mem.offset != 0)
-                has_bc_clobber = 1;
+            /* (Offset stores used to clobber BC via `ld bc,N; add hl,bc` for
+               the offset add and disqualified the whole function from BC
+               residency. gen_st_mem now emits that add BC-clean, avoid_bc=1
+               — inc/dec chain or an A-through add — so an offset store keeps a
+               BC-homed base/value alive and is no longer a clobber.) */
+            /* A WIDE (double / long long, width>4) LD_MEM/ST_MEM lowers to a
+               dload/dstore helper CALL that clobbers BC with no save/restore
+               point (unlike IR_CALL/IR_HCALL), so a BC-resident base can't
+               survive it. (width==4 long is already covered by has_long.) */
+            if (o->kind == IR_LD_MEM || o->kind == IR_ST_MEM) {
+                int vw = 0;
+                if (o->dst >= 0 && o->dst < f->n_vregs)
+                    vw = f->vregs[o->dst].width;
+                if (o->src[0] >= 0 && o->src[0] < f->n_vregs
+                    && f->vregs[o->src[0]].width > vw)
+                    vw = f->vregs[o->src[0]].width;
+                if (vw > 4) has_bc_clobber = 1;
+            }
             /* l_case / l_long_case walk the table through BC, so a
                PR_BC value can't survive a table-dispatch IR_SWITCH
                (and the helper jumps away — no save/restore point).

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -1592,6 +1592,7 @@ int ir_lower_func(FILE *out, Func *f)
            clean the NOPs it leaves. Gated on c_word_resident ⇒ inert
            (byte-identical) when off. */
         int reassoc = ir_opt_reassoc_reduction(f);
+        int rcoal   = ir_opt_reduce_coalesce(f);
         int cse     = ir_opt_cse(f);
         /* After cse so duplicate per-lane address ADDs have been
            merged; before the long-push inserter. */
@@ -1637,7 +1638,7 @@ int ir_lower_func(FILE *out, Func *f)
              || packs > 0 || dce > 0 || early > 0
              || late > 0 || match > 0 || narrow > 0 || ivnarrow > 0
              || cse > 0 || pushes > 0 || deadret > 0 || reassoc > 0
-             || pruned > 0)
+             || rcoal > 0 || pruned > 0)
             && getenv("IR_OPT_VERBOSE"))
             fprintf(stderr,
                     "ir_opt: %d prune, %d licm, %d ivsr, %d early, %d st2ld, "

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -101,6 +101,12 @@ typedef struct {
     int cur_func_uses_params;
     int cur_home_is_word, cur_func_whome;
     int cur_byte_home_vreg, cur_byte_home_dirty, cur_func_ehome;
+    /* DE-home co-design: the general (non-accumulate) width-2 vreg the
+       orchestrator elected to keep in DE across a loop (e.g. searchbench `hi`),
+       or -1. Set by the orchestrator's residency decision; while it's live, the
+       binop/compare folds keep DE clean (read operands in place, no pair stage)
+       and the deref push/pop's DE, so the home survives the whole region. */
+    int cur_de_home;
     int cur_home_region_lo, cur_home_region_hi, cur_home_exit_flush_bb;
     int *bb_byte_out;
     /* Parallel to bb_byte_out: was the slot-backed byte home DIRTY (E holds
@@ -137,6 +143,7 @@ static LowerState L = {
     .rs = { .fa = -1, .i64_acc = -1 },
     .cur_hl_addr_off = -1, .cur_func_uses_params = 1,
     .cur_func_whome = -1, .cur_byte_home_vreg = -1, .cur_func_ehome = -1,
+    .cur_de_home = -1,
     .cur_home_region_lo = -1, .cur_home_region_hi = -1,
     .cur_home_exit_flush_bb = -1, .pending_spill_v = -1,
 };
@@ -502,6 +509,9 @@ static void home_flush(FILE *out, const Func *f);
 static void home_clobber(FILE *out, const Func *f);
 static int  home_rehome(FILE *out, const Func *f);
 static int  home_is_slotbacked(const Func *f, int v);
+static const Op *find_unique_def(const Func *f, int v);
+static const Op *find_unique_use(const Func *f, int v);
+static int  de_home_indexed_add_ok(const Func *f, const Op *o);
 static void cache_de(int v);
 static void cache_bc(int v);
 static void cache_dehl(int v);
@@ -1810,13 +1820,18 @@ int ir_lower_func(FILE *out, Func *f)
             L.cur_home_is_word = 1;
             L.cur_func_whome = f->word_home_vreg;
             L.la.cur_branch_test_kind = 0;
+            /* Same DE-home fold arming as the render, so op_de_clean's region
+               proof here matches what the render will actually emit. */
+            if (f->de_home_general) L.cur_de_home = f->word_home_vreg;
             compute_home_region(f, f->word_home_vreg, bb_alias, &wlo, &whi);
             L.cur_home_is_word = 0;
             L.cur_func_whome = -1;
+            L.cur_de_home = -1;
             if (wlo < 0) {
                 memcpy(f->vreg_to_phys, wh_prepick,
                        (size_t)f->n_vregs * sizeof(int));
                 f->word_home_vreg = -1;
+                f->de_home_general = 0;
                 ir_assign_slots(f);
             }
         }
@@ -2020,6 +2035,7 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
     L.cur_func_ehome = -1;
     L.cur_home_is_word = 0;
     L.cur_func_whome = -1;
+    L.cur_de_home = -1;          /* set by the orchestrator's DE-home decision */
     for (int v = 0; v < f->n_vregs; v++)
         if (f->vreg_to_phys
             && byte_home_slotbacked(f->vreg_to_phys[v])) { L.cur_func_ehome = v; break; }
@@ -2033,6 +2049,10 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
         L.cur_func_whome = f->word_home_vreg;
         L.cur_func_ehome = L.cur_func_whome;
         L.cur_home_is_word = 1;
+        /* General (non-accumulate) DE-home: arm the (ix+d) compare/ALU folds so
+           the region stays DE-clean. -1 for a reduction accumulator (the
+           try_word_accumulate path already keeps DE = home). */
+        if (f->de_home_general) L.cur_de_home = f->word_home_vreg;
     }
     /* Home-resident loop: where the slot-backed home stays in E/D (or DE)
        across a loop, suppress per-iter spills + assert residency at the

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 /* Global FRAMEPTR opt-in: -1 disabled, 1 IX, 0 IY. Owned by the
    compiler (data.c) but consulted directly here so the lowerer stays
@@ -487,6 +488,8 @@ static PhysReg byte_home_phys(const Func *f, int v);
 static int  byte_home_slotbacked(PhysReg pr);
 static const char *byte_home_reg(PhysReg pr);
 static int  byte_home_holds(int v);
+static PhysReg idxhalf_phys(const Func *f, int v);
+static const char *idxhalf_reg(PhysReg pr);
 static void byte_home_note(int v);
 static void byte_home_flush(FILE *out, const Func *f);
 /* Word (int) DE-home — width-aware siblings of the byte-home helpers; the
@@ -1365,6 +1368,155 @@ static int op_is_commutative(OpKind kind)
         || kind == IR_OR  || kind == IR_XOR;
 }
 
+/* Promote hot, currently-spilled SINGLE-DEF width-1 vregs to free index-register
+   halves (PR_IYL/IYH/IXL/IXH) — a slotless, clobber-free extra byte home. Purely
+   additive: only takes vregs the allocator left in a slot (IR_PR_SPILL), so it
+   never displaces a register home; a value that can't be placed simply stays in
+   its slot. Safe because:
+   - SINGLE-DEF ⇒ the def dominates every use (SSA), so the half is always valid
+     at a read (no belief/carry machinery needed);
+   - NO calls/asm in the function ⇒ the index reg is never clobbered (the operand
+     loader never stages there either);
+   - index halves only reach BASE-page ops (ld/add/sub/and/or/xor/cp a,iyl) —
+     the CB-page in-place shift paths gate on byte_home_phys, which excludes
+     index halves, so `sla iyl` (which doesn't exist) is never emitted.
+   z80/z80n/ez80 only (index-half ALU). Runs after ir_alloc, before
+   ir_assign_slots (so promoted vregs get needs_slot=0).
+
+   OPT-IN (IR_IDXHALF): DISABLED by default. Homing a byte in an index-register
+   half CLOBBERS the whole index register (IX/IY), but IY is callee-saved in the
+   z88dk ABI — e.g. l_qsort/l_bsearch hold the comparator function pointer in IY
+   across every comparator call (l_setiy + asm_l_qsort). A leaf comparator that
+   homes a byte in IYL/IYH corrupts that pointer → crash (was: stdlib bsearch
+   suite). Making this sound needs the function to push/pop the index register it
+   uses (with the matching param/frame-offset compensation across every calling
+   convention + teardown path); until that lands, the feature is off by default.
+   Set IR_IDXHALF to re-enable for measurement. */
+static void assign_idxhalf_homes(Func *f)
+{
+    if (!getenv("IR_IDXHALF")) return;   /* opt-in: unsound re callee-saved IX/IY */
+    if (!(c_cpu == CPU_Z80 || IS_Z80N() || IS_EZ80())) return;
+    if (!f || f->n_vregs <= 0 || !f->vreg_to_phys) return;
+    /* No calls/asm — else IX/IY would be trashed mid-live-range. */
+    for (int b = 0; b < f->n_bbs; b++)
+        for (int j = 0; j < f->bbs[b].n_ops; j++) {
+            OpKind k = f->bbs[b].ops[j].kind;
+            if (k == IR_CALL || k == IR_HCALL || k == IR_ASM) return;
+        }
+    /* Candidate halves — never offer halves of the FRAME register (it's used as
+       a pair by every (ix+d)/(iy+d) access, and the frame isn't a vreg so the
+       interval check can't see it). The frame reg is fixed globally by the
+       -frameix/-frameiy option: c_framepointer_is_ix == 1 → IX is the frame,
+       == 0 → IY is the frame, == -1 → sp-mode, neither. (fp_active is per-
+       function but unreliable here — frame_size isn't set until ir_assign_slots
+       runs after this pass; the global choice is the safe, stable gate.) A
+       non-frame index reg's own tenant (an idx2 counter/param) IS a vreg, so its
+       half availability is decided per byte by live-interval overlap below. */
+    PhysReg halves[4]; int nhalves = 0;
+    if (c_framepointer_is_ix != 0) {   /* IY is not the frame */
+        halves[nhalves++] = IR_PR_IYL; halves[nhalves++] = IR_PR_IYH;
+    }
+    if (c_framepointer_is_ix != 1) {   /* IX is not the frame */
+        halves[nhalves++] = IR_PR_IXL; halves[nhalves++] = IR_PR_IXH;
+    }
+    if (nhalves == 0) { return; }
+    /* Per-vreg def count, a DEPTH-WEIGHTED use score (a use in a loop body is
+       worth far more than a straight-line one — a byte compared each inner
+       iteration appears only ONCE statically but runs many times), and a
+       conservative live interval [first,last] in linear op order. Params are
+       live from entry (first=0). ir_op_defs is used so a self-stepped op
+       (defines src[0], not dst) is counted correctly. */
+    int nv = f->n_vregs;
+    int *ndef = calloc((size_t)nv, sizeof(int));
+    long *wuse = calloc((size_t)nv, sizeof(long));   /* depth-weighted use score */
+    int *first = malloc((size_t)nv * sizeof(int));
+    int *last  = malloc((size_t)nv * sizeof(int));
+    if (!ndef || !wuse || !first || !last) {
+        free(ndef); free(wuse); free(first); free(last); return;
+    }
+    for (int v = 0; v < nv; v++) { first[v] = INT_MAX; last[v] = -1; }
+    /* Cheap loop-nesting depth per BB (selection ranking only — never affects
+       correctness): count the back-edge spans [target..source] (id-based,
+       contiguous approximation) each BB falls in. f->bbs[].loop_depth is not
+       populated at this stage. */
+    int *bdep = calloc((size_t)f->n_bbs, sizeof(int));
+    if (bdep)
+        for (int i = 0; i < f->n_bbs; i++)
+            for (int s = 0; s < ir_bb_n_succ(&f->bbs[i]); s++) {
+                int t = ir_bb_succ_at(&f->bbs[i], s);
+                if (t < 0 || t > i) continue;             /* back-edge: t <= i */
+                for (int b = t; b <= i && b < f->n_bbs; b++) bdep[b]++;
+            }
+    int g = 0;
+    for (int b = 0; b < f->n_bbs; b++) {
+        int dep = bdep ? bdep[b] : 0;
+        if (dep > 4) dep = 4;
+        long w = 1L << (3 * dep);            /* depth 0→1, 1→8, 2→64, … (~8×/level) */
+        for (int j = 0; j < f->bbs[b].n_ops; j++, g++) {
+            const Op *o = &f->bbs[b].ops[j];
+            int d[8], u[16];
+            int nd = ir_op_defs(o, d, 8);
+            for (int k = 0; k < nd; k++) if (d[k] >= 0 && d[k] < nv) {
+                ndef[d[k]]++;
+                if (g < first[d[k]]) first[d[k]] = g;
+                if (g > last[d[k]])  last[d[k]]  = g;
+            }
+            int un = ir_op_uses(o, u, 16);
+            for (int k = 0; k < un; k++) if (u[k] >= 0 && u[k] < nv) {
+                wuse[u[k]] += w;
+                if (g < first[u[k]]) first[u[k]] = g;
+                if (g > last[u[k]])  last[u[k]]  = g;
+            }
+        }
+    }
+    for (int v = 0; v < nv; v++)
+        if (f->vregs[v].flags & (IR_VREG_PARAM | IR_VREG_PARAM_IN_PLACE))
+            first[v] = 0;                                   /* live from entry */
+    /* Greedily place the hottest eligible bytes; each into the first candidate
+       half free over its interval (no overlapping vreg on the same half or on
+       the whole pair). Multiple bytes can share a pair (IYL + IYH) or reuse a
+       half's pair across disjoint ranges. */
+    for (;;) {
+        int best = -1;
+        for (int v = 0; v < nv; v++) {
+            if (f->vreg_to_phys[v] != IR_PR_SPILL) continue;   /* additive only */
+            if (f->vregs[v].width != 1) continue;
+            /* PARAMs are live-in from the caller with NO def op that writes the
+               half — the incoming value would never reach a slotless index home
+               (and ndef counts only its in-body redefs, hiding this). Exclude. */
+            if (f->vregs[v].flags & (IR_VREG_PARAM | IR_VREG_PARAM_IN_PLACE))
+                continue;
+            if (ndef[v] != 1) continue;                        /* SSA dominance */
+            if (wuse[v] < 8) continue;                         /* hot: ≥1 loop use */
+            if (last[v] < 0) continue;                         /* dead */
+            if (f->vregs[v].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE))
+                continue;
+            if (best < 0 || wuse[v] > wuse[best]) best = v;
+        }
+        if (best < 0) break;
+        int placed = 0;
+        for (int h = 0; h < nhalves && !placed; h++) {
+            PhysReg H = halves[h];
+            PhysReg pair = (H == IR_PR_IYL || H == IR_PR_IYH) ? IR_PR_IY : IR_PR_IX;
+            int conflict = 0;
+            for (int u = 0; u < nv && !conflict; u++) {
+                PhysReg pu = f->vreg_to_phys[u];
+                if (pu != H && pu != pair) continue;   /* same half, or full-pair tenant */
+                int s = first[best] > first[u] ? first[best] : first[u];
+                int e = last[best]  < last[u]  ? last[best]  : last[u];
+                if (s <= e) conflict = 1;              /* intervals overlap */
+            }
+            if (!conflict) { f->vreg_to_phys[best] = H; placed = 1; }
+        }
+        if (!placed) {
+            /* No half free over its range — mark ineligible so the scan
+               advances (keep it spilled). */
+            ndef[best] = 0;
+        }
+    }
+    free(ndef); free(wuse); free(first); free(last); free(bdep);
+}
+
 int ir_lower_func(FILE *out, Func *f)
 {
     if (!f) {
@@ -1496,6 +1648,7 @@ int ir_lower_func(FILE *out, Func *f)
     ir_compute_op_liveness(f);
     ir_compute_live_ranges(f);
     ir_alloc(f);
+    assign_idxhalf_homes(f);
     ir_assign_slots(f);
     /* IR_DUMP_ALLOC prints the IR with phys-reg assignments and live ranges
        (distinct from the pre-lower IR_DUMP — reflects the allocator's view). */

--- a/src/80cc/ir_lower_analysis.inc.c
+++ b/src/80cc/ir_lower_analysis.inc.c
@@ -1,5 +1,48 @@
 /* ir_lower_analysis.inc.c — part of ir_lower.c, #included (single TU). Do not compile standalone. */
 
+/* The single op that USES vreg v, or NULL if v has zero or multiple uses.
+   Whole-function scan (uses via ir_op_uses). */
+static const Op *find_unique_use(const Func *f, int v)
+{
+    const Op *found = NULL;
+    if (v < 0 || v >= f->n_vregs) return NULL;
+    for (int i = 0; i < f->n_bbs; i++) {
+        const BB *bb = &f->bbs[i];
+        for (int j = 0; j < bb->n_ops; j++) {
+            int u[16];
+            int nu = ir_op_uses(&bb->ops[j], u, (int)(sizeof u / sizeof u[0]));
+            for (int k = 0; k < nu; k++)
+                if (u[k] == v) {
+                    if (found && found != &bb->ops[j]) return NULL;
+                    found = &bb->ops[j];
+                }
+        }
+    }
+    return found;
+}
+
+/* The single op that defines vreg v, or NULL if v has zero or multiple defs.
+   Whole-function scan (defs counted via ir_op_defs, POSTSTEP included). Used by
+   the general DE-home indexed-deref fold to inspect a shift's shape. */
+static const Op *find_unique_def(const Func *f, int v)
+{
+    const Op *found = NULL;
+    if (v < 0 || v >= f->n_vregs) return NULL;
+    for (int i = 0; i < f->n_bbs; i++) {
+        const BB *bb = &f->bbs[i];
+        for (int j = 0; j < bb->n_ops; j++) {
+            int defs[8];
+            int nd = ir_op_defs(&bb->ops[j], defs, 8);
+            for (int k = 0; k < nd; k++)
+                if (defs[k] == v) {
+                    if (found) return NULL;   /* multiple defs */
+                    found = &bb->ops[j];
+                }
+        }
+    }
+    return found;
+}
+
 /* Max BB id in the natural loop of back-edge latch->header: the header plus
    every block that can reach the latch without passing through the header
    (backward reachability over preds). Returns latch's id if any body block is

--- a/src/80cc/ir_lower_analysis.inc.c
+++ b/src/80cc/ir_lower_analysis.inc.c
@@ -580,6 +580,12 @@ static int vreg_in_register_pool(const Func *f, int v)
 static int byte_dst_cache_ok(const Func *f, int v)
 {
     if (byte_home_is_slotbacked(f, v)) return 0;
+    /* Index-half home (IXL/IXH/IYL/IYH): reads go through the half register
+       (`ld a,iyl`), NOT the A-cache — so the value MUST be written to the half
+       at every def. Leaving it only in A (cur_dst_dead byte immediately
+       consumed by a WIDENING read, which reloads the half) reads a never-written
+       home. Force the store, same as a slot-backed home. */
+    if (idxhalf_phys(f, v) != IR_PR_NONE) return 0;
     return L.la.cur_dst_dead || vreg_in_register_pool(f, v);
 }
 

--- a/src/80cc/ir_lower_cmp.inc.c
+++ b/src/80cc/ir_lower_cmp.inc.c
@@ -24,10 +24,15 @@ static int try_cmp_ixd_fold(FILE *out, const Func *f, const Op *op)
     if (!fp_active(f) || L.la.cur_branch_test_kind == 0) return 0;
     if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
     /* Reduction word-home (cur_de_home<0) region: word_dehome_signed_test
-       handles the DE-clean loop test. The GENERAL DE-home (cur_de_home>=0)
-       relies on THIS fold to keep its compares DE-clean — the home reads from
-       e/d in place — so let it fire there. */
-    if (L.cur_home_is_word && L.cur_de_home < 0) return 0;
+       handles the i-in-SLOT loop test. For a loop test whose operands are NOT
+       the home (e.g. the counter in idx2 / BC vs a slot bound), let the fold
+       fire — it reads iyl/iyh/(ix+d)/reg-half through A, never touching DE, so
+       the DE-resident accumulator survives. (An operand that IS the home would
+       be read from e/d, also DE-clean, but that path is the general DE-home's.) */
+    if (L.cur_home_is_word && L.cur_de_home < 0) {
+        int hs0 = op->src[0], hs1 = op->src[1];
+        if (hs0 == L.cur_func_whome || hs1 == L.cur_func_whome) return 0;
+    }
     int idxhalf_ok = (c_cpu == CPU_Z80 || IS_Z80N());   /* z180 traps index halves */
     OpKind k = op->kind;
     int s0 = op->src[0], s1 = op->src[1];

--- a/src/80cc/ir_lower_cmp.inc.c
+++ b/src/80cc/ir_lower_cmp.inc.c
@@ -9,8 +9,102 @@ static int cpu_has_index_halves(void)
     return c_cpu == CPU_Z80 || IS_Z80N() || IS_EZ80();
 }
 
+/* Byte-wise operand fold for an int compare (branch-fused). Reads BOTH operands
+   where they already live — register halves, (ix+d) slots, or idx2 halves — and
+   subtracts byte-wise through A, so no operand is staged into a pair (`ld
+   de,(ix+d); sbc hl,de`) or push/pop'd (idx2). Fires only when at least one
+   operand is memory/index (else `sbc hl,de` on two gp pairs is shorter). Gated to
+   the 2-op-`ld hl,(ix+d)` CPUs (z80/z80n/z180); ez80/kc160/rabbit load a slot word
+   in one instr so gain nothing. idx2-half operands (`sub iyl`) are z80/z80n only
+   (z180 traps undocumented index-half ops). Covers LT/LE/GT/GE (all reduced to one
+   byte-wise subtract + CF) and EQ/NE. Default-on; IR_NO_IXD_FOLD opts out. */
+static int try_cmp_ixd_fold(FILE *out, const Func *f, const Op *op)
+{
+    if (getenv("IR_NO_IXD_FOLD")) return 0;
+    if (!fp_active(f) || L.la.cur_branch_test_kind == 0) return 0;
+    if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
+    /* Reduction word-home (cur_de_home<0) region: word_dehome_signed_test
+       handles the DE-clean loop test. The GENERAL DE-home (cur_de_home>=0)
+       relies on THIS fold to keep its compares DE-clean — the home reads from
+       e/d in place — so let it fire there. */
+    if (L.cur_home_is_word && L.cur_de_home < 0) return 0;
+    int idxhalf_ok = (c_cpu == CPU_Z80 || IS_Z80N());   /* z180 traps index halves */
+    OpKind k = op->kind;
+    int s0 = op->src[0], s1 = op->src[1];
+    if (s0 < 0 || s1 < 0 || s0 == s1) return 0;
+    if (s0 >= f->n_vregs || s1 >= f->n_vregs) return 0;
+    if (f->vregs[s0].width != 2 || f->vregs[s1].width != 2) return 0;
+    switch (k) {
+    case IR_CMP_LT: case IR_CMP_LE: case IR_CMP_GT: case IR_CMP_GE:
+    case IR_CMP_ULT: case IR_CMP_ULE: case IR_CMP_UGT: case IR_CMP_UGE:
+    case IR_CMP_EQ: case IR_CMP_NE: break;
+    default: return 0;
+    }
+    char s0lo[16], s0hi[16], s1lo[16], s1hi[16];
+    int c0 = cmp_byte_src(f, s0, idxhalf_ok, s0lo, s0hi, sizeof s0lo);
+    int c1 = cmp_byte_src(f, s1, idxhalf_ok, s1lo, s1hi, sizeof s1lo);
+    if (c0 == 0 || c1 == 0) return 0;          /* an operand not readable in place */
+    if (c0 == 1 && c1 == 1) return 0;          /* both gp pairs → sbc hl,de is shorter */
+
+    /* Lazy-spill bookkeeping (mirror the load path we replace). Key on how
+       cmp_byte_src ACTUALLY read the operand, not on whether it could be a slot:
+       a spilled vreg that was cache-served from HL/DE/BC (class 1) is a cacheread,
+       NOT a reload — recording it as a reload would keep its (now dead) feeding
+       store alive. Only class 2 via a real (ix+d) slot is a genuine reload (idx2
+       halves are registers). */
+    if (c0 == 2 && op_is_ixd_slot(f, s0)) ss_note_reload(f, s0); else ss_note_cache_read(f, s0);
+    if (c1 == 2 && op_is_ixd_slot(f, s1)) ss_note_reload(f, s1); else ss_note_cache_read(f, s1);
+
+    int br_true = (L.la.cur_branch_test_kind == IR_BR_COND);
+
+    if (k == IR_CMP_EQ || k == IR_CMP_NE) {
+        int lbl = L.cmp_label_counter++;
+        emit(out, "ld\ta,%s", s0lo);
+        emit(out, "sub\t%s", s1lo);
+        emit(out, "jr\tnz,L_f%d_cmp_ok_%d", L.func_emit_idx, lbl);   /* low bytes differ */
+        emit(out, "ld\ta,%s", s0hi);
+        emit(out, "sub\t%s", s1hi);
+        fprintf(out, "L_f%d_cmp_ok_%d:\n", L.func_emit_idx, lbl);
+        /* Z set iff both bytes equal. */
+        int jump_when_eq = (k == IR_CMP_EQ) ? br_true : !br_true;
+        emit(out, "jp\t%s,L_f%d_bb_%d", jump_when_eq ? "z" : "nz",
+             L.func_emit_idx, L.la.cur_branch_test_label);
+        L.rs.a = -1;
+        L.la.cur_skip_next_op = 1;
+        return 1;
+    }
+
+    /* Ordered: reduce all four to one byte-wise subtract M - N; CF = (M < N).
+       LT/GE compute src0-src1; GT/LE compute src1-src0 (the `> / <=` forms are
+       the strict-less / not-strict-less of the reversed operands). */
+    int is_signed  = (k==IR_CMP_LT || k==IR_CMP_LE || k==IR_CMP_GT || k==IR_CMP_GE);
+    int swap       = (k==IR_CMP_GT || k==IR_CMP_LE || k==IR_CMP_UGT || k==IR_CMP_ULE);
+    int true_on_cf = (k==IR_CMP_LT || k==IR_CMP_GT || k==IR_CMP_ULT || k==IR_CMP_UGT);
+    const char *Mlo, *Mhi, *Nlo, *Nhi;
+    if (!swap) { Mlo=s0lo; Mhi=s0hi; Nlo=s1lo; Nhi=s1hi; }   /* src0 - src1 */
+    else       { Mlo=s1lo; Mhi=s1hi; Nlo=s0lo; Nhi=s0hi; }   /* src1 - src0 */
+    emit(out, "ld\ta,%s", Mlo);
+    emit(out, "sub\t%s", Nlo);
+    emit(out, "ld\ta,%s", Mhi);
+    emit(out, "sbc\ta,%s", Nhi);
+    if (is_signed) {                            /* S^V → CF = signed (M < N) */
+        int lbl = L.cmp_label_counter++;
+        emit(out, "jp\tpo,L_f%d_cmp_ok_%d", L.func_emit_idx, lbl);
+        emit(out, "xor\t0x80");
+        fprintf(out, "L_f%d_cmp_ok_%d:\n", L.func_emit_idx, lbl);
+        emit(out, "rla");
+    }
+    int want_cf = (true_on_cf == br_true);
+    emit(out, "jp\t%s,L_f%d_bb_%d", want_cf ? "c" : "nc",
+         L.func_emit_idx, L.la.cur_branch_test_label);
+    L.rs.a = -1;
+    L.la.cur_skip_next_op = 1;
+    return 1;
+}
+
 static int gen_cmp_lt_ge(FILE *out, Func *f, const Op *op)
 {
+    if (try_cmp_ixd_fold(out, f, op)) return 0;
     int is_signed = (op->kind == IR_CMP_LT || op->kind == IR_CMP_GE);
     int cf_true_long = (op->kind == IR_CMP_ULT || op->kind == IR_CMP_LT);
     /* gbz80 lacks jp po/pe so the inline S^V correction can't run — sign-flip
@@ -382,6 +476,7 @@ static void load_cmp_swap_operands(FILE *out, const Func *f, const Op *op)
 
 static int gen_cmp_gt_le(FILE *out, Func *f, const Op *op)
 {
+    if (try_cmp_ixd_fold(out, f, op)) return 0;
     int is_signed = (op->kind == IR_CMP_GT || op->kind == IR_CMP_LE);
     /* After swap-load, CF=true means src1 < src0 = src0 > src1 → GT/UGT. */
     int cf_true_gt = (op->kind == IR_CMP_UGT || op->kind == IR_CMP_GT);
@@ -511,6 +606,7 @@ static int gen_cmp_gt_le(FILE *out, Func *f, const Op *op)
 
 static int gen_cmp_eq_ne(FILE *out, Func *f, const Op *op)
 {
+    if (try_cmp_ixd_fold(out, f, op)) return 0;
     /* Long compare: byte-wise XOR-then-OR chain, Z iff all 4 bytes match. */
     int src0w = (op->src[0] >= 0) ? f->vregs[op->src[0]].width : 0;
     if (src0w == 4) {

--- a/src/80cc/ir_lower_cmp.inc.c
+++ b/src/80cc/ir_lower_cmp.inc.c
@@ -21,8 +21,14 @@ static int cpu_has_index_halves(void)
 static int try_cmp_ixd_fold(FILE *out, const Func *f, const Op *op)
 {
     if (getenv("IR_NO_IXD_FOLD")) return 0;
-    if (!fp_active(f) || L.la.cur_branch_test_kind == 0) return 0;
+    if (L.la.cur_branch_test_kind == 0) return 0;
     if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
+    /* Fires in BOTH fp and sp mode. In sp there are no (ix+d) slot operands
+       (op_is_ixd_slot is fp-gated → cmp_byte_src yields only reg-half / idx-half /
+       none), so the fold applies to a compare whose operands are the value/counter
+       in idx2 (IX, z80/z80n — z180 excluded by idxhalf_ok) or a gp-pair half:
+       `ld a,l; sub ixl; ld a,h; sbc a,ixh` instead of push ix;pop de;sbc hl,de —
+       cheaper and DE-clean. A slot operand yields class 0 → the fold defers. */
     /* Reduction word-home (cur_de_home<0) region: word_dehome_signed_test
        handles the i-in-SLOT loop test. For a loop test whose operands are NOT
        the home (e.g. the counter in idx2 / BC vs a slot bound), let the fold

--- a/src/80cc/ir_lower_ops.inc.c
+++ b/src/80cc/ir_lower_ops.inc.c
@@ -1719,7 +1719,17 @@ static int gen_shl(FILE *out, Func *f, const Op *op)
 /* Add a small constant to HL. |off| <= 3 uses inc/dec hl (1 byte /
    6T each); larger offsets load the scratch pair (BC when DE must be
    preserved, e.g. long loads). */
-static void emit_hl_add_offset(FILE *out, int off, int use_bc)
+static void emit_pair_add_de_clean(FILE *out, const char *pair, const char *lo,
+                                   const char *hi, int k, int a_free);
+
+/* Add `off` to HL. `use_bc` picks BC vs DE as the `ld rp,off; add hl,rp` scratch
+   (a caller with a live DE value passes use_bc=1, and vice-versa). `avoid_bc`
+   is stronger: keep BOTH BC and DE intact (e.g. an offset store where DE holds
+   the value AND a BC-resident base/value must survive) — small offsets use an
+   inc/dec chain, larger ones an A-through add (emit_pair_add_de_clean). This is
+   what lets a struct-field STORE preserve a BC-homed base, so offset stores no
+   longer disqualify the function from register residency. */
+static void emit_hl_add_offset(FILE *out, int off, int use_bc, int avoid_bc)
 {
     if (off == 0) return;
     if (off > 0 && off <= 3) {
@@ -1728,6 +1738,12 @@ static void emit_hl_add_offset(FILE *out, int off, int use_bc)
     }
     if (off < 0 && off >= -3) {
         for (int i = 0; i < -off; i++) emit(out, "dec\thl");
+        return;
+    }
+    if (avoid_bc) {
+        /* BC- and DE-clean: inc/dec chain (small) or A-through add (larger,
+           when A is free). Never touches BC, so a BC-homed base survives. */
+        emit_pair_add_de_clean(out, "hl", "l", "h", off, L.rs.a < 0);
         return;
     }
     emit(out, "ld\t%s,%d", use_bc ? "bc" : "de", off);
@@ -1783,7 +1799,7 @@ static int gen_ld_mem(FILE *out, Func *f, const Op *op)
                 emit(out, "ld\thl,_%s", ir_sym_name(op->mem.sym));
         } else {
             load_to_hl(out, f, op->mem.base);
-            emit_hl_add_offset(out, op->mem.offset, 0);  /* base+off (DE free) */
+            emit_hl_add_offset(out, op->mem.offset, 0, 0);  /* base+off (DE free) */
         }
         emit(out, "call\t%s", acc_prim(f, op->dst, "load"));
         if (!wide_acc_result_dead_in_acc(f, op->dst)) {
@@ -1941,7 +1957,7 @@ static int gen_ld_mem(FILE *out, Func *f, const Op *op)
             emit(out, "ld\te,(hl)");
             emit(out, "inc\thl");
             emit(out, "ld\td,(hl)");                   /* DE = *p, HL = p+1 */
-            emit_hl_add_offset(out, op->mem.post_step - 1, 0);  /* HL = p+step */
+            emit_hl_add_offset(out, op->mem.post_step - 1, 0, 0);  /* HL = p+step */
             if (vreg_in_pr_bc(f, base)) {
                 emit(out, "ld\tc,l");
                 emit(out, "ld\tb,h");                  /* BC home = p+step */
@@ -2005,7 +2021,7 @@ static int gen_ld_mem(FILE *out, Func *f, const Op *op)
             /* Width 4 can't clobber DE (needed for the high half) —
                scratch through BC; widths 1/2 use DE. Small offsets
                become inc/dec hl chains. */
-            emit_hl_add_offset(out, op->mem.offset, dst_w == 4);
+            emit_hl_add_offset(out, op->mem.offset, dst_w == 4, 0);
         }
         if (dst_w == 1) {
             /* Byte load into A. If dst is dead-after-next (the
@@ -2132,7 +2148,7 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
                 emit(out, "ld\thl,_%s", ir_sym_name(op->mem.sym));
         } else {
             load_to_hl(out, f, op->mem.base);
-            emit_hl_add_offset(out, op->mem.offset, 0);  /* base+off (DE free) */
+            emit_hl_add_offset(out, op->mem.offset, 0, 0);  /* base+off (DE free) */
         }
         emit_acc_store_hl(out, f, op->src[0]);
         invalidate_hl_bc();          /* clears both wide-acc cells */
@@ -2204,7 +2220,7 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
         if (op->src[0] < 0) {
             int w = kind_scalar_width(op->mem.elem);
             load_to_hl(out, f, op->mem.base);
-            emit_hl_add_offset(out, op->mem.offset, 1);  /* use BC scratch → keep DE */
+            emit_hl_add_offset(out, op->mem.offset, 1, 1);  /* use BC scratch → keep DE */
             emit_folded_imm_store(out, w, (uint32_t)op->imm);
             if (w > 1 || op->mem.offset != 0)
                 invalidate_hl_cache();
@@ -2221,7 +2237,7 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
                vreg picks up the store value. */
             invalidate_de_cache();
             load_to_hl(out, f, op->mem.base);
-            emit_hl_add_offset(out, op->mem.offset, 1);
+            emit_hl_add_offset(out, op->mem.offset, 1, 1);
             emit(out, "ld\t(hl),e");
             /* HL walked to base+offset — the cache claim on base is
                stale for offset != 0 (a following [base+k] store would
@@ -2242,7 +2258,7 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
                    would clobber DE or BC.) */
                 if (!hl_has(op->mem.base))
                     load_to_hl(out, f, op->mem.base);
-                emit_hl_add_offset(out, op->mem.offset, 0); /* inc/dec only */
+                emit_hl_add_offset(out, op->mem.offset, 0, 0); /* inc/dec only */
                 store_byte_adv(out, "c", 0);
                 store_byte_adv(out, "b", 0);
                 store_byte_adv(out, "e", 0);
@@ -2290,7 +2306,7 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
                 emit(out, "push\tde");          /* save HIGH half */
                 emit(out, "push\thl");          /* save LOW half */
                 load_to_hl_adj(out, f, op->mem.base, 4);
-                emit_hl_add_offset(out, op->mem.offset, 1);
+                emit_hl_add_offset(out, op->mem.offset, 1, 1);
                 emit(out, "pop\tbc");           /* BC = LOW */
                 if (IS_EZ80()) {
                     emit(out, "ld\t(hl),bc");   /* ez80: *HL = BC (HL preserved) */
@@ -2314,7 +2330,7 @@ static int gen_st_mem(FILE *out, Func *f, const Op *op)
             load_to_hl(out, f, op->src[0]);
             emit(out, "ex\tde,hl");         /* DE = value */
             load_to_hl(out, f, op->mem.base);
-            emit_hl_add_offset(out, op->mem.offset, 1);
+            emit_hl_add_offset(out, op->mem.offset, 1, 1);
             if (IS_EZ80()) {
                 emit(out, "ld\t(hl),de");   /* ez80: *HL = DE */
             } else {
@@ -2438,6 +2454,7 @@ static int try_fp_bytewise_commutative(FILE *out, const Func *f, const Op *op,
 static int try_binop_ixd_fold(FILE *out, Func *f, const Op *op,
                               const char *lo_op, const char *hi_op)
 {
+    if (getenv("IR_NO_ALU_FOLD")) return 0;
     if (L.cur_de_home < 0) return 0;           /* only inside a DE-home region */
     if (!fp_active(f)) return 0;
     if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;

--- a/src/80cc/ir_lower_ops.inc.c
+++ b/src/80cc/ir_lower_ops.inc.c
@@ -1427,6 +1427,15 @@ static int gen_shl(FILE *out, Func *f, const Op *op)
 {
     int skip_byte = L.la.cur_skip_shl_byte;
     L.la.cur_skip_shl_byte = 0;
+    /* General DE-home indexed deref: when this const-shift's ONLY use is an
+       ADD that try_de_home_indexed_add rematerializes from BC (`add hl,bc`),
+       its result is dead — skip the whole op (compute + store). */
+    if (L.cur_de_home >= 0 && op->dst >= 0 && op->src[1] < 0
+        && f->vregs[op->dst].width == 2) {
+        const Op *use = find_unique_use(f, op->dst);
+        if (use && use->kind == IR_ADD && de_home_indexed_add_ok(f, use))
+            return 0;
+    }
     if (op->dst >= 0 && f->vregs[op->dst].width == 1) {
         /* Byte shift+test fuse already did `home<<=1` via `sla <home>`: the
            shifted value is in the home register. In-place SHL → nothing to
@@ -2417,9 +2426,128 @@ static int try_fp_bytewise_commutative(FILE *out, const Func *f, const Op *op,
     return 1;
 }
 
+/* Byte-wise ALU fold for a width-2 int op, used inside a DE-home region to keep
+   DE (the resident home) clean: reads both operands where they live — register
+   halves (c/b, l/h, e/d), (ix+d) slots, idx2 halves — and computes the result
+   through A into HL, so no operand is staged into DE (the normal `ld de,src1;
+   add hl,de` would clobber the home). The home itself, when an operand, is read
+   from DE (e/d) in place; when it's the dst, commit_hl_result re-establishes it
+   via ex de,hl. Result → HL → commit_hl_result. lo_op/hi_op are the low/high byte
+   mnemonic prefixes incl. separator. Gated on L.cur_de_home (the orchestrator's
+   residency decision); -1 ⇒ never fires ⇒ byte-identical. Returns 1 if emitted. */
+static int try_binop_ixd_fold(FILE *out, Func *f, const Op *op,
+                              const char *lo_op, const char *hi_op)
+{
+    if (L.cur_de_home < 0) return 0;           /* only inside a DE-home region */
+    if (!fp_active(f)) return 0;
+    if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
+    if (op->dst < 0 || f->vregs[op->dst].width != 2) return 0;
+    int s0 = op->src[0], s1 = op->src[1];
+    if (s0 < 0 || s1 < 0) return 0;
+    if (s0 >= f->n_vregs || s1 >= f->n_vregs) return 0;
+    if (f->vregs[s0].width != 2 || f->vregs[s1].width != 2) return 0;
+    if (L.pending_spill_v >= 0) return 0;      /* byte ops clobber HL; see cmp fold */
+    int idxhalf_ok = (c_cpu == CPU_Z80 || IS_Z80N());
+    char s0lo[16], s0hi[16], s1lo[16], s1hi[16];
+    int c0 = cmp_byte_src(f, s0, idxhalf_ok, s0lo, s0hi, sizeof s0lo);
+    int c1 = cmp_byte_src(f, s1, idxhalf_ok, s1lo, s1hi, sizeof s1lo);
+    if (c0 == 0 || c1 == 0) return 0;
+
+    /* Lazy-spill bookkeeping keyed on how the operand was actually read (a real
+       (ix+d) slot read = reload; register/idx = cacheread). */
+    if (c0 == 2 && op_is_ixd_slot(f, s0)) ss_note_reload(f, s0); else ss_note_cache_read(f, s0);
+    if (c1 == 2 && op_is_ixd_slot(f, s1)) ss_note_reload(f, s1); else ss_note_cache_read(f, s1);
+
+    emit(out, "ld\ta,%s", s0lo);
+    emit(out, "%s%s", lo_op, s1lo);
+    emit(out, "ld\tl,a");
+    emit(out, "ld\ta,%s", s0hi);
+    emit(out, "%s%s", hi_op, s1hi);
+    emit(out, "ld\th,a");
+    invalidate_hl_cache();
+    commit_hl_result(out, f, op->dst);
+    return 1;
+}
+
+/* General DE-home: `dst = other + home` (dst != home) where the home rides DE.
+   Load `other` into HL (DE-preserving) and `add hl,de` — the home in DE survives,
+   so the region stays DE-clean. Cheaper than the byte-wise ALU fold (a single
+   pair add, no result reassembly). Returns 1 if emitted. */
+static int try_de_home_operand_add(FILE *out, Func *f, const Op *op)
+{
+    if (L.cur_de_home < 0 || !L.cur_home_is_word) return 0;
+    if (op->dst < 0 || f->vregs[op->dst].width != 2) return 0;
+    if (op->dst == L.cur_func_whome) return 0;    /* dst==home → try_word_accumulate */
+    int home = L.cur_func_whome;
+    if (op->src[0] != home && op->src[1] != home) return 0;
+    if (op->src[0] < 0 || op->src[1] < 0) return 0;
+    if (!byte_home_holds(home)) return 0;         /* home actually resident in DE */
+    int other = (op->src[0] == home) ? op->src[1] : op->src[0];
+    if (other == home) return 0;
+    load_to_hl(out, f, other);                    /* HL = other; DE = home preserved */
+    emit(out, "add\thl,de");                      /* HL = other + home */
+    invalidate_hl_cache();
+    commit_hl_result(out, f, op->dst);
+    return 1;
+}
+
+/* General DE-home indexed word deref: `dst = base + (idx << k)` where idx rides
+   BC and base is remat'd — `ld hl,base; add hl,bc` (2^k times). HL + BC only, so
+   the home in DE survives (vs the default `add hl,hl; ex de,hl; ld hl,base; add
+   hl,de`, which clobbers DE). Guarded by de_home_indexed_add_ok. Returns 1. */
+static int try_de_home_indexed_add(FILE *out, Func *f, const Op *op)
+{
+    if (!de_home_indexed_add_ok(f, op)) return 0;
+    for (int which = 0; which < 2; which++) {
+        int sidx = op->src[which], sbase = op->src[which ^ 1];
+        const Op *d = find_unique_def(f, sidx);
+        if (!d || d->kind != IR_SHL || d->src[1] >= 0) continue;
+        if (d->imm < 1 || d->imm > 2) continue;
+        int idx = d->src[0];
+        if (idx < 0 || f->vreg_to_phys[idx] != IR_PR_BC) continue;
+        if (!emit_remat_word(out, f, sbase, "hl")) continue;
+        int n = 1 << (int)d->imm;
+        for (int i = 0; i < n; i++) emit(out, "add\thl,bc");
+        invalidate_hl_cache();
+        commit_hl_result(out, f, op->dst);
+        return 1;
+    }
+    return 0;
+}
+
+/* General DE-home home-def `home = src0 +/- imm` (small imm): compute the new
+   home in HL (`ld hl,src0; inc/dec hl` chain — DE-clean since src0 loads from
+   BC/slot, never DE) then `ex de,hl` to re-establish DE = home + reassert
+   residency. The non-accumulate analog of try_word_accumulate (which handles
+   `home = home OP w`). Returns 1 if emitted. */
+static int try_de_home_def(FILE *out, Func *f, const Op *op)
+{
+    if (L.cur_de_home < 0 || !L.cur_home_is_word) return 0;
+    if (op->dst != L.cur_func_whome) return 0;
+    if (op->dst < 0 || f->vregs[op->dst].width != 2) return 0;
+    if (op->kind != IR_ADD && op->kind != IR_SUB) return 0;
+    if (op->src[0] < 0 || op->src[1] >= 0) return 0;   /* src0 vreg + const imm */
+    if (op->imm < 0 || op->imm > 4) return 0;
+    load_to_hl(out, f, op->src[0]);                    /* HL = src0 (DE-clean) */
+    for (long i = 0; i < op->imm; i++)
+        emit(out, op->kind == IR_ADD ? "inc\thl" : "dec\thl");
+    emit(out, "ex\tde,hl");                            /* DE = new home; HL junk */
+    invalidate_hl_cache();
+    cache_de(op->dst);
+    byte_home_note(op->dst);
+    L.cur_byte_home_dirty = 1;
+    return 1;
+}
+
 static int gen_add(FILE *out, Func *f, const Op *op)
 {
     if (try_word_accumulate(out, f, op))
+        return 0;
+    if (try_de_home_def(out, f, op))
+        return 0;
+    if (try_de_home_operand_add(out, f, op))
+        return 0;
+    if (try_de_home_indexed_add(out, f, op))
         return 0;
     if (op->dst >= 0 && f->vregs[op->dst].width == 1) {
         /* Byte add in A. Commutative — pick the A-resident operand as
@@ -2704,6 +2832,7 @@ static int gen_add(FILE *out, Func *f, const Op *op)
         commit_hl_result(out, f, op->dst);
         return 0;
     }
+    if (try_binop_ixd_fold(out, f, op, "add\ta,", "adc\ta,")) return 0;
     load_binop_operands(out, f, op);
     emit(out, "add\thl,de");
     /* PR_DE dst: commit moves HL→DE via ex de,hl (+4 T), saving the ~28-T
@@ -2714,6 +2843,8 @@ static int gen_add(FILE *out, Func *f, const Op *op)
 
 static int gen_sub(FILE *out, Func *f, const Op *op)
 {
+    if (try_de_home_def(out, f, op))
+        return 0;
     if (op->dst >= 0 && f->vregs[op->dst].width == 1) {
         /* Byte sub in A. Not commutative: A = src[0] - src[1]. If only
            src[1] is A-resident, spill it to its slot first so loading
@@ -2973,6 +3104,7 @@ static int gen_sub(FILE *out, Func *f, const Op *op)
         store_dehl_finalize(out, f, op->dst);
         return 0;
     }
+    if (try_binop_ixd_fold(out, f, op, "sub\t", "sbc\ta,")) return 0;
     load_binop_operands(out, f, op);
     if (IS_RABBIT()) {
         emit(out, "sub\thl,de");        /* Rabbit native (r2k+), DE preserved */
@@ -3639,6 +3771,11 @@ static int gen_bitop(FILE *out, Func *f, const Op *op)
         return 0;
     }
 
+    {
+        char m[8];
+        snprintf(m, sizeof m, "%s\t", mnem);
+        if (try_binop_ixd_fold(out, f, op, m, m)) return 0;
+    }
     load_binop_operands(out, f, op);    /* HL=src[0], DE=src[1] */
     /* Rabbit native HL=HL<op>DE in 1 byte (and/or r2k+, xor r4k); DE
        preserved so the HL finalize below is unchanged. Off elsewhere:

--- a/src/80cc/ir_lower_ops.inc.c
+++ b/src/80cc/ir_lower_ops.inc.c
@@ -1365,6 +1365,23 @@ static void byte_alu_operand(FILE *out, const Func *f,
                              const char *prefix, int m)
 {
     if (a_has(m))  { emit(out, "%sa", prefix); return; }
+    /* Index-half home as an ALU source (add a,iyl / sub iyl / cp iyl …): the
+       half is always valid and A is always the other operand, so no prefix
+       reinterpretation issue. Must precede the slot read — an index home has
+       no slot. */
+    PhysReg ih = idxhalf_phys(f, m);
+    if (ih != IR_PR_NONE) { emit(out, "%s%s", prefix, idxhalf_reg(ih)); return; }
+    /* Byte home (PR_C/E/D/B) currently live in its register: read it directly
+       (`xor e`, `add a,c` …). Must precede the slot read — a slot-backed E/D
+       home may be DIRTY (the live value is in the register, the slot stale), and
+       a slotless C/B home has no slot at all. (Latent before index halves: the
+       commutative-operand order always loaded the byte home to A via
+       load_byte_to_a; a home value only reaches here as the 2nd operand once
+       another home occupies A.) */
+    if (byte_home_holds(m)) {
+        PhysReg bh = byte_home_phys(f, m);
+        if (bh != IR_PR_NONE) { emit(out, "%s%s", prefix, byte_home_reg(bh)); return; }
+    }
     if (hl_has(m)) { ss_note_cache_read(f, m); emit(out, "%sl", prefix); return; }
     if (de_has(m)) { ss_note_cache_read(f, m); emit(out, "%se", prefix); return; }
     if (bc_has(m)) { ss_note_cache_read(f, m); emit(out, "%sc", prefix); return; }

--- a/src/80cc/ir_lower_regcache.inc.c
+++ b/src/80cc/ir_lower_regcache.inc.c
@@ -1446,7 +1446,13 @@ static int cmp_fold_static_class(const Func *f, int v)
    the emitter. Branch-fusion is checked by the callers. */
 static int cmp_ixd_fold_de_clean_ok(const Func *f, const Op *o)
 {
-    if (L.cur_de_home < 0 || getenv("IR_NO_IXD_FOLD")) return 0;
+    /* Fires for the GENERAL DE-home (cur_de_home>=0) and the word-ACCUMULATOR
+       home (cur_home_is_word, cur_de_home<0). In the word-acc case the fold is
+       only DE-clean when NEITHER operand is the home (a bare loop test on the
+       counter etc.) — mirrors try_cmp_ixd_fold's word-acc gate. */
+    int word_acc = (L.cur_de_home < 0 && L.cur_home_is_word);
+    if (L.cur_de_home < 0 && !word_acc) return 0;
+    if (getenv("IR_NO_IXD_FOLD")) return 0;
     if (!fp_active(f)) return 0;
     if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
     switch (o->kind) {
@@ -1457,10 +1463,41 @@ static int cmp_ixd_fold_de_clean_ok(const Func *f, const Op *o)
     }
     int s0 = o->src[0], s1 = o->src[1];
     if (s0 < 0 || s1 < 0 || s0 == s1) return 0;
+    if (word_acc && (s0 == L.cur_func_whome || s1 == L.cur_func_whome)) return 0;
     int c0 = cmp_fold_static_class(f, s0);
     int c1 = cmp_fold_static_class(f, s1);
     if (c0 == 0 || c1 == 0) return 0;
     if (c0 == 1 && c1 == 1) return 0;    /* both gp pairs → sbc hl,de path */
+    return 1;
+}
+
+/* General DE-home ALU fold: a width-2 ADD/SUB/AND/OR/XOR that try_binop_ixd_fold
+   lowers byte-wise through A (`ld a,<lo>; <op> <lo'>; ld l,a; …`) reading both
+   operands in place — never staging one into DE — with the result committed to a
+   non-home spill slot (DE-preserving in fp). DE-clean, so a general DE-home
+   survives it. Mirrors try_binop_ixd_fold's gates so the region proof agrees with
+   the emitter. (ADD also has the home-operand / indexed-deref paths handled
+   separately; this covers the both-operands-foldable, neither-is-home case, and
+   is the ONLY path for AND/OR/XOR.) */
+static int binop_ixd_fold_de_clean_ok(const Func *f, const Op *o)
+{
+    if (getenv("IR_NO_ALU_FOLD")) return 0;
+    if (L.cur_de_home < 0 || getenv("IR_NO_IXD_FOLD")) return 0;
+    if (!fp_active(f)) return 0;
+    if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
+    switch (o->kind) {
+    case IR_ADD: case IR_SUB: case IR_AND: case IR_OR: case IR_XOR: break;
+    default: return 0;
+    }
+    if (o->dst < 0 || o->dst >= f->n_vregs || f->vregs[o->dst].width != 2) return 0;
+    if (o->dst == L.cur_func_whome) return 0;          /* home-def uses ex de,hl */
+    if (!f->vreg_to_phys || f->vreg_to_phys[o->dst] == IR_PR_DE) return 0; /* dst not DE */
+    int s0 = o->src[0], s1 = o->src[1];
+    if (s0 < 0 || s1 < 0) return 0;
+    int c0 = cmp_fold_static_class(f, s0);
+    int c1 = cmp_fold_static_class(f, s1);
+    if (c0 == 0 || c1 == 0) return 0;
+    if (c0 != 2 && c1 != 2) return 0;    /* need >=1 mem/idx (else add hl,de path) */
     return 1;
 }
 
@@ -1543,6 +1580,11 @@ static int op_de_clean(const Func *f, const Op *o)
             && L.la.cur_branch_test_kind != 0
             && word_dehome_signed_test_shape_ok(f, o))
             return 1;
+        /* Branch-fused int loop test (counter in idx2/BC vs slot, operands not
+           the home) lowered by the (ix+d)/idx-half compare fold — A-only, DE
+           survives. Covers the word-acc home's i-in-idx2 test. */
+        if (L.la.cur_branch_test_kind != 0 && cmp_ixd_fold_de_clean_ok(f, o))
+            return 1;
         /* --- General (non-accumulate) DE-home region ops (cur_de_home>=0) --- */
         if (L.cur_de_home >= 0) {
             /* Branch-fused int compare lowered by try_cmp_ixd_fold: reads both
@@ -1574,6 +1616,10 @@ static int op_de_clean(const Func *f, const Op *o)
             if ((o->kind == IR_ADD || o->kind == IR_SUB)
                 && o->dst == L.cur_func_whome && o->src[0] >= 0 && o->src[1] < 0
                 && o->imm >= 0 && o->imm <= 4)
+                return 1;
+            /* Byte-wise ALU fold (ADD/SUB/AND/OR/XOR of foldable operands): reads
+               in place through A, result to a non-home spill — DE-clean. */
+            if (binop_ixd_fold_de_clean_ok(f, o))
                 return 1;
         }
     }
@@ -1679,13 +1725,13 @@ static int op_de_clean_static(const Func *f, const BB *bb, int j)
             if (sw <= 2) return 1;
         }
         /* Branch consumed by a general DE-home folded int compare. */
-        if (L.cur_de_home >= 0 && prv->dst == o->src[0]
+        if ((L.cur_de_home >= 0 || L.cur_home_is_word) && prv->dst == o->src[0]
             && cmp_ixd_fold_de_clean_ok(f, prv))
             return 1;
     }
     /* General DE-home: a branch-fused int compare lowered by try_cmp_ixd_fold
        (recognised structurally — the compare feeds the next branch). */
-    if (L.cur_de_home >= 0 && j + 1 < bb->n_ops
+    if ((L.cur_de_home >= 0 || L.cur_home_is_word) && j + 1 < bb->n_ops
         && cmp_ixd_fold_de_clean_ok(f, o)) {
         const Op *nxt = &bb->ops[j + 1];
         if ((nxt->kind == IR_BR_ZERO || nxt->kind == IR_BR_COND)

--- a/src/80cc/ir_lower_regcache.inc.c
+++ b/src/80cc/ir_lower_regcache.inc.c
@@ -195,6 +195,18 @@ static void load_to_hl_adj(FILE *out, const Func *f, int vreg_id, int sp_adj)
         return;
     }
     int width = f->vregs[vreg_id].width;
+    /* Index-half home widened to HL: read the half via A (ld l,iyl is illegal —
+       DD reinterprets both operands), zero-extend. Always valid; no slot. */
+    if (width == 1) {
+        PhysReg ih = idxhalf_phys(f, vreg_id);
+        if (ih != IR_PR_NONE) {
+            emit(out, "ld\ta,%s", idxhalf_reg(ih));
+            emit(out, "ld\tl,a");
+            emit(out, "ld\th,0");
+            hl_about_to_change(vreg_id);
+            return;
+        }
+    }
     /* A-cache hit for byte vregs: a dead-skipped byte producer left the
        value ONLY in A (no slot store), so the slot read below would return
        garbage. */
@@ -604,6 +616,13 @@ static void store_hl(FILE *out, const Func *f, int vreg_id)
 static void load_byte_to_a(FILE *out, const Func *f, int vreg_id)
 {
     if (a_has(vreg_id)) return;
+    /* Index-half home: always valid (slotless, never clobbered) — read direct. */
+    PhysReg ih = idxhalf_phys(f, vreg_id);
+    if (ih != IR_PR_NONE) {
+        emit(out, "ld\ta,%s", idxhalf_reg(ih));
+        cache_a(vreg_id);
+        return;
+    }
     /* Byte home (PR_C/E/D/B): when the register currently holds this vreg,
        read it directly (C-home: always; E/D-home: when not clobbered). */
     PhysReg bh = byte_home_phys(f, vreg_id);
@@ -641,6 +660,14 @@ static void load_byte_to_a(FILE *out, const Func *f, int vreg_id)
 /* Store A to a vreg's 8-bit frame slot. Clobbers HL+E. */
 static void store_a_byte(FILE *out, const Func *f, int vreg_id)
 {
+    /* Index-half home: write the half, keep A cached. Slotless + clobber-free
+       so no slot store, no dirty tracking — the value simply rides the half. */
+    PhysReg ih = idxhalf_phys(f, vreg_id);
+    if (ih != IR_PR_NONE) {
+        emit(out, "ld\t%s,a", idxhalf_reg(ih));
+        cache_a(vreg_id);
+        return;
+    }
     /* Byte home: keep the value in the home register, elide the slot store.
        - C/B (slotless): rides the register for the whole function.
        - E/D (slot-backed): mark DIRTY — spilled to the slot before a
@@ -1211,6 +1238,33 @@ static const char *byte_home_reg(PhysReg pr)
 }
 static int  byte_home_holds(int v) { return v >= 0 && L.cur_byte_home_vreg == v; }
 static void byte_home_note(int v)  { L.cur_byte_home_vreg = v; }
+
+/* Index-half byte home (PR_IXL/IXH/IYL/IYH): a SEPARATE, simpler mechanism from
+   the E/D/C/B home above. Slotless and clobber-free in the no-call region the
+   proposer requires, so the value is ALWAYS in its half from its def — no belief
+   variable, no lazy-spill, no cross-BB carry. Recognised purely by vreg_to_phys;
+   every byte read/write/ALU path consults this and routes through A (ld a,iyl /
+   ld iyl,a) or uses the half as an ALU source (add a,iyl / sub iyl / cp iyl).
+   z80/z80n/ez80 only (see cpu_has_index_halves). */
+static PhysReg idxhalf_phys(const Func *f, int v)
+{
+    if (v < 0 || !f || !f->vreg_to_phys) return IR_PR_NONE;
+    PhysReg pr = f->vreg_to_phys[v];
+    if (pr == IR_PR_IXL || pr == IR_PR_IXH
+        || pr == IR_PR_IYL || pr == IR_PR_IYH)
+        return pr;
+    return IR_PR_NONE;
+}
+static const char *idxhalf_reg(PhysReg pr)
+{
+    switch (pr) {
+    case IR_PR_IXL: return "ixl";
+    case IR_PR_IXH: return "ixh";
+    case IR_PR_IYL: return "iyl";
+    case IR_PR_IYH: return "iyh";
+    default:        return NULL;
+    }
+}
 /* Is v homed in a clobberable slot-backed byte register (PR_E/PR_D)? */
 static int byte_home_is_slotbacked(const Func *f, int v)
 {

--- a/src/80cc/ir_lower_regcache.inc.c
+++ b/src/80cc/ir_lower_regcache.inc.c
@@ -1322,6 +1322,53 @@ static int word_dehome_signed_test_shape_ok(const Func *f, const Op *o)
     return 1;
 }
 
+/* A width-2 vreg in a frame slot reachable via (ix+d) in fp mode — a byte at
+   (ix+d)/(ix+d+1) can be folded straight into an ALU/compare op instead of
+   reloading the whole word into a pair. Ordinary spilled locals + PARAM_IN_PLACE. */
+static int op_is_ixd_slot(const Func *f, int v)
+{
+    if (v < 0 || v >= f->n_vregs) return 0;
+    if (!fp_active(f)) return 0;
+    if (f->vregs[v].width != 2) return 0;
+    if (f->vregs[v].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE)) return 0;
+    if (!f->vreg_to_phys || f->vreg_to_phys[v] != IR_PR_SPILL) return 0;
+    if (slot_off(f, v) < 0) return 0;
+    int ix = slot_ix_off(f, v);
+    return fp_offset_fits(ix) && fp_offset_fits(ix + 1);
+}
+
+/* Fill lo[]/hi[] with the 8-bit ALU operand for each byte of vreg v, read IN
+   PLACE — a register-pair half (c/b, l/h, e/d), an (ix+d) slot, or an idx2 half
+   (iyl/iyh). Returns 2 if v is memory/index (folding it saves a pair load/push),
+   1 if it's a gp-register pair (cheap either way), 0 if unreadable in place.
+   Shared by the compare fold (ir_lower_cmp) and the ALU fold (ir_lower_ops). */
+static int cmp_byte_src(const Func *f, int v, int idxhalf_ok,
+                        char *lo, char *hi, size_t n)
+{
+    if (bc_has(v)) { snprintf(lo,n,"c"); snprintf(hi,n,"b"); return 1; }
+    if (hl_has(v)) { snprintf(lo,n,"l"); snprintf(hi,n,"h"); return 1; }
+    if (de_has(v)) { snprintf(lo,n,"e"); snprintf(hi,n,"d"); return 1; }
+    /* Resident word DE-home: the DE regcache belief may be dropped at a region
+       header (residency is asserted via byte_home_holds, not cache_de), so
+       consult residency directly — the home rides e/d by the region proof. */
+    if (L.cur_home_is_word && v == L.cur_func_whome && v >= 0
+        && byte_home_holds(v) && f->vregs[v].width == 2) {
+        snprintf(lo, n, "e"); snprintf(hi, n, "d"); return 1;
+    }
+    if (op_is_ixd_slot(f, v)) {
+        int ix = slot_ix_off(f, v);
+        snprintf(lo, n, "(%s%+d)", frame_reg(), ix);
+        snprintf(hi, n, "(%s%+d)", frame_reg(), ix + 1);
+        return 2;
+    }
+    if (idxhalf_ok && vreg_in_idx2(f, v) && f->vregs[v].width == 2) {
+        const char *r = (f->idx2_reg == IR_PR_IX) ? "ix" : "iy";
+        snprintf(lo, n, "%sl", r); snprintf(hi, n, "%sh", r);
+        return 2;
+    }
+    return 0;
+}
+
 static int cmp_bytewise_ok(const Func *f, const Op *o)
 {
     if (L.la.cur_branch_test_kind == 0) return 0;
@@ -1372,6 +1419,75 @@ static int is_word_accumulate(const Func *f, const Op *o)
     if (o->src[0] != o->dst && o->src[1] != o->dst) return 0;
     if (o->dst >= f->n_vregs || f->vregs[o->dst].width != 2) return 0;
     return 1;
+}
+
+/* General DE-home (cur_de_home>=0): allocation-based class of a compare operand
+   for the (ix+d) fold — 1 = read cheaply from a register half (home e/d, or a
+   BC/DE/HL tenant), 2 = read in place from an (ix+d) slot or an idx2 half, 0 =
+   not foldable. Keyed on the FIXED physical assignment (the static region proof
+   runs before the regcache is populated, so runtime caches are unknown here). */
+static int cmp_fold_static_class(const Func *f, int v)
+{
+    if (v < 0 || v >= f->n_vregs || f->vregs[v].width != 2) return 0;
+    if (v == L.cur_func_whome) return 1;              /* home rides DE (e/d) */
+    if (!f->vreg_to_phys) return 0;
+    int phys = f->vreg_to_phys[v];
+    if (phys == IR_PR_BC || phys == IR_PR_DE || phys == IR_PR_HL) return 1;
+    if (op_is_ixd_slot(f, v)) return 2;
+    if ((c_cpu == CPU_Z80 || IS_Z80N()) && vreg_in_idx2(f, v)) return 2;
+    return 0;
+}
+
+/* An int compare inside the general DE-home region that try_cmp_ixd_fold will
+   lower DE-clean (reads both operands in place through A, never staging one into
+   DE). Requires >=1 operand mem/idx (else the fold defers to `sbc hl,de`, which
+   here PRESERVES DE only when the home is the DE operand — handled separately).
+   Mirrors try_cmp_ixd_fold's structural gates so the region proof agrees with
+   the emitter. Branch-fusion is checked by the callers. */
+static int cmp_ixd_fold_de_clean_ok(const Func *f, const Op *o)
+{
+    if (L.cur_de_home < 0 || getenv("IR_NO_IXD_FOLD")) return 0;
+    if (!fp_active(f)) return 0;
+    if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)) return 0;
+    switch (o->kind) {
+    case IR_CMP_LT: case IR_CMP_LE: case IR_CMP_GT: case IR_CMP_GE:
+    case IR_CMP_ULT: case IR_CMP_ULE: case IR_CMP_UGT: case IR_CMP_UGE:
+    case IR_CMP_EQ: case IR_CMP_NE: break;
+    default: return 0;
+    }
+    int s0 = o->src[0], s1 = o->src[1];
+    if (s0 < 0 || s1 < 0 || s0 == s1) return 0;
+    int c0 = cmp_fold_static_class(f, s0);
+    int c1 = cmp_fold_static_class(f, s1);
+    if (c0 == 0 || c1 == 0) return 0;
+    if (c0 == 1 && c1 == 1) return 0;    /* both gp pairs → sbc hl,de path */
+    return 1;
+}
+
+/* General DE-home indexed word deref address: `dst = base + (idx << k)` (k in
+   1..2) with idx riding BC and base rematerializable (LD_IMM/LD_SYM). Lowered
+   `ld hl,base; add hl,bc` (2^k times) — HL + BC only, so the home in DE survives.
+   Shared by try_de_home_indexed_add (emitter) and op_de_clean (region proof). */
+static int de_home_indexed_add_ok(const Func *f, const Op *o)
+{
+    if (L.cur_de_home < 0 || !L.cur_home_is_word) return 0;
+    if (o->kind != IR_ADD) return 0;
+    if (o->dst < 0 || o->dst >= f->n_vregs || f->vregs[o->dst].width != 2) return 0;
+    if (o->src[0] < 0 || o->src[1] < 0) return 0;
+    if (!f->vreg_to_phys) return 0;
+    for (int which = 0; which < 2; which++) {
+        int sidx = o->src[which], sbase = o->src[which ^ 1];
+        const Op *d = find_unique_def(f, sidx);
+        if (!d || d->kind != IR_SHL || d->src[1] >= 0) continue;
+        if (d->imm < 1 || d->imm > 2) continue;
+        int idx = d->src[0];
+        if (idx < 0 || idx >= f->n_vregs) continue;
+        if (f->vreg_to_phys[idx] != IR_PR_BC) continue;
+        if (!L.remat_def || sbase < 0 || sbase >= f->n_vregs
+            || !L.remat_def[sbase]) continue;
+        return 1;
+    }
+    return 0;
 }
 
 /* Is op `o`'s lowering proven DE-clean — does the slot-backed byte home (in
@@ -1427,6 +1543,39 @@ static int op_de_clean(const Func *f, const Op *o)
             && L.la.cur_branch_test_kind != 0
             && word_dehome_signed_test_shape_ok(f, o))
             return 1;
+        /* --- General (non-accumulate) DE-home region ops (cur_de_home>=0) --- */
+        if (L.cur_de_home >= 0) {
+            /* Branch-fused int compare lowered by try_cmp_ixd_fold: reads both
+               operands in place through A, never staging one into DE. */
+            if (L.la.cur_branch_test_kind != 0 && cmp_ixd_fold_de_clean_ok(f, o))
+                return 1;
+            /* RET of a width<=2 value: the return sits in HL, DE untouched, then
+               the function leaves — the home need not survive past it. */
+            if (o->kind == IR_RET) {
+                int rw = (o->src[0] >= 0 && o->src[0] < f->n_vregs)
+                       ? f->vregs[o->src[0]].width : 0;
+                return rw <= 2;
+            }
+            /* Word const shift (mid=(lo+hi)>>1): srl h;rr l — HL only, DE clean. */
+            if ((o->kind == IR_SHL || o->kind == IR_SHR) && dw == 2
+                && o->src[1] < 0 && o->dst != L.cur_func_whome)
+                return 1;
+            /* `dst = other + home` (dst != home): try_de_home_operand_add loads
+               other→HL and `add hl,de` — the home in DE survives. */
+            if (o->kind == IR_ADD && dw == 2 && o->dst != L.cur_func_whome
+                && o->src[0] >= 0 && o->src[1] >= 0
+                && (o->src[0] == L.cur_func_whome || o->src[1] == L.cur_func_whome))
+                return 1;
+            /* Indexed word deref address `base + (idx<<k)` via ld hl,base;add hl,bc. */
+            if (de_home_indexed_add_ok(f, o))
+                return 1;
+            /* Home-def `home = src0 +/- imm` (try_de_home_def): computes in HL
+               then ex de,hl → re-establishes DE = home. */
+            if ((o->kind == IR_ADD || o->kind == IR_SUB)
+                && o->dst == L.cur_func_whome && o->src[0] >= 0 && o->src[1] < 0
+                && o->imm >= 0 && o->imm <= 4)
+                return 1;
+        }
     }
     switch (o->kind) {
     case IR_NOP: case IR_BR:
@@ -1529,6 +1678,19 @@ static int op_de_clean_static(const Func *f, const BB *bb, int j)
                    ? f->vregs[prv->src[0]].width : 4;
             if (sw <= 2) return 1;
         }
+        /* Branch consumed by a general DE-home folded int compare. */
+        if (L.cur_de_home >= 0 && prv->dst == o->src[0]
+            && cmp_ixd_fold_de_clean_ok(f, prv))
+            return 1;
+    }
+    /* General DE-home: a branch-fused int compare lowered by try_cmp_ixd_fold
+       (recognised structurally — the compare feeds the next branch). */
+    if (L.cur_de_home >= 0 && j + 1 < bb->n_ops
+        && cmp_ixd_fold_de_clean_ok(f, o)) {
+        const Op *nxt = &bb->ops[j + 1];
+        if ((nxt->kind == IR_BR_ZERO || nxt->kind == IR_BR_COND)
+            && nxt->src[0] == o->dst)
+            return 1;
     }
     return op_de_clean(f, o);
 }

--- a/src/80cc/ir_opt.c
+++ b/src/80cc/ir_opt.c
@@ -896,10 +896,46 @@ static int ivsr_basic_iv(Func *f, int v, int lo, int hi, int ph,
     return 1;
 }
 
+/* Affine-multiple recogniser: is `x` a pure constant multiple `C*iv` of a single
+   basic IV, built from single-use in-loop shifts/adds/subs (the shift-and-add
+   form the const-mult strength reducer emits for a non-power-of-2 scale, e.g. a
+   struct-array stride `i*6 = (i<<2)+(i<<1)`)? Recurses the def tree; every
+   interior node must be a single-use in-loop temp so folding the whole term away
+   is safe (the now-dead sub-ops are removed by DCE). All leaves must be the SAME
+   basic IV. Returns 1 with *iv_out (the basic IV) and *C (the coefficient). */
+static int ivsr_affine_coeff(Func *f, int x, int lo, int hi, int ph,
+                             int *iv_out, int64_t *C, int depth)
+{
+    int64_t k, d;
+    if (ivsr_basic_iv(f, x, lo, hi, ph, &k, &d)) { *iv_out = x; *C = 1; return 1; }
+    if (depth >= 6) return 0;
+    int n_in, ib, ii, n_out, ob, oi;
+    ivsr_def_sites(f, x, lo, hi, &n_in, &ib, &ii, &n_out, &ob, &oi);
+    if (n_in != 1 || n_out != 0) return 0;
+    if (ivsr_uses_in_loop(f, x, lo, hi) != 1) return 0;   /* single-use ⇒ DCE-safe */
+    if (ivsr_used_outside(f, x, lo, hi)) return 0;
+    Op *o = &f->bbs[ib].ops[ii];
+    if (o->kind == IR_SHL && o->src[1] == -1 && o->imm >= 0 && o->imm < 16) {
+        int iva; int64_t ca;
+        if (!ivsr_affine_coeff(f, o->src[0], lo, hi, ph, &iva, &ca, depth + 1)) return 0;
+        *iv_out = iva; *C = ca << o->imm; return 1;
+    }
+    if ((o->kind == IR_ADD || o->kind == IR_SUB) && o->src[1] >= 0) {
+        int iva, ivb; int64_t ca, cb;
+        if (!ivsr_affine_coeff(f, o->src[0], lo, hi, ph, &iva, &ca, depth + 1)) return 0;
+        if (!ivsr_affine_coeff(f, o->src[1], lo, hi, ph, &ivb, &cb, depth + 1)) return 0;
+        if (iva != ivb) return 0;                          /* one basic IV only */
+        *iv_out = iva; *C = (o->kind == IR_ADD) ? ca + cb : ca - cb; return 1;
+    }
+    return 0;
+}
+
 /* Is `x` a derived-IV scaling term off a basic IV in loop [lo,hi]?
    Either x is itself a basic IV (scale 1, *shl_bb = -1) or x is a
    single-use `SHL x <- iv, s` whose iv is a basic IV (scale 2^s, *shl_bb
-   points at the SHL). Fills *iv / *scale / *K / *D. */
+   points at the SHL). Fills *iv / *scale / *K / *D. As a fallback, x may be a
+   NON-power-of-2 affine multiple `C*iv` (shift-and-add form, struct-array
+   stride) — then *shl_bb = -1 and the dead term sub-ops are cleaned by DCE. */
 static int ivsr_iv_term(Func *f, int x, int lo, int hi, int ph,
                         int *iv_out, int64_t *scale, int64_t *K, int64_t *D,
                         int *shl_bb, int *shl_idx)
@@ -914,18 +950,32 @@ static int ivsr_iv_term(Func *f, int x, int lo, int hi, int ph,
     ivsr_def_sites(f, x, lo, hi, &n_in, &in_bb, &in_idx,
                    &n_out, &out_bb, &out_idx);
     if (n_in != 1 || n_out != 0) return 0;
-    Op *sh = &f->bbs[in_bb].ops[in_idx];
-    if (sh->kind != IR_SHL || sh->src[1] != -1) return 0;
-    if (sh->imm < 0 || sh->imm >= 16) return 0;
-    if (!ivsr_basic_iv(f, sh->src[0], lo, hi, ph, &k, &d)) return 0;
-    /* The SHL must feed only this loop (its sole consumer is the ADD we
-       are about to fold away), else NOPing it drops a live value. */
+    /* The term must feed only this loop (its sole consumer is the ADD we are
+       about to fold away), else folding it drops a live value. */
     if (ivsr_uses_in_loop(f, x, lo, hi) != 1) return 0;
     if (ivsr_used_outside(f, x, lo, hi)) return 0;
-    *iv_out = sh->src[0]; *scale = (int64_t)1 << sh->imm;
-    *K = k; *D = d;
-    *shl_bb = in_bb; *shl_idx = in_idx;
-    return 1;
+    Op *sh = &f->bbs[in_bb].ops[in_idx];
+    if (sh->kind == IR_SHL && sh->src[1] == -1
+        && sh->imm >= 0 && sh->imm < 16
+        && ivsr_basic_iv(f, sh->src[0], lo, hi, ph, &k, &d)) {
+        *iv_out = sh->src[0]; *scale = (int64_t)1 << sh->imm;
+        *K = k; *D = d;
+        *shl_bb = in_bb; *shl_idx = in_idx;
+        return 1;
+    }
+    /* Non-power-of-2 affine multiple `C*iv` (struct-array stride). Fold the
+       whole shift-and-add term away (DCE removes the dead sub-ops) and step the
+       pointer by C. IR_NO_IVSR_AFFINE opts out. */
+    if (!getenv("IR_NO_IVSR_AFFINE")) {
+        int iva; int64_t C;
+        if (ivsr_affine_coeff(f, x, lo, hi, ph, &iva, &C, 0) && C >= 2
+            && ivsr_basic_iv(f, iva, lo, hi, ph, &k, &d)) {
+            *iv_out = iva; *scale = C; *K = k; *D = d;
+            *shl_bb = -1; *shl_idx = -1;
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /* Every in-loop use of `d` must be redirectable by ivsr_rewrite_use
@@ -1031,6 +1081,11 @@ static int ivsr_try_lftr(Func *f, int lo, int hi, int ph,
     for (int t = 0; t < n_cand; t++)
         if (cand[t].iv == iv && cand[t].D > 0 && cand[t].K >= 0) { c = t; break; }
     if (c < 0) return 0;
+    /* LFTR scales the bound by `<< sh` (below), which is only valid for a
+       power-of-2 scale. A non-power-of-2 stride (struct-array walking pointer)
+       keeps its basic IV for the exit test — the strength reduction still
+       applies, just without counter elimination. */
+    if ((cand[c].scale & (cand[c].scale - 1)) != 0) return 0;
     /* The exit bound. Two cases:
        - a proven-nonnegative COMPILE-TIME CONSTANT: p_end = base + N*scale, a
          single pre-header ADD (the original, cheapest path);
@@ -1179,7 +1234,15 @@ static int ivsr_process_loop(Func *f, int h, int latch, int ph)
                    there (measured: ez80 +8% if suppressed) — leave IVSR on. */
                 if (!getenv("IR_NO_IVSR_SUPPRESS")
                     && (c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)
+                    && (scale & (scale - 1)) == 0    /* power-of-2 scale only */
                     && ivsr_base_is_const_sym(f, base, lo, hi)) {
+                    /* Power-of-2 scale: recomputing `base + iv*2^k` from the
+                       resident index is cheap (`add hl,hl`), so a walking pointer
+                       is a redundant 2nd loop-carried value — suppress it (queen).
+                       A NON-power-of-2 scale (struct-array stride, e.g. i*6) has
+                       an expensive multi-op recompute THROUGH DE, which also
+                       blocks a DE-resident accumulator; there the walking pointer
+                       is the win (structbench -32%), so this gate is skipped. */
                     int addr_uses = ivsr_uses_in_op(&f->bbs[b].ops[j], iv);
                     if (sb >= 0)
                         addr_uses += ivsr_uses_in_op(&f->bbs[sb].ops[si], iv);
@@ -1263,17 +1326,17 @@ int ir_opt_ivsr(Func *f)
        per-iteration slot RMW costs more than the SHL;ADD removed). The
        allocator's PR_BC envelope is function-wide and barred by any
        width-4 vreg (long ops stage through BC) or BC-clobbering op
-       (IR_ST_MEM vreg+offset, non-char IR_SWITCH, IR_ASM). Mirror that
-       gate here so IVSR fires only where BC residency is reachable — md5
-       (full of UINT4) would otherwise regress 13%. */
+       (non-char IR_SWITCH, IR_ASM). Mirror that gate here so IVSR fires only
+       where BC residency is reachable — md5 (full of UINT4) would otherwise
+       regress 13%. (Offset stores USED to bar it too — `ld bc,N; add hl,bc`
+       for the offset add — but gen_st_mem now emits that BC-clean, so an
+       array-of-struct write no longer blocks the walking pointer.) */
     for (int v = 0; v < f->n_vregs; v++)
         if (f->vregs[v].width == 4) return 0;
     for (int b = 0; b < f->n_bbs; b++) {
         BB *bb = &f->bbs[b];
         for (int j = 0; j < bb->n_ops; j++) {
             const Op *o = &bb->ops[j];
-            if (o->kind == IR_ST_MEM && o->mem.kind == IR_MEM_VREG
-                && o->mem.offset != 0) return 0;
             if (o->kind == IR_SWITCH && !(o->sw && o->sw->is_char)) return 0;
             if (o->kind == IR_ASM) return 0;
         }
@@ -2247,6 +2310,113 @@ int ir_opt_const_fold(Func *f)
 extern int c_word_resident;
 
 #define RR_MAX_CHAIN 16
+
+/* Reduction-chain coalescing. A left-leaning fold into a loop-carried word —
+   `s = ((s + a) + b) + c` — lowers to a chain of ADDs through single-use temps:
+       t0 = s + a;  t1 = t0 + b;  s = t1 + c
+   so `s` is read only at the innermost add and written only at the outermost,
+   and word_acc (which wants `s = s OP w`) never sees it → s spills to a slot/TOS.
+   This renames the single-use spine temps (t0,t1) back to `s`, giving the
+   in-place form
+       s = s + a;  s = s + b;  s = s + c
+   which word_acc then homes in DE (`add hl,de; ex de,hl` per step — sdcc's
+   shape). The IR is already load/add-interleaved, so no op moves; the rename is
+   sound because each spine temp is single-use (only the next add's src0) and `s`
+   is not otherwise referenced across the chain span. IR_NO_REDUCE_COALESCE opts
+   out. */
+int ir_opt_reduce_coalesce(Func *f)
+{
+    if (!f) return 0;
+    if (!c_word_resident || getenv("IR_NO_WORD_RESIDENT")) return 0;
+    if (getenv("IR_NO_REDUCE_COALESCE")) return 0;
+    int nv = f->n_vregs;
+    if (nv <= 0) return 0;
+
+    /* Function-wide use counts + single-def sites (mirror reassoc). */
+    int *use_cnt = calloc((size_t)nv, sizeof(int));
+    int *def_bb  = calloc((size_t)nv, sizeof(int));
+    int *def_idx = calloc((size_t)nv, sizeof(int));
+    int *def_cnt = calloc((size_t)nv, sizeof(int));
+    if (!use_cnt || !def_bb || !def_idx || !def_cnt) {
+        free(use_cnt); free(def_bb); free(def_idx); free(def_cnt); return 0;
+    }
+    for (int b = 0; b < f->n_bbs; b++)
+        for (int j = 0; j < f->bbs[b].n_ops; j++) {
+            Op *o = &f->bbs[b].ops[j];
+            int u[16];
+            int nu = ir_op_uses(o, u, (int)(sizeof u / sizeof u[0]));
+            for (int k = 0; k < nu; k++)
+                if (u[k] >= 0 && u[k] < nv) use_cnt[u[k]]++;
+            if (o->dst >= 0 && o->dst < nv)
+                if (def_cnt[o->dst]++ == 0) { def_bb[o->dst] = b; def_idx[o->dst] = j; }
+        }
+
+    int changed = 0;
+    for (int b = 0; b < f->n_bbs; b++) {
+        BB *bb = &f->bbs[b];
+        for (int h = 0; h < bb->n_ops; h++) {
+            Op *top = &bb->ops[h];
+            if (top->kind != IR_ADD) continue;
+            int acc = top->dst;
+            if (acc < 0 || acc >= nv || f->vregs[acc].width != 2) continue;
+            if (f->vregs[acc].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE))
+                continue;
+            if (top->src[0] == acc || top->src[1] < 0) continue; /* not left-leaning */
+
+            /* Walk the src[0] spine of single-use ADD temps; it must bottom out
+               with an add whose src[0] IS acc (the innermost `s + a`). */
+            int spine[RR_MAX_CHAIN];   /* op indices, spine[0]=h (top) */
+            int sn = 0, ok = 1, bottom = -1;
+            spine[sn++] = h;
+            int cur = top->src[0];
+            while (1) {
+                if (cur < 0 || cur >= nv) { ok = 0; break; }
+                if (use_cnt[cur] != 1) { ok = 0; break; }          /* temp: single-use */
+                if (def_cnt[cur] != 1 || def_bb[cur] != b) { ok = 0; break; }
+                if (f->vregs[cur].width != 2) { ok = 0; break; }
+                int di = def_idx[cur];
+                Op *da = &bb->ops[di];
+                if (da->kind != IR_ADD || da->src[0] < 0 || da->src[1] < 0) { ok = 0; break; }
+                if (sn >= RR_MAX_CHAIN) { ok = 0; break; }
+                spine[sn++] = di;
+                if (da->src[0] == acc) { bottom = di; break; }     /* fold closes on acc */
+                cur = da->src[0];
+            }
+            if (!ok || bottom < 0 || sn < 2) continue;
+
+            /* Span the chain occupies; acc must not be referenced inside it
+               except as the bottom's src[0] and the top's dst (no partial-sum
+               reader between the rewritten steps). */
+            int lo = h, hi = h;
+            for (int i = 0; i < sn; i++) { if (spine[i] < lo) lo = spine[i]; if (spine[i] > hi) hi = spine[i]; }
+            int acc_refs = 0;
+            for (int q = lo; q <= hi; q++) {
+                Op *o = &bb->ops[q];
+                if (o->dst == acc) acc_refs++;
+                int u[16];
+                int nu = ir_op_uses(o, u, (int)(sizeof u / sizeof u[0]));
+                for (int k = 0; k < nu; k++) if (u[k] == acc) acc_refs++;
+            }
+            if (acc_refs != 2) continue;   /* dst@top + src0@bottom only */
+
+            /* Rename every spine temp (all but the top, whose dst is already
+               acc) to acc: set its def's dst and its single use (the next
+               spine op's src0) to acc. */
+            for (int i = 1; i < sn; i++) {
+                Op *sp = &bb->ops[spine[i]];
+                int t = sp->dst;
+                sp->dst = acc;                       /* def now writes acc */
+                Op *parent = &bb->ops[spine[i - 1]]; /* consumes t as src[0] */
+                if (parent->src[0] == t) parent->src[0] = acc;
+                else if (parent->src[1] == t) parent->src[1] = acc;
+            }
+            changed++;
+        }
+    }
+    free(use_cnt); free(def_bb); free(def_idx); free(def_cnt);
+    return changed;
+}
+
 int ir_opt_reassoc_reduction(Func *f)
 {
     if (!f) return 0;

--- a/src/80cc/ir_opt.c
+++ b/src/80cc/ir_opt.c
@@ -5,6 +5,7 @@
  * compiler internals (no ccdefs.h) so ir_selftest can link standalone.
  */
 
+#include "ccdefs.h"
 #include "ir_opt.h"
 #include "ir_analysis.h"
 
@@ -831,6 +832,38 @@ static int ivsr_uses_in_loop(Func *f, int v, int lo, int hi)
     return c;
 }
 
+/* Count uses of `v` in a single op. */
+static int ivsr_uses_in_op(const Op *o, int v)
+{
+    int uses[8];
+    int nu = ir_op_uses(o, uses, 8);
+    int c = 0;
+    for (int k = 0; k < nu; k++) if (uses[k] == v) c++;
+    return c;
+}
+
+/* True if `base`'s reaching def is an IR_LD_SYM (a compile-time-constant
+   address, e.g. a static array). Such a base makes recomputing the indexed
+   address `base + iv*scale` cheap (ld hl,SYM; add hl,de) — no persistent
+   pointer register needed. Scans out-of-loop defs (base is loop-invariant). */
+static int ivsr_base_is_const_sym(Func *f, int base, int lo, int hi)
+{
+    if (base < 0 || base >= f->n_vregs) return 0;
+    for (int b = 0; b < f->n_bbs; b++) {
+        if (b >= lo && b <= hi) continue;
+        BB *bb = &f->bbs[b];
+        for (int j = 0; j < bb->n_ops; j++) {
+            const Op *o = &bb->ops[j];
+            int defs[8];
+            int nd = ir_op_defs(o, defs, 8);
+            for (int k = 0; k < nd; k++)
+                if (defs[k] == base)
+                    return o->kind == IR_LD_SYM;   /* only LD_SYM counts */
+        }
+    }
+    return 0;
+}
+
 /* Recognise a basic IV `v`: exactly one in-loop self-step def
    (v = v ± c via INC/DEC/ADD-imm/SUB-imm) and exactly one out-of-loop
    def that is an LD_IMM init in the pre-header `ph`. Returns 1 and fills
@@ -1125,6 +1158,34 @@ static int ivsr_process_loop(Func *f, int h, int latch, int ph)
                 if (ni != 1 || ib != b || ii != j) continue;
                 if (ivsr_used_outside(f, d, lo, hi)) continue;
                 if (!ivsr_d_rewritable(f, d, lo, hi, b, j)) continue;
+
+                /* Redundant-pointer gate: when the base is a constant address
+                   (LD_SYM) AND the index `iv` is independently live — it has
+                   in-loop uses beyond this derived address, so it survives LFTR
+                   and must stay resident anyway — a stepped pointer is a SECOND
+                   loop-carried value competing for the one BC home. It loses,
+                   spills to a slot, and the per-iteration slot RMW costs more
+                   than recomputing `base + iv*scale` from the resident index
+                   (sdcc's strategy; queenbench's `safe`). Suppress here.
+                   Detect "survives LFTR": after this reduction removes iv's use
+                   in the address derivation (the SHL, or the ADD when scale==1),
+                   iv still has >2 in-loop uses (LFTR needs exactly 2 = step +
+                   exit test). A pure array-walk (ptrbench) has exactly 2 left →
+                   not suppressed, IVSR still fires. IR_NO_IVSR_SUPPRESS opts out.
+                   Gated to z80/z80n/z180 — the CPUs where a slot-homed pointer's
+                   `ld hl,(ix+d)` is 2 ops, so maintaining a spilled pointer costs
+                   more than recomputing. ez80/kc160/rabbit have a 1-op word slot
+                   load (+ native indexing), so the walking pointer stays cheaper
+                   there (measured: ez80 +8% if suppressed) — leave IVSR on. */
+                if (!getenv("IR_NO_IVSR_SUPPRESS")
+                    && (c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180)
+                    && ivsr_base_is_const_sym(f, base, lo, hi)) {
+                    int addr_uses = ivsr_uses_in_op(&f->bbs[b].ops[j], iv);
+                    if (sb >= 0)
+                        addr_uses += ivsr_uses_in_op(&f->bbs[sb].ops[si], iv);
+                    int remaining = ivsr_uses_in_loop(f, iv, lo, hi) - addr_uses;
+                    if (remaining > 2) continue;   /* iv survives → pointer redundant */
+                }
 
                 cand[n_cand].d = d;     cand[n_cand].base = base;
                 cand[n_cand].iv = iv;

--- a/src/80cc/ir_opt.h
+++ b/src/80cc/ir_opt.h
@@ -180,6 +180,11 @@ int ir_opt_const_fold(Func *f);
    (inert when off ⇒ byte-identical). Returns chains reassociated. */
 int ir_opt_reassoc_reduction(Func *f);
 
+/* Coalesce a left-leaning reduction chain `s=((s+a)+b)+c` (through single-use
+   spine temps) back into in-place `s=s+a; s=s+b; s=s+c`, so word_acc can DE-home
+   the accumulator. Gated on c_word_resident; IR_NO_REDUCE_COALESCE opts out. */
+int ir_opt_reduce_coalesce(Func *f);
+
 /* long_inc_mhl (the long (*p)++ triple → HCALL l_long_inc_mhl) lives
    in the ir_match table as `incmhl`; --opt-disable=pattern:incmhl. */
 

--- a/test/suites/Makefile
+++ b/test/suites/Makefile
@@ -4,7 +4,8 @@
 SUBDIRS = string ctype stdio stdlib math md5 regex sccz80 zx far
 # benchmark suites (also self-checking via host-verified assertEqual)
 SUBDIRS += charbench crcbench intbench ptrbench sieve rle \
-           sortbench queenbench searchbench switchbench
+           sortbench queenbench searchbench switchbench \
+           structbench vecbench recordbench maskbench
 
 ifeq ($(COMPILER),80cc)
 SUBDIRS += long_ir

--- a/test/suites/long_ir/Makefile
+++ b/test/suites/long_ir/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED -lmath48 -lmath16
 # the lib — needed by fastcall AND __sdcccall(1) function-pointer calls.
 JPTH = ../../../libsrc/l/sccz80/9-common/l_jpix.asm ../../../libsrc/l/sccz80/9-common/l_jpiy.asm
 
-all:	test.bin test_gbz80.bin test_8080.bin test_8085.bin irgaps.bin irgaps_gbz80.bin irgaps_8080.bin irgaps_8085.bin structval.bin structval_gbz80.bin structval_8080.bin structval_8085.bin fixed.bin sdcccall.bin sdcccall_kc160.bin wr.bin wr_fp.bin fp_promote.bin fp_promote_reg.bin fp_promote_f48f16.bin fp_promote_accum.bin aggregate_init.bin fnptr_fastcall.bin faslot.bin libcall_abi.bin const_mult.bin cmp_gt.bin cmp_sign.bin remat.bin idxcmp.bin idxcmp_fp.bin idxhome.bin idxhome_fp.bin longlong.bin bitfield.bin umaxd.bin fp_to_int.bin
+all:	test.bin test_gbz80.bin test_8080.bin test_8085.bin irgaps.bin irgaps_gbz80.bin irgaps_8080.bin irgaps_8085.bin structval.bin structval_gbz80.bin structval_8080.bin structval_8085.bin fixed.bin sdcccall.bin sdcccall_kc160.bin wr.bin wr_fp.bin fp_promote.bin fp_promote_reg.bin fp_promote_f48f16.bin fp_promote_accum.bin aggregate_init.bin fnptr_fastcall.bin faslot.bin libcall_abi.bin const_mult.bin cmp_gt.bin cmp_sign.bin remat.bin idxcmp.bin idxcmp_fp.bin ixdcmp.bin ixdcmp_fp.bin dehome.bin dehome_fp.bin idxhome.bin idxhome_fp.bin longlong.bin bitfield.bin umaxd.bin fp_to_int.bin
 
 test.bin: $(SOURCES) long_ir.c
 	$(compile)
@@ -109,6 +109,29 @@ remat.bin: $(SOURCES) remat.c
 
 idxcmp.bin: $(SOURCES) idxcmp.c
 	$(compile)
+	$(runtest)
+
+# Byte-wise (ix+d) int compare fold. sp build (fold fp-gated → inert) validates
+# the ordinary compare path; ixdcmp_fp below exercises the fold itself.
+ixdcmp.bin: $(SOURCES) ixdcmp.c
+	$(compile)
+	$(runtest)
+
+# fp-mode: params are (ix+d) slots, so every relation folds byte-wise in place.
+ixdcmp_fp.bin: $(SOURCES) ixdcmp.c
+	$(call compile,-Cc-frameix)
+	$(runtest)
+
+# General DE-home co-design. sp build: feature inert (fp-only) → validates the
+# ordinary path. fp build (-Cc-frameix): the inlined binary searches home lo/hi
+# in DE across the loop — exercises the compare fold, add hl,de, indexed deref,
+# and ex-de-hl home-def.
+dehome.bin: $(SOURCES) dehome.c
+	$(compile)
+	$(runtest)
+
+dehome_fp.bin: $(SOURCES) dehome.c
+	$(call compile,-Cc-frameix)
 	$(runtest)
 
 # Index-half BYTE HOME (second byte home in IYL/IXL). sp-mode (the default

--- a/test/suites/long_ir/Makefile
+++ b/test/suites/long_ir/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED -lmath48 -lmath16
 # the lib — needed by fastcall AND __sdcccall(1) function-pointer calls.
 JPTH = ../../../libsrc/l/sccz80/9-common/l_jpix.asm ../../../libsrc/l/sccz80/9-common/l_jpiy.asm
 
-all:	test.bin test_gbz80.bin test_8080.bin test_8085.bin irgaps.bin irgaps_gbz80.bin irgaps_8080.bin irgaps_8085.bin structval.bin structval_gbz80.bin structval_8080.bin structval_8085.bin fixed.bin sdcccall.bin sdcccall_kc160.bin wr.bin wr_fp.bin fp_promote.bin fp_promote_reg.bin fp_promote_f48f16.bin fp_promote_accum.bin aggregate_init.bin fnptr_fastcall.bin faslot.bin libcall_abi.bin const_mult.bin cmp_gt.bin cmp_sign.bin remat.bin idxcmp.bin idxcmp_fp.bin longlong.bin bitfield.bin umaxd.bin fp_to_int.bin
+all:	test.bin test_gbz80.bin test_8080.bin test_8085.bin irgaps.bin irgaps_gbz80.bin irgaps_8080.bin irgaps_8085.bin structval.bin structval_gbz80.bin structval_8080.bin structval_8085.bin fixed.bin sdcccall.bin sdcccall_kc160.bin wr.bin wr_fp.bin fp_promote.bin fp_promote_reg.bin fp_promote_f48f16.bin fp_promote_accum.bin aggregate_init.bin fnptr_fastcall.bin faslot.bin libcall_abi.bin const_mult.bin cmp_gt.bin cmp_sign.bin remat.bin idxcmp.bin idxcmp_fp.bin idxhome.bin idxhome_fp.bin longlong.bin bitfield.bin umaxd.bin fp_to_int.bin
 
 test.bin: $(SOURCES) long_ir.c
 	$(compile)
@@ -109,6 +109,20 @@ remat.bin: $(SOURCES) remat.c
 
 idxcmp.bin: $(SOURCES) idxcmp.c
 	$(compile)
+	$(runtest)
+
+# Index-half BYTE HOME (second byte home in IYL/IXL). sp-mode (the default
+# compile) has IY free, so this build exercises the index-half home on z80;
+# the assert is width-independent so gbz80/8080/8085 validate the slot fallback.
+idxhome.bin: $(SOURCES) idxhome.c
+	$(compile)
+	$(runtest)
+
+# fp-mode: exercises INTERVAL REUSE of the index reg — mix2's `len` param owns IY
+# only at entry (end = data+len), then `b` reuses IYL for the loop. The sp build
+# above has IY free outright; this one proves the live-interval overlap path.
+idxhome_fp.bin: $(SOURCES) idxhome.c
+	$(call compile,-Cc-frameix)
 	$(runtest)
 
 # Same test in FRAME-POINTER mode: the index-half signed compare

--- a/test/suites/long_ir/dehome.c
+++ b/test/suites/long_ir/dehome.c
@@ -1,0 +1,80 @@
+/* General DE-home co-design (default-on; IR_NO_DE_HOME opts out). In fp mode an
+ * inlined integer binary search keeps a loop-carried NON-accumulate word (lo or
+ * hi) resident in the DE pair across the whole loop, instead of a frame slot.
+ * The region is kept DE-clean by: the (ix+d) byte-wise compare fold (loop test +
+ * the v==key / v<key value compares), an `add hl,de` for the home-operand add
+ * (mid = lo + hi), `ld hl,base; add hl,bc` for the indexed deref (table[mid]),
+ * and `ex de,hl` for the home-def (hi = mid - 1 / lo = mid + 1).
+ *
+ * Each kernel is a distinct shape variation that the allocator homes in DE:
+ *   bs_int   — hi is the home (hi = mid-1), signed bound, stride-2 int deref
+ *   bs_lo    — flipped operand order (mid = hi+lo) so lo can be the home
+ *   bs_uns   — unsigned array + unsigned compare
+ *   bs_short — short (16-bit) element, signed
+ * The asserts are width-independent (indices/returns fit 16-bit), so the sp
+ * build (feature inert — it is fp-only) validates the ordinary path too. The
+ * checksum is host-verified. Correctness traps: reading the home from e/d in
+ * place, the `ex de,hl` home-def re-establishing DE, and the deref recomputed
+ * from BC (`add hl,bc`) rather than clobbering DE. */
+#include "test.h"
+
+static int      dh_ai[128];
+static unsigned dh_au[128];
+static short    dh_as[128];
+
+static int bs_int(int key)
+{
+    int lo = 0, hi = 127;
+    while (lo <= hi) { int m = (lo + hi) >> 1; int v = dh_ai[m];
+        if (v == key) return m; if (v < key) lo = m + 1; else hi = m - 1; }
+    return -1;
+}
+static int bs_lo(int key)
+{
+    int lo = 0, hi = 127;
+    while (lo <= hi) { int m = (hi + lo) >> 1; int v = dh_ai[m];
+        if (v < key) lo = m + 1; else if (v > key) hi = m - 1; else return m; }
+    return -1;
+}
+static int bs_uns(unsigned key)
+{
+    int lo = 0, hi = 127;
+    while (lo <= hi) { int m = (lo + hi) >> 1; unsigned v = dh_au[m];
+        if (v == key) return m; if (v < key) lo = m + 1; else hi = m - 1; }
+    return -1;
+}
+static int bs_short(int key)
+{
+    int lo = 0, hi = 127;
+    while (lo <= hi) { int m = (lo + hi) >> 1; int v = dh_as[m];
+        if (v == key) return m; if (v < key) lo = m + 1; else hi = m - 1; }
+    return -1;
+}
+
+static void test_de_home(void)
+{
+    int i;
+    unsigned chk = 0;
+    for (i = 0; i < 128; i++) {
+        dh_ai[i] = i * 3 - 100;
+        dh_au[i] = (unsigned)(i * 7u + 3u);
+        dh_as[i] = (short)(i * 2 - 50);
+    }
+    for (i = -200; i < 500; i += 3) {
+        chk = (unsigned)((chk * 31u + (unsigned)(bs_int(i) + 1)) & 0xffffu);
+        chk = (unsigned)((chk * 31u + (unsigned)(bs_lo(i) + 1)) & 0xffffu);
+    }
+    for (i = 0; i < 1000; i += 7)
+        chk = (unsigned)((chk * 31u + (unsigned)(bs_uns((unsigned)i) + 1)) & 0xffffu);
+    for (i = -100; i < 300; i += 3)
+        chk = (unsigned)((chk * 31u + (unsigned)(bs_short(i) + 1)) & 0xffffu);
+    Assert(chk == 12235u, "DE-home binary-search checksum (host-verified)");
+}
+
+int main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    suite_setup("General DE-home binary search");
+    suite_add_test(test_de_home);
+    return suite_run();
+}

--- a/test/suites/long_ir/idxhome.c
+++ b/test/suites/long_ir/idxhome.c
@@ -1,0 +1,48 @@
+/* Index-half byte home: a hot, single-def, currently-spilled width-1 vreg is
+ * promoted to an index-register half (PR_IYL/IYH/IXL/IXH) — a slotless,
+ * clobber-free SECOND byte home alongside the E/D home. z80/z80n/ez80 only,
+ * where a free index reg exists (sp-mode: IY free → IYL/IYH).
+ *
+ * This is charbench's schar_mix shape: `acc` (multi-def) takes E, and the
+ * per-iteration byte `b` (single-def `*data++`) takes IYL — read/written via A
+ * (ld a,iyl / ld iyl,a) and used as a base-page ALU source (sub iyl / add a,iyl
+ * / xor iyl). Correctness traps: the half must survive the whole diamond loop
+ * (never clobbered), the right register, and NO CB-page op ever hits it
+ * (`sla iyl` doesn't exist — shifts route through A). The assert is
+ * width-independent so it also validates the slot fallback on non-index CPUs. */
+#include "test.h"
+
+static signed char sbuf[24];
+
+/* Signed accumulate with a per-iteration byte b and a shift — two live bytes
+ * (acc + b) across an if/else diamond, the two-byte-home shape. */
+static signed char mix2(signed char *data, unsigned int len)
+{
+    signed char acc = -1;
+    signed char *end = data + len;
+    while (data < end) {
+        signed char b = *data++;
+        if (b < 0) acc = (signed char)(acc - b);
+        else       acc = (signed char)(acc + b);
+        acc = (signed char)((acc << 1) ^ b);
+    }
+    return acc;
+}
+
+static void test_idxhome(void)
+{
+    int i;
+    for (i = 0; i < 24; i++) sbuf[i] = (signed char)((i * 11) - 128);
+    /* host-computed reference over the full buffer */
+    Assert((unsigned char)mix2(sbuf, 24) == 0x0Fu, "idxhome: two byte homes (acc=E, b=half)");
+    /* partial length exercises a different trip count / carry */
+    Assert((unsigned char)mix2(sbuf, 7) == 0xDCu, "idxhome: partial length");
+}
+
+int main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    suite_setup("Index-half byte home");
+    suite_add_test(test_idxhome);
+    return suite_run();
+}

--- a/test/suites/long_ir/ixdcmp.c
+++ b/test/suites/long_ir/ixdcmp.c
@@ -1,0 +1,59 @@
+/* Byte-wise (ix+d) operand fold for int compares. In fp mode (-frameix) an int
+ * compare whose operands live in (ix+d) slots / idx2 halves / register pairs is
+ * lowered by reading each operand's bytes IN PLACE and subtracting through A
+ * (`ld a,<lo>; sub <lo'>; ld a,<hi>; sbc a,<hi'>` + S^V for signed), instead of
+ * staging a slot into a pair + `sbc hl,de`. Gated to z80/z80n/z180.
+ *
+ * These tiny functions keep both operands as (ix+d) PARAM_IN_PLACE slots, so the
+ * fp build exercises the both-operands-folded byte-wise path across ALL six
+ * relations + signed/unsigned; the asserts are width-independent so the sp build
+ * (fold inert) validates the ordinary path too. Correctness traps: the M-N
+ * subtraction direction, the CF/!CF branch polarity, the S^V signed correction
+ * (negative + overflow operands), the LE/GT reduction to strict-less-of-reversed,
+ * and the two-byte EQ check (low- vs high-byte differences). */
+#include "test.h"
+
+static int slt(int a, int b) { if (a <  b) return 1; return 0; }
+static int sle(int a, int b) { if (a <= b) return 1; return 0; }
+static int sgt(int a, int b) { if (a >  b) return 1; return 0; }
+static int sge(int a, int b) { if (a >= b) return 1; return 0; }
+static int seq(int a, int b) { if (a == b) return 1; return 0; }
+static int sne(int a, int b) { if (a != b) return 1; return 0; }
+
+static int ult(unsigned a, unsigned b) { if (a <  b) return 1; return 0; }
+static int ule(unsigned a, unsigned b) { if (a <= b) return 1; return 0; }
+static int ugt(unsigned a, unsigned b) { if (a >  b) return 1; return 0; }
+static int uge(unsigned a, unsigned b) { if (a >= b) return 1; return 0; }
+
+static void test_ixdcmp(void)
+{
+    /* Signed ordered, incl. negatives. */
+    Assert(slt(-5, 3) == 1 && slt(3, -5) == 0 && slt(4, 4) == 0, "signed <");
+    Assert(sle(4, 4) == 1 && sle(4, 5) == 1 && sle(5, 4) == 0,   "signed <=");
+    Assert(sgt(3, -5) == 1 && sgt(-5, 3) == 0 && sgt(4, 4) == 0, "signed >");
+    Assert(sge(4, 4) == 1 && sge(5, 4) == 1 && sge(4, 5) == 0,   "signed >=");
+    /* Signed overflow region — the S^V correction is what makes these right. */
+    Assert(slt(-32768, 32767) == 1, "signed < across the overflow boundary");
+    Assert(sge(-32768, 32767) == 0, "signed >= across the overflow boundary");
+    Assert(sgt(32767, -32768) == 1, "signed > across the overflow boundary");
+    Assert(sle(32767, -32768) == 0, "signed <= across the overflow boundary");
+    /* Equality — low-byte vs high-byte differences. */
+    Assert(seq(0x1234, 0x1234) == 1, "== equal");
+    Assert(seq(0x1234, 0x1235) == 0, "== low byte differs");
+    Assert(seq(0x1234, 0x1334) == 0, "== high byte differs");
+    Assert(seq(-1, -1) == 1,         "== negative equal");
+    Assert(sne(0x1234, 0x1235) == 1 && sne(0x1234, 0x1234) == 0, "!=");
+    /* Unsigned ordered, incl. high-bit values (would misorder if treated signed). */
+    Assert(ult(3, 50000u) == 1 && ult(50000u, 3) == 0,          "unsigned <");
+    Assert(ule(50000u, 50000u) == 1 && ule(50001u, 50000u) == 0, "unsigned <=");
+    Assert(ugt(50000u, 3) == 1 && ugt(3, 50000u) == 0,          "unsigned >");
+    Assert(uge(50000u, 50000u) == 1 && uge(3, 50000u) == 0,     "unsigned >=");
+}
+
+int main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    suite_setup("Byte-wise (ix+d) int compare fold");
+    suite_add_test(test_ixdcmp);
+    return suite_run();
+}

--- a/test/suites/long_ir/long_ir.c
+++ b/test/suites/long_ir/long_ir.c
@@ -1955,9 +1955,31 @@ static void test_struct(void)
     Assert(aw_l(-3)  == -2, "negative int arg sign-extended to long param");
 }
 
+/* Reduction-chain coalescing: a left-leaning multi-term reduction
+   `s = ((s + a[i]) + K1) + K2` lowers through single-use spine temps, which
+   ir_opt_reduce_coalesce renames back to the accumulator so word_acc can DE-home
+   it (`add hl,de; ex de,hl` per term). This checks the coalesced chain computes
+   the same result as the host — a miscompile in the rename would corrupt it. */
+static int rchain_a[50];
+static unsigned int rchain(int n)
+{
+    unsigned int s = 0;
+    int i;
+    for (i = 0; i < n; i++)
+        s = (s + (unsigned int)rchain_a[i] + 11u + 5u) & 0xffffu;
+    return s;
+}
+static void test_reduce_chain(void)
+{
+    int i;
+    for (i = 0; i < 50; i++) rchain_a[i] = i * 3 - 20;
+    Assert(rchain(50) == 3475u, "reduction-chain accumulator (coalesced, host-verified)");
+}
+
 int suite_long_ir(void)
 {
     suite_setup("long IR ops");
+    suite_add_test(test_reduce_chain);
     suite_add_test(test_struct);
     suite_add_test(test_add);
     suite_add_test(test_sub);

--- a/test/suites/maskbench/Makefile
+++ b/test/suites/maskbench/Makefile
@@ -1,0 +1,52 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+
+
+
+test.bin: $(SOURCES)
+	$(compile)
+	$(runtest)
+
+test_r2ka.bin: $(SOURCES)
+	$(compile_r2ka)
+	$(runtest_r2ka)
+
+test_r4k.bin: $(SOURCES)
+	$(compile_r4k)
+	$(runtest_r4k)
+
+test_z180.bin: $(SOURCES)
+	$(compile_z180)
+	$(runtest_z180)
+
+test_8080.bin: $(SOURCES)
+	$(compile_8080)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(compile_8085)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(compile_gbz80)
+	$(runtest_gbz80)
+
+test_ez80_z80.bin: $(SOURCES)
+	$(compile_ez80_z80)
+	$(runtest_ez80_z80)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/maskbench/maskbench.c
+++ b/test/suites/maskbench/maskbench.c
@@ -1,0 +1,69 @@
+/*
+ * maskbench.c — masked binary search, compiler comparison.
+ *
+ * A binary search whose key is masked per element: `v = tab[mid] & mask`. The
+ * loop is the searchbench shape (general DE-home on `hi`) PLUS a width-2 bitwise
+ * AND of two non-home operands (the indexed load and the mask param). That AND is
+ * the case the byte-wise (ix+d) ALU fold targets: inside the DE-home region it is
+ * lowered `ld a,l; and (ix+mask); ld a,h; and (ix+mask+1)` — reading both operands
+ * in place through A, never staging one into DE, so `hi` survives in DE.
+ *
+ * mask = 0x7ff keeps the search identical to the plain version; the checksum is
+ * host-verified and width-independent.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include "test.h"
+
+#define N       512
+#define LOOKUPS 1000
+#define REPS    6
+#define CHK     60689u        /* host-verified */
+
+static int tab[N];
+
+static int bsearch_masked(int key, int mask)
+{
+    int lo = 0, hi = N - 1;
+    while (lo <= hi) {
+        int mid = (lo + hi) >> 1;
+        int v = tab[mid] & mask;
+        if (v == key) return mid;
+        if (v < key) lo = mid + 1;
+        else         hi = mid - 1;
+    }
+    return -1;
+}
+
+static void mask_run(void)
+{
+    unsigned int chk = 0, lcg;
+    int r, q;
+    for (r = 0; r < N; r++) tab[r] = r * 3;
+    for (r = 0; r < REPS; r++) {
+        lcg = (unsigned int)(0x51EDu + r);
+        for (q = 0; q < LOOKUPS; q++) {
+            int key;
+            lcg = (unsigned int)((lcg * 181u + 17u) & 0xffffu);
+            key = (int)(lcg & 0x7ffu);
+            int idx = bsearch_masked(key, 0x7ff);
+            if (idx >= 0) chk = (unsigned int)((chk + (unsigned int)(idx + 1)) & 0xffffu);
+        }
+    }
+    Assert(chk == CHK, "masked binary search checksum (host-verified)");
+}
+
+int suite_mask(void)
+{
+    suite_setup("Masked Binary Search");
+    suite_add_test(mask_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    (void)argc; (void)argv;
+    res += suite_mask();
+    exit(res);
+}

--- a/test/suites/recordbench/Makefile
+++ b/test/suites/recordbench/Makefile
@@ -1,0 +1,52 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+
+
+
+test.bin: $(SOURCES)
+	$(compile)
+	$(runtest)
+
+test_r2ka.bin: $(SOURCES)
+	$(compile_r2ka)
+	$(runtest_r2ka)
+
+test_r4k.bin: $(SOURCES)
+	$(compile_r4k)
+	$(runtest_r4k)
+
+test_z180.bin: $(SOURCES)
+	$(compile_z180)
+	$(runtest_z180)
+
+test_8080.bin: $(SOURCES)
+	$(compile_8080)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(compile_8085)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(compile_gbz80)
+	$(runtest_gbz80)
+
+test_ez80_z80.bin: $(SOURCES)
+	$(compile_ez80_z80)
+	$(runtest_ez80_z80)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/recordbench/recordbench.c
+++ b/test/suites/recordbench/recordbench.c
@@ -1,0 +1,61 @@
+/*
+ * recordbench.c — stationary struct-pointer field churn, compiler comparison.
+ *
+ * A single hot struct pointer with heavy read/write field traffic — the
+ * state-machine / record-update shape:
+ *     for (i) { p->a = p->a+p->b; p->c ^= p->a; if (p->c&1) p->d+=p->e ... }
+ *
+ * The base pointer never moves, so this is the pure (iy+d) case (no stepping):
+ * with `p` in an index register every field is a single `(iy+d)` access; without
+ * it, `p` is reloaded and each `p->field` recomputes base+offset. Complements
+ * structbench (which walks) — here the win is purely constant-offset addressing.
+ *
+ * All field values are 15-bit-masked and the checksum 16-bit-masked, so it
+ * matches on a 16-bit target and a 32-bit host.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "test.h"
+
+#define ITERS  6000
+#define CHK    4389u        /* host-verified */
+
+struct st { int a, b, c, d, e; };
+static struct st S;
+
+static unsigned int churn(struct st *p, int it)
+{
+    unsigned int chk = 0;
+    int i;
+    for (i = 0; i < it; i++) {
+        p->a = (p->a + p->b) & 0x7fff;
+        p->c = (p->c ^ p->a);
+        if (p->c & 1) p->d = (p->d + p->e) & 0x7fff;
+        else          p->e = (p->e + p->a) & 0x7fff;
+        p->b = (p->b + p->c) & 0x7fff;
+        chk = (chk + (unsigned int)p->a + (unsigned int)p->d) & 0xffffu;
+    }
+    return chk;
+}
+
+static void record_run(void)
+{
+    S.a = 1; S.b = 2; S.c = 3; S.d = 4; S.e = 5;
+    Assert(churn(&S, ITERS) == CHK, "struct-pointer field churn checksum (host-verified)");
+}
+
+int suite_record(void)
+{
+    suite_setup("Record field-churn Tests");
+    suite_add_test(record_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    (void)argc; (void)argv;
+    res += suite_record();
+    exit(res);
+}

--- a/test/suites/structbench/Makefile
+++ b/test/suites/structbench/Makefile
@@ -1,0 +1,52 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+
+
+
+test.bin: $(SOURCES)
+	$(compile)
+	$(runtest)
+
+test_r2ka.bin: $(SOURCES)
+	$(compile_r2ka)
+	$(runtest_r2ka)
+
+test_r4k.bin: $(SOURCES)
+	$(compile_r4k)
+	$(runtest_r4k)
+
+test_z180.bin: $(SOURCES)
+	$(compile_z180)
+	$(runtest_z180)
+
+test_8080.bin: $(SOURCES)
+	$(compile_8080)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(compile_8085)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(compile_gbz80)
+	$(runtest_gbz80)
+
+test_ez80_z80.bin: $(SOURCES)
+	$(compile_ez80_z80)
+	$(runtest_ez80_z80)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/structbench/structbench.c
+++ b/test/suites/structbench/structbench.c
@@ -1,0 +1,65 @@
+/*
+ * structbench.c — array-of-structs field access, compiler comparison.
+ *
+ * The hot loop walks an array of 3-int structs, reading all three fields
+ * per element and writing one back:
+ *     for (i=0;i<n;i++){ s += arr[i].x + arr[i].y + arr[i].z; arr[i].z = s; }
+ *
+ * This is the textbook index-register pattern: one element base with several
+ * constant-offset fields. Optimal codegen keeps the element pointer in an
+ * index register and reaches each field via (iy+d) — `ld l,(iy+0);ld h,(iy+1)`
+ * for .x, `(iy+2)` for .y, `(iy+4)` for .z, plus a store through `(iy+4)` — and
+ * steps the pointer once per element with `add iy,de` (de = sizeof(struct)).
+ * Without a pointer-in-index home the base address `arr + i*6` is recomputed
+ * from the loop index every iteration (i*4 + i*2 + arr) and each field walks HL.
+ *
+ * All values are 16-bit-masked, so the checksum is identical on a 16-bit target
+ * and a 32-bit host.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "test.h"
+
+#define N     200
+#define REPS  40
+#define CHK   18423u        /* host-verified */
+
+struct pt { int x, y, z; };
+static struct pt arr[N];
+
+static unsigned int walk(int n)
+{
+    unsigned int s = 0;
+    int i;
+    for (i = 0; i < n; i++) {
+        s = (s + (unsigned int)arr[i].x + (unsigned int)arr[i].y
+               + (unsigned int)arr[i].z) & 0xffffu;
+        arr[i].z = (int)(s & 0x7fff);      /* write-back through the field */
+    }
+    return s;
+}
+
+static void struct_run(void)
+{
+    unsigned int chk = 0;
+    int r, i;
+    for (i = 0; i < N; i++) { arr[i].x = i; arr[i].y = i * 2; arr[i].z = i * 3; }
+    for (r = 0; r < REPS; r++) chk = (chk + walk(N)) & 0xffffu;
+    Assert(chk == CHK, "struct field-walk checksum (host-verified)");
+}
+
+int suite_struct(void)
+{
+    suite_setup("Struct field-access Tests");
+    suite_add_test(struct_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    (void)argc; (void)argv;
+    res += suite_struct();
+    exit(res);
+}

--- a/test/suites/vecbench/Makefile
+++ b/test/suites/vecbench/Makefile
@@ -1,0 +1,52 @@
+include ../make.config
+
+
+
+SOURCES += $(wildcard *.c)
+OBJECTS := $(SOURCES:.c=.o)
+CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
+
+
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+
+
+
+test.bin: $(SOURCES)
+	$(compile)
+	$(runtest)
+
+test_r2ka.bin: $(SOURCES)
+	$(compile_r2ka)
+	$(runtest_r2ka)
+
+test_r4k.bin: $(SOURCES)
+	$(compile_r4k)
+	$(runtest_r4k)
+
+test_z180.bin: $(SOURCES)
+	$(compile_z180)
+	$(runtest_z180)
+
+test_8080.bin: $(SOURCES)
+	$(compile_8080)
+	$(runtest_8080)
+
+test_8085.bin: $(SOURCES)
+	$(compile_8085)
+	$(runtest_8085)
+
+test_gbz80.bin: $(SOURCES)
+	$(compile_gbz80)
+	$(runtest_gbz80)
+
+test_ez80_z80.bin: $(SOURCES)
+	$(compile_ez80_z80)
+	$(runtest_ez80_z80)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
+
+
+clean:
+	rm -f test*.bin *.map $(OBJECTS) zcc_opt.def *~

--- a/test/suites/vecbench/vecbench.c
+++ b/test/suites/vecbench/vecbench.c
@@ -1,0 +1,67 @@
+/*
+ * vecbench.c — dual-array numeric kernels, compiler comparison.
+ *
+ * Two hot loops that walk TWO arrays in lockstep:
+ *     saxpy:  for (i) y[i] = a*x[i] + y[i];
+ *     dot:    for (i) s   += x[i] * y[i];
+ *
+ * Unlike the single-array walk (ptrbench index_walk), this needs two live
+ * element pointers at once — the register-pressure case for the index-register
+ * co-design: one walking pointer in an index register (stepped `add iy,de`,
+ * deref `(iy+d)`), the other in a gp pair. Without that, both addresses are
+ * recomputed from the index each iteration.
+ *
+ * short elements + 16-bit-masked arithmetic, so the checksum matches on a
+ * 16-bit target and a 32-bit host.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "test.h"
+
+#define N     300
+#define REPS  30
+#define CHK   28042u        /* host-verified */
+
+static short vx[N], vy[N];
+
+static unsigned int dot(int n)
+{
+    unsigned int s = 0;
+    int i;
+    for (i = 0; i < n; i++)
+        s = (s + (unsigned int)((unsigned int)(unsigned short)vx[i]
+                              * (unsigned int)(unsigned short)vy[i])) & 0xffffu;
+    return s;
+}
+
+static void saxpy(int n, int a)
+{
+    int i;
+    for (i = 0; i < n; i++)
+        vy[i] = (short)((a * vx[i] + vy[i]) & 0xffff);
+}
+
+static void vec_run(void)
+{
+    unsigned int chk = 0;
+    int r, i;
+    for (i = 0; i < N; i++) { vx[i] = (short)(i % 50); vy[i] = (short)((i * 7) % 40); }
+    for (r = 0; r < REPS; r++) { saxpy(N, 3); chk = (chk + dot(N)) & 0xffffu; }
+    Assert(chk == CHK, "dual-array saxpy+dot checksum (host-verified)");
+}
+
+int suite_vec(void)
+{
+    suite_setup("Dual-array Vector Tests");
+    suite_add_test(vec_run);
+    return suite_run();
+}
+
+int main(int argc, char *argv[])
+{
+    int res = 0;
+    (void)argc; (void)argv;
+    res += suite_vec();
+    exit(res);
+}


### PR DESCRIPTION
Improve codegen for struct/array loops and completes the DE-home line of work. All features default-on with per-feature opt-outs

 * DE-home — byte-wise (ix+d)/idx2 int-compare + ALU folds (operands read in place), a general loop-carried word homed in DE across a loop with the region kept DE-clean: searchbench-fp -14%. (IR_NO_DE_HOME, IR_NO_IXD_FOLD, IR_NO_ALU_FOLD)
 * Struct / array-of-struct residency — BC-clean offset stores (recordbench -27%); reduction-chain coalescing; IVSR non-power-of-2 (struct) strides → walking pointer (structbench -32%). ALU fold wired into the region proof (maskbench). (IR_NO_REDUCE_COALESCE, IR_NO_IVSR_AFFINE)
 * idx2 / walking-pointer allocation tuning — gate spare-index counter homing on z80/z80n/z180 when it feeds address/ALU work (rle -7.8%); suppress a redundant IVSR pointer for constant-base power-of-2-stride loops (queen -5.8%). (IR_NO_IDX2_COUNTER, IR_NO_IVSR_SUPPRESS)
 * index-half byte homes — opt-in only (IR_IDXHALF), off by default; unsound re callee-saved IX/IY (eg fails the bsearch tests)
 * New benches/tests — structbench, vecbench, recordbench, maskbench + dehome/reduce_chain long_ir regressions.
