### PR TITLE
Optimization ideas for float32

### DIFF
--- a/libsrc/math/float/math32/asm/z80/d32_fsadd.asm
+++ b/libsrc/math/float/math32/asm/z80/d32_fsadd.asm
@@ -71,26 +71,20 @@ PUBLIC m32_fsadd, m32_fsadd_callee
     add hl,hl                   ; unpack op1
     ld c,h                      ; save op1.e in c
 
-    ld a,h
-    or a
-    jr Z,faunp1                 ; add implicit bit if op1.e!=0
-    scf
-
-.faunp1
+    ld a,255
+    add a,h                     ; CF = (op1.e != 0) to add implicit bit
     rr l                        ; rotate in op1.m's implicit bit
     ld a,b                      ; place op1.s in a[7]
 
     exx
 
-    ld hl,002h                  ; get second operand off of the stack
-    add hl,sp
-    ld e,(hl+)
-    ld d,(hl+)
-    ld c,(hl+)
-    ld h,(hl)
-    ld l,c                      ; hlde = seeeeeee emmmmmmm mmmmmmmm mmmmmmmm
+    pop bc                      ; get second operand off of the stack (preserve stack)
+    pop de
+    pop hl                      ; hlde = seeeeeee emmmmmmm mmmmmmmm mmmmmmmm
+    push hl
+    push de
+    push bc
     jp farejoin
-
 
 ; enter here for floating subtract callee, x-y x on stack, y in dehl, result in dehl
 .m32_fssub_callee
@@ -107,21 +101,16 @@ PUBLIC m32_fsadd, m32_fsadd_callee
     add hl,hl                   ; unpack op1
     ld c,h                      ; save op1.e in c
 
-    ld a,h
-    or a
-    jr Z,faunp1_callee          ; add implicit bit if op1.e!=0
-    scf
-
-.faunp1_callee
+    ld a,255
+    add a,h                     ; CF = (op1.e != 0) to add implicit bit
     rr l                        ; rotate in op1.m's implicit bit
     ld a,b                      ; place op1.s in a[7]
 
     exx
 
-    pop bc                      ; pop return address
+    pop hl                      ; pop return address
     pop de                      ; get second operand off of the stack
-    pop hl                      ; hlde = seeeeeee emmmmmmm mmmmmmmm mmmmmmmm
-    push bc                     ; return address on stack
+    ex (sp),hl                  ; hlde = seeeeeee emmmmmmm mmmmmmmm mmmmmmmm, return address to stack
 
 .farejoin
     ld b,h                      ; save op2.s in b[7]
@@ -132,12 +121,8 @@ PUBLIC m32_fsadd, m32_fsadd_callee
     xor b                       ; check if op1.s==op2.s
     ex af,af                    ; save results sign in f' (C clear in af')
 
-    ld a,h
-    or a
-    jr Z,faunp2                 ; add implicit bit if op2.e!=0
-    scf
-
-.faunp2
+    ld a,255
+    add a,h                     ; CF = (op2.e != 0) to add implicit bit
     rr l                        ; rotate in op2.m's implicit bit
     xor a
     ld h,a                      ; op2 mantissa: h = 00000000, lde = 1mmmmmmm mmmmmmmm mmmmmmmm
@@ -297,7 +282,6 @@ PUBLIC m32_fsadd, m32_fsadd_callee
 
 .foverflow
     ld a,b
-    and 080h
     or 07fh                     ; max exponent, preserve sign
     ld d,a
     ld e,080h                   ; IEEE infinity (zero mantissa)

--- a/libsrc/math/float/math32/asm/z80/f32_floor.asm
+++ b/libsrc/math/float/math32/asm/z80/f32_floor.asm
@@ -22,6 +22,6 @@ PUBLIC _m32_floorf
     ; negative with fraction: trunc - 1
     push de
     push hl
-    ld de,$3f80
+    ld de,$bf80
     ld hl,$0000
-    jp m32_fssub_callee
+    jp m32_fsadd_callee         ; add -1

--- a/libsrc/math/float/math32/asm/z80/f32_floor.asm
+++ b/libsrc/math/float/math32/asm/z80/f32_floor.asm
@@ -2,7 +2,7 @@
 SECTION code_clib
 SECTION code_fp_math32
 
-EXTERN m32_fssub_callee
+EXTERN m32_fsadd_callee
 EXTERN m32_discardfraction
 
 PUBLIC m32_floor_fastcall


### PR DESCRIPTION
Just few low-hanging-fruit changes done in web interface of github (so it's mess split into 3 commits, not cleaned up).

NOT tested (beyond CI), and gains are calculated in my head, so I may be wrong about something.

So this is for someone else to pick up, verify, look for other spots in the lib and measure the real impact of these changes.

Summary of ideas:
implicit 1 creation:
```
  ld a,255
  add a,h  ; CF from (255 + exp) means CF = (exp != 0)
```

callee with two 16bit args: `ex (hl),sp` is 19T, while `pop bc : push bc` is 21T

caller with two 16b args: a quick guesstimate in head is 3x pop+push is 63T, the hl<-sp+2 and fetching them byte by byte is like 71T? (I assume `ld e,(hl+)` is `ld e,(hl) : inc hl`)

And the floor for negative value with fraction can do `+(-1)` instead of `-1` saving the sign flip of `m32_fssub_callee`, as the constant is set in floor anyway, so the sign flip can be baked in.

Sorry for not doing this properly and deeply, but this was just some quick fun for me, feel free to even ignore/close if nobody wants to pick on this. (I just have read talk about float32 being behind MS implementation and I got slightly curious to read into it for few minutes I had, just to figure out I would need to extract it into separate project and actually step over it in debugger as the code flow gets quickly more tricky to follow just in head ... but on the first read it feels like there should be more to gain with decent effort, not talking about effort like squeezing out last byte of 256 byte intro, just first-iteration effort).