### PR TITLE
  80cc: live-range IY residency, options rationalisation, and design ADRs

### DIFF
--- a/src/80cc/adr/0001-ir-backend-pipeline.md
+++ b/src/80cc/adr/0001-ir-backend-pipeline.md
@@ -1,0 +1,49 @@
+# ADR 0001 — IR-based back end and the compilation pipeline
+
+Status: Accepted
+
+## Context
+
+z88dk's original small-C compiler (sccz80) emits z80 directly from the AST while
+parsing — fast, but it leaves little room for machine-independent analysis or
+optimisation, and retargeting to other 8-bit CPUs means threading target
+conditionals through the whole emitter. 80cc was written to get a real
+optimising, retargetable back end while reusing the small-C front end.
+
+## Decision
+
+Compile through a typed **intermediate representation** with a clear pipeline:
+
+```
+AST  →  ir_build  →  IR  →  ir_analysis  →  ir_alloc  →  ir_lower  →  asm
+```
+
+- **ir_build** (`ir_build.c`) lowers the front end's AST into IR: a `Func` of
+  basic blocks (`BB`), each a list of three-address `Op`s over **virtual
+  registers** (`VReg`). Ops are close to machine level (loads/stores, ALU,
+  compares, branches, calls) but target-independent. See `ir.h` / `IR.md`.
+- **ir_analysis** (`ir_analysis.c`) computes liveness: per-BB `live_in`/
+  `live_out`, per-op live sets (`live_in_per_op`), and per-vreg `LiveRange`
+  `[start,end]` intervals in a flattened (BB-id-order) op-index space. These are
+  the substrate the allocator and lowerer reason over.
+- **ir_alloc** (`ir_alloc.c`) assigns each vreg a **physical home** (a register
+  or a frame slot) — see ADR 0002/0003. It only *decides*; it emits nothing.
+- **ir_lower** (`ir_lower.c` + the `ir_lower_*.inc.c` units) walks the IR and
+  emits target assembly, consulting the allocation. Machine specifics (CPU
+  quirks, addressing, calling convention, frame layout) live here.
+
+The IR layer is deliberately dependency-light: `ir.h` includes only
+`ir_kind.h` (the shared type-kind enum), not the full front-end `ccdefs.h`, so
+`ir_selftest` and the analysis/alloc layers link without the front end.
+
+## Consequences
+
+- **Retargeting** is concentrated in ir_lower (per-CPU macros `IS_Z80N()`,
+  `c_cpu == CPU_Z180`, …) rather than smeared across parsing.
+- **Optimisation** (IVSR/strength reduction, LICM, CSE, peephole, residency) has
+  a stable IR + liveness to work on (`ir_opt.c`, `ast_opt.c`).
+- **A hard split** between *decide* (ir_alloc) and *emit* (ir_lower) is the
+  backbone of the residency design: the allocator records `vreg_to_phys[]`; the
+  lowerer must faithfully realise it. The soundness contract between the two is
+  the subject of ADR 0004.
+- The front end is reused as-is; 80cc is a back end, not a new compiler.

--- a/src/80cc/adr/0002-z80-register-model.md
+++ b/src/80cc/adr/0002-z80-register-model.md
@@ -1,0 +1,54 @@
+# ADR 0002 — The z80 register reality and the vreg → physical-register model
+
+Status: Accepted
+
+## Context
+
+A textbook register allocator assumes a bank of interchangeable registers and
+free graph colouring. The z80 (and its 8-bit relatives) violate every part of
+that assumption, and the allocator must respect the machine, not fight it.
+
+The realities:
+
+- **HL is reserved scratch**, not allocatable. Nearly every ALU op, dereference,
+  and address calculation needs HL as the working register.
+- **Two-address, fixed-register ops.** `add hl,rr` / `sbc hl,rr` require the
+  accumulator in HL and the other operand in one of BC/DE/SP; `ex de,hl` is the
+  word-move primitive. Operand registers are *constrained*, not freely coloured.
+- **Operand staging clobbers registers.** The operand loader stages a binop's
+  second operand through **DE** (`add hl,de`), and helper calls clobber A/BC/DE.
+  So keeping a value in a register across an op is only sound if that op does
+  not clobber the register.
+- **The allocatable pool is tiny:** BC, DE, IX, IY, the byte halves
+  (C/B/E/D/A and the index halves), and the config-gated alt/shadow bank
+  (BC'/DE'/HL'). IX is the frame pointer under `-frameix`; IY under `-frameiy`.
+- **CPU variance:** gbz80/8080/8085 have no IX/IY at all; z180 traps the
+  undocumented index-half opcodes; kc160/rabbit have cheap native
+  `ld rr,(sp+d)`; only some CPUs have hardware multiply.
+
+## Decision
+
+- Model each value as a **`VReg`** with a `Kind`, a `width` (1/2/4/8 bytes), and
+  flags; give it a **`PhysReg`** home in `vreg_to_phys[]`: a register
+  (`IR_PR_HL/DE/BC/DEHL`, the byte homes `IR_PR_C/B/E/D`, the index homes
+  `IR_PR_IX/IY` + halves, the alt bank), a stack transient (`IR_PR_STACK`), or a
+  **frame slot** (`IR_PR_SPILL`).
+- Treat **HL as un-allocatable scratch** by construction — no vreg is ever homed
+  in HL for a region; HL is where the lowerer computes.
+- Encode register **effect sets** as a `RegMask` bitset (`IR_R_HL/DE/BC/IX/IY/…`)
+  so soundness can be reasoned about uniformly (ADR 0004's `op_clobbers`).
+- Make residency decisions **register-CONSTRAINED**: a pointer deref wants HL; an
+  `add` operand wants DE or BC; an accumulator that must survive HL+DE-clobbering
+  address arithmetic wants IY (the one pair ALU staging never touches).
+
+## Consequences
+
+- The allocator is **not** a classic linear-scan/colouring allocator; it is a set
+  of constrained, benefit-ranked *pickers* plus live-range packing (ADR 0003).
+- The scarcity is real: after HL (scratch) and the frame pointer (IX or IY),
+  there are effectively **two-and-a-bit** allocatable word pairs (BC, the other
+  index reg, and DE only when it is not needed for staging). This ceiling is why
+  making a value's live range *shorter* (so registers can be reused) generalises
+  better than trying to hold *more* values for a whole region.
+- Everything is **CPU-gated**: a feature that needs `add iy,de` or a hardware
+  multiply is enabled only where the CPU provides it.

--- a/src/80cc/adr/0003-register-residency.md
+++ b/src/80cc/adr/0003-register-residency.md
@@ -1,0 +1,76 @@
+# ADR 0003 — Register residency: region homes, the orchestrator, and live-range packing
+
+Status: Accepted
+
+## Context
+
+The scarce, constrained register file (ADR 0002) makes *keeping hot values in
+registers* the dominant back-end optimisation. 80cc's residency machinery grew
+in two eras, and both are still live. This ADR describes what each does and how
+they compose, so the whole is legible.
+
+## Decision
+
+Residency is **region-home-or-slot** with two cooperating mechanisms, plus a
+peephole cache underneath.
+
+### 1. Region homes — the proposer/arbiter orchestrator (`ir_alloc.c`)
+
+A value can win a **dedicated register for a whole loop region**. Each residency
+class has a *proposer* that emits `Cand`idates with a depth-weighted benefit:
+
+- `pr_bc_propose` — a loop pointer/IV in BC.
+- `word_acc_propose` — a loop-carried word accumulator in DE (`add hl,de; ex de,hl`).
+- `de_home_general_propose` — a general loop-carried word in DE.
+- `iv_propose` — an induction variable.
+- `byte_home_propose` — a char accumulator in a byte half (C/B/E/D).
+- `idx2_propose` / `idx3_propose` — a loop-invariant / second word in the spare
+  index register(s) (IX/IY opposite the frame pointer), opt-in.
+- `exx_propose` — a loop-invariant in the alt/shadow bank, opt-in.
+
+`unified_arbitrate` picks winners by benefit over **whole-function / loop-extended
+intervals** — i.e. one occupant per register per region. That coarseness is
+deliberate in places (a loop-carried tenant blocks its whole loop; the extension
+guards a real correctness case).
+
+### 2. Live-range packing — the fine passes
+
+Run *after* the arbiter, over the SPILL leftovers, using **tight per-op
+intervals** so several disjoint values can time-share one register:
+
+- `ir_bc_pack` — packs disjoint call-free word temps into BC (greedy interval
+  scheduling); "multiple BC use within a function".
+- `ir_iy_reduction_pack` — homes a DE-dirty reduction chain / loop-carried
+  accumulator in **IY** (`add iy,de`), the one pair immune to HL+DE staging;
+  includes benefit-ranked arbitration to evict a lower-value idx2 occupant.
+  Gated `IR_LRA`.
+- `ir_stack_spill` — parks a single-def/single-use straight-line transient on the
+  **stack** (`push hl` … `pop`) instead of a frame slot.
+
+The two fine passes that share the *single-BB tight-interval shape* analysis
+consume one `compute_spill_shapes()` (see the SpillShape struct); each keeps only
+its own placement policy.
+
+### 3. The peephole value cache (`ir_lower_regcache.inc.c`)
+
+Underneath both, `L.rs.{hl,de,bc,a}` remembers what a register currently holds so
+an immediately-following op can reuse it without a reload. It is evicted as soon
+as the next op loads its operands — a local optimisation, not residency.
+
+## Consequences
+
+- A value that wins no region home and no pack becomes a **slot vreg**: every use
+  is load→compute→store, saved only by the peephole cache. In a spill-bound inner
+  loop this thrashes — the motivation for the live-range packing era.
+- The **generalising direction is shorter ranges, not bigger regions.** Attempts
+  to hold *more* values for a whole region (wider DE reservation, cross-row
+  pointers) repeatedly hit the register-file ceiling; giving a value a register
+  for just the span it is live (BC-pack, IY reduction) fits by construction.
+- **DE cannot be a persistent second home** in general: the operand loader owns
+  DE for staging the second ALU operand, so almost every spill span crosses a
+  DE-clobbering op. IY is the workaround (immune to staging). This is a
+  fundamental z80 wall, not a missing feature — see ADR 0002.
+- The long-term consolidation (one live-range allocator subsuming the region
+  pickers) is desirable for maintainability but is a rewrite of default-on
+  codegen under a byte-identical constraint (ADR 0004); do it incrementally, if
+  at all. The fine passes already share their analysis.

--- a/src/80cc/adr/0004-soundness-and-gating.md
+++ b/src/80cc/adr/0004-soundness-and-gating.md
@@ -1,0 +1,69 @@
+# ADR 0004 — Soundness: `op_clobbers`, `IR_VERIFY`, revert-to-slot, and gating
+
+Status: Accepted
+
+## Context
+
+Residency is where back-end bugs breed: if the allocator believes a value stays
+in register R across some op, but the op's lowering actually clobbers R, the
+value is silently corrupted. 80cc accumulated a history of exactly this
+("residency whack-a-mole"). The design answer is a small set of invariants that
+make a wrong residency decision cost *a spill or a loud abort, never a wrong
+answer*.
+
+## Decision
+
+### `op_clobbers(f, op) → RegMask` — the verified effect model
+
+A single function (`ir_lower.c`) classifies which value-registers an op's
+lowering may write. Opaque ops (`CALL`, `ASM`, memset/memcpy, wide helpers)
+return `IR_R_ALL`; `HCALL` consults the helper table (ADR 0005); the default is
+HL + A + DE (staging) + flags + the result/operand homes, plus BC for wide
+(DEHL) ops. A value in register R survives op O **iff R ∉ op_clobbers(O)**. This
+is the one predicate every residency decision rests on.
+
+`op_clobbers_relaxed` is the same model under the hypothesis that ADD/SUB/CMP
+stage their second operand through BC instead of DE (the `hl,bc` forms) — used to
+reason about whether DE could be freed.
+
+### `IR_VERIFY` — cross-check the model against reality
+
+With `IR_VERIFY` set, each op's *emitted assembly* is parsed and the registers it
+actually writes are asserted to be a subset of `op_clobbers`. A `push R … pop R`
+pair is recognised as preserving R. This catches model/emitter drift — the
+classic source of residency miscompiles — across the whole corpus, before it
+becomes a wrong answer. (It cannot see inside a called helper; that is the
+helper table's job, ADR 0005.)
+
+### Revert-to-slot + `require_slot` — fail safe, not wrong
+
+- A residency decision that cannot be realised **falls back to a frame slot**
+  rather than being forced. A bad decision costs a spill.
+- If the lowerer is ever asked to read a value that is in no live register and
+  has no slot, `require_slot` **aborts loudly** with a `file:line:` message,
+  rather than emitting a below-frame read. A loud abort is a bug report; a wrong
+  answer is a silent field failure.
+- Any not-yet-implemented residency path fails the same way (a marked op with no
+  emitter support aborts, it does not fall through to a clobbering path).
+
+### Byte-identical-off gating
+
+Every residency feature is behind a gate (`IR_NO_*` to opt a default-on feature
+out; `IR_LRA` to opt an in-progress one in). The invariant: **with the feature
+off, codegen is byte-identical** to before it existed, verified by an asm diff
+across the CPU matrix (normalising only the compile-timestamp / temp-filename
+header noise). A new feature is landed *inert* first, proven byte-identical, then
+turned on. This makes every change bisectable and makes "does this feature cause
+regression X" answerable by flipping one env var.
+
+## Consequences
+
+- The soundness argument for a register surviving an op is the **same predicate**
+  (`op_clobbers`-clean over the span) whether the home is whole-region or a short
+  live range — one invariant, applied at different granularities.
+- New allocation work follows a fixed discipline: model it in `op_clobbers`,
+  land it gated + inert + byte-identical, validate with `IR_VERIFY` and the
+  correctness suites (ADR references the `test/suites` matrix), then measure.
+- Because a bad decision degrades to a slot or a loud abort, the allocator can be
+  *aggressive* without being *dangerous* — the cost of an over-reach is
+  performance, not correctness.

--- a/src/80cc/adr/0005-helper-clobber-table.md
+++ b/src/80cc/adr/0005-helper-clobber-table.md
@@ -1,0 +1,45 @@
+# ADR 0005 — The runtime-helper clobber table (`__preserve_regs`)
+
+Status: Accepted
+
+## Context
+
+Codegen synthesises calls to `l_` runtime helpers (multiply, divide, shifts,
+long/float ops) that have no C prototype. In `op_clobbers` (ADR 0004) an `HCALL`
+was modelled as `IR_R_ALL` — fully conservative: it may clobber everything. That
+is safe but pessimistic: it means **no value can stay resident across any helper
+call**, so a loop that calls (e.g.) `l_mult` every iteration cannot keep its
+accumulator in a register — even though the integer helpers touch neither the
+index registers nor the alt/shadow bank.
+
+This is the compiler-internal half of the `__preserve_regs` idea (the header
+attribute `__preserves_regs(...)` is the other, C-prototype half — parsed but not
+yet consumed). See `PRESERVE_REGS_PLAN.md`.
+
+## Decision
+
+Maintain a small **audited whitelist** (`helper_preserves_index_alt`) of `l_`
+helpers verified against the library asm to use neither IX/IY nor the alt bank —
+the integer word/byte arithmetic family (`l_mult`, `l_mulu_32_16x16`, `l_div`,
+`l_asr`/`l_lsr`/`l_lsl`, `l_neg`, …). For those, `op_clobbers(HCALL)` returns
+`HL | DE | BC | A | F | MEM` and **preserves IX/IY/BC'/DE'/HL'**, so an index or
+alt-bank home survives the call. Everything else — unknown, long/i64, float, far,
+explicit index-manipulation helpers — stays `IR_R_ALL`.
+
+The whitelist is **conservative by construction**: an omission costs residency
+(the value spills), never correctness; only a mis-*inclusion* would be a silent
+miscompile, so a name is added only after confirming its asm (all CPU variants)
+is index- and alt-clean.
+
+## Consequences
+
+- Index/alt-bank residency (idx2/idx3, the IY reduction home, exx) can span a
+  preserving helper call — the call-heavy hot loops (e.g. a dot product that
+  calls `l_mult` per element) become reachable, not just the call-free ones.
+- `IR_VERIFY` (ADR 0004) verifies the *call site* (`call l_x` touches no index
+  reg), but **cannot** see inside the helper body — so the whitelist's safety
+  rests on the manual asm audit, not the verifier. Grow it carefully.
+- This is the seam for the full `__preserve_regs` feature: the header attribute,
+  once consumed, would populate the same `CallInfo.clobbers`/`HelperInfo.clobbers`
+  masks for C-prototype library functions (Track A), reusing this exact
+  mechanism.

--- a/src/80cc/adr/0006-multi-cpu-retargeting.md
+++ b/src/80cc/adr/0006-multi-cpu-retargeting.md
@@ -1,0 +1,48 @@
+# ADR 0006 — Multi-CPU retargeting
+
+Status: Accepted
+
+## Context
+
+z88dk targets a family of 8-bit CPUs: the Z80 supersets (z80n, z180, ez80,
+rabbit/r2ka…r6k, kc160) and the leaner relatives (gbz80, 8080, 8085). 80cc must
+emit correct — and where possible, better — code for all of them from one IR,
+without smearing CPU conditionals across the whole compiler.
+
+## Decision
+
+Keep the pipeline **CPU-agnostic up to the lowerer** (ADR 0001): `ir_build`,
+`ir_opt`/`ir_match`, and `ir_alloc` reason about vregs and effects, not
+instructions. **All CPU knowledge lives in `ir_lower`** and is driven by:
+
+- The global `c_cpu` and predicates `IS_Z80N()/IS_EZ80()/IS_RABBIT()/IS_GBZ80()/
+  IS_8085()/IS_KC160()`, `c_cpu == CPU_Z80/Z180`.
+- Per-`Func` **feature bits** (`IR_FEAT_CB_BITOPS / EX_DE_HL / IX / DJNZ`, …)
+  stamped by `ir_features_from_cpu()`, consulted by `ir_match` fusions and the
+  lowerer's substitutions.
+
+Two workstreams, by CPU class:
+
+- **Exploit** (supersets: ez80, z80n, rabbit, kc160) — already correct as Z80;
+  work is pure optimisation using the richer instructions (hardware multiply,
+  native `ld rr,(sp+d)`, `mlt`, `add iy,de`, …). Residency/codegen features are
+  CPU-gated on to these where they pay (ADR 0002/0003).
+- **Substitute** (leaner: gbz80, 8080, 8085) — must *replace* Z80-only idioms:
+  no `ex de,hl`, no `(ix+d)` frame access, no index registers at all. The
+  lowerer emits the equivalent (e.g. copy via a scratch, sp-relative addressing).
+
+z80asm already encodes every target's mnemonics, so this is purely a
+compiler-*emission* problem — no assembler work.
+
+## Consequences
+
+- A residency or codegen feature is only enabled where the CPU supports its
+  primitive (e.g. the IY reduction home needs `add iy,de` → z80/z80n/z180/ez80/
+  rabbit; excluded on gbz80/8080/8085/kc160). Gating lives at the feature's
+  admission check, not scattered.
+- The correctness matrix is **all CPUs**: the test suites run each program across
+  the full CPU set (per-CPU exit-checked), because a Z80-correct change can emit
+  an illegal instruction on gbz80/8080/8085.
+- Frame addressing has three modes (sp / `-frameix` / `-frameiy`) that the
+  lowerer selects; features that touch the frame or index registers must respect
+  which register is the frame pointer (see ADR 0002).

--- a/src/80cc/adr/0007-kind-width-type-model.md
+++ b/src/80cc/adr/0007-kind-width-type-model.md
@@ -1,0 +1,41 @@
+# ADR 0007 — The type-kind / width model on VRegs
+
+Status: Accepted (enforcement hardening ongoing)
+
+## Context
+
+Every `VReg` carries two type axes: a **`kind`** (`KIND_CHAR/INT/LONG/PTR/CPTR/
+FLOAT/…`) and a **`width`** in bytes (1/2/4/6/8). The lowerer and analyses switch
+on both — width for how many bytes to move/compute, kind for signedness and
+pointer-ness. Keeping the two consistent is a correctness requirement, and a
+recurring source of bugs when they drift.
+
+## Decision
+
+- **The constructors keep kind and width consistent by construction:**
+  `ir_vreg_new(kind)` sets `width = kind_width(kind)`; `new_temp(width)` sets
+  `kind = int_kind_for_width(width)`; `new_temp_kind(kind)` derives the width.
+  Create vregs through these.
+- **Kind is the authoritative axis; width is derived from it.** Where they
+  disagree, kind is intended to be the truth (a `KIND_LONG` value is 4 bytes even
+  if a stray `width` says otherwise).
+- **`IR_VERIFY` cross-checks the invariant** (`ir_analysis.c`: "kind K implies
+  width W but width is X"), the same verify discipline as `op_clobbers`
+  (ADR 0004).
+
+## Consequences
+
+- **The known hazard:** many `f->vregs[v].width = X` *mutations* scattered
+  through `ir_build.c` (binop result widths, CONV dsts, widenings) change `width`
+  without updating `kind`, so the two can diverge. That divergence is the root of
+  the `umaxd` fp abort class: the width-based lowering widens an operand *by its
+  width*, and a `kind=LONG,width=2` vreg then reads/extends the wrong number of
+  bytes. sp-mode often masks it (slot-backed, silently wrong); fp fail-safe
+  aborts. See `KIND_WIDTH_REFACTOR_PLAN.md`.
+- **The hardening (planned, not complete):** route width changes through a
+  mutator that updates kind (or forbid raw width writes), then promote the
+  `IR_VERIFY` kind/width check from warning to enforced. Until then, treat a
+  kind/width mismatch report as a real bug, and prefer the constructors over raw
+  `.width =` when writing new IR-building code.
+- The wide (6/8-byte) kinds are handled specially — not in registers — see
+  ADR 0009.

--- a/src/80cc/adr/0008-ivsr-strength-reduction.md
+++ b/src/80cc/adr/0008-ivsr-strength-reduction.md
@@ -1,0 +1,48 @@
+# ADR 0008 — Induction-variable strength reduction (IVSR) and LFTR
+
+Status: Accepted
+
+## Context
+
+The dominant cost in array/pointer loops is recomputing an element address every
+iteration. For `for (i=0; i<n; i++) sum += a[i]`, naive codegen computes
+`&a[i] = base + i*sizeof(elem)` from scratch each pass (a shift + add through
+HL/DE). A stepped pointer that just advances by the element stride is far cheaper
+— and it is what a resident register can then hold across the loop (ADR 0003).
+
+## Decision
+
+`ir_opt_ivsr` (`ir_opt.c`, gated `IR_NO_IVSR`) rewrites derived induction
+variables into **stepped pointers**:
+
+- Detect a derived IV `d = base + iv*scale (+K)` inside a loop where `base` is
+  loop-invariant and `iv` is a basic IV.
+- Create a new pointer vreg `p`, tagged `IR_VREG_INDUCTION` so the allocator's
+  BC pool admits it (the one twice-written — init + step — vreg it accepts), and:
+  - **pre-header init:** `p = base + K*scale`;
+  - **latch step:** `p += stride*scale` (an `inc bc` / `add` that stays BC-clean);
+  - rewrite the in-loop uses of `d` to `p`, NOP the original shift/add.
+- **LFTR** (linear function test replacement): when the basic IV survives only as
+  the loop's step + exit test, rewrite the exit test in terms of `p` and
+  eliminate the basic IV entirely.
+
+A **redundant-pointer suppress** heuristic avoids creating a stepped pointer when
+the index is independently live and the base is a constant address with a
+power-of-2 scale — there, recomputing `base + iv<<k` from the resident index is
+cheaper than maintaining a second loop-carried value competing for BC.
+
+IVSR bails where BC residency is unreachable (any width-4 vreg — long ops stage
+through BC; `IR_ASM`; non-char `IR_SWITCH`), mirroring the allocator's BC
+envelope so it only fires where the stepped pointer can actually live in BC.
+
+## Consequences
+
+- IVSR is the producer that **feeds the BC walking-pointer home** (ADR 0003):
+  the stepped pointer it creates is exactly what `pr_bc_propose` keeps resident.
+- It is **paired with, not a substitute for, register residency.** IVSR cuts the
+  address recompute; residency then keeps the pointer and the accumulator in
+  registers. A register-starved loop (pointer + index + accumulator) still needs
+  the residency work to place the survivors.
+- The suppress heuristic and the BC-reachability bail are load-bearing: without
+  them IVSR can create a second loop-carried value that spills and costs more
+  than it saves.

--- a/src/80cc/adr/0009-wide-value-accumulator.md
+++ b/src/80cc/adr/0009-wide-value-accumulator.md
@@ -1,0 +1,46 @@
+# ADR 0009 — Wide (6/8-byte) value handling via a memory accumulator
+
+Status: Accepted
+
+## Context
+
+The register file tops out at pairs (16 bits) and, with `DEHL`, 32 bits
+(ADR 0002). But C on these targets also has `long long` (8 bytes) and `double` /
+`long double` (6-byte MBF here). There is no register home wide enough, and
+building one out of the alt bank + main bank would consume the entire machine.
+
+## Decision
+
+Wide (>4-byte) values live **in memory** and are computed through a **universal
+memory accumulator + runtime helpers**, not registers:
+
+- **`__i64_acc`** — the universal 64-bit integer accumulator; `l_i64_*` helpers
+  operate on it.
+- **FA** — the float accumulator; the float helpers operate on it.
+
+Dedicated IR ops carry these instead of the register-oriented ALU ops:
+
+- **`IR_ACC_BINOP`** — a wide binary op: two wide operands staged into the
+  accumulator via `acc_prim(f, v, "load"/"push"/"loadpush")` (which selects the
+  i64 vs FA primitive for the value's kind), then the `l_i64_*`/float helper.
+- **`IR_ACC_CMP`** — a wide compare (same operand staging, flag result).
+- **`IR_ACC_UNOP`** — a wide unary op; `AccSubkind` selects how the accumulator
+  is wired.
+
+Calls follow suit: a wide argument is loaded into the accumulator (`__i64_acc` or
+FA) and the callee binds it there; a `long long` return pushes a hidden pointer
+to `&__i64_acc` as the result buffer and reads it back into the dst's slot
+(`CallInfo.ret_longlong`).
+
+## Consequences
+
+- In `op_clobbers` (ADR 0004), `IR_ACC_BINOP/CMP/UNOP` are modelled as
+  **`IR_R_ALL`** — they are opaque wide-helper calls that may touch the whole
+  register set, so no register residency survives across them.
+- Wide values are **never candidates for the residency machinery** (BC/DE/IY
+  homes, packing) — they are memory-resident by design. Residency reasons about
+  width ≤ 2 (and DEHL width-4) only.
+- Presence of any width-4 vreg already bars IVSR's BC envelope (ADR 0008); wide
+  (6/8) values likewise sit outside the register-allocation model entirely. This
+  keeps the register allocator's world small and the wide arithmetic correct via
+  the audited helper library.

--- a/src/80cc/adr/0010-ast-vs-ir-optimisation-layering.md
+++ b/src/80cc/adr/0010-ast-vs-ir-optimisation-layering.md
@@ -1,0 +1,57 @@
+# ADR 0010 — AST-level and IR-level optimisation: a deliberate two-level split
+
+Status: Accepted
+
+## Context
+
+Optimisation runs at two levels, which can *look* like duplication:
+
+- **AST level** (`ast_opt.c`, via `ast_opt_run` during parsing in `declparse.c`):
+  constant folding (`ast_fold_constants`), algebraic simplification
+  (`ast_simplify_algebraic`: `x+0→x`, `x*1→x`, `x-x→0`), scalar strength
+  reduction (`try_strength_reduce`: `x*const` → shifts/adds), and
+  canonicalisation (commuting commutative operands; folding `x = x OP y` into
+  `OP_A*` compound-assign nodes).
+- **IR level** (`ir_opt.c`, on the lowered IR): CSE, LICM (`ir_opt_licm`), and
+  induction-variable strength reduction (`ir_opt_ivsr`, ADR 0008).
+
+Both "fold" and both have a "strength reduction," so the question is why the
+split is the right design.
+
+## Decision
+
+Keep both levels — they are **complementary and each earns its place**; this is
+a deliberate layering, not redundancy to remove.
+
+1. **AST opts are a first-class, beneficial source-level pass.** They:
+   - work with full C **type semantics** (integer promotion, signed/unsigned
+     fold width, decimal/fixed-point literal folding) that are clearest on the
+     typed AST and awkward to reconstruct later;
+   - **shrink the IR before it is built**, so every downstream pass (analysis,
+     allocation, lowering) has less to chew on;
+   - **canonicalise** the tree into the shapes `ir_build` is written to consume —
+     `OP_A*` compound-assign nodes and commuted operands. `ir_build` depends on
+     this normalisation, so ast_opt is load-bearing, not optional.
+2. **IR opts do what only the lowered form allows.** CSE across synthesised
+   address arithmetic, loop-invariant motion, and induction-variable SR need the
+   three-address IR + liveness + loop structure that do not exist at the AST.
+3. **The apparent overlap is not the same work twice.** The two "strength
+   reductions" are different transforms (scalar `x*const` at AST vs loop
+   walking-pointer IVSR at IR). Constant folding legitimately happens at both
+   because constants arise at both levels — source literals (AST) and the address
+   arithmetic that lowering synthesises (IR).
+
+(The classic *AST-direct code generator* was retired in favour of the IR pipeline
+— see the header of `ast_codegen2.c` — but that was the codegen *walker*, not the
+AST *optimiser*. `ast_opt` is independent of it and remains in active use.)
+
+## Consequences
+
+- **Put a new optimisation where its information lives:** type-aware folding,
+  algebraic identities, and source-level canonicalisation → AST; anything needing
+  liveness, live ranges, the lowered op stream, or machine addressing → IR.
+- Both levels stay; there is no goal to collapse them. If a *specific* transform
+  is ever found to belong at the other level, move that one transform (updating
+  `ir_build`'s assumptions if it was an AST canonicaliser), verified byte-
+  identical (ADR 0004) — but the two-level structure itself is the intended
+  design.

--- a/src/80cc/adr/0011-index-register-allocation.md
+++ b/src/80cc/adr/0011-index-register-allocation.md
@@ -1,0 +1,72 @@
+# ADR 0011 — Index-register (IX/IY) allocation and reservation
+
+Status: Accepted
+
+## Context
+
+The z80 family has exactly two index registers, IX and IY. They are precious:
+they enable `(ix+d)`/`(iy+d)` addressing and are the only spare 16-bit homes once
+BC/DE are committed to loop pointers/IVs (ADR 0002), but each `(ix+d)` access is
+slow (2 opcodes / ~19T) and IX/IY are **callee-saved**, so using one costs a
+prologue/epilogue push-pop. The back end has two competing consumers for them:
+
+- a **frame pointer** (fp-mode, `-fframe-pointer`), addressing locals via `ix+d`;
+- **residency**: `idx2` (a loop-invariant base, ADR 0003) and the **LRA reduction
+  accumulator** (IY reduction-chain home, ADR 0003 / LIVERANGE_ALLOC_PLAN).
+
+The choice of frame mode changes which index register is free for residency, and
+some platforms reserve an index register for their own use (interrupt state,
+runtime). We need one coherent model for who gets IX and who gets IY.
+
+## Decision
+
+Roles are assigned by frame mode:
+
+|                             | IX                         | IY                        |
+|-----------------------------|----------------------------|---------------------------|
+| **sp-mode** (default)       | idx2 — loop-invariant base | LRA reduction accumulator |
+| **fp-mode** (`-fframe-pointer`) | frame pointer          | LRA reduction accumulator |
+
+Consequences of the layout:
+
+1. **The LRA accumulator is always IY**, in both modes — which is why the
+   accumulate primitive is standardised on `add iy,de` rather than `add ix,de`
+   (IX is the one already spoken for in fp-mode).
+2. **sp-mode is the sweet spot**: both index registers are productive at once —
+   IX parks the invariant base, IY carries the reduction accumulator. fp-mode
+   spends IX on the frame, leaving only IY for residency, so the LRA wins are
+   smaller in fp than sp.
+3. `-frameiy` (IY-as-frame) was **removed**: a target that must reserve IX
+   assembles with `z80asm -IXIY` (which swaps the two throughout), so a second
+   frame-register mode buys nothing.
+
+**Reservation.** A platform removes an index register from play with:
+
+- `--reserve-regs-iy` → IY is never used for residency (LRA, idx3, the fp-mode
+  idx2, and byte-half homes of IYL/IYH).
+- `--reserve-regs-ix` (sp-mode) → IX is not used as the idx2 spare. (In fp-mode
+  IX is unconditionally the frame pointer, so this flag only affects sp-mode.)
+
+With the default residency set (idx3 and, historically, LRA gated), **sp-mode
+plus `--reserve-regs-ix` uses no index register at all** — the escape hatch for a
+platform that needs both IX and IY untouched (combine with `--reserve-regs-iy`
+once other IY features are on).
+
+**Naming.** The user-facing controls are the frame mode and `--reserve-regs-*`
+("what may the compiler touch"). The residency strategy knobs are internal tuning:
+`--reg-index-invariant` (idx2; the *spare* index reg — IX in sp, IY in fp) stays
+on by default; `--reg-iy-half` (idx3; a second word in IY via **undocumented**
+index-half opcodes, z80/z80n only) and `--exx` stay off — experimental, with a
+history of callee-saved miscompiles.
+
+## Consequences
+
+- Every site that decides to use IX or IY consults the mode (`c_framepointer_is_ix`)
+  and the reserve flags (`c_reserve_ix`/`c_reserve_iy`): `ir_idx2_reg`,
+  `ir_idx3_reg`, `lra_iy_available`, and the byte-half candidate offering in the
+  lowerer. Adding a new index-register consumer means gating it the same way.
+- Because the LRA accumulator and the frame never both want IX, there is no
+  arbitration between them; the only intra-mode contention is idx2-vs-LRA for IY
+  in fp-mode, resolved by benefit ranking (ADR 0003).
+- The reserve flags are off by default and, when off, are **byte-identical** to
+  the prior compiler (ADR 0004).

--- a/src/80cc/adr/0012-frame-pointer-default-by-cpu.md
+++ b/src/80cc/adr/0012-frame-pointer-default-by-cpu.md
@@ -1,0 +1,61 @@
+# ADR 0012 — Per-CPU default for the frame pointer
+
+Status: Accepted (implementation pending — see Consequences)
+
+## Context
+
+ADR 0011 describes the two frame modes: `-fframe-pointer` (IX is a frame pointer,
+locals addressed `(ix+d)`) and `-fomit-frame-pointer` (no frame pointer, locals
+addressed relative to SP). The current default is sp (omit) on every CPU, chosen
+historically for *correctness* (see below), not speed.
+
+A full benchmark sweep (BENCH_MATRIX.txt, 16/7 snapshot — 23 benches × the CPU
+matrix, fp vs sp) shows the mode choice is not uniform across CPUs. Whether fp
+helps depends on one architectural property: **does the CPU have cheap
+stack-relative addressing?**
+
+- **z80 / z80n / z180** have neither native `ld rr,(sp+d)` nor 16-bit indexed
+  loads. In sp mode every local address is materialised with
+  `ld hl,off; add hl,sp; …`; fp reads it in place via `(ix+d)`. fp is faster and
+  smaller across essentially the whole suite.
+- **ez80** additionally has native 16-bit indexed load/store `ld rr,(ix+d)` /
+  `ld (ix+d),rr` — a single instruction that *only* fp can use (there is no
+  `ld rr,(sp+d)` in z80 mode). On 16-bit-heavy code this is a large win; fp is
+  both much faster and smaller. This is the strongest case in the matrix.
+- **Rabbit (r2ka / r4k) and kc160** have native cheap **stack-relative**
+  addressing, so sp is already as good as `(ix+d)`. fp then only adds IX
+  save/restore overhead and larger encodings — a net wash-to-loss, and bigger
+  code.
+- **gbz80 / 8080 / 8085** have no index registers, so fp is impossible; sp is
+  forced (`c_framepointer_is_ix` is already pinned to -1 for these in main.c).
+
+## Decision
+
+Make the frame-pointer default **per-CPU**:
+
+- **Default `-fframe-pointer` (IX frame): z80, z80n, z180, ez80.**
+- **Default `-fomit-frame-pointer` (sp): r2ka, r4k, kc160** (and gbz80 / 8080 /
+  8085, where it is forced).
+
+Both flags remain user-overridable on every CPU (ADR 0011); this only changes the
+default `c_framepointer_is_ix` chosen per CPU in the CPU-setup code.
+
+## Consequences
+
+- **Gated on the IX-clobber safety audit — this is the real blocker, not perf.**
+  fp keeps IX live across calls, and several classic-lib asm routines clobber IX
+  (the callback-via-IX class; qsort/bsearch are fixed, but the general "save IX
+  around calls to IX-clobbering helpers" work is not complete). Flipping the
+  default before that audit is closed could miscompile programs that call those
+  routines. So the perf decision is made, but the *rollout* waits on IX safety.
+- Implementation is a per-CPU assignment of the default `c_framepointer_is_ix`
+  (1 for z80/z80n/z180/ez80, -1 otherwise) in main.c's CPU setup, replacing the
+  current uniform -1 default. The existing forced -1 for gbz80/8080/8085 stays.
+- Test infra already exercises both modes (`FP=1` builds the fp variant); after
+  the flip, the *default* suite run covers fp on the four CPUs and the `FP`
+  toggle should be re-pointed to exercise the non-default mode if per-mode
+  coverage is still wanted.
+- Numbers backing this live in BENCH_MATRIX.txt (per the ADR convention, kept out
+  of this document); re-check them if the CPU cost model or residency changes.
+
+See ADR 0011 (index-register roles / reservation) and ADR 0002 (register model).

--- a/src/80cc/adr/README.md
+++ b/src/80cc/adr/README.md
@@ -22,6 +22,7 @@ ez80, rabbit, gbz80, 8080, 8085, kc160).
 | [0009](0009-wide-value-accumulator.md) | Wide (6/8-byte) value handling via a memory accumulator (`__i64_acc` / FA) |
 | [0010](0010-ast-vs-ir-optimisation-layering.md) | AST-level and IR-level optimisation: a deliberate two-level split |
 | [0011](0011-index-register-allocation.md) | Index-register (IX/IY) allocation by frame mode, and reservation |
+| [0012](0012-frame-pointer-default-by-cpu.md) | Per-CPU default for the frame pointer (fp on z80/z80n/z180/ez80) |
 
 Derived from the `*_PLAN.md` working notes: 0006 ← MULTICPU_IR, 0007 ← KIND_WIDTH,
 0008 ← IVSR, 0009 ← the long-long/double accumulator design. Transient

--- a/src/80cc/adr/README.md
+++ b/src/80cc/adr/README.md
@@ -1,0 +1,36 @@
+# 80cc Architecture Decision Records
+
+These ADRs describe **how the 80cc back end works and why** — the durable design,
+as distinct from the many `*_PLAN.md` files (which are transient, per-effort
+working notes). Read these to understand the compiler; read the plans only for
+the history of a specific optimisation.
+
+80cc is one of z88dk's C compilers: a small-C front end feeding an SSA-ish
+intermediate representation and a retargetable 8-bit back end (z80, z80n, z180,
+ez80, rabbit, gbz80, 8080, 8085, kc160).
+
+| ADR | Topic |
+|-----|-------|
+| [0001](0001-ir-backend-pipeline.md) | IR-based back end and the compilation pipeline |
+| [0002](0002-z80-register-model.md) | The z80 register reality and the vreg → physical-register model |
+| [0003](0003-register-residency.md) | Register residency: region-home-or-slot, the orchestrator, and live-range packing |
+| [0004](0004-soundness-and-gating.md) | Soundness: `op_clobbers`, `IR_VERIFY`, revert-to-slot, `require_slot`, and byte-identical gating |
+| [0005](0005-helper-clobber-table.md) | The runtime-helper clobber table (`__preserve_regs`) |
+| [0006](0006-multi-cpu-retargeting.md) | Multi-CPU retargeting (CPU-agnostic pipeline; CPU knowledge in the lowerer) |
+| [0007](0007-kind-width-type-model.md) | The type-kind / width model on VRegs |
+| [0008](0008-ivsr-strength-reduction.md) | Induction-variable strength reduction (IVSR) and LFTR |
+| [0009](0009-wide-value-accumulator.md) | Wide (6/8-byte) value handling via a memory accumulator (`__i64_acc` / FA) |
+| [0010](0010-ast-vs-ir-optimisation-layering.md) | AST-level and IR-level optimisation: a deliberate two-level split |
+
+Derived from the `*_PLAN.md` working notes: 0006 ← MULTICPU_IR, 0007 ← KIND_WIDTH,
+0008 ← IVSR, 0009 ← the long-long/double accumulator design. Transient
+per-optimisation plans (BC_PACK, PTRBENCH_*, the residency levers, MR_SQUASH,
+REORG, the `*_BUG` post-mortems) stay as plans, not ADRs.
+
+## Conventions
+
+- **Status** of each ADR: Accepted / Superseded / Proposed.
+- Performance figures live in commit messages and plan docs, **never in ADRs or
+  code comments** (they go stale; the mechanism/rationale is what endures).
+- Each residency feature is gated so the compiler is **byte-identical with it
+  off** — see ADR 0004. New residency work should preserve that property.

--- a/src/80cc/adr/README.md
+++ b/src/80cc/adr/README.md
@@ -21,6 +21,7 @@ ez80, rabbit, gbz80, 8080, 8085, kc160).
 | [0008](0008-ivsr-strength-reduction.md) | Induction-variable strength reduction (IVSR) and LFTR |
 | [0009](0009-wide-value-accumulator.md) | Wide (6/8-byte) value handling via a memory accumulator (`__i64_acc` / FA) |
 | [0010](0010-ast-vs-ir-optimisation-layering.md) | AST-level and IR-level optimisation: a deliberate two-level split |
+| [0011](0011-index-register-allocation.md) | Index-register (IX/IY) allocation by frame mode, and reservation |
 
 Derived from the `*_PLAN.md` working notes: 0006 ← MULTICPU_IR, 0007 ← KIND_WIDTH,
 0008 ← IVSR, 0009 ← the long-long/double accumulator design. Transient

--- a/src/80cc/data.c
+++ b/src/80cc/data.c
@@ -96,6 +96,14 @@ int debuglevel;
  */
 int c_framepointer_is_ix;
 
+/* Platform-reserved index registers: when set, the compiler must not use that
+   index register for ANY residency (idx2/idx3/exx-adjacent/LRA-IY homes).
+   --reserve-regs-iy leaves at most one index register (IX); --reserve-regs-ix
+   (sp-mode) removes IX as the spare index register so, with the default
+   idx3/LRA off, no index register is used at all. */
+int c_reserve_iy = 0;
+int c_reserve_ix = 0;
+
 /* Keep one loop-invariant in the spare index register (the one NOT used as
    the frame pointer). Command-line settable (--idx2-invariant / --no-idx2-
    invariant); IR_NO_IDX2 in the environment forces off. Resolved per-CPU to

--- a/src/80cc/data.h
+++ b/src/80cc/data.h
@@ -62,6 +62,8 @@ extern SYMBOL *currfn;
 extern int debuglevel;
 extern int c_assembler_type;
 extern int c_framepointer_is_ix;
+extern int c_reserve_iy;
+extern int c_reserve_ix;
 extern int c_idx2_invariant;
 extern int c_idx3_residency;
 extern int c_exx_residency;
@@ -78,14 +80,10 @@ extern char *c_bss_section;
 extern char *c_data_section;
 extern char *c_rodata_section;
 extern int c_disable_builtins;
-extern uint32_t c_speed_optimisation;
 /* AST optimiser pass disable bitmask — set via --opt-disable=<name,...>
    (handler in main.c). Bits are checked in ast_opt_run; setting a bit
    makes that pass become a no-op. Useful for bisecting miscompiles. */
 extern uint32_t c_opt_disable;
-/* Function codegen goes through the IR pipeline (ir_build → ir_lower),
-   now the sole codegen path (forced on at startup). */
-extern int      c_use_ir;
 #define OPT_DISABLE_FOLD            (1u << 0)
 #define OPT_DISABLE_PROP            (1u << 1)
 #define OPT_DISABLE_SIMPLIFY        (1u << 2)

--- a/src/80cc/ir.h
+++ b/src/80cc/ir.h
@@ -114,6 +114,10 @@ typedef enum {
                                         call — gen_call's whole-function BC-save
                                         must ignore it (Part 1). Slotless like any
                                         PR_BC vreg (stamped `ld bc,hl` at its def). */
+    IR_VREG_DE_PACK        = 1 << 8, /* LRA Phase 1: single-BB call-free word temp
+                                        locally allocated to DE (op_clobbers-clean
+                                        span, DE otherwise idle). DE sibling of
+                                        BC_PACK; call-free so gen_call ignores it. */
 } VRegFlags;
 
 typedef struct {
@@ -123,7 +127,7 @@ typedef struct {
                            locals, overloaded as the slot byte count
                            (int16_t fits arrays up to ~32KB). */
     SYMBOL  *sym;       /* backing sym (NULL = compiler temp) */
-    uint8_t  flags;     /* VRegFlags bitset */
+    uint16_t flags;     /* VRegFlags bitset (>8 bits: IR_VREG_DE_PACK=1<<8) */
 } VReg;
 
 /* ----- Memory operand --------------------------------------------------- */
@@ -527,6 +531,12 @@ typedef struct {
     SwitchInfo *sw;         /* IR_SWITCH only — heap allocated */
     const char *asm_text;   /* IR_ASM raw asm payload */
 
+    /* LRA Phase 4: stage src[1] into BC (`add hl,bc`/`sbc hl,bc`) rather than
+       DE, so a DE-packed value (IR_VREG_DE_PACK) survives this op untouched.
+       Set by ir_bc_pack when it commits a DE placement whose span covers this
+       ADD/SUB/CMP; honored by load_binop_operands + gen_add/sub/cmp (IR_LRA). */
+    uint8_t     lra_stage_src1_bc;
+
     /* Source location for debug / -gcline output. */
     const char *file;
     int         line;
@@ -756,6 +766,19 @@ int ir_bb_succ_at(const BB *bb, int i);   /* -1 if out of range */
 const char *ir_op_name(OpKind kind);
 
 const char *ir_phys_name(PhysReg pr);
+
+/* LRA (ir_lower.c): the verified per-op value-register clobber model + a vreg's
+   physical-register mask. Shared with the allocator (ir_alloc.c) so the DE-local
+   pack proves clean spans against the SAME model IR_VERIFY checks. */
+RegMask op_clobbers(const Func *f, const Op *op);
+/* Like op_clobbers, but models the relaxed lowering of the ops with a `hl,bc`
+   alternate form (ADD/SUB and word compares): src[1] is staged into BC instead
+   of DE, so DE is dropped from the clobber set (unless DE is the op's result or
+   operand home) and BC is added. Wide (DEHL/i64) forms have no BC-only variant
+   and are returned unchanged. LRA Phase-4 step 1: the DE-clean-modulo-staging
+   model the DE-pack is measured against. */
+RegMask op_clobbers_relaxed(const Func *f, const Op *op);
+RegMask phys_regmask(const Func *f, int vreg);
 
 /* ----- Compiler-internal accessors ------------------------------------- */
 

--- a/src/80cc/ir.h
+++ b/src/80cc/ir.h
@@ -534,7 +534,8 @@ typedef struct {
     /* LRA Phase 4: stage src[1] into BC (`add hl,bc`/`sbc hl,bc`) rather than
        DE, so a DE-packed value (IR_VREG_DE_PACK) survives this op untouched.
        Set by ir_bc_pack when it commits a DE placement whose span covers this
-       ADD/SUB/CMP; honored by load_binop_operands + gen_add/sub/cmp (IR_LRA). */
+       ADD/SUB/CMP; honored by load_binop_operands + gen_add/sub/cmp. Only the
+       experimental IR_LRA_DEPACK path sets this (the default-on LRA never does). */
     uint8_t     lra_stage_src1_bc;
 
     /* Source location for debug / -gcline output. */

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -1425,6 +1425,279 @@ static int lra_bc_emittable(const Func *f, const Op *o)
     return o->dst >= 0 && o->dst < f->n_vregs && f->vregs[o->dst].width == 2;
 }
 
+/* LRA Phase 2c: is IY available as a reduction-chain home in this function?
+   Needs a CPU with IY + `add iy,de` (excludes gbz80/808x), sp-mode (IY free;
+   -frameiy uses it as the frame ptr — widen to -frameix later), IY not already
+   claimed by idx2/idx3/exx, and not an interrupt/naked function. */
+static int lra_iy_available(const Func *f)
+{
+    if (f->is_interrupt || f->is_naked) return 0;
+    /* CPU must have IY + `add iy,de` (excludes gbz80/8080/8085). z180/ez80/rabbit
+       support the full-word add iy,rr (only the index-HALF ops trap on z180). */
+    if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180
+          || IS_EZ80() || IS_RABBIT())) return 0;
+    /* IY is free in sp-mode (-1) and -frameix (1, IX is the frame); NOT under
+       -frameiy (0, IY is the frame). The fp epilogue frame fix + IY-occupancy
+       arbitration (below) + the FULL-live-range IY-clean check (rejects an
+       accumulator live across an IY-clobbering call — the remat.c fp miscompile,
+       now fixed) make fp sound. */
+    if (c_framepointer_is_ix == 0) return 0;
+    return 1;   /* IY occupancy handled (with benefit arbitration) in the pass */
+}
+
+/* A vreg that can be a reduction-chain member homed in IY: a plain width-2
+   spill temp (no address-taken/volatile/param). */
+static int lra_iy_chain_ok(const Func *f, int v)
+{
+    if (v < 0 || v >= f->n_vregs) return 0;
+    if (f->vregs[v].width != 2) return 0;
+    if (f->vreg_to_phys[v] != IR_PR_SPILL) return 0;      /* free / not already placed */
+    if (f->vregs[v].flags & (IR_VREG_ADDR_TAKEN | IR_VREG_VOLATILE | IR_VREG_PARAM))
+        return 0;
+    return 1;
+}
+
+/* LRA Phase 2c (IR_LRA-gated): home a DE-dirty straight-line reduction chain in
+   IY. A chain is a run of width-2 ADDs c0=x+y, c1=c0+z, c2=c1+w… where each
+   partial feeds the NEXT add as an operand and is otherwise dead (single use),
+   all spilling in one loop-body BB. The addends' address computation owns HL+DE
+   (and BC holds the loop ptr/IV), so the partials can't home in BC/DE and spill
+   to slots. IY is immune to that clobbering, so the whole chain time-shares ONE
+   IY register: c0 inits it (`push hl; pop iy` via commit_hl_result), c1.. via
+   `add iy,de` (Phase 2b emitter). Sets f->idx3_reg=IY so vreg_idx_home sees the
+   members and the prologue saves IY (frame_has_saved_iy). Runs AFTER ir_bc_pack
+   (takes the SPILL losers) and before ir_stack_spill. Gated; byte-identical off. */
+static void ir_iy_reduction_pack(Func *f, const int *bb_in_loop,
+                                 const int *use_count)
+{
+    if (!getenv("IR_LRA")) return;
+    if (!lra_iy_available(f)) return;
+
+    /* RAW use counts (the passed use_count is depth-weighted — no good for a
+       single-use test). raw_uses[v] = number of ops that read v. Also mark
+       deref bases: a value used as a MEM_VREG base (or POSTSTEP subject) is a
+       POINTER — it must stay addressable (`ld a,(hl)` etc.), NOT get homed in IY
+       via add-iy-de (its deref would need (iy+d) / a separate path). The
+       accumulator detector otherwise matches a walking pointer `p = p + stride`
+       (same `s = s OP x` shape); excluding bases prevents that (test_remat_counter). */
+    int *raw_uses = calloc((size_t)f->n_vregs, sizeof(int));
+    int *is_base  = calloc((size_t)f->n_vregs, sizeof(int));
+    if (!raw_uses || !is_base) { free(raw_uses); free(is_base); return; }
+    for (int b = 0; b < f->n_bbs; b++)
+        for (int j = 0; j < f->bbs[b].n_ops; j++) {
+            const Op *o = &f->bbs[b].ops[j];
+            int u[16], nu = ir_op_uses(o, u, 16);
+            for (int k = 0; k < nu; k++)
+                if (u[k] >= 0 && u[k] < f->n_vregs) raw_uses[u[k]]++;
+            if (o->mem.kind == IR_MEM_VREG && o->mem.base >= 0
+                && o->mem.base < f->n_vregs) is_base[o->mem.base] = 1;
+            if (o->kind == IR_POSTSTEP && o->src[0] >= 0
+                && o->src[0] < f->n_vregs) is_base[o->src[0]] = 1;
+        }
+
+    /* Loop-carried accumulator (checked FIRST — it is live the whole loop, so
+       homing it saves per-iteration slot traffic word_acc/DE-home couldn't). A
+       width-2 spill s self-updated `s = s OP x` (ADD/SUB) in a loop, live across
+       the back-edge (live-in AND live-out of the update's BB). word_acc left it
+       spilling because DE is dirtied by the addend's address calc or a call; IY
+       survives both (op_clobbers respects the helper table — l_mult etc. preserve
+       IY), so s rides IY the whole loop: init `ld iy,K`/push;pop, updates
+       `add iy,de` (Phase 2b aliased path), read at exit. Requires the ENTIRE loop
+       region IY-clean. Scored by depth-weighted use_count (hotness) and compared
+       against the best chain below — one IY user per function, take the hotter.
+       (matrixbench has a COLD outer checksum accumulator AND the HOT inner
+       stencil chain; the score picks the chain.) */
+    int acc = -1, acc_bb = -1; long acc_score = 0;
+    for (int v = 0; v < f->n_vregs; v++) {
+        if (!lra_iy_chain_ok(f, v) || is_base[v]) continue;   /* not a deref-base pointer */
+        int ub = -1;
+        for (int b = 0; b < f->n_bbs && ub < 0; b++) {
+            if (!bb_in_loop[b]) continue;
+            for (int j = 0; j < f->bbs[b].n_ops; j++) {
+                const Op *o = &f->bbs[b].ops[j];
+                if ((o->kind == IR_ADD || o->kind == IR_SUB)
+                    && o->dst == v && (o->src[0] == v || o->src[1] == v)) { ub = b; break; }
+            }
+        }
+        if (ub < 0) continue;
+        const BB *ubb = &f->bbs[ub];
+        if (!ubb->live_in || !ubb->live_out) continue;
+        if (!ir_bitset_get((const BitSet *)ubb->live_in, v)
+            || !ir_bitset_get((const BitSet *)ubb->live_out, v)) continue;   /* loop-carried */
+        /* IY-clean over the accumulator's FULL span — anywhere it is LIVE, not
+           just the loop. An IY-clobbering op is a problem iff it isn't v's own
+           write (an `add iy,de` / `ld iy` legitimately sets IY=v) AND v is
+           live-OUT of it (needed afterwards). This catches a call BEFORE the loop
+           that v is carried across (`chk=0; o=encode_pairs(); for(...)chk+=...` —
+           the remat.c:48 fp miscompile) while allowing the last-use op (RET /
+           the exit compare reads v then IY is free) and v's own updates. */
+        int clean = 1;
+        for (int b = 0; b < f->n_bbs && clean; b++) {
+            const BB *cb = &f->bbs[b];
+            if (!cb->live_in_per_op) continue;
+            for (int k = 0; k < cb->n_ops; k++) {
+                const Op *o = &cb->ops[k];
+                if (o->dst == v) continue;                    /* v's own write */
+                if (!(op_clobbers(f, o) & IR_R_IY)) continue;
+                const BitSet *lo = (k + 1 < cb->n_ops)
+                    ? (const BitSet *)cb->live_in_per_op[k + 1]
+                    : (const BitSet *)cb->live_out;
+                if (lo && ir_bitset_get(lo, v)) { clean = 0; break; }  /* v survives an IY clobber */
+            }
+        }
+        if (!clean) continue;
+        if ((long)use_count[v] > acc_score) { acc = v; acc_bb = ub; acc_score = use_count[v]; }
+    }
+
+    /* Find the single BEST (longest = most spill traffic saved) reduction chain
+       in the function. ONE chain per function: the members of one chain have
+       disjoint consecutive ranges and safely time-share IY, but two chains in
+       different BBs can be simultaneously live (matrixbench: a row-offset chain
+       lives across the neighbour-sum chain) and would collide in the one IY
+       register. Proper inter-chain interference needs live ranges (not built
+       here) — that's Phase 2d. */
+    int best[32], best_nm = 0, best_bb = -1; long best_score = 0;
+    for (int b = 0; b < f->n_bbs; b++) {
+        if (!bb_in_loop[b]) continue;
+        BB *bb = &f->bbs[b];
+        for (int j = 0; j < bb->n_ops; j++) {
+            if (bb->ops[j].kind != IR_ADD) continue;
+            int d0 = bb->ops[j].dst;
+            if (!lra_iy_chain_ok(f, d0) || is_base[d0]) continue;  /* fresh spill, not a ptr */
+            /* Grow the chain within this BB: follow the single-use partial into
+               the next ADD that consumes it. Each partial (incl. the head) must
+               be consumed ONLY by that add (raw single use) so the members'
+               ranges are disjoint and can share one IY register. */
+            int members[32]; int nm = 0; members[nm++] = d0;
+            int cur = d0, ci = j;
+            while (nm < 32 && raw_uses[cur] == 1) {
+                int nb = -1, nd = -1;
+                for (int k = ci + 1; k < bb->n_ops; k++) {
+                    const Op *p = &bb->ops[k];
+                    if (p->kind == IR_ADD && (p->src[0] == cur || p->src[1] == cur)) {
+                        nb = k; nd = p->dst; break;
+                    }
+                }
+                if (nb < 0 || !lra_iy_chain_ok(f, nd) || is_base[nd]) break;
+                members[nm++] = nd; cur = nd; ci = nb;
+            }
+            if (nm < 2) continue;                          /* need >=1 accumulate add */
+            /* IY must stay clean across the whole chain span [j..ci] (no CALL/
+               ASM / non-preserving HCALL — op_clobbers respects the helper table). */
+            int clean = 1;
+            for (int k = j; k <= ci && clean; k++)
+                if (op_clobbers(f, &bb->ops[k]) & IR_R_IY) clean = 0;
+            if (!clean) continue;
+            /* Score by depth-weighted hotness (sum of members' weighted uses) so
+               a hot inner-loop chain outranks a cold one. */
+            long score = 0;
+            for (int m = 0; m < nm; m++) score += use_count[members[m]];
+            if (score > best_score) {
+                best_score = score; best_nm = nm; best_bb = b;
+                for (int m = 0; m < nm; m++) best[m] = members[m];
+            }
+        }
+    }
+    /* One IY user per function: the higher-scoring of {accumulator, chain}. */
+    int win_acc = (acc >= 0 && acc_score >= best_score);
+    long win_score = win_acc ? acc_score : best_score;
+    if (!win_acc && best_nm < 2) { free(raw_uses); free(is_base); return; }   /* no candidate */
+
+    /* IY-occupancy ARBITRATION (2d). If idx2/idxhalf already homed value(s) in
+       IY, our candidate must OUTSCORE them (depth-weighted uses) to claim it.
+       fp-mode: idx2's index-home is ~a wash there (`push iy;pop hl` costs the
+       same as an `(ix+d)` slot read), while our `add iy,de` accumulate is a real
+       win — and idx2 in fp doesn't even save the caller's IY, whereas taking IY
+       for the reduction does (frame_has_saved_iy) — so eviction is a strict
+       improvement when we outscore it. sp-mode: idx2's IY-home is genuinely
+       cheaper than a slot, so DON'T evict (keep the current free-IY-only rule);
+       occ_score is set to LONG_MAX to force a bail. */
+    long occ_score = 0; int occ_n = 0;
+    for (int v = 0; v < f->n_vregs; v++) {
+        PhysReg p = f->vreg_to_phys[v];
+        if (p == IR_PR_IY || p == IR_PR_IYL || p == IR_PR_IYH) {
+            occ_score += use_count[v]; occ_n++;
+        }
+    }
+    if (occ_n > 0) {
+        /* fp-mode: idx2's index-home is a WASH (`push iy;pop hl` == `(ix+d)`
+           slot read), so ANY real reduction candidate (its `add iy,de` saves the
+           accumulator RMW) is a net win over it — evict unconditionally. A
+           use_count comparison would wrongly keep idx2 (it counts the base ptr's
+           many reads but not that each costs the same in a slot). sp-mode: idx2's
+           IY-home genuinely beats an expensive sp slot, so never evict — bail and
+           leave IY to idx2 (matches the pre-arbitration free-IY-only rule). */
+        if (c_framepointer_is_ix != 1) { free(raw_uses); free(is_base); return; }
+        for (int v = 0; v < f->n_vregs; v++) {
+            PhysReg p = f->vreg_to_phys[v];
+            if (p == IR_PR_IY || p == IR_PR_IYL || p == IR_PR_IYH)
+                f->vreg_to_phys[v] = IR_PR_SPILL;   /* revert-to-slot */
+        }
+        if (getenv("IR_ALLOC_PROBE"))
+            fprintf(stderr, "IY_EVICT %d idx2 occupant(s) (fp wash) for candidate score=%ld\n",
+                    occ_n, win_score);
+    }
+    (void)occ_score;
+
+    if (win_acc) {
+        f->vreg_to_phys[acc] = IR_PR_IY;
+        f->idx3_reg = IR_PR_IY;
+        if (getenv("IR_ALLOC_PROBE"))
+            fprintf(stderr, "IY_ACC v%d bb%d score=%ld (loop-carried accumulator)\n",
+                    acc, acc_bb, acc_score);
+    } else {
+        for (int m = 0; m < best_nm; m++) f->vreg_to_phys[best[m]] = IR_PR_IY;
+        f->idx3_reg = IR_PR_IY;
+        if (getenv("IR_ALLOC_PROBE")) {
+            fprintf(stderr, "IY_REDUCE bb%d members=%d score=%ld:", best_bb, best_nm, best_score);
+            for (int m = 0; m < best_nm; m++) fprintf(stderr, " v%d", best[m]);
+            fprintf(stderr, "\n");
+        }
+    }
+    free(raw_uses); free(is_base);
+}
+
+/* Single-BB tight-interval SHAPE of a spill temp — the analysis both ir_bc_pack
+   and ir_stack_spill need. A width-2 vreg is `local` iff all its refs are in one
+   BB, the first ref is its def, and it is neither live-in nor live-out of that BB
+   (born-and-killed each execution). [lo,hi] is its tight op interval (local op
+   indices in bb_of); `uses` is its raw use count. Placement policy (BC-clean
+   span / call-free / single-use / stack hazards) stays in each pass — this is
+   just the shared shape, computed once. */
+typedef struct { int local, bb_of, lo, hi, uses; } SpillShape;
+
+static SpillShape *compute_spill_shapes(const Func *f)
+{
+    SpillShape *sh = calloc((size_t)(f->n_vregs > 0 ? f->n_vregs : 1), sizeof *sh);
+    if (!sh) return NULL;
+    for (int v = 0; v < f->n_vregs; v++) {
+        if (f->vregs[v].width != 2) continue;
+        int bb_of = -1, lo = INT_MAX, hi = -1, first_is_def = 0, multi = 0, uses = 0;
+        for (int i = 0; i < f->n_bbs && !multi; i++) {
+            const BB *bb = &f->bbs[i];
+            for (int j = 0; j < bb->n_ops; j++) {
+                const Op *o = &bb->ops[j];
+                int is_def = (o->dst == v);
+                int u[16]; int nu = ir_op_uses(o, u, (int)(sizeof u / sizeof u[0]));
+                int is_use = 0;
+                for (int k = 0; k < nu; k++) if (u[k] == v) { is_use = 1; uses++; }
+                if (!is_def && !is_use) continue;
+                if (bb_of == -1) { bb_of = i; first_is_def = is_def; }
+                else if (bb_of != i) { multi = 1; break; }
+                if (j < lo) lo = j;
+                if (j > hi) hi = j;
+            }
+        }
+        if (multi || bb_of < 0 || hi < 0 || !first_is_def) continue;
+        const BB *bb = &f->bbs[bb_of];
+        if (bb->live_out && ir_bitset_get((const BitSet *)bb->live_out, v)) continue;
+        if (bb->live_in  && ir_bitset_get((const BitSet *)bb->live_in,  v)) continue;
+        sh[v].local = 1; sh[v].bb_of = bb_of; sh[v].lo = lo; sh[v].hi = hi;
+        sh[v].uses = uses;
+    }
+    return sh;
+}
+
 static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
                        const int *bb_first_op, const int *def_kind,
                        const int *write_count, const int *use_count)
@@ -1448,35 +1721,18 @@ static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
     int *ithi  = calloc((size_t)f->n_vregs, sizeof(int));
     int *itbb  = calloc((size_t)f->n_vregs, sizeof(int));
     int *itdop = calloc((size_t)f->n_vregs, sizeof(int));   /* def op idx in itbb */
-    if (!itloc || !itlo || !ithi || !itbb || !itdop) {
-        free(itloc); free(itlo); free(ithi); free(itbb); free(itdop); return;
+    SpillShape *sh = compute_spill_shapes(f);
+    if (!itloc || !itlo || !ithi || !itbb || !itdop || !sh) {
+        free(itloc); free(itlo); free(ithi); free(itbb); free(itdop); free(sh); return;
     }
 
+    /* itloc = single-BB-local (shared shape) AND the BC-specific span admission:
+       every op after the def must be call-free + BC-preserving + width-4-free. */
     for (int v = 0; v < f->n_vregs; v++) {
-        if (f->vregs[v].width != 2) continue;
-        int bb_of = -1, lo = INT_MAX, hi = -1, first_is_def = 0, multi = 0;
-        for (int i = 0; i < f->n_bbs && !multi; i++) {
-            const BB *bb = &f->bbs[i];
-            for (int j = 0; j < bb->n_ops; j++) {
-                const Op *o = &bb->ops[j];
-                int is_def = (o->dst == v);
-                int is_use = 0;
-                int u[16];
-                int nu = ir_op_uses(o, u, (int)(sizeof u / sizeof u[0]));
-                for (int k = 0; k < nu; k++) if (u[k] == v) { is_use = 1; break; }
-                if (!is_def && !is_use) continue;
-                if (bb_of == -1) { bb_of = i; first_is_def = is_def; }
-                else if (bb_of != i) { multi = 1; break; }
-                if (j < lo) lo = j;
-                if (j > hi) hi = j;
-            }
-        }
-        if (multi || bb_of < 0 || hi < 0 || !first_is_def) continue;
-        const BB *bb = &f->bbs[bb_of];
-        if (bb->live_out && ir_bitset_get((const BitSet *)bb->live_out, v)) continue;
-        if (bb->live_in  && ir_bitset_get((const BitSet *)bb->live_in,  v)) continue;
+        if (!sh[v].local) continue;
+        const BB *bb = &f->bbs[sh[v].bb_of];
         int span_ok = 1;
-        for (int j = lo + 1; j <= hi && span_ok; j++) {
+        for (int j = sh[v].lo + 1; j <= sh[v].hi && span_ok; j++) {
             const Op *o = &bb->ops[j];
             if (o->kind == IR_CALL || o->kind == IR_HCALL || o->kind == IR_ASM
                 || !bc_pack_span_kind_ok(o->kind)
@@ -1485,11 +1741,12 @@ static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
         }
         if (!span_ok) continue;
         itloc[v] = 1;
-        itlo[v]  = bb_first_op[bb_of] + lo;
-        ithi[v]  = bb_first_op[bb_of] + hi;
-        itbb[v]  = bb_of;
-        itdop[v] = lo;                 /* first_is_def ⇒ def is at op index lo */
+        itlo[v]  = bb_first_op[sh[v].bb_of] + sh[v].lo;
+        ithi[v]  = bb_first_op[sh[v].bb_of] + sh[v].hi;
+        itbb[v]  = sh[v].bb_of;
+        itdop[v] = sh[v].lo;           /* first_is_def ⇒ def is at op index lo */
     }
+    free(sh);
 
     /* Candidate flat interval [flo,fhi], sorted by flo for greedy scheduling. */
     typedef struct { int vreg, flo, fhi; } PackCand;
@@ -1746,7 +2003,8 @@ static void ir_stack_spill(Func *f, const int *bb_first_op, const int *def_kind,
 
     typedef struct { int vreg, flo, fhi; } SCand;
     SCand *cand = calloc((size_t)f->n_vregs, sizeof(SCand));
-    if (!cand) return;
+    SpillShape *sh = compute_spill_shapes(f);
+    if (!cand || !sh) { free(cand); free(sh); return; }
     int nc = 0;
 
     for (int v = 0; v < f->n_vregs; v++) {
@@ -1758,28 +2016,12 @@ static void ir_stack_spill(Func *f, const int *bb_first_op, const int *def_kind,
         if (write_count[v] != 1) continue;
         if (!bc_safe_producer(def_kind[v])) continue;
 
-        /* Single BB, tight [lo,hi], first ref is the def, exactly one use. */
-        int bb_of = -1, lo = INT_MAX, hi = -1, first_is_def = 0, multi = 0, uses = 0;
-        for (int i = 0; i < f->n_bbs && !multi; i++) {
-            const BB *bb = &f->bbs[i];
-            for (int j = 0; j < bb->n_ops; j++) {
-                const Op *o = &bb->ops[j];
-                int is_def = (o->dst == v);
-                int u[16]; int nu = ir_op_uses(o, u, (int)(sizeof u / sizeof u[0]));
-                int is_use = 0;
-                for (int k = 0; k < nu; k++) if (u[k] == v) { is_use = 1; uses++; }
-                if (!is_def && !is_use) continue;
-                if (bb_of == -1) { bb_of = i; first_is_def = is_def; }
-                else if (bb_of != i) { multi = 1; break; }
-                if (j < lo) lo = j;
-                if (j > hi) hi = j;
-            }
-        }
-        if (multi || bb_of < 0 || hi < 0 || !first_is_def || uses != 1) continue;
+        /* Shared shape: single-BB, first-ref-is-def, not live across the BB, tight
+           [lo,hi]; plus stack_spill's own "exactly one use". */
+        if (!sh[v].local || sh[v].uses != 1) continue;
+        int bb_of = sh[v].bb_of, lo = sh[v].lo, hi = sh[v].hi;
 
         const BB *bb = &f->bbs[bb_of];
-        if (bb->live_out && ir_bitset_get((const BitSet *)bb->live_out, v)) continue;
-        if (bb->live_in  && ir_bitset_get((const BitSet *)bb->live_in,  v)) continue;
         if (op_dst_spill_is_dead(bb, lo)) continue;   /* value rides HL — no win */
         /* A value consumed by an IMMEDIATELY-following COMMUTATIVE binop rides a
            register straight into it (the lowering swaps it into the HL operand
@@ -1820,7 +2062,7 @@ static void ir_stack_spill(Func *f, const int *bb_first_op, const int *def_kind,
     }
     if (getenv("IR_ALLOC_PROBE"))
         fprintf(stderr, "STACK_SPILL placed=%d of candidates=%d\n", placed, nc);
-    free(cand);
+    free(cand); free(sh);
 }
 
 /* Diagnostic probe (IR_ALLOC_PROBE): count spilled width-2 temps whose whole
@@ -2628,6 +2870,9 @@ void ir_alloc(Func *f)
            it only claims BC where no loop home owns it. */
         ir_bc_pack(f, first_use, last_use, bb_first_op, def_kind,
                    write_count, use_count);
+        /* LRA Phase 2c (IR_LRA): home a DE-dirty reduction chain in IY (add iy,de),
+           taking the spill losers BC couldn't. Byte-identical off. */
+        ir_iy_reduction_pack(f, bb_in_loop, use_count);
         /* Stack-transient spill (default on, IR_NO_STACK_SPILL opts out): the register-pressure
            fallback below BC-pack — a single-def/single-use word transient with
            no register free goes on the stack (push/pop) instead of a slot. */

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -1413,6 +1413,18 @@ static int bc_pack_op_touches_w4(const Func *f, const Op *o)
    IR_VREG_BC_PACK so gen_call's whole-function BC-save ignores them.
 
    Default ON; IR_NO_BC_PACK opts out (restores the pre-pack codegen exactly). */
+
+/* LRA Phase-4: is op j one whose src[1]→BC staging the emitter (steps 3-4)
+   actually implements? Only width-2 ADD/SUB have the `add hl,bc` / `sbc hl,bc`
+   form wired in gen_add/gen_sub. Any other op that (per op_clobbers) may touch
+   DE — CMP, byte ops, MUL, etc. — must BLOCK the DE placement rather than be
+   marked, so the loud-abort backstop in load_binop_operands can never fire. */
+static int lra_bc_emittable(const Func *f, const Op *o)
+{
+    if (o->kind != IR_ADD && o->kind != IR_SUB) return 0;
+    return o->dst >= 0 && o->dst < f->n_vregs && f->vregs[o->dst].width == 2;
+}
+
 static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
                        const int *bb_first_op, const int *def_kind,
                        const int *write_count, const int *use_count)
@@ -1559,8 +1571,119 @@ static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
         last_fhi = cand[i].fhi;
         packed++;
     }
+    /* ---- LRA Phase 4 step 2 (IR_LRA): DE as a SECOND local home -----------
+       For the itloc candidates BC couldn't take (BC held by a loop home →
+       clash), try DE: place a candidate in DE when its span is DE-CLEAN under
+       the RELAXED model (op_clobbers_relaxed — ADD/SUB/CMP stage src[1] into BC
+       not DE) AND DE is otherwise idle over the span (no PR_DE/E/D tenant). On
+       commit, MARK each relaxed op (`lra_stage_src1_bc`) so steps 3-4's loader +
+       `hl,bc` emitter route its src[1] through BC, keeping the DE resident live.
+       Relaxing an op needs BC free across it (staging clobbers BC), so a span
+       crossing a live BC tenant stays DE-dirty (rejected `bc_busy`).
+
+       NOTE: gated IR_LRA (byte-identical OFF). With IR_LRA on this is WIP until
+       step 4 lands — the marks are set but not yet honored by the emitter, so a
+       placed value is clobbered by its span's DE-staging (silent wrong value,
+       IR_LRA-only). Steps 3-4 complete the mechanism; step 5 validates on. */
+    int de_packed = 0, de_rej_dirty = 0, de_rej_clash = 0, de_avail = 0;
+    int de_rej_bc_busy = 0, de_marks = 0, de_rej_noop = 0;
+    if (getenv("IR_LRA")) {
+        int de_last = -1;
+        for (int i = 0; i < nc; i++) {
+            int v = cand[i].vreg;
+            if (f->vreg_to_phys[v] != IR_PR_SPILL) continue;   /* BC already took it */
+            de_avail++;
+            BB *bb = &f->bbs[itbb[v]];
+            int base = bb_first_op[itbb[v]];
+            int llo = itdop[v];                                /* def op (local) */
+            int lhi = ithi[v] - base;                          /* last ref (local) */
+            int relax_ok = 1, relax_bc_blocked = 0;
+            for (int j = llo + 1; j <= lhi && relax_ok; j++) {
+                RegMask cs = op_clobbers(f, &bb->ops[j]);
+                if (op_clobbers_relaxed(f, &bb->ops[j]) & IR_R_DE) {
+                    relax_ok = 0;                              /* non-relaxable DE clobber */
+                    continue;
+                }
+                /* This op was relaxed (strict-DE, relaxed-clean) → its BC-staging
+                   needs BC free at this flat index. An op whose src[1] IS the
+                   packed value reads it straight from DE (`add hl,de`) — no
+                   staging, no BC needed, so it never blocks. */
+                if ((cs & IR_R_DE) && bb->ops[j].src[1] != v) {
+                    /* The emitter only BC-stages width-2 ADD/SUB; a DE-staging
+                       op it can't rewrite (CMP / byte / etc.) blocks placement. */
+                    if (!lra_bc_emittable(f, &bb->ops[j])) { relax_ok = 0; continue; }
+                    int fidx = base + j, bc_busy = 0;
+                    for (int k = 0; k < f->n_vregs && !bc_busy; k++) {
+                        PhysReg pk = f->vreg_to_phys[k];
+                        if (pk != IR_PR_BC && pk != IR_PR_C && pk != IR_PR_B) continue;
+                        /* Check the tenant's live interval (tight for an itloc
+                           BC_PACK tenant, extended for a loop-home) against this
+                           op — a BC_PACK value live ACROSS the marked op (its
+                           tight span covers fidx) genuinely holds BC and blocks
+                           the BC-staging; only skip it where fidx is outside. */
+                        int klo = itloc[k] ? itlo[k] : first_use[k];
+                        int khi = itloc[k] ? ithi[k] : last_use[k];
+                        if (fidx >= klo && fidx <= khi) bc_busy = 1;
+                    }
+                    if (bc_busy) { relax_ok = 0; relax_bc_blocked = 1; }
+                }
+            }
+            if (!relax_ok) {
+                if (relax_bc_blocked) de_rej_bc_busy++; else de_rej_dirty++;
+                continue;
+            }
+            if (cand[i].flo <= de_last) continue;              /* overlaps a DE sibling */
+            /* DE-tenant overlap (a value already resident in DE across the span). */
+            int clash = 0;
+            for (int j = 0; j < f->n_vregs && !clash; j++) {
+                PhysReg pj = f->vreg_to_phys[j];
+                if (pj != IR_PR_DE && pj != IR_PR_E && pj != IR_PR_D) continue;
+                if (f->vregs[j].flags & IR_VREG_DE_PACK) continue;   /* our own */
+                int jlo = itloc[j] ? itlo[j] : first_use[j];
+                int jhi = itloc[j] ? ithi[j] : last_use[j];
+                int s = cand[i].flo > jlo ? cand[i].flo : jlo;
+                int e = cand[i].fhi < jhi ? cand[i].fhi : jhi;
+                if (s <= e) clash = 1;
+            }
+            if (clash) { de_rej_clash++; continue; }
+            /* --- Identify the ops to mark. Evaluate with v still SPILL so
+               op_clobbers isolates the STAGING-DE bit (once v is PR_DE an op
+               using v carries DE as an operand home and the `!relaxed-DE` test
+               would wrongly fail). Skip src[1]==v (v is consumed from DE,
+               nothing staged). A mark = a DE-clobbering staging op the peephole
+               cannot carry the resident across → the traffic the home saves. */
+            int nm = 0;
+            for (int j = llo + 1; j <= lhi; j++) {
+                if (bb->ops[j].src[1] == v || !lra_bc_emittable(f, &bb->ops[j])) continue;
+                if ((op_clobbers(f, &bb->ops[j]) & IR_R_DE)
+                    && !(op_clobbers_relaxed(f, &bb->ops[j]) & IR_R_DE))
+                    nm++;
+            }
+            /* marks==0 ⇒ every use is adjacent / src[1]-consumed, so the
+               existing peephole DE-cache already carries v across its whole
+               span (the `ex de,hl` operand-swap keeps it there). A PR_DE home
+               would be byte-identical — a no-op placement. Only place (and pay
+               the BC-staging of steps 3-4) when it rescues real slot traffic. */
+            if (nm == 0) { de_rej_noop++; continue; }
+            for (int j = llo + 1; j <= lhi; j++) {
+                if (bb->ops[j].src[1] == v || !lra_bc_emittable(f, &bb->ops[j])) continue;
+                if ((op_clobbers(f, &bb->ops[j]) & IR_R_DE)
+                    && !(op_clobbers_relaxed(f, &bb->ops[j]) & IR_R_DE))
+                    bb->ops[j].lra_stage_src1_bc = 1;
+            }
+            de_marks += nm;
+            /* --- COMMIT: place v in DE. */
+            f->vreg_to_phys[v] = IR_PR_DE;
+            f->vregs[v].flags |= IR_VREG_DE_PACK;
+            de_last = cand[i].fhi;
+            de_packed++;
+        }
+    }
     if (getenv("IR_ALLOC_PROBE"))
-        fprintf(stderr, "BC_PACK packed=%d of candidates=%d\n", packed, nc);
+        fprintf(stderr, "BC_PACK packed=%d of candidates=%d  DE_PACK placed=%d "
+                "(avail=%d dirty=%d bc_busy=%d clash=%d noop=%d marks=%d)\n",
+                packed, nc, de_packed, de_avail, de_rej_dirty, de_rej_bc_busy,
+                de_rej_clash, de_rej_noop, de_marks);
     free(cand); free(itloc); free(itlo); free(ithi); free(itbb); free(itdop);
 }
 

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -30,6 +30,8 @@
 
 /* -1 = sp mode (no IX/IY frame pointer); else the frame register is live. */
 extern int c_framepointer_is_ix;
+/* When set the platform reserves IY — no IY residency (LRA-IY, idx2/idx3). */
+extern int c_reserve_iy;
 
 /* Word DE-home tentative-pick undo: the picker evicts other PR_DE tenants to
    give the home exclusive DE, which is a net loss if the home's loop doesn't
@@ -1426,22 +1428,21 @@ static int lra_bc_emittable(const Func *f, const Op *o)
 }
 
 /* LRA Phase 2c: is IY available as a reduction-chain home in this function?
-   Needs a CPU with IY + `add iy,de` (excludes gbz80/808x), sp-mode (IY free;
-   -frameiy uses it as the frame ptr — widen to -frameix later), IY not already
-   claimed by idx2/idx3/exx, and not an interrupt/naked function. */
+   Needs a CPU with IY + `add iy,de` (excludes gbz80/808x), IY not reserved by
+   the platform (--reserve-regs-iy) nor claimed by idx2/idx3/exx, and not an
+   interrupt/naked function. IY is free in both sp-mode (-1) and fp-mode (1, IX
+   is the frame). */
 static int lra_iy_available(const Func *f)
 {
     if (f->is_interrupt || f->is_naked) return 0;
+    if (c_reserve_iy) return 0;                 /* IY reserved by the platform */
     /* CPU must have IY + `add iy,de` (excludes gbz80/8080/8085). z180/ez80/rabbit
        support the full-word add iy,rr (only the index-HALF ops trap on z180). */
     if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180
           || IS_EZ80() || IS_RABBIT())) return 0;
-    /* IY is free in sp-mode (-1) and -frameix (1, IX is the frame); NOT under
-       -frameiy (0, IY is the frame). The fp epilogue frame fix + IY-occupancy
-       arbitration (below) + the FULL-live-range IY-clean check (rejects an
-       accumulator live across an IY-clobbering call — the remat.c fp miscompile,
-       now fixed) make fp sound. */
-    if (c_framepointer_is_ix == 0) return 0;
+    /* fp soundness: the fp epilogue frame fix + IY-occupancy arbitration (below)
+       + the FULL-live-range IY-clean check (rejects an accumulator live across an
+       IY-clobbering call — the remat.c fp miscompile, now fixed). */
     return 1;   /* IY occupancy handled (with benefit arbitration) in the pass */
 }
 
@@ -1457,7 +1458,7 @@ static int lra_iy_chain_ok(const Func *f, int v)
     return 1;
 }
 
-/* LRA Phase 2c (IR_LRA-gated): home a DE-dirty straight-line reduction chain in
+/* LRA Phase 2c: home a DE-dirty straight-line reduction chain in
    IY. A chain is a run of width-2 ADDs c0=x+y, c1=c0+z, c2=c1+w… where each
    partial feeds the NEXT add as an operand and is otherwise dead (single use),
    all spilling in one loop-body BB. The addends' address computation owns HL+DE
@@ -1466,11 +1467,12 @@ static int lra_iy_chain_ok(const Func *f, int v)
    IY register: c0 inits it (`push hl; pop iy` via commit_hl_result), c1.. via
    `add iy,de` (Phase 2b emitter). Sets f->idx3_reg=IY so vreg_idx_home sees the
    members and the prologue saves IY (frame_has_saved_iy). Runs AFTER ir_bc_pack
-   (takes the SPILL losers) and before ir_stack_spill. Gated; byte-identical off. */
+   (takes the SPILL losers) and before ir_stack_spill. DEFAULT ON; IR_NO_LRA
+   opts out (--reserve-regs-iy also disables it via lra_iy_available). */
 static void ir_iy_reduction_pack(Func *f, const int *bb_in_loop,
                                  const int *use_count)
 {
-    if (!getenv("IR_LRA")) return;
+    if (getenv("IR_NO_LRA")) return;
     if (!lra_iy_available(f)) return;
 
     /* RAW use counts (the passed use_count is depth-weighted — no good for a
@@ -1828,7 +1830,7 @@ static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
         last_fhi = cand[i].fhi;
         packed++;
     }
-    /* ---- DE as a SECOND local home (IR_LRA) -------------------------------
+    /* ---- DE as a SECOND local home (experimental: IR_LRA_DEPACK) ----------
        For the itloc candidates BC couldn't take (BC held by a loop home →
        clash), try DE: place a candidate in DE when its span is DE-CLEAN under
        the RELAXED model (op_clobbers_relaxed — ADD/SUB/CMP stage src[1] into BC
@@ -1842,10 +1844,13 @@ static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
        loader structurally blocks — freeing DE needs BC-staging, but BC is
        exactly what's contended in the loops that would benefit, so placements
        come out empty. Kept as the mechanism + measurement; IY is the workaround
-       that actually pays (ir_iy_reduction_pack). See ADR 0003. */
+       that actually pays (ir_iy_reduction_pack). See ADR 0003. Stays behind an
+       explicit opt-in (IR_LRA_DEPACK), NOT the default-on IR_NO_LRA gate: the
+       BC-form emitter is incomplete, so a placement that DID fire would trip the
+       load_binop_operands fail-loud backstop. */
     int de_packed = 0, de_rej_dirty = 0, de_rej_clash = 0, de_avail = 0;
     int de_rej_bc_busy = 0, de_marks = 0, de_rej_noop = 0;
-    if (getenv("IR_LRA")) {
+    if (getenv("IR_LRA_DEPACK")) {
         int de_last = -1;
         for (int i = 0; i < nc; i++) {
             int v = cand[i].vreg;
@@ -2870,8 +2875,8 @@ void ir_alloc(Func *f)
            it only claims BC where no loop home owns it. */
         ir_bc_pack(f, first_use, last_use, bb_first_op, def_kind,
                    write_count, use_count);
-        /* LRA Phase 2c (IR_LRA): home a DE-dirty reduction chain in IY (add iy,de),
-           taking the spill losers BC couldn't. Byte-identical off. */
+        /* LRA Phase 2c (default on, IR_NO_LRA opts out): home a DE-dirty
+           reduction chain in IY (add iy,de), taking the spill losers BC couldn't. */
         ir_iy_reduction_pack(f, bb_in_loop, use_count);
         /* Stack-transient spill (default on, IR_NO_STACK_SPILL opts out): the register-pressure
            fallback below BC-pack — a single-def/single-use word transient with

--- a/src/80cc/ir_alloc.c
+++ b/src/80cc/ir_alloc.c
@@ -1828,20 +1828,21 @@ static void ir_bc_pack(Func *f, const int *first_use, const int *last_use,
         last_fhi = cand[i].fhi;
         packed++;
     }
-    /* ---- LRA Phase 4 step 2 (IR_LRA): DE as a SECOND local home -----------
+    /* ---- DE as a SECOND local home (IR_LRA) -------------------------------
        For the itloc candidates BC couldn't take (BC held by a loop home →
        clash), try DE: place a candidate in DE when its span is DE-CLEAN under
        the RELAXED model (op_clobbers_relaxed — ADD/SUB/CMP stage src[1] into BC
        not DE) AND DE is otherwise idle over the span (no PR_DE/E/D tenant). On
-       commit, MARK each relaxed op (`lra_stage_src1_bc`) so steps 3-4's loader +
+       commit, MARK each relaxed op (`lra_stage_src1_bc`) so the loader +
        `hl,bc` emitter route its src[1] through BC, keeping the DE resident live.
        Relaxing an op needs BC free across it (staging clobbers BC), so a span
        crossing a live BC tenant stays DE-dirty (rejected `bc_busy`).
 
-       NOTE: gated IR_LRA (byte-identical OFF). With IR_LRA on this is WIP until
-       step 4 lands — the marks are set but not yet honored by the emitter, so a
-       placed value is clobbered by its span's DE-staging (silent wrong value,
-       IR_LRA-only). Steps 3-4 complete the mechanism; step 5 validates on. */
+       DORMANT in practice: this is the "persistent DE second home" the operand
+       loader structurally blocks — freeing DE needs BC-staging, but BC is
+       exactly what's contended in the loops that would benefit, so placements
+       come out empty. Kept as the mechanism + measurement; IY is the workaround
+       that actually pays (ir_iy_reduction_pack). See ADR 0003. */
     int de_packed = 0, de_rej_dirty = 0, de_rej_clash = 0, de_avail = 0;
     int de_rej_bc_busy = 0, de_marks = 0, de_rej_noop = 0;
     if (getenv("IR_LRA")) {
@@ -1996,8 +1997,7 @@ static void ir_stack_spill(Func *f, const int *bb_first_op, const int *def_kind,
        load_to_* pop is checked before any cache hit (else a stale cache_hl/de
        skips the balancing pop → sp-1 write / stack leak; 8085's LD_IMM `ld de,K`
        fastpath via spill_de_unless_dead was the crash). EXCLUDED: ez80/kc160/
-       rabbit (cheap native sp-relative slots — parking doesn't pay). Wins
-       matrixbench: z80 sp -12.9%, 8080 -12.4%, gbz80 -9.5%, 8085 -8.5%. */
+       rabbit (cheap native sp-relative slots — parking doesn't pay). */
     if (!(c_cpu == CPU_Z80 || IS_Z80N() || c_cpu == CPU_Z180
           || IS_8080() || IS_8085() || IS_GBZ80())) return;
 

--- a/src/80cc/ir_build.c
+++ b/src/80cc/ir_build.c
@@ -3705,7 +3705,8 @@ static int build_expr_hinted(Builder *b, Node *n, int hint)
            and uses an overlapping-`ldir` fill for larger ones. Any const
            count (1..65536, ldir's BC limit) inlines; non-const falls
            through to the library memset (redirected below). */
-        if (strcmp(n->sym->name, "__builtin_memset") == 0
+        if (!c_disable_builtins
+            && strcmp(n->sym->name, "__builtin_memset") == 0
             && n_args == 3) {
             Node *cnt = array_get_byindex(n->args, 2);
             if (cnt && cnt->ast_type == AST_LITERAL
@@ -3728,7 +3729,8 @@ static int build_expr_hinted(Builder *b, Node *n, int hint)
            tiny counts unroll, larger ones use `ldir`, any const count
            (1..65536) inlines; non-const falls back to the library
            memcpy. memcpy returns dst (the dst vreg still holds it). */
-        if (strcmp(n->sym->name, "__builtin_memcpy") == 0
+        if (!c_disable_builtins
+            && strcmp(n->sym->name, "__builtin_memcpy") == 0
             && n_args == 3) {
             Node *cnt = array_get_byindex(n->args, 2);
             if (cnt && cnt->ast_type == AST_LITERAL
@@ -3749,7 +3751,8 @@ static int build_expr_hinted(Builder *b, Node *n, int hint)
         /* Inline __builtin_strcpy (always — variable length, no const
            needed): IR_STRCPY (dst, src), lowered to a NUL-terminated
            copy loop. strcpy returns dst. */
-        if (strcmp(n->sym->name, "__builtin_strcpy") == 0
+        if (!c_disable_builtins
+            && strcmp(n->sym->name, "__builtin_strcpy") == 0
             && n_args == 2 && ir_inline_block_ops_ok()) {
             int dst_v = build_expr(b, array_get_byindex(n->args, 0));
             if (dst_v < 0) return -1;
@@ -3765,7 +3768,8 @@ static int build_expr_hinted(Builder *b, Node *n, int hint)
            string, src[1] = char vreg (or -1 + imm for a literal char),
            lowered to a scan loop leaving the match pointer / NULL in the
            result vreg. */
-        if (strcmp(n->sym->name, "__builtin_strchr") == 0
+        if (!c_disable_builtins
+            && strcmp(n->sym->name, "__builtin_strchr") == 0
             && n_args == 2 && ir_inline_block_ops_ok()) {
             Node *c_node = array_get_byindex(n->args, 1);
             int str_v = build_expr(b, array_get_byindex(n->args, 0));

--- a/src/80cc/ir_compiler_glue.c
+++ b/src/80cc/ir_compiler_glue.c
@@ -54,16 +54,18 @@ const SYMBOL *ir_namespace_bank_fn(const char *ns_name)
 }
 
 /* Spare index register for a loop-invariant resident — the one opposite the
-   frame pointer. c_framepointer_is_ix: 1=IX frame→spare IY, 0=IY frame→spare
-   IX, -1=sp-mode→IX (both free, pick IX). 808x/gbz80 have no index regs →
-   gate on CPU. */
+   frame pointer. c_framepointer_is_ix: 1=IX frame→spare IY, -1=sp-mode→IX (both
+   free, pick IX). 808x/gbz80 have no index regs → gate on CPU. A platform can
+   remove the spare from play: --reserve-regs-iy (the fp-mode spare) or, in
+   sp-mode, --reserve-regs-ix. */
 int ir_idx2_reg(void)
 {
     if (!c_idx2_invariant) return IR_PR_NONE;
     if (getenv("IR_NO_IDX2")) return IR_PR_NONE;
     if (IS_808x() || IS_GBZ80()) return IR_PR_NONE;
-    if (c_framepointer_is_ix == 1) return IR_PR_IY;   /* frame IX → spare IY */
-    return IR_PR_IX;                                  /* frame IY, or sp-mode → IX */
+    if (c_framepointer_is_ix == 1)                    /* frame IX → spare IY */
+        return c_reserve_iy ? IR_PR_NONE : IR_PR_IY;
+    return c_reserve_ix ? IR_PR_NONE : IR_PR_IX;      /* sp-mode → IX */
 }
 
 /* Second index-register home = IY, available ONLY in true sp-mode (no frame
@@ -77,6 +79,7 @@ int ir_idx3_reg(void)
 {
     if (!c_idx3_residency) return IR_PR_NONE;
     if (getenv("IR_NO_IDX3")) return IR_PR_NONE;
+    if (c_reserve_iy) return IR_PR_NONE;               /* IY reserved by platform */
     if (ir_idx2_reg() != IR_PR_IX) return IR_PR_NONE;  /* need IX as idx2 */
     if (c_framepointer_is_ix != -1) return IR_PR_NONE; /* IY is the frame */
     if (!(c_cpu == CPU_Z80 || IS_Z80N())) return IR_PR_NONE;

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -1346,9 +1346,13 @@ static int lower_ret(FILE *out, Func *f, const Op *op)
     if (fp_active(f) && !L.cur_frameless) {
         /* FP teardown: IX holds the saved-IX address (frame_top). `ld sp,ix`
            drops the locals, then `pop ix` restores caller's IX. Both preserve
-           DEHL (and HL alone), so int-return and long-return converge here. */
+           DEHL (and HL alone), so int-return and long-return converge here.
+           idx3/IY-home in fp mode: the prologue pushed ix THEN iy, so after
+           `ld sp,ix` (ix == &saved_iy) the saved IY is on top — pop it BEFORE
+           the frame ptr, or `pop ix` would read the IY slot. */
         const char *fr = frame_reg();
         emit(out, "ld\tsp,%s", fr);
+        if (frame_has_saved_iy(f)) emit(out, "pop\tiy");
         emit(out, "pop\t%s", fr);
     } else if (!L.cur_frameless && f->frame_size > 0) {
         if (use_add_sp(f, f->frame_size, is_acc ? 0 : 2)) {
@@ -1383,15 +1387,16 @@ static int lower_ret(FILE *out, Func *f, const Op *op)
     if (!fp_active(f) && frame_has_saved_fp(f)) {
         /* Acc-tier function under -frameix: body addressed sp-relative, but
            entry pushed IX (gen_push_frame). The locals (if any) were dropped
-           above, so sp now points at the saved IX — restore the caller's
-           frame pointer so `ret` reads the return address. Touches only
-           IX/SP, leaving the return value in HL/DEHL/FA intact. */
+           above, so sp now points at the saved regs — pop the saved IY first
+           (pushed last, on top) then restore the caller's IX (frame ptr) so
+           `ret` reads the return address. Touches only IX/IY/SP, leaving the
+           return value in HL/DEHL/FA intact. (fp_active handled IY in its own
+           teardown above; this branch is the !fp_active acc-tier case only.) */
+        if (frame_has_saved_iy(f)) emit(out, "pop\tiy");
         emit(out, "pop\t%s", frame_reg());
-    }
-    if (frame_has_saved_iy(f)) {
-        /* Restore caller's IY (idx3). The locals were dropped above, so sp now
-           points at the saved IY; pop it before the return address is read.
-           Touches only IY/SP — the return value in HL/DEHL is preserved. */
+    } else if (!fp_active(f) && frame_has_saved_iy(f)) {
+        /* Pure sp-mode idx3 (no saved IX): sp now points at the saved IY; pop it
+           before the return address is read. Touches only IY/SP. */
         emit(out, "pop\tiy");
     }
     if (f->is_interrupt) {

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -269,18 +269,31 @@ static int wide_acc_result_dead_in_acc(const Func *f, int v);
 /* IR_SPILL_STATS (Phase-0 measurement): -1 = not yet probed, else 0/1. */
 static int spill_stats_on = -1;
 
+/* IR_VERIFY (LRA Phase-0): per-op capture of emitted instruction text so the
+   op_clobbers model can be cross-checked against what the emitter actually
+   writes. Inert (no codegen change); only active under IR_VERIFY. */
+static int  verify_on = -1;
+static char verify_buf[8192];
+static int  verify_len;
+
 static void vemit(FILE *out, const char *fmt, va_list ap)
 {
     if (spill_stats_on < 0) spill_stats_on = getenv("IR_SPILL_STATS") ? 1 : 0;
-    if (spill_stats_on) {
-        /* Count a slot-traffic proxy from the fully-expanded instruction text.
-           Buffer here only when stats are on; the emitted bytes are unchanged. */
+    if (verify_on < 0)      verify_on      = getenv("IR_VERIFY") ? 1 : 0;
+    if (spill_stats_on || verify_on) {
+        /* Fully-expanded instruction text. Buffer only when a probe is on; the
+           emitted bytes are unchanged. */
         char buf[256];
         va_list ap2; va_copy(ap2, ap);
         vsnprintf(buf, sizeof buf, fmt, ap2);
         va_end(ap2);
-        if (strstr(buf, "(ix") || strstr(buf, "(iy")) L.spill_ix++;
-        if (strstr(buf, "add\thl,sp")) L.spill_sp++;
+        if (spill_stats_on) {
+            if (strstr(buf, "(ix") || strstr(buf, "(iy")) L.spill_ix++;
+            if (strstr(buf, "add\thl,sp")) L.spill_sp++;
+        }
+        if (verify_on && verify_len + (int)strlen(buf) + 2 < (int)sizeof verify_buf)
+            verify_len += snprintf(verify_buf + verify_len,
+                                   sizeof verify_buf - verify_len, "%s\n", buf);
     }
     fputc('\t', out);
     vfprintf(out, fmt, ap);
@@ -830,6 +843,405 @@ static void store_byte_adv(FILE *out, const char *reg, int last)
 #include "ir_lower_ops.inc.c"
 #include "ir_lower_call.inc.c"
 #include "ir_lower_cmp.inc.c"
+
+/* ===== LRA Phase 0: op_clobbers model + IR_VERIFY cross-check =============
+   Read-only classification of which physical value-registers an op's lowering
+   writes, plus a verifier that parses the emitted asm and asserts the actual
+   writes are a subset of the model. Inert (IR_VERIFY only); the substrate the
+   live-range allocator's soundness rests on (a value in register r survives an
+   op iff r is NOT in op_clobbers(op)). */
+
+/* A register-name token (as emitted, lowercase) → value-register mask. */
+static RegMask lra_reg_of(const char *t)
+{
+    if (!t[0]) return 0;
+    if (t[0] == '(') return IR_R_MEM;                 /* (hl) (de) (nn) (ix+d) */
+    if (!strcmp(t,"a"))  return IR_R_A;
+    if (!strcmp(t,"f")||!strcmp(t,"af")) return IR_R_F | (t[1]=='f'?IR_R_A:0);
+    if (!strcmp(t,"h")||!strcmp(t,"l")||!strcmp(t,"hl")) return IR_R_HL;
+    if (!strcmp(t,"d")||!strcmp(t,"e")||!strcmp(t,"de")) return IR_R_DE;
+    if (!strcmp(t,"b")||!strcmp(t,"c")||!strcmp(t,"bc")) return IR_R_BC;
+    if (!strncmp(t,"ix",2)) return IR_R_IX;           /* ix ixl ixh */
+    if (!strncmp(t,"iy",2)) return IR_R_IY;
+    if (!strcmp(t,"sp")) return IR_R_SP;
+    return 0;                                         /* immediate / label / cc */
+}
+
+/* One emitted instruction line → the value-registers it WRITES. Sets *unknown
+   if the mnemonic isn't modelled (so the verifier can report it rather than
+   silently trust). */
+static RegMask lra_line_writes(const char *line, int *unknown)
+{
+    char m[16] = {0}, o0[64] = {0}, o1[64] = {0};
+    const char *p = line;
+    int i = 0;
+    while (*p && *p != ' ' && *p != '\t' && i < 15) m[i++] = *p++;
+    while (*p == ' ' || *p == '\t') p++;
+    /* operands: split on first comma */
+    const char *comma = strchr(p, ',');
+    if (comma) {
+        int n = (int)(comma - p); if (n > 63) n = 63;
+        memcpy(o0, p, (size_t)n);
+        const char *q = comma + 1; while (*q == ' ') q++;
+        i = 0; while (*q && *q!='\n' && *q!=';' && i < 63) o1[i++] = *q++;
+    } else {
+        i = 0; while (*p && *p!='\n' && *p!=';' && i < 63) o0[i++] = *p++;
+    }
+    RegMask w = 0;
+    /* gbz80 auto-step pointer forms: ld a,(hl+) / ld (hl-),a step HL */
+    if (strstr(line,"hl+")||strstr(line,"hl-")) w |= IR_R_HL;
+    if (strstr(line,"de+")||strstr(line,"de-")) w |= IR_R_DE;
+
+    if (!strcmp(m,"ld"))                                 w |= lra_reg_of(o0);
+    else if (!strcmp(m,"add")||!strcmp(m,"adc")||!strcmp(m,"sbc"))
+                                                         w |= lra_reg_of(o0)|IR_R_F;
+    else if (!strcmp(m,"sub")||!strcmp(m,"and")||!strcmp(m,"or")||!strcmp(m,"xor"))
+                                                         w |= IR_R_A|IR_R_F;
+    else if (!strcmp(m,"cp"))                            w |= IR_R_F;
+    else if (!strcmp(m,"inc")||!strcmp(m,"dec"))         w |= lra_reg_of(o0)|IR_R_F;
+    else if (!strcmp(m,"sla")||!strcmp(m,"sra")||!strcmp(m,"srl")||!strcmp(m,"rl")
+          || !strcmp(m,"rr")||!strcmp(m,"rlc")||!strcmp(m,"rrc")||!strcmp(m,"swap"))
+                                                         w |= lra_reg_of(o0)|IR_R_F;
+    else if (!strcmp(m,"rlca")||!strcmp(m,"rrca")||!strcmp(m,"rla")||!strcmp(m,"rra"))
+                                                         w |= IR_R_A|IR_R_F;
+    else if (!strcmp(m,"neg")||!strcmp(m,"cpl"))         w |= IR_R_A|IR_R_F;
+    else if (!strcmp(m,"bit")||!strcmp(m,"set")||!strcmp(m,"res")) w |= (m[0]=='b'?IR_R_F:lra_reg_of(o1));
+    else if (!strcmp(m,"ex"))                            w |= lra_reg_of(o0)|lra_reg_of(o1);
+    else if (!strcmp(m,"exx"))                           w |= IR_R_HL|IR_R_DE|IR_R_BC;
+    else if (!strcmp(m,"push"))                          w |= IR_R_SP|IR_R_MEM;
+    else if (!strcmp(m,"pop"))                           w |= lra_reg_of(o0)|IR_R_SP;
+    else if (!strcmp(m,"call")||!strcmp(m,"rst")) {
+        /* The shift helpers (l_asr/l_lsr/l_lsl + _u / _dehl) are BC-clean by
+           contract (see gen_shr) — don't attribute BC to them, else a 16-bit
+           shift would spuriously look like it clobbers a BC resident. */
+        int bc_clean = (strstr(o0,"l_asr")||strstr(o0,"l_lsr")||strstr(o0,"l_lsl"));
+        w |= IR_R_A|IR_R_HL|IR_R_DE|IR_R_F|IR_R_MEM | (bc_clean ? 0 : IR_R_BC);
+    }
+    else if (!strcmp(m,"djnz"))                          w |= IR_R_BC|IR_R_F;
+    else if (!strcmp(m,"mlt"))                           w |= lra_reg_of(o0);              /* z180 */
+    else if (!strcmp(m,"mul")||!strcmp(m,"muls"))        w |= lra_reg_of(o0)|IR_R_F;        /* z80n/kc160 */
+    else if (!strcmp(m,"div")||!strcmp(m,"divu")||!strcmp(m,"divs"))
+                                                         w |= lra_reg_of(o0)|IR_R_A|IR_R_F; /* kc160 */
+    else if (!strcmp(m,"ldi")||!strcmp(m,"ldd")||!strcmp(m,"ldir")||!strcmp(m,"lddr"))
+                                                         w |= IR_R_HL|IR_R_DE|IR_R_BC|IR_R_MEM|IR_R_F;
+    else if (!strcmp(m,"scf")||!strcmp(m,"ccf"))         w |= IR_R_F;
+    else if (!strcmp(m,"ret")||!strcmp(m,"jp")||!strcmp(m,"jr")||!strcmp(m,"nop")
+          || !strcmp(m,"di")||!strcmp(m,"ei")||!strcmp(m,"halt")||!strcmp(m,"reti")
+          || !strcmp(m,"retn")) { /* control/none */ }
+    else if (m[0])                                       *unknown = 1;
+    return w;
+}
+
+/* A vreg's physical register as a mask (its result-home). Byte halves map to
+   their pair; SPILL/none → 0 (the value's home is memory, written via HL/MEM). */
+RegMask phys_regmask(const Func *f, int v)
+{
+    if (v < 0 || !f->vreg_to_phys) return 0;
+    switch (f->vreg_to_phys[v]) {
+    case IR_PR_A:                 return IR_R_A;
+    case IR_PR_HL:                return IR_R_HL;
+    case IR_PR_DE: case IR_PR_E: case IR_PR_D: return IR_R_DE;
+    case IR_PR_BC: case IR_PR_C: case IR_PR_B: return IR_R_BC;
+    case IR_PR_DEHL:              return IR_R_HL|IR_R_DE;
+    case IR_PR_IX: case IR_PR_IXL: case IR_PR_IXH: return IR_R_IX;
+    case IR_PR_IY: case IR_PR_IYL: case IR_PR_IYH: return IR_R_IY;
+    default:                      return 0;
+    }
+}
+
+/* Helper clobber table (PRESERVE_REGS Track B). Names here are the `l_` runtime
+   helpers AUDITED (grep of libsrc/l + libsrc/math asm) to use neither IX/IY nor
+   the alt/shadow bank (exx) — so a value homed in IX/IY/BC'/DE'/HL' survives the
+   call. CONSERVATIVE by construction: an unknown or unaudited helper is NOT
+   listed and falls through to IR_R_ALL, so a mis-omission costs residency, never
+   correctness. A mis-INCLUSION would be a silent miscompile, so only add a name
+   after confirming its asm (all CPU variants) is index+alt clean. Long/i64/float/
+   far/fnptr helpers (l_long_*, l_i64_*, l_f*, lp_*, l_setix/iy, l_jpix/iy) DO use
+   the index regs and must never be listed. */
+static int helper_preserves_index_alt(const char *name)
+{
+    static const char *const clean[] = {
+        /* multiplies (16x16, narrowing 16x16->32) */
+        "l_mult", "l_mult_u", "l_mulu_32_16x16",
+        /* divides / modulo (16-bit) */
+        "l_div", "l_div_u",
+        /* shifts (BC-clean-by-contract shift family; asr verified, lsr/lsl same) */
+        "l_asr", "l_lsr", "l_lsl",
+        /* unary */
+        "l_neg", "l_abs",
+    };
+    for (size_t i = 0; i < sizeof clean / sizeof clean[0]; i++)
+        if (!strcmp(name, clean[i])) return 1;
+    return 0;
+}
+
+/* The model: registers op's lowering may clobber (value regs only; SP/MEM are
+   stack/memory bookkeeping, checked separately). First cut — refined against
+   the IR_VERIFY log. Under-approx is caught by the verifier; over-approx is
+   sound but costs residency. */
+RegMask op_clobbers(const Func *f, const Op *op)
+{
+    int dw = (op->dst >= 0 && op->dst < f->n_vregs) ? f->vregs[op->dst].width : 0;
+    /* Width of the WIDEST operand, not just the dst: a 32-bit compare/store has
+       a width-2 (bool) dst but width-4 operands, and its lowering uses the DEHL
+       helpers + BC (and cleans a pushed long via `pop bc`). */
+    int ow = dw;
+    for (int s = 0; s < 2; s++)
+        if (op->src[s] >= 0 && op->src[s] < f->n_vregs
+            && f->vregs[op->src[s]].width > ow) ow = f->vregs[op->src[s]].width;
+    RegMask wide = (ow >= 4) ? (IR_R_HL|IR_R_DE|IR_R_BC) : 0;   /* DEHL/i64 helpers use BC */
+    RegMask dst  = phys_regmask(f, op->dst);                    /* result home */
+    /* An operand's register can itself be written: an aliased two-address ALU
+       (dst=src0) and — crucially — a `*p++` deref that steps its pointer
+       operand (`inc bc` when p is BC-homed). Folding operand homes in keeps the
+       model precise there without blanket-pessimising BC on plain loads. */
+    RegMask ops = phys_regmask(f, op->src[0]) | phys_regmask(f, op->src[1])
+                | (op->mem.kind == IR_MEM_VREG ? phys_regmask(f, op->mem.base) : 0);
+    switch (op->kind) {
+    case IR_NOP: case IR_BR: case IR_PHI:
+        return 0;
+    case IR_HCALL:
+        /* Helper clobber table (PRESERVE_REGS Track B): the audited integer
+           word/byte arithmetic helpers touch neither the index registers nor
+           the alt bank (verified against libsrc/l asm), so they PRESERVE IX/IY/
+           BC'/DE'/HL' — only the main bank + flags + memory are clobbered. That
+           lets an IX/IY/alt-bank home survive the call. Unknown/long/float/i64/
+           far helpers stay conservative (IR_R_ALL). */
+        if (op->hcall && op->hcall->name && helper_preserves_index_alt(op->hcall->name))
+            return IR_R_HL | IR_R_DE | IR_R_BC | IR_R_A | IR_R_F | IR_R_MEM;
+        return IR_R_ALL;
+    case IR_CALL: case IR_ASM: case IR_PUSH_ARG:
+    case IR_PUSH_STRUCT: case IR_SWITCH: case IR_RET: case IR_MEMSET:
+    case IR_MEMCPY: case IR_ACC_UNOP: case IR_ACC_BINOP: case IR_ACC_CMP:
+        return IR_R_ALL;               /* opaque: helper call / whole-reg-set */
+    case IR_MUL:
+        return IR_R_HL|IR_R_DE|IR_R_BC|IR_R_A|IR_R_F;
+    case IR_SHL: case IR_SHR:
+        /* z80n stages the shift count into B for `bsrl/bsra de,b`. */
+        return IR_R_HL|IR_R_DE|IR_R_A|IR_R_F|wide|dst|ops
+             | (IS_Z80N() ? IR_R_BC : 0);
+    case IR_CMP_EQ: case IR_CMP_NE:
+    case IR_CMP_LT: case IR_CMP_LE: case IR_CMP_GT: case IR_CMP_GE:
+    case IR_CMP_ULT: case IR_CMP_ULE: case IR_CMP_UGT: case IR_CMP_UGE:
+        /* 8085 word compares stage an operand into BC (`ld c,e; ld b,d`). */
+        return IR_R_HL|IR_R_DE|IR_R_A|IR_R_F|wide|dst|ops
+             | (IS_8085() ? IR_R_BC : 0);
+    default:
+        /* Everything else — loads/materialise/MOV/ALU/compare/conv/shift/store:
+           HL workhorse + A scratch + DE (operand staging / `ex de,hl` word
+           commit) + flags + result home + operand homes; wide (DEHL) uses BC. */
+        return IR_R_HL|IR_R_DE|IR_R_A|IR_R_F|wide|dst|ops;
+    }
+}
+
+/* The relaxed model (LRA Phase-4 step 1). ADD/SUB and the word compares stage
+   src[1] into DE today purely so a `add hl,de`/`sbc hl,de` can fire; the same
+   op has a `add hl,bc`/`sbc hl,bc` form that stages into BC instead, leaving DE
+   untouched. Model that alternate: drop the staging-DE bit and add BC. DE is
+   kept if the op still needs it as its result home or an operand home (a value
+   already resident in DE), and the whole relaxation is skipped for wide
+   (width>=4) ops, whose DEHL/i64 helpers have no BC-only form. */
+RegMask op_clobbers_relaxed(const Func *f, const Op *op)
+{
+    RegMask m = op_clobbers(f, op);
+    int has_bc_form = (op->kind == IR_ADD || op->kind == IR_SUB
+        || (op->kind >= IR_CMP_EQ && op->kind <= IR_CMP_UGE));
+    if (!has_bc_form) return m;
+    /* Widest operand/dst width — the DEHL helpers (>=4) genuinely need DE. */
+    int ow = (op->dst >= 0 && op->dst < f->n_vregs) ? f->vregs[op->dst].width : 0;
+    for (int s = 0; s < 2; s++)
+        if (op->src[s] >= 0 && op->src[s] < f->n_vregs
+            && f->vregs[op->src[s]].width > ow) ow = f->vregs[op->src[s]].width;
+    if (ow >= 4) return m;
+    /* DE required independently of staging: result home or an operand home. */
+    RegMask need_de = (phys_regmask(f, op->dst)
+        | phys_regmask(f, op->src[0]) | phys_regmask(f, op->src[1])
+        | (op->mem.kind == IR_MEM_VREG ? phys_regmask(f, op->mem.base) : 0))
+        & IR_R_DE;
+    if (!need_de) m &= ~IR_R_DE;   /* staging routed off DE */
+    m |= IR_R_BC;                  /* ...and into BC (the `hl,bc` form) */
+    return m;
+}
+
+/* Cross-check the just-lowered op's emitted instructions against op_clobbers.
+   Logs (does not abort) so a full corpus run reveals every model gap. */
+static void ir_verify_op(const Func *f, const Op *op, const char *buf)
+{
+    RegMask actual = 0, pushed = 0; int unknown = 0;
+    char line[256]; const char *p = buf;
+    while (*p) {
+        int i = 0; while (*p && *p != '\n' && i < 255) line[i++] = *p++;
+        line[i] = 0; if (*p == '\n') p++;
+        if (!line[0]) continue;
+        /* A push R / pop R pair PRESERVES R (net not clobbered), even if R is
+           used as scratch in between: record what's saved, and on a matching
+           pop clear that reg from the accumulated writes. */
+        if (!strncmp(line, "push", 4)) {
+            RegMask r = lra_reg_of(line + 5);
+            pushed |= r;
+        } else if (!strncmp(line, "pop", 3)) {
+            RegMask r = lra_reg_of(line + 4);
+            if (pushed & r) { actual &= ~r; pushed &= ~r; continue; }  /* restore */
+        }
+        actual |= lra_line_writes(line, &unknown);
+    }
+    RegMask model = op_clobbers(f, op);
+    /* SP (stack-spill push/pop, ret) and MEM are stack/memory bookkeeping, not
+       value-register residency — not part of the clobber soundness check. */
+    RegMask leak = actual & ~model & ~IR_R_MEM & ~IR_R_SP;
+    if (leak) {
+        fprintf(stderr, "IR_VERIFY: %s writes %#x not in clobbers %#x | asm:",
+                ir_op_name(op->kind), (unsigned)leak, (unsigned)model);
+        const char *q = buf; char ln[256];
+        while (*q) { int k=0; while (*q && *q!='\n' && k<255) ln[k++]=*q++; ln[k]=0; if(*q=='\n')q++;
+            int u2=0; if (ln[0] && (lra_line_writes(ln,&u2) & leak)) fprintf(stderr, " [%s]", ln); }
+        fprintf(stderr, "\n");
+    }
+    if (unknown)
+        fprintf(stderr, "IR_VERIFY: %s emitted an unmodelled mnemonic\n",
+                ir_op_name(op->kind));
+}
+
+/* LRA Phase-1 opportunity probe (IR_LRA_PROBE): for each single-BB, call-free,
+   slot-resident word temp, does BC / DE stay op_clobbers-CLEAN across its span?
+   That is exactly "could a local allocator keep it in that register." Measures
+   the Phase-1 prize with the verified clobber model before building the pass. */
+static void lra_phase1_probe(const Func *f)
+{
+    if (!getenv("IR_LRA_PROBE")) return;
+    int elig = 0, bc_clean = 0, de_clean = 0, either = 0;
+    for (int v = 0; v < f->n_vregs; v++) {
+        if (f->vregs[v].width != 2) continue;
+        if (f->vreg_to_phys && f->vreg_to_phys[v] != IR_PR_SPILL) continue;
+        if (f->vregs[v].flags & (IR_VREG_PARAM|IR_VREG_ADDR_TAKEN|IR_VREG_VOLATILE))
+            continue;
+        int bb = -1, lo = 1<<30, hi = -1, multi = 0, firstdef = 0;
+        for (int i = 0; i < f->n_bbs && !multi; i++) {
+            const BB *b = &f->bbs[i];
+            for (int j = 0; j < b->n_ops; j++) {
+                const Op *o = &b->ops[j];
+                int isdef = (o->dst == v), isuse = 0, u[16];
+                int nu = ir_op_uses(o, u, 16);
+                for (int k = 0; k < nu; k++) if (u[k] == v) { isuse = 1; break; }
+                if (!isdef && !isuse) continue;
+                if (bb < 0) { bb = i; firstdef = isdef; }
+                else if (bb != i) { multi = 1; break; }
+                if (j < lo) lo = j;
+                if (j > hi) hi = j;
+            }
+        }
+        if (multi || bb < 0 || hi < 0 || !firstdef) continue;
+        const BB *b = &f->bbs[bb];
+        int callfree = 1;
+        for (int j = lo; j <= hi; j++) {
+            OpKind k = b->ops[j].kind;
+            if (k == IR_CALL || k == IR_HCALL || k == IR_ASM) { callfree = 0; break; }
+        }
+        if (!callfree) continue;
+        elig++;
+        int bcc = 1, dec = 1;
+        for (int j = lo + 1; j <= hi; j++) {
+            RegMask c = op_clobbers(f, &b->ops[j]);
+            if (c & IR_R_BC) bcc = 0;
+            if (c & IR_R_DE) dec = 0;
+        }
+        bc_clean += bcc; de_clean += dec; either += (bcc || dec);
+    }
+    if (elig)
+        fprintf(stderr, "LRA_P1: eligible=%d bc_clean=%d de_clean=%d either=%d\n",
+                elig, bc_clean, de_clean, either);
+}
+
+/* Phase-2a prize probe (IR_SPLIT_PROBE, inert). Runs AFTER ir_alloc (phys known)
+   and ir_compute_live_ranges (liveness known). Per function, over innermost loop
+   bodies, reports: max simultaneous live width-2 vregs (register PRESSURE), the
+   count of SPILLED width-2 vregs live in a loop, and how many of those an IY home
+   would CAPTURE (range op_clobbers-IY-clean — no CALL/HCALL/ASM = IR_R_ALL — and
+   IY otherwise free). Quantifies the splitting-allocator + IY prize before the
+   emitter/allocator get built. Read-only; no codegen change (byte-identical). */
+static void lra_split_probe(const Func *f)
+{
+    static int fidx = 0;
+    int myidx = fidx++;
+    if (!getenv("IR_SPLIT_PROBE")) return;
+    if (f->n_bbs <= 0 || f->n_vregs <= 0) return;
+
+    int total = 0;
+    for (int b = 0; b < f->n_bbs; b++) total += f->bbs[b].n_ops;
+    if (total <= 0) return;
+
+    /* Loop membership (id-range back-edge approximation — f->bbs[].loop_depth is
+       never populated; exact natural-loop nesting is overkill for a probe): for
+       each back-edge p->h (successor h with id <= p), mark [h..p] as in-loop. */
+    int *bb_loop = calloc((size_t)f->n_bbs, sizeof *bb_loop);
+    if (!bb_loop) return;
+    for (int p = 0; p < f->n_bbs; p++) {
+        int ns = ir_bb_n_succ(&f->bbs[p]);
+        for (int s = 0; s < ns; s++) {
+            int h = ir_bb_succ_at(&f->bbs[p], s);
+            if (h < 0 || h > p) continue;                 /* not a back-edge */
+            for (int b = h; b <= p; b++) bb_loop[b] = 1;
+        }
+    }
+
+    const Op **flat = calloc((size_t)total, sizeof *flat);
+    int *in_loop = calloc((size_t)total, sizeof *in_loop);
+    if (!flat || !in_loop) { free(flat); free(in_loop); free(bb_loop); return; }
+    int gi = 0, any_loop = 0;
+    for (int b = 0; b < f->n_bbs; b++) {
+        any_loop |= bb_loop[b];
+        for (int j = 0; j < f->bbs[b].n_ops; j++, gi++) {
+            flat[gi] = &f->bbs[b].ops[j];
+            in_loop[gi] = bb_loop[b];
+        }
+    }
+    if (!any_loop) { free(flat); free(in_loop); free(bb_loop); return; }
+
+    /* Register pressure: max over loop-body ops of |live width-2 vregs|. */
+    int pressure = 0;
+    for (int b = 0; b < f->n_bbs; b++) {
+        BB *bb = &f->bbs[b];
+        if (!bb_loop[b] || !bb->live_in_per_op) continue;
+        for (int k = 0; k < bb->n_ops; k++) {
+            const BitSet *ls = (const BitSet *)bb->live_in_per_op[k];
+            if (!ls) continue;
+            int cnt = 0;
+            for (int v = 0; v < f->n_vregs; v++)
+                if (f->vregs[v].width == 2 && ir_bitset_get(ls, v)) cnt++;
+            if (cnt > pressure) pressure = cnt;
+        }
+    }
+
+    int spilled = 0, iy_cap = 0;
+    for (int v = 0; v < f->n_vregs; v++) {
+        if (f->vregs[v].width != 2) continue;
+        if (f->vreg_to_phys && f->vreg_to_phys[v] != IR_PR_SPILL) continue;
+        const LiveRange *lr = ir_live_range(f, v);
+        if (!lr || lr->start < 0) continue;
+        int loopy = 0;
+        for (int k = lr->start; k <= lr->end && k < total; k++)
+            if (in_loop[k]) { loopy = 1; break; }
+        if (!loopy) continue;
+        spilled++;
+        int iy_clean = 1;
+        for (int k = lr->start; k <= lr->end && k < total; k++)
+            if (op_clobbers(f, flat[k]) & IR_R_IY) { iy_clean = 0; break; }
+        int iy_free = 1;
+        for (int u = 0; u < f->n_vregs && iy_free; u++) {
+            PhysReg pu = f->vreg_to_phys ? f->vreg_to_phys[u] : IR_PR_NONE;
+            if (pu != IR_PR_IY && pu != IR_PR_IYL && pu != IR_PR_IYH) continue;
+            if (ir_live_ranges_overlap(f, v, u)) iy_free = 0;
+        }
+        if (iy_clean && iy_free) iy_cap++;
+    }
+
+    if (spilled || pressure)
+        fprintf(stderr, "SPLIT_PROBE fn#%d: loop_word_pressure=%d "
+                "spilled_loop_words=%d iy_capturable=%d\n",
+                myidx, pressure, spilled, iy_cap);
+    free(flat); free(in_loop); free(bb_loop);
+}
+
 static int lower_op(FILE *out, Func *f, const Op *op)
 {
     /* Track the op's source location (independent of C_LINE emit mode) so
@@ -1947,6 +2359,7 @@ int ir_lower_func(FILE *out, Func *f)
     ir_compute_op_liveness(f);
     ir_compute_live_ranges(f);
     ir_alloc(f);
+    lra_split_probe(f);          /* Phase-2a prize probe (IR_SPLIT_PROBE, inert) */
     assign_idxhalf_homes(f);
     compute_no_slot_bytes(f);
     ir_assign_slots(f);
@@ -2322,6 +2735,7 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
     /* Per-pass state reset (everything that was at function entry except
        func_emit_idx, which the caller bumps once for both passes). */
     L.cmp_label_counter = 0;
+    if (!lazy) lra_phase1_probe(f);   /* once per function (non-lazy pass) */
     L.lazy_spill_on = lazy;
     L.pending_spill_v = -1;
     cur_lazy_out = out;
@@ -3191,11 +3605,13 @@ static int lower_func_render(FILE *out, Func *f, int lazy,
                global index so pass 1 records against it and pass 2's
                verdict (ss_store_dead) is read for it. */
             L.ss_cur_g = L.ss_op_base ? L.ss_op_base[bb->id] + j : -1;
+            if (verify_on > 0) verify_len = 0;   /* capture this op's emitted asm */
             if (op->kind == IR_RET) {
                 rc = lower_ret(out, f, op);
             } else {
                 rc = lower_op(out, f, op);
             }
+            if (verify_on > 0) { verify_buf[verify_len] = 0; ir_verify_op(f, op, verify_buf); }
             L.ss_cur_g = -1;
             if (rc != 0) goto cleanup_err;
             if (L.la.cur_skip_next_op) {

--- a/src/80cc/ir_lower.c
+++ b/src/80cc/ir_lower.c
@@ -29,6 +29,8 @@
    compiler (data.c) but consulted directly here so the lowerer stays
    decoupled from ccdefs.h. */
 extern int c_framepointer_is_ix;
+extern int c_reserve_iy;   /* platform reserves IY — no IY residency */
+extern int c_reserve_ix;   /* platform reserves IX (sp-mode) — no IX residency */
 
 /* Per-TU string-literal queue label number. String literal addresses
    emit as `ld hl,i_<litlab>+<offset>` (IR_LD_STR). */
@@ -2111,19 +2113,19 @@ static void assign_idxhalf_homes(Func *f)
             if (k == IR_CALL || k == IR_HCALL || k == IR_ASM) return;
         }
     /* Candidate halves — never offer halves of the FRAME register (it's used as
-       a pair by every (ix+d)/(iy+d) access, and the frame isn't a vreg so the
-       interval check can't see it). The frame reg is fixed globally by the
-       -frameix/-frameiy option: c_framepointer_is_ix == 1 → IX is the frame,
-       == 0 → IY is the frame, == -1 → sp-mode, neither. (fp_active is per-
-       function but unreliable here — frame_size isn't set until ir_assign_slots
-       runs after this pass; the global choice is the safe, stable gate.) A
-       non-frame index reg's own tenant (an idx2 counter/param) IS a vreg, so its
-       half availability is decided per byte by live-interval overlap below. */
+       a pair by every (ix+d) access, and the frame isn't a vreg so the interval
+       check can't see it), nor of a platform-reserved index register
+       (--reserve-regs-ix/-iy). c_framepointer_is_ix == 1 → IX is the frame,
+       == -1 → sp-mode (no frame). (fp_active is per-function but unreliable here
+       — frame_size isn't set until ir_assign_slots runs after this pass; the
+       global choice is the safe, stable gate.) A non-frame index reg's own
+       tenant (an idx2 counter/param) IS a vreg, so its half availability is
+       decided per byte by live-interval overlap below. */
     PhysReg halves[4]; int nhalves = 0;
-    if (c_framepointer_is_ix != 0) {   /* IY is not the frame */
+    if (!c_reserve_iy) {               /* IY never the frame; offer unless reserved */
         halves[nhalves++] = IR_PR_IYL; halves[nhalves++] = IR_PR_IYH;
     }
-    if (c_framepointer_is_ix != 1) {   /* IX is not the frame */
+    if (c_framepointer_is_ix != 1 && !c_reserve_ix) {   /* IX not the frame nor reserved */
         halves[nhalves++] = IR_PR_IXL; halves[nhalves++] = IR_PR_IXH;
     }
     if (nhalves == 0) { return; }

--- a/src/80cc/ir_lower_analysis.inc.c
+++ b/src/80cc/ir_lower_analysis.inc.c
@@ -183,7 +183,8 @@ static void load_binop_operands(FILE *out, const Func *f, const Op *op)
        gen_add/gen_sub, which emit the `add hl,bc` / `sbc hl,bc` form. If a marked
        op reaches the generic DE-staging loader instead, that path would clobber
        the DE resident (silent wrong value), so fail LOUD rather than fall through.
-       Only reachable under IR_LRA (marks are set only there); byte-identical off. */
+       Only reachable under IR_LRA_DEPACK (marks are set only there); the
+       default-on LRA (IY reduction) never sets them. */
     if (op->lra_stage_src1_bc) {
         ir_lower_loc();
         fprintf(stderr, "ir_lower: BC-staged op reached the DE-staging loader "

--- a/src/80cc/ir_lower_analysis.inc.c
+++ b/src/80cc/ir_lower_analysis.inc.c
@@ -178,17 +178,17 @@ static void compute_home_region(const Func *f, int home,
 */
 static void load_binop_operands(FILE *out, const Func *f, const Op *op)
 {
-    /* LRA Phase 4: this op was marked (ir_bc_pack) to stage src[1] into BC so a
-       DE-packed value in its span survives. The BC-form staging + `hl,bc`
-       emitter are Phase-4 steps 3-4 — not yet implemented. Fail LOUD rather than
-       fall through to the DE-staging path (which would clobber the DE resident →
-       silent wrong value). Only reachable under IR_LRA (marks are set only
-       there); byte-identical off. Step 3 replaces this with the BC-stage load. */
+    /* BACKSTOP: an op marked to stage src[1] into BC (so a DE resident in its
+       span survives — see ir_bc_pack / ADR 0003) is meant to be intercepted by
+       gen_add/gen_sub, which emit the `add hl,bc` / `sbc hl,bc` form. If a marked
+       op reaches the generic DE-staging loader instead, that path would clobber
+       the DE resident (silent wrong value), so fail LOUD rather than fall through.
+       Only reachable under IR_LRA (marks are set only there); byte-identical off. */
     if (op->lra_stage_src1_bc) {
         ir_lower_loc();
-        fprintf(stderr, "ir_lower: LRA Phase-4 BC-staging not yet implemented "
-                "(op marked lra_stage_src1_bc; steps 3-4 pending). Aborting "
-                "rather than emit a DE-clobbering staging load.\n");
+        fprintf(stderr, "ir_lower: BC-staged op reached the DE-staging loader "
+                "(unhandled lra_stage_src1_bc — gen_add/gen_sub should intercept). "
+                "Aborting rather than emit a DE-clobbering staging load.\n");
         exit(1);
     }
     if (op->src[1] < 0) {

--- a/src/80cc/ir_lower_analysis.inc.c
+++ b/src/80cc/ir_lower_analysis.inc.c
@@ -178,6 +178,19 @@ static void compute_home_region(const Func *f, int home,
 */
 static void load_binop_operands(FILE *out, const Func *f, const Op *op)
 {
+    /* LRA Phase 4: this op was marked (ir_bc_pack) to stage src[1] into BC so a
+       DE-packed value in its span survives. The BC-form staging + `hl,bc`
+       emitter are Phase-4 steps 3-4 — not yet implemented. Fail LOUD rather than
+       fall through to the DE-staging path (which would clobber the DE resident →
+       silent wrong value). Only reachable under IR_LRA (marks are set only
+       there); byte-identical off. Step 3 replaces this with the BC-stage load. */
+    if (op->lra_stage_src1_bc) {
+        ir_lower_loc();
+        fprintf(stderr, "ir_lower: LRA Phase-4 BC-staging not yet implemented "
+                "(op marked lra_stage_src1_bc; steps 3-4 pending). Aborting "
+                "rather than emit a DE-clobbering staging load.\n");
+        exit(1);
+    }
     if (op->src[1] < 0) {
         /* Literal RHS — doesn't touch HL. */
         load_to_hl(out, f, op->src[0]);  /* no-op on HL hit; records cacheread */
@@ -245,6 +258,56 @@ static void load_binop_operands(FILE *out, const Func *f, const Op *op)
 static void cache_hl(int vreg)
 {
     hl_about_to_change(vreg);
+}
+
+static int  bc_has(int v);
+static void cache_bc(int v);
+static void invalidate_bc_cache(void);
+
+/* LRA Phase 4 (steps 3-4): load operands for a MARKED binop —
+   src[0]→HL, src[1]→BC (NOT DE), leaving DE untouched so a DE-packed resident
+   in this op's span survives. The consumer then emits the `hl,bc` form
+   (`add hl,bc` / `or a; sbc hl,bc`). Sound because ir_bc_pack marks the op only
+   when BC is free across it (no live BC tenant) and src[1] is not the resident.
+   src[0] MAY be the resident (in DE): copy DE→HL (never `ex de,hl`, which would
+   evict it). src[1] is staged via HL as scratch, then src[0] (re)loaded into HL
+   — both DE-clean, and src[0]'s load leaves BC intact. */
+static void load_binop_operands_bc(FILE *out, const Func *f, const Op *op)
+{
+    int s0 = op->src[0], s1 = op->src[1];
+    /* 1. src[0] → HL. If it is the DE resident, copy DE→HL (never `ex de,hl`,
+       which would evict it); otherwise load_to_hl (DE-clean for width-2). */
+    if (s0 >= 0 && de_has(s0)) {
+        cache_hl(s0);                  /* resolve any pending HL spill first */
+        emit(out, "ld\tl,e");
+        emit(out, "ld\th,d");
+    } else {
+        load_to_hl(out, f, s0);
+    }
+    /* 2. src[1] → BC without disturbing HL(src0) or DE(resident). Cheap hits
+       first; else stage via HL under a push/pop so src[0] survives even when it
+       is an unhomed HL-only transient. */
+    if (s1 < 0) {
+        emit(out, "ld\tbc,%lld", (long long)op->imm);
+        invalidate_bc_cache();
+        return;
+    }
+    if (bc_has(s1)) return;
+    if (de_has(s1)) {                  /* not the resident (marking excludes it) */
+        emit(out, "ld\tc,e");
+        emit(out, "ld\tb,d");
+        cache_bc(s1);
+        return;
+    }
+    emit(out, "push\thl");             /* save src[0] */
+    L.cur_sp_adjust += 2;
+    load_to_hl(out, f, s1);            /* HL = src1 (DE-clean; sp-adj tracked) */
+    emit(out, "ld\tc,l");
+    emit(out, "ld\tb,h");
+    cache_bc(s1);
+    emit(out, "pop\thl");              /* HL = src[0] restored */
+    L.cur_sp_adjust -= 2;
+    cache_hl(s0);
 }
 
 /* Sole choke point for an HL clobber/load. When a width-2 spill is pending

--- a/src/80cc/ir_lower_ops.inc.c
+++ b/src/80cc/ir_lower_ops.inc.c
@@ -2909,6 +2909,35 @@ static int gen_add(FILE *out, Func *f, const Op *op)
         commit_hl_result(out, f, op->dst);
         return 0;
     }
+    /* LRA Phase 2b: accumulate directly in an index home. When dst is IX/IY-homed
+       (idx2/idx3) and one src shares that exact home — the running chain value is
+       already resident in the index reg — load the OTHER operand into DE and
+       `add <idx>,de` (or `add <idx>,<idx>` for x+x), keeping the result in the
+       index reg. Avoids the push/pop round-trip (load acc, add hl,de, store acc)
+       the generic path would emit. The FIRST add of a chain (no src in the home
+       yet) falls through and commit_hl_result inits the reg via `push hl;pop iy`.
+       Byte-identical by default (no index homes unless --idx3 / idx2). */
+    if (op->dst >= 0 && op->dst < f->n_vregs && f->vregs[op->dst].width == 2
+        && vreg_idx_home(f, op->dst) != IR_PR_NONE) {
+        PhysReg home = f->vreg_to_phys[op->dst];
+        const char *ir = idx_pr_name(home);
+        int acc = -1, other = -1;
+        if (op->src[0] >= 0 && f->vreg_to_phys[op->src[0]] == home)
+            { acc = op->src[0]; other = op->src[1]; }
+        else if (op->src[1] >= 0 && f->vreg_to_phys[op->src[1]] == home)
+            { acc = op->src[1]; other = op->src[0]; }
+        if (acc >= 0 && ir) {
+            if (other >= 0 && f->vreg_to_phys[other] == home) {
+                emit(out, "add\t%s,%s", ir, ir);      /* x + x (both in reg) */
+            } else {
+                if (other < 0) emit(out, "ld\tde,%lld", (long long)op->imm);
+                else           load_to_de(out, f, other);  /* HL scratch; reg preserved */
+                emit(out, "add\t%s,de", ir);
+                invalidate_de_cache();
+            }
+            return 0;                                  /* result stays in the index reg */
+        }
+    }
     if (try_word_accumulate(out, f, op))
         return 0;
     if (try_de_home_def(out, f, op))

--- a/src/80cc/ir_lower_ops.inc.c
+++ b/src/80cc/ir_lower_ops.inc.c
@@ -2900,6 +2900,15 @@ static int try_index_half_word_add(FILE *out, Func *f, const Op *op)
 
 static int gen_add(FILE *out, Func *f, const Op *op)
 {
+    /* LRA Phase 4: marked (ir_bc_pack) to stage src[1] into BC so a DE-packed
+       resident in this op's span survives — `add hl,bc`. Pre-empts every
+       DE-using path below. */
+    if (op->lra_stage_src1_bc) {
+        load_binop_operands_bc(out, f, op);
+        emit(out, "add\thl,bc");
+        commit_hl_result(out, f, op->dst);
+        return 0;
+    }
     if (try_word_accumulate(out, f, op))
         return 0;
     if (try_de_home_def(out, f, op))
@@ -3204,6 +3213,16 @@ static int gen_add(FILE *out, Func *f, const Op *op)
 
 static int gen_sub(FILE *out, Func *f, const Op *op)
 {
+    /* LRA Phase 4: marked to stage src[1] into BC — `or a; sbc hl,bc` — so a
+       DE-packed resident in this op's span survives. Word only (marking
+       restricts to width-2 ADD/SUB); pre-empts the DE-using paths below. */
+    if (op->lra_stage_src1_bc) {
+        load_binop_operands_bc(out, f, op);
+        emit(out, "or\ta");
+        emit(out, "sbc\thl,bc");
+        commit_hl_result(out, f, op->dst);
+        return 0;
+    }
     if (try_de_home_def(out, f, op))
         return 0;
     if (op->dst >= 0 && f->vregs[op->dst].width == 1) {

--- a/src/80cc/long_ir.c
+++ b/src/80cc/long_ir.c
@@ -1,10 +1,9 @@
 /* IR long-arithmetic isolation test.
  *
- * Each `long_*_*` function does ONE long op and returns the result.
- * `main` collects them and asserts every result. Compiled with
- * -Cc--use-ir so each `long_*_*` function exercises the IR's long
- * lowering. main is on legacy (variadic printf, l_longjmp from
- * Assert all bail) but reads the IR-produced longs via cross-call.
+ * Each `long_*_*` function does ONE long op and returns the result,
+ * exercising the IR's long lowering. `main` collects them and asserts
+ * every result; it uses variadic printf + l_longjmp (from Assert) and
+ * reads the IR-produced longs via cross-call.
  *
  * The _Float16 / double tests (test_float16 / test_double) need the
  * float libraries linked — run this suite with `--math32 --math16`

--- a/src/80cc/main.c
+++ b/src/80cc/main.c
@@ -49,7 +49,6 @@ int c_old_diagnostic_fmt = 0;
    the legacy emit-while-parsing path and the AST walker are both gone. */
 int c_ast_print = 0;         /* 1 = print the AST per function and skip codegen */
 int c_ast_print_types = 0;   /* 1 = decorate print_ast output with type info */
-int c_use_ir = 0;            /* 1 = route function codegen through ir_build → ir_lower */
 char *c_zcc_opt = "zcc_opt.def";
 
 /* Settings for genmath + math48 */
@@ -60,7 +59,6 @@ int c_fp_size = 6;
 
 enum maths_mode c_maths_mode = MATHS_Z80;
 
-uint32_t c_speed_optimisation = OPT_RSHIFT32|OPT_LSHIFT32;
 uint32_t c_opt_disable = 0;
 
 char *c_rodata_section = "rodata_compiler";
@@ -90,8 +88,8 @@ static void SetDefine(option *arg, char *val);
 static void SetUndefine(option *arg, char *val);
 static void SetIncludePath(option *arg, char *val);
 static void DispInfo(option *arg, char *val);
-static void opt_code_speed(option *arg, char* val);
 static void opt_disable(option *arg, char *val);
+static void opt_code_speed_inert(option *arg, char *val);
 static void atexit_deallocate(void);
 
 
@@ -130,7 +128,6 @@ static option  sccz80_opts[] = {
     { 0, "fp-mode=z88", OPT_ASSIGN|OPT_INT, "Use 40 bit z88 doubles", &c_maths_mode, NULL, MATHS_Z88 },
     { 0, "fp-mode=am9511", OPT_ASSIGN|OPT_INT, "Use 32 bit AM9511 doubles", &c_maths_mode, NULL, MATHS_AM9511 },
     
-    { 0, "noaltreg", OPT_BOOL, "Try not to use the alternative register set", &c_notaltreg, NULL, 0 },
     { 0, "standard-escape-chars", OPT_BOOL, "Use standard mappings for \\r and \\n (inert — escapes are always standard)", &c_standard_escapecodes, NULL, 0},
     { 0, "set-r2l-by-default", OPT_BOOL, "Use r->l calling convention by default", &c_use_r2l_calling_convention, NULL, 0 },
     { 0, "constseg", OPT_STRING|OPT_DOUBLE_DASH, "=<name> Set the const section name", &c_rodata_section, NULL, 0 },
@@ -139,19 +136,20 @@ static option  sccz80_opts[] = {
     { 0, "dataseg", OPT_STRING|OPT_DOUBLE_DASH, "=<name> Set the data section name", &c_data_section, NULL, 0 },
     { 0, "initseg", OPT_STRING|OPT_DOUBLE_DASH, "=<name> Set the initialisation section name", &c_init_section, NULL, 0 },
     { 0, "gcline", OPT_BOOL, "Generate C_LINE directives", &c_cline_directive, NULL, 0 },
-    { 0, "opt-code-speed", OPT_FUNCTION|OPT_STRING|OPT_DOUBLE_DASH, "Optimise for speed not size", NULL, opt_code_speed, 0},
     { 0, "opt-disable", OPT_FUNCTION|OPT_STRING|OPT_DOUBLE_DASH, "=<list> Disable named AST optimiser passes (comma-separated). Names: all, fold, prop, simplify, typecheck, compoundify, strength-reduce, cse, cse-synth, licm, dse, dead-code, thread-jumps, demote-poststep, loop-reverse; pattern:<name> disables one IR pattern-matcher entry. Useful for bisecting miscompiles.", NULL, opt_disable, 0 },
+    { 0, "opt-code-speed", OPT_FUNCTION|OPT_STRING|OPT_DOUBLE_DASH, "(inert) Accepted for --math16 alias / sccz80-family CLI compatibility; no effect in the IR back end", NULL, opt_code_speed_inert, 0 },
     { 0, "ast-print", OPT_BOOL|OPT_DOUBLE_DASH, "(experimental) Build the AST per function, print it to stderr, and skip code generation", &c_ast_print, NULL, 0 },
     { 0, "ast-print-types", OPT_BOOL|OPT_DOUBLE_DASH, "(experimental) Decorate the AST print with type/qualifier/attribute info; implies --ast-print", &c_ast_print_types, NULL, 0 },
-    { 0, "use-ir", OPT_BOOL|OPT_DOUBLE_DASH, "(experimental) Route function codegen through the new IR pipeline (ir_build → ir_lower). Phase 1 — most C constructs unsupported", &c_use_ir, NULL, 0 },
-    { 0, "", OPT_HEADER, "Framepointer configuration (for debugging):", NULL, NULL, 0 },
-    { 0, "frameix", OPT_ASSIGN|OPT_INT, "Use ix as the frame pointer", &c_framepointer_is_ix, NULL, 1},
-    { 0, "frameiy", OPT_ASSIGN|OPT_INT, "Use iy as the frame pointer", &c_framepointer_is_ix, NULL, 0},
-    { 0, "idx2-invariant", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Hold a loop-invariant in the spare index register (opposite the frame pointer)", &c_idx2_invariant, NULL, 1},
-    { 0, "no-idx2-invariant", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Disable the spare-index-register loop-invariant resident", &c_idx2_invariant, NULL, 0},
-    { 0, "idx3", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Hold a second loop-carried word in IY (sp-mode, z80/z80n only)", &c_idx3_residency, NULL, 1},
-    { 0, "no-idx3", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Disable the second index-register (IY) residency", &c_idx3_residency, NULL, 0},
-    { 0, "exx", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Hold a loop-invariant in the exx/alt register set (sp-mode, z80/z80n)", &c_exx_residency, NULL, 1},
+    { 0, "", OPT_HEADER, "Frame pointer / index-register reservation:", NULL, NULL, 0 },
+    { 0, "fframe-pointer", OPT_ASSIGN|OPT_INT, "Use IX as a frame pointer (address locals via ix+d)", &c_framepointer_is_ix, NULL, 1},
+    { 0, "fomit-frame-pointer", OPT_ASSIGN|OPT_INT, "Omit the frame pointer; address locals via sp (default)", &c_framepointer_is_ix, NULL, -1},
+    { 0, "reserve-regs-iy", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Reserve IY: never use it for residency (leaves at most one index register)", &c_reserve_iy, NULL, 1},
+    { 0, "reserve-regs-ix", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Reserve IX (sp-mode): do not use it as the spare index register", &c_reserve_ix, NULL, 1},
+    { 0, "reg-index-invariant", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Hold a loop-invariant in the spare index register (IX in sp-mode, IY in fp-mode)", &c_idx2_invariant, NULL, 1},
+    { 0, "no-reg-index-invariant", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Disable the spare-index-register loop-invariant resident", &c_idx2_invariant, NULL, 0},
+    { 0, "reg-iy-half", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "(experimental) Hold a second loop-carried word in IY via index-half ops (ld iyl,c / sub iyl); sp-mode, z80/z80n only — undocumented opcodes, IY is callee-saved", &c_idx3_residency, NULL, 1},
+    { 0, "no-reg-iy-half", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Disable the index-half IY residency", &c_idx3_residency, NULL, 0},
+    { 0, "exx", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "(experimental) Hold a loop-invariant in the exx/alt register set (sp-mode, z80/z80n)", &c_exx_residency, NULL, 1},
     { 0, "no-exx", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Disable exx/alt register-set residency", &c_exx_residency, NULL, 0},
     { 0, "byte-resident", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Keep a hot loop-carried char accumulator in a byte register", &c_byte_resident, NULL, 1},
     { 0, "no-byte-resident", OPT_ASSIGN|OPT_INT|OPT_DOUBLE_DASH, "Disable byte-register residency for char accumulators", &c_byte_resident, NULL, 0},
@@ -267,10 +265,6 @@ int main(int argc, char** argv)
         info();
         exit(1);
     }
-
-    /* The IR is the only codegen path — the AST walker has been removed.
-       An IR translation failure is fatal (no fallback); see declparse. */
-    c_use_ir = 1;
 
     if ( c_maths_mode == MATHS_IEEE ) {
         c_fp_size = 4;
@@ -902,44 +896,6 @@ void closeout(void)
 
 
 
-
-static void opt_code_speed(option *arg, char* val)
-{
-    char   *ptr = val - 1;
-
-    c_speed_optimisation = 0;
-
-    do {
-        ptr++;
-        if ( strncmp(ptr,"all",3) == 0 ) {
-            c_speed_optimisation = ~0;
-            break;
-        } else if ( strncmp(ptr, "lshift32", 8) == 0 ) {
-            c_speed_optimisation |= OPT_LSHIFT32;
-        } else if ( strncmp(ptr, "rshift32", 8) == 0 ) {
-            c_speed_optimisation |= OPT_RSHIFT32;
-        } else if ( strncmp(ptr, "add32", 5) == 0 ) {
-            c_speed_optimisation |= OPT_ADD32;
-        } else if ( strncmp(ptr, "sub32", 5) == 0 ) {
-            c_speed_optimisation |= OPT_SUB32;
-        } else if ( strncmp(ptr, "sub16", 5) == 0 ) {
-            c_speed_optimisation |= OPT_SUB16;
-        } else if ( strncmp(ptr, "intcompare", 10) == 0 ) {
-            c_speed_optimisation |= OPT_INT_COMPARE;
-        } else if ( strncmp(ptr, "charcompare", 10) == 0 ) {
-            c_speed_optimisation |= OPT_CHAR_COMPARE;
-        } else if ( strncmp(ptr, "longcompare", 11) == 0 ) {
-            c_speed_optimisation |= OPT_LONG_COMPARE;
-        } else if ( strncmp(ptr, "ucharmult", 9) == 0 ) {
-            c_speed_optimisation |= OPT_UCHAR_MULT;
-        } else if ( strncmp(ptr, "floatconst", 10) == 0 ) {
-            c_speed_optimisation |= OPT_DOUBLE_CONST;
-        }
-    } while ( (ptr = strchr(ptr, ',')) != NULL );
-}
-
-
-
 /* Parse --opt-disable=<csv> into the c_opt_disable bitmask. Each name
    in the list flips one bit; the special name "all" sets all bits.
    Unknown names are silently ignored — preserves forward compatibility
@@ -963,6 +919,17 @@ static const struct { const char *name; uint32_t bit; } opt_disable_names[] = {
     { "demote-poststep", OPT_DISABLE_DEMOTE_POSTSTEP },
     { "loop-reverse",    OPT_DISABLE_LOOP_REVERSE },
 };
+
+/* --opt-code-speed is an sccz80/sdcc speed-optimisation knob. zcc forwards it to
+   the shared sccz80-family arg channel (e.g. --math16 expands to
+   --opt-code-speed=inlineints), so 80cc must ACCEPT it — but the IR back end does
+   not act on it (only the retired AST codegen consulted c_speed_optimisation).
+   Parse and ignore. */
+static void opt_code_speed_inert(option *arg, char *val)
+{
+    (void)arg;
+    (void)val;
+}
 
 static void opt_disable(option *arg, char *val)
 {

--- a/src/80cc/regression/arith.sh
+++ b/src/80cc/regression/arith.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # 80cc regression: long mul/div/mod, int mod, OP_LNEG on long, and
-# local array initializer lists. All compiled with --use-ir, linked
+# local array initializer lists. All compiled through the IR pipeline, linked
 # with z80_clib + math libs, run under z88dk-ticks, and checked
 # against expected HL at the harness exit point.
 
@@ -23,8 +23,8 @@ run_test() {
     local bin="$WORK/$name.bin"
     local trace="$WORK/$name.trace"
     printf '%s\n' "$src" > "$cfile"
-    if ! ( cd "$WORK" && "$COMPILER" --use-ir "$name.c" 2>/dev/null ); then
-        fail=$((fail+1)); failures+=("$name: 80cc --use-ir failed"); return
+    if ! ( cd "$WORK" && "$COMPILER" "$name.c" 2>/dev/null ); then
+        fail=$((fail+1)); failures+=("$name: 80cc failed"); return
     fi
     if ! ( cd "$WORK" && reg_z80asm "$bin" "$HARNESS" "$asm" 2>/dev/null ); then
         fail=$((fail+1)); failures+=("$name: z80asm failed"); return

--- a/src/80cc/regression/fix16.sh
+++ b/src/80cc/regression/fix16.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 80cc regression: _Accum (fix-point) end-to-end.
 #
-# Each test compiles a short C program with --use-ir, links with the
+# Each test compiles a short C program, links with the
 # fix16 library, and runs under z88dk-ticks. main returns the test's
 # expected outcome via HL — checked at the harness's exit point. The
 # IR pipeline handles float literal → _Accum scaling (×256), routes
@@ -40,8 +40,8 @@ run_test() {
     local trace="$WORK/$name.trace"
 
     printf '%s\n' "$src" > "$cfile"
-    if ! ( cd "$WORK" && "$COMPILER" --use-ir "$name.c" 2>/dev/null ); then
-        fail=$((fail+1)); failures+=("$name: 80cc --use-ir failed"); return
+    if ! ( cd "$WORK" && "$COMPILER" "$name.c" 2>/dev/null ); then
+        fail=$((fail+1)); failures+=("$name: 80cc failed"); return
     fi
     if ! ( cd "$WORK" && reg_z80asm "$bin" "$HARNESS" "$asm" 2>/dev/null ); then
         fail=$((fail+1)); failures+=("$name: z80asm failed"); return

--- a/src/80cc/regression/ir_coverage.sh
+++ b/src/80cc/regression/ir_coverage.sh
@@ -18,7 +18,7 @@ ok=0
 fail=0
 failures=()
 
-# Compile $2 with --use-ir and assert no ir_build deferral fires
+# Compile $2 and assert no ir_build deferral fires
 # AND (optionally) that the asm contains a marker pattern $3.
 # $1 is the test name; $4 is the C source.
 run_cover() {
@@ -29,7 +29,7 @@ run_cover() {
     local asm="$WORK/$name.asm"
     local log="$WORK/$name.log"
     printf '%s\n' "$src" > "$cfile"
-    if ! ( cd "$WORK" && "$COMPILER" --use-ir "$name.c" 2>"$log" ); then
+    if ! ( cd "$WORK" && "$COMPILER" "$name.c" 2>"$log" ); then
         fail=$((fail+1))
         failures+=("$name: compile failed")
         return

--- a/src/80cc/regression/variadic.sh
+++ b/src/80cc/regression/variadic.sh
@@ -7,8 +7,7 @@
 # loadargc() convention. Also locks in the LIBRARY-symbol
 # no-underscore call form.
 #
-# All tests pass `--use-ir`. Without it the IR pipeline isn't
-# engaged and the test is irrelevant.
+# The IR pipeline is the sole codegen path, so every test exercises it.
 
 set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
@@ -40,8 +39,8 @@ run_ir_test() {
     local asm="$WORK/$name.asm"
 
     printf '%s\n' "$src" > "$cfile"
-    if ! ( cd "$WORK" && "$COMPILER" --use-ir "$name.c" 2>/dev/null ); then
-        fail=$((fail+1)); failures+=("$name: 80cc --use-ir failed"); return
+    if ! ( cd "$WORK" && "$COMPILER" "$name.c" 2>/dev/null ); then
+        fail=$((fail+1)); failures+=("$name: 80cc failed"); return
     fi
     local slurped
     slurped=$(asm_slurp "$asm")

--- a/test/suites/bench.sh
+++ b/test/suites/bench.sh
@@ -42,7 +42,7 @@ BUILDS=(
   "sdcc default|zcc +test -compiler=sdcc -vn"
   "ez80clang default|zcc +test -compiler=ez80clang -vn"
   "80cc default|zcc +test -compiler=80cc -vn"
-  "80cc -frameiy|zcc +test -compiler=80cc -Cc-frameiy -vn"
+  "80cc -fframe-pointer|zcc +test -compiler=80cc -Cc-fframe-pointer -vn"
   "80cc --opt-disable=cse-synth|zcc +test -compiler=80cc -Cc--opt-disable=cse-synth -vn"
   "80cc --opt-disable=all|zcc +test -compiler=80cc -Cc--opt-disable=all -vn"
 )

--- a/test/suites/benchcmp.sh
+++ b/test/suites/benchcmp.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # benchcmp.sh — cross-compiler benchmark comparison for the z88dk bench suites.
 #
-# Compiles each benchmark with sccz80, sdcc, 80cc (fp = -frameix) and 80cc (sp)
+# Compiles each benchmark with sccz80, sdcc, 80cc (fp = -fframe-pointer) and 80cc (sp)
 # via the +test framework, runs it under z88dk-ticks, and prints a table of
 # ticks / binary size / pass-fail. Each bench is built and run from its OWN
 # directory so file-reading tests (md5 reads md5test.bin) find their inputs.
@@ -48,7 +48,7 @@ fi
 
 # config label : extra zcc flags
 configs="sccz80:-compiler=sccz80 sdcc:-compiler=sdcc \
-80cc-fp:-compiler=80cc_-Cc-frameix 80cc-sp:-compiler=80cc"
+80cc-fp:-compiler=80cc_-Cc-fframe-pointer 80cc-sp:-compiler=80cc"
 
 CFLAGS="-I../../framework -DNO_LOG_RUNNING -DNO_LOG_PASSED"
 tmp=$(mktemp -d)

--- a/test/suites/charbench/Makefile
+++ b/test/suites/charbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all:	test.bin 
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/crcbench/Makefile
+++ b/test/suites/crcbench/Makefile
@@ -9,7 +9,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all:	test.bin 
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -17,6 +17,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/fixedbench/Makefile
+++ b/test/suites/fixedbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/hashbench/Makefile
+++ b/test/suites/hashbench/Makefile
@@ -6,13 +6,17 @@ SOURCES += $(wildcard *.c)
 OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/histbench/Makefile
+++ b/test/suites/histbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/intbench/Makefile
+++ b/test/suites/intbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all:	test.bin 
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/interpbench/Makefile
+++ b/test/suites/interpbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/lexbench/Makefile
+++ b/test/suites/lexbench/Makefile
@@ -6,13 +6,17 @@ SOURCES += $(wildcard *.c)
 OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/listbench/Makefile
+++ b/test/suites/listbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/long_ir/Makefile
+++ b/test/suites/long_ir/Makefile
@@ -92,7 +92,7 @@ ternwiden.bin: $(SOURCES) ternwiden.c
 	$(runtest)
 
 ternwiden_fp.bin: $(SOURCES) ternwiden.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 fp_to_int.bin: $(SOURCES) fp_to_int.c
@@ -126,7 +126,7 @@ narrowmul.bin: $(SOURCES) narrowmul.c
 	$(runtest)
 
 narrowmul_fp.bin: $(SOURCES) narrowmul.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 narrowmul_8080.bin: $(SOURCES) narrowmul.c
@@ -142,7 +142,7 @@ derefcmp.bin: $(SOURCES) derefcmp.c
 	$(runtest)
 
 derefcmp_fp.bin: $(SOURCES) derefcmp.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 bytecmp.bin: $(SOURCES) bytecmp.c
@@ -150,7 +150,7 @@ bytecmp.bin: $(SOURCES) bytecmp.c
 	$(runtest)
 
 bytecmp_fp.bin: $(SOURCES) bytecmp.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 bytecmp_8080.bin: $(SOURCES) bytecmp.c
@@ -189,11 +189,11 @@ ixdcmp.bin: $(SOURCES) ixdcmp.c
 
 # fp-mode: params are (ix+d) slots, so every relation folds byte-wise in place.
 ixdcmp_fp.bin: $(SOURCES) ixdcmp.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 # General DE-home co-design. sp build: feature inert (fp-only) → validates the
-# ordinary path. fp build (-Cc-frameix): the inlined binary searches home lo/hi
+# ordinary path. fp build (-Cc-fframe-pointer): the inlined binary searches home lo/hi
 # in DE across the loop — exercises the compare fold, add hl,de, indexed deref,
 # and ex-de-hl home-def.
 dehome.bin: $(SOURCES) dehome.c
@@ -201,7 +201,7 @@ dehome.bin: $(SOURCES) dehome.c
 	$(runtest)
 
 dehome_fp.bin: $(SOURCES) dehome.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 # Loop register allocator Phase A: two walking pointers homed BC+DE across a
@@ -212,7 +212,7 @@ looppr.bin: $(SOURCES) looppr.c
 	$(runtest)
 
 looppr_fp.bin: $(SOURCES) looppr.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 # Reduction write-back DE-home (in-place `a[i]=f(sum)`; fp-only feature,
@@ -224,7 +224,7 @@ redwb.bin: $(SOURCES) redwb.c
 	$(runtest)
 
 redwb_fp.bin: $(SOURCES) redwb.c
-	$(call compile,-Cc-frameix -DREDWB_CHK=34070u)
+	$(call compile,-Cc-fframe-pointer -DREDWB_CHK=34070u)
 	$(runtest)
 
 redwb_8080.bin: $(SOURCES) redwb.c
@@ -236,7 +236,7 @@ addrcse.bin: $(SOURCES) addrcse.c
 	$(runtest)
 
 addrcse_fp.bin: $(SOURCES) addrcse.c
-	$(call compile,-Cc-frameix -DADDRCSE_CHK=32076u)
+	$(call compile,-Cc-fframe-pointer -DADDRCSE_CHK=32076u)
 	$(runtest)
 
 # Index-half BYTE HOME (second byte home in IYL/IXL). sp-mode (the default
@@ -250,14 +250,14 @@ idxhome.bin: $(SOURCES) idxhome.c
 # only at entry (end = data+len), then `b` reuses IYL for the loop. The sp build
 # above has IY free outright; this one proves the live-interval overlap path.
 idxhome_fp.bin: $(SOURCES) idxhome.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 # Same test in FRAME-POINTER mode: the index-half signed compare
 # (ld a,iyl; sub (ix+d); ...) is fp-only + index-half-CPU-only, so the sp build
 # above exercises only the push iy;pop hl fallback. This binary hits the fp path.
 idxcmp_fp.bin: $(SOURCES) idxcmp.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 longlong.bin: $(SOURCES) longlong.c
@@ -284,7 +284,7 @@ wr.bin: $(SOURCES) word_resident.c
 # region-exit-flush hoist (the sum stored once at the loop exit, not per iter) —
 # is fp-only, so the sp-built wr.bin above never exercises it. This binary does.
 wr_fp.bin: $(SOURCES) word_resident.c
-	$(call compile,-Cc-frameix)
+	$(call compile,-Cc-fframe-pointer)
 	$(runtest)
 
 fp_promote.bin: $(SOURCES) fp_promote.c

--- a/test/suites/make.config
+++ b/test/suites/make.config
@@ -25,12 +25,12 @@ COMPILER ?= sccz80
 # Rules for building suites
 FRAMEWORK_DIR ?= ../../framework
 SOURCES = $(wildcard $(FRAMEWORK_DIR)/*.c)
-# FP=1 builds every suite with the 80cc IX-frame-pointer mode (-Cc-frameix),
-# so the fp residency paths get the same behavioural coverage as sp. Empty
-# (the default) leaves codegen unchanged.
+# FP=1 builds every suite with the 80cc IX-frame-pointer mode
+# (-Cc-fframe-pointer), so the fp residency paths get the same behavioural
+# coverage as sp. Empty (the default) leaves codegen unchanged.
 FPFLAG =
 ifdef FP
-FPFLAG = -Cc-frameix
+FPFLAG = -Cc-fframe-pointer
 endif
 CFLAGS = -I$(FRAMEWORK_DIR)  -compiler=$(COMPILER) $(FPFLAG)
 

--- a/test/suites/maskbench/Makefile
+++ b/test/suites/maskbench/Makefile
@@ -9,7 +9,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -17,6 +17,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/matrixbench/Makefile
+++ b/test/suites/matrixbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/md5/Makefile
+++ b/test/suites/md5/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all:	test.bin 
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_z80n.bin test_kc160.bin
 endif
 
 
@@ -18,6 +18,14 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
+
+test_kc160.bin: $(SOURCES)
+	$(compile_kc160)
+	$(runtest_kc160)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/ptrbench/Makefile
+++ b/test/suites/ptrbench/Makefile
@@ -9,7 +9,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all:	test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -17,6 +17,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/queenbench/Makefile
+++ b/test/suites/queenbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/recordbench/Makefile
+++ b/test/suites/recordbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/rle/Makefile
+++ b/test/suites/rle/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all:	test.bin 
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/sccz80/Makefile
+++ b/test/suites/sccz80/Makefile
@@ -4,6 +4,9 @@ include ../make.config
 
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
+# --opt-code-speed is an sccz80-only knob; 80cc (and other compilers) reject it.
+OPT_CODE_SPEED := $(if $(filter sccz80,$(COMPILER)),-Cc--opt-code-speed=all)
+
 TARGET_Z80N = test_z80n_rshift.bin test_z80n_lshift.bin
 TARGET_8080 = test_8080_bitfields.bin test_8080_rshift.bin test_8080_lshift.bin test_8080_compare.bin test_8080_compare0.bin test_8080_compare_const.bin test_8080_compare_mconst.bin test_8080_mult.bin test_8080_division.bin test_8080_bitwise.bin
 TARGET_8085 = test_8085_bitfields.bin test_8085_rshift.bin test_8085_lshift.bin test_8085_compare.bin test_8085_compare0.bin test_8085_compare_const.bin test_8085_compare_mconst.bin test_8085_mult.bin test_8085_division.bin test_8085_bitwise.bin
@@ -34,7 +37,7 @@ test_callee.bin: $(SOURCES) callee.c
 	$(runtest)
 
 test_compare.bin: $(SOURCES) compare.c
-	$(call compile, -Cc--opt-code-speed=all,)
+	$(call compile, $(OPT_CODE_SPEED),)
 	$(runtest)
 
 

--- a/test/suites/searchbench/Makefile
+++ b/test/suites/searchbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/sieve/Makefile
+++ b/test/suites/sieve/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/sortbench/Makefile
+++ b/test/suites/sortbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/spectralnorm/Makefile
+++ b/test/suites/spectralnorm/Makefile
@@ -11,12 +11,16 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 # so cross-compiler comparison is apples-to-apples); the index-register-less
 # CPUs (8080/8085/gbz80 — the strategic sp-mode targets) use the 32-bit MBF
 # library, mirroring the math suite.
-all:	test.bin test_8080.bin test_8085.bin test_gbz80.bin
+all:	test.bin test_8080.bin test_8085.bin test_gbz80.bin test_z80n.bin
 
 
 test.bin: $(SOURCES)
 	$(call compile,-DMATH32 -D__MATH_MATH32 -fp-mode=ieee,-lmath32)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(call compile_z80n,-DMATH32 -D__MATH_MATH32 -fp-mode=ieee,-lmath32)
+	$(runtest_z80n)
 
 test_8080.bin: $(SOURCES)
 	$(call compile_8080,--math-mbf32)

--- a/test/suites/strbench/Makefile
+++ b/test/suites/strbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/structbench/Makefile
+++ b/test/suites/structbench/Makefile
@@ -7,13 +7,17 @@ OBJECTS := $(SOURCES:.c=.o)
 CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 
 
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 
 
 
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/switchbench/Makefile
+++ b/test/suites/switchbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/vecbench/Makefile
+++ b/test/suites/vecbench/Makefile
@@ -10,7 +10,7 @@ CFLAGS +=  -DNO_LOG_RUNNING -DNO_LOG_PASSED
 ifeq ($(COMPILER),xcc)
 all: test.bin
 else
-all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin
+all:	test.bin test_r2ka.bin test_8080.bin test_8085.bin test_gbz80.bin test_z180.bin test_ez80_z80.bin test_r4k.bin test_kc160.bin test_z80n.bin
 endif
 
 
@@ -18,6 +18,10 @@ endif
 test.bin: $(SOURCES)
 	$(compile)
 	$(runtest)
+
+test_z80n.bin: $(SOURCES)
+	$(compile_z80n)
+	$(runtest_z80n)
 
 test_r2ka.bin: $(SOURCES)
 	$(compile_r2ka)

--- a/test/suites/zx/zx_saddrpleft.c
+++ b/test/suites/zx/zx_saddrpleft.c
@@ -21,7 +21,8 @@ static void dummy()
 static void evaluate(int a, int m)  __naked
 {
 #asm
-    ld     ix,2
+    push   ix
+    ld     ix,4
     add    ix,sp
     ld     e,(ix+0)
     ld     d,0
@@ -37,7 +38,7 @@ static void evaluate(int a, int m)  __naked
     push   af
     pop    hl
     ld     (_old_regs+6),hl
-    ld     ix,2
+    ld     ix,4
     add    ix,sp
     ld     e,(ix+0)
     ld     d,0
@@ -53,6 +54,7 @@ static void evaluate(int a, int m)  __naked
     push   af
     pop    hl
     ld     (_new_regs+6),hl
+    pop    ix
     ret
 #endasm
 }


### PR DESCRIPTION
Advances the 80cc back end with a live-range allocator that homes reduction values in IY, a clean-up of the CLI option surface, and a set of Architecture Decision Records documenting the
  back end. Based on current master (no file overlap with the intervening m100/copt changes).
    
  LRA — IY-reduction residency (now default-on). A live-range allocator homes DE-dirty straight-line reduction chains (c0=x+y, c1=c0+z, …) and loop-carried accumulators (s = s OP x) in IY, accumulating via add iy,de. Covers z80/z80n/z180/ez80/rabbit in both sp and fp modes, with benefit-ranked arbitration against idx2. 

  Representative wins (80cc-sp, vs the pre-LRA snapshot — full matrix in test/suites/BENCH_MATRIX.txt):
  - matrixbench: z80 −15%, z180 −15%, ez80 −17%
  - vecbench: z80 −6%
  
  Benches without reduction-loop structure are unchanged (the feature is targeted, and gate-off is byte-identical).

  CLI options rationalisation.
  - Frame pointer: -frameix/-frameiy → -fframe-pointer / -fomit-frame-pointer (sp default; byte-identical rename).
  - New --reserve-regs-ix / --reserve-regs-iy — remove an index register from residency (sp + --reserve-regs-ix uses none).
  - --idx2-invariant → --reg-index-invariant, --idx3 → --reg-iy-half; idx3/exx flagged experimental.
  - Removed dead --use-ir / --noaltreg; --opt-code-speed kept as an inert accepted flag (the --math16 alias forwards it to the shared compiler channel).
  - Fix: --disable-builtins was parsed but never consulted — now respected (gates the string/mem builtin inlining, matching sccz80).


  Architecture Decision Records. New src/80cc/adr/ (0001–0012) documenting the IR pipeline, register model, residency, soundness/gating, helper clobber table, multi-CPU retargeting,  kind/width model, IVSR, wide-value accumulator, AST-vs-IR layering, index-register allocation, and the per-CPU frame-pointer default decision.
