### PR TITLE
[cpm][newlib] console output is lost after an intervening fopen (#3022)

### DIFF
--- a/test/suites/target_io/console_after_fopen.c
+++ b/test/suites/target_io/console_after_fopen.c
@@ -1,0 +1,36 @@
+/*
+ * console_after_fopen.c -- console output must survive an intervening fopen().
+ *
+ * Bug demonstrator for z88dk/z88dk#3022 (newlib +cpm CP/M FCB file driver).
+ *
+ * The program prints a marker to the console, opens (and closes) a file, then
+ * prints a second marker:
+ *
+ *     puts("CONSOLE-BEFORE-FOPEN");
+ *     fopen("caf.dat","w"); fclose(...);
+ *     puts("CONSOLE-AFTER-FOPEN");
+ *
+ * EXPECTED (and observed on the classic clib, -clib=default): both markers
+ * reach the console.
+ *
+ * ACTUAL on newlib (-clib=new): only the first marker appears.  Opening a file
+ * rebinds the stdout console stream onto the CP/M file driver, so the second
+ * puts() is misrouted into the file instead of the console.  The file write
+ * path itself is fine -- it is the console stream that gets corrupted.
+ *
+ * The run recipe in the Makefile greps the emulator's console output for the
+ * second marker, so the classic target passes and the newlib target fails.
+ */
+#include <stdio.h>
+
+int main(void)
+{
+    puts("CONSOLE-BEFORE-FOPEN");
+
+    FILE *fp = fopen("caf.dat", "w");
+    if (fp)
+        fclose(fp);
+
+    puts("CONSOLE-AFTER-FOPEN");
+    return 0;
+}


### PR DESCRIPTION
During testing the new CP/M FCB file driver (#3025), Claude noticed that any console output after an `fopen()` call appears to be misrouted into the file.  Testing revealed this to be a newlib CP/M stdio/fcntl defect, not a compiler calling-convention one — the classic clib is unaffected.

This PR includes a test case failing under newlib and working under classic written by Claude showing the behavior. I have tested using the ntcvm emulator

I do not understand fully what is going on so the test case may be wrong.

---

_claude word salat:_

Adds a minimal repro for a newlib `+cpm` defect found while wiring the new CP/M
FCB file driver (#3025): opening a file corrupts the stdout console stream, so
console output after an `fopen` is misrouted into the file.

**Repro** (stock z88dk, no clang):

```
zcc +cpm -clib=new     -create-app -o caf console_after_fopen.c   # newlib
zcc +cpm -clib=default -create-app -o caf console_after_fopen.c   # classic
```

Run under a CP/M emulator (verified with ntvcm):

- **classic** prints both `CONSOLE-BEFORE-FOPEN` and `CONSOLE-AFTER-FOPEN` ✓
- **newlib** prints only `CONSOLE-BEFORE-FOPEN` — the second `puts()` is
  misrouted into the file ✗

The file write path itself is fine (the file is created correctly); it is the
console stream that gets rebound onto the file driver. Reproduces identically
under SDCC (`-clib=sdcc_iy`), so it is a newlib CP/M stdio/fcntl issue, not a
compiler calling-convention one. The classic clib is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
