### PR TITLE
math16 - z80 & 8085 optimisation

### DIFF
--- a/libsrc/math/float/math16/README.md
+++ b/libsrc/math/float/math16/README.md
@@ -3,7 +3,7 @@
 
 This is the z88dk 16-bit IEEE-754 standard math16 half precision floating point maths package, designed to work with the SCCZ80 IEEE-754 half precision 16-bit interfaces.
   
-This library is designed for z80, z180, z80n, and **Intel 8085** processors. On z180 and [ZX Spectrum Next](https://www.specnext.com/) z80n, hardware `16_8x8` multiply accelerates mantissa work. On 8085, CPU-specific cores live under `asm/8085/` (shared specials/coeffs under `asm/`) (no `exx`/IX/IY; stack frames for the second operand) and link as **`math16_8085.lib`** via `--math16` with `-clib=8085`.
+This library is designed for z80, z180, z80n, and Intel 8085 processors. On z180 and [ZX Spectrum Next](https://www.specnext.com/) z80n, hardware `16_8x8` multiply accelerates mantissa work. On 8085, CPU-specific cores live under `asm/8085/` (shared specials/coeffs under `asm/`) (no `exx`/IX/IY; stack frames for the second operand) and link as **`math16_8085.lib`** via `--math16` with `-clib=8085`.
 
 The specialised nature of 16-bit floating point implies that this is an adjunct or special purpose maths library. It can be used to accelerate the calculation of floating point, where the results are only needed to 3.5 significant digits. Applications can include video games, or neural networks, for example. There is **no stdio / printf / scanf / dtoa requirement** on the math16 product itself; apps that need float print may pair another float library (e.g. math32) for I/O only.
 
@@ -18,7 +18,8 @@ The specialised nature of 16-bit floating point implies that this is an adjunct 
   *  All the code is re-entrant.
 
   *  Z80 family: register use is limited to the main and alternate set (including af'). NO index registers were abused in the process.
-  *  **8085:** no alternate register set; second f24 operand and temps on the **stack** only (`ld de,sp+*`, `ld hl,(de)`). Extended 8085 ops preferred. Library asm is not copt’d.
+
+ *  8085: no alternate register set; second f24 operand and temps on the **stack** only (`ld de,sp+*`, `ld hl,(de)`). Extended 8085 ops preferred. Library asm is not copt’d.
 
   *  Made for the Spectrum Next. The z80n `mul de` and the z180 `mlt nn` multiply instructions are used to full advantage to accelerate all floating point calculations.
 
@@ -157,23 +158,45 @@ Normal functions `f16_`, assume the calling convention of sccz80 or sdcc dependi
 
 The library is laid out in these directories.
 
-### z80
+### asm/
 
-Contains the assembly language implementation of the maths library.  This includes the maths functions expected by the IEEE-754 standard and various low level functions necessary to implement a float package accessible from assembly language.  These functions are the intrinsic `math16` functions.
+Shared portable pieces used by every CPU product: specials (`zero` / `inf` / `nan` / `neg` / `sigdig`) and polynomial coefficient tables (`coeff_f16_*`).
+
+### asm/z80/
+
+Z80-family cores (also assembled for z180 / z80n / r2ka / … where the same sources apply). Intrinsic half and f24 operations, expand/pack, poly, sqrt, compare, etc.
+
+### asm/8085/
+
+Intel 8085 cores only (`math16_8085.lib`). Same public entry names as the Z80 tree where the API matches; implementation is stack-based (no `exx` / IX / IY). See **CPU implementation strategies** below and `asm/8085/README`.
 
 ### c
 
-Contains the trigonometric, logarithmic, power and other functions implemented in C. Currently, compiled versions of these functions are prepared and saved in `c/asm` to be assembled and built as required.
+Contains the trigonometric, logarithmic, power and other functions implemented in C. Currently, compiled versions of these functions are prepared and saved in `c/asm` to be assembled and built as required. Higher-level 8085-only C lives under `c/8085/` when present.
 
 ### c/sdcc and c/sccz80
 
-Contains the zsdcc and the sccz80 C compiler interface and is implemented using the assembly language interface in the z80 directory. Float conversion between the math16 IEEE-754 format and the format expected by zsdcc and sccz80 occurs here.
+Contains the zsdcc and the sccz80 C compiler interface and is implemented using the assembly language interface in the `asm/z80` (or `asm/8085`) directory. Float conversion between the math16 IEEE-754 format and the format expected by zsdcc and sccz80 occurs here.
 
 ### lm16
 
 Glue that connects the compilers and standard assembly interface to the `math16` library.  The purpose is to define aliases that connect the standard names to the math16 specific names.  These functions make up the complete z88dk math16 library that is linked against on the compile line as `-lmath16`.
 
 An alias is provided to simplify usage of the library. `--math16` provides all the required linkages and definitions, as a simple command line alternative to `-lmath16 -Cc-D__MATH_MATH16 -D__MATH_MATH16`.
+
+## CPU implementation strategies
+
+Half and f24 **semantics** (bias, rounding sticky rules, specials at pack/expand) are shared. **Code paths are CPU-specific** — there is no single cross-CPU source for hot cores.
+
+| Area | Shared strategy | Z80-family | 8085 |
+|------|-----------------|------------|------|
+| **Half×half mul** (`asm_f16_mul_callee`) | Packed field extract; 11-bit mants; integer product; place (`>>5` / `>>6`+inc exp); pack via `asm_f16_f24` | `ex af,af` for sign; `srl`/`bit`/`set`; local Runer112 mulu with early-out entry for 11-bit and bit15-specialised entry for f24 | Sign on stack; open-coded logical EHL `>>`; one early-out `f16_8085_mulu_32_16x16` for both packed and f24 |
+| **f24 mul** (poly / inv / div / sqrt) | Left-aligned 16-bit mants; exp sum with bias 127; renorm + sticky | Alternate register set for second operand | Stack frame for second f24 (`ld de,sp+*`) |
+| **Expand** (`asm_f24_f16`) | Half → f24 | `rr hl` / `rra` path (cheaper on Z80) | Field extract + `add hl,hl` ×5 + implicit bit (no cheap 16-bit `rr`) |
+| **Pack** (`asm_f16_f24`) | f24 → half with low-bit rounding | `add hl,hl` for mant positioning | Same idea (`add hl,hl` ×3 + sign via A) |
+| **Add / compare / …** | Same algorithms | `exx`, native CB shifts | Stack second operand; open-coded shifts |
+
+Deliberate non-goals: one shared mul body for both CPUs; forcing Z80 expand into the 8085 field form (or the reverse) — each form is the cheaper expand on that ISA.
 
 ## Function Discussion
 
@@ -293,23 +316,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
----
-
-## Intel 8085 product (`math16_8085.lib`)
-
-| Item | Detail |
-|------|--------|
-| Build | `make -C libsrc/math/float/math16` → `math16_8085.lib` (also `make -C c 8085` for higher C) |
-| Install | `make -C libsrc install` → `lib/clibs/math16_8085.lib` |
-| Link | `zcc +… -clib=8085 --math16 …` → `-lmath16_8085` via `@{ZCC_LIBCPU}` |
-| Layout | Cores `asm/8085/` + shared `asm/` (specials, coeffs); higher sccz80 C in `c/8085/`; lists `newlibfiles_8085.lst` |
-| Compilers | **sccz80** primary (`l_f16_*`); **80cc** shares `l_f16_*`; **sdcc** explicit half surface as on Z80 (no native half codegen) |
-| Tests | `test/suites/math` recipe `test_math16_8085.bin` (`-m8085` ticks) |
-| Adjunct | No printf/scanf/dtoa in this library |
-
-**Correctness (2026-07):** Z80 `test_math16.bin` **13/13**. 8085 `test_math16_8085.bin` **13/13** (`-m8085`). Higher C via `c/8085/` + `--math16`.
-
-Internal **f24** ABI (d/e/hl) matches the Z80 documentation above; only implementation differs. Cores use stack frames (no `exx`); sccz80 callee entry is **`[uret][x]`**, HL=y. `asm_f24_f16` uses **B** as temp — frexp/ldexp-style helpers must preserve BC across expand.
-

--- a/libsrc/math/float/math16/asm/8085/README
+++ b/libsrc/math/float/math16/asm/8085/README
@@ -1,8 +1,32 @@
-8085 math16 cores (CPU-specific). Built with -m8085; no exx/IX/IY.
-Stack-only second operands; f24 layout d=exp, e=sign, hl=mant.
+# 8085 math16 cores
 
-Shared portable pieces live in parent asm/:
-  asm_f16_{zero,inf,nan,neg,sigdig}.asm  — specials (8080-safe)
-  coeff_f16_*.asm                 — polynomial tables (DEFQ rodata)
+CPU-specific half / f24 implementation. Assembled with `-m8085` into **`math16_8085.lib`** (`newlibfiles_8085.lst`).
 
-Product: math16_8085.lib via newlibfiles_8085.lst
+## Rules
+
+- No `exx`, IX, or IY. Second f24 operand and temps on the **stack** only (`ld de,sp+*`, `ld hl,(de)`, `ld (de),hl`).
+- Prefer 8085 extended ops (`rl de`, `sra hl`, `sub hl,bc`, …) where they help.
+- **Never** `pop af` a return address (F bit 3 hardwired 0). Use BC/DE/HL for return words; `pop af` only to discard unused stack words.
+- Library asm is not run through copt.
+
+## Shared with Z80 product
+
+Portable specials and coeffs live in parent `asm/`:
+
+- `asm_f16_{zero,inf,nan,neg,sigdig}.asm`
+- `coeff_f16_*.asm`
+
+Public entry **names** match the Z80 cores where the API is the same (`asm_f16_mul_callee`, `asm_f24_add_f24`, …).
+
+## Strategy vs Z80 (summary)
+
+Full table: parent **`README.md` → CPU implementation strategies**.
+
+| Topic | 8085 choice |
+|-------|-------------|
+| Half×half mul | Packed 11×11 (same algorithm as Z80; stack/sign/shift encoding differs) |
+| f24 mul | Stack frame; single early-out 16×16 helper |
+| Expand | Field extract + `add hl,hl` (no cheap `rr hl`) |
+| Pack | `add hl,hl` mant positioning |
+
+No cross-CPU single source for these hot paths — each tree is optimised for its ISA.

--- a/libsrc/math/float/math16/asm/8085/asm_f16_mul.asm
+++ b/libsrc/math/float/math16/asm/8085/asm_f16_mul.asm
@@ -3,6 +3,9 @@
 ;-------------------------------------------------------------------------
 ;  asm_f16_mul — 8085 half mul (stack-balanced)
 ;-------------------------------------------------------------------------
+; Half×half (asm_f16_mul_callee): packed field extract + 11×11 + pack.
+; f24_mul: stack frame for poly/inv/div (left-aligned 16-bit mants).
+;
 ; f24_mul_f24 after CALL: [cret][X.hl][X.de]
 ; Frame after setup: [cret][Y.hl][Y.de][X.hl][X.de]
 ;   Y.hl +2 (mant), Y.de +4 (E=sign,D=exp), X.hl +6, X.de +8
@@ -11,8 +14,9 @@
 SECTION code_clib
 SECTION code_fp_math16
 
-EXTERN asm_f24_f16
 EXTERN asm_f16_f24
+EXTERN asm_f16_zero
+EXTERN asm_f16_inf
 EXTERN asm_f24_zero
 EXTERN asm_f24_inf
 
@@ -21,20 +25,233 @@ PUBLIC asm_f24_mul_callee
 PUBLIC asm_f24_mul_f24
 PUBLIC f16_8085_mulu_32_16x16
 
+;-------------------------------------------------------------------------
+; Packed half×half mul (8085-native: no exx / ex af,af / srl / bit / set).
+; Half: S EEEEE MMMMMMMMMM.  mant11 = (hl & 0x3ff) | 0x400.
+; Product p in [2^20, ~2^22) fits in EHL (D=0).
+;   p <  2^21: mant = p >> 5
+;   p >= 2^21: mant = p >> 6, exp++
+; then asm_f16_f24.
+;-------------------------------------------------------------------------
+
+; enter: HL=y, stack=[uret][x] → half product in HL
 .asm_f16_mul_callee
-    ; HL=y, stack=[uret][x]
-    ; Mul is commutative: leave y on stack as f24_mul's X, x in DEHL as Y.
-    call asm_f24_f16            ; y → f24
-    push de
-    push hl                     ; [y.hl][y.de][uret][x]
-    ld de,sp+6
-    ld hl,(de)                  ; x half
-    call asm_f24_f16            ; x → f24 in DEHL
-    call asm_f24_mul_f24        ; drops y; leaves [uret][x]
-    pop bc                      ; uret
-    pop af                      ; consume x
-    push bc
+    pop bc                      ; uret (never pop af for return)
+    pop de                      ; x half
+    push bc                     ; [uret]
+
+    ld a,d
+    xor h
+    and 080h
+    push af                     ; [sign][uret]  sign in A[7]
+
+    ; ---- y: exp + mant11 ----
+    ld a,h
+    and 07ch
+    jp Z,hmul_uzero
+    rrca
+    rrca
+    ld b,a                      ; B = y.exp
+    ld a,h
+    and 003h
+    or 004h
+    ld h,a                      ; HL = y mant11
+    push hl                     ; [ym][sign][uret]
+
+    ; ---- x: exp + mant11 ----
+    ld a,d
+    and 07ch
+    jr Z,hmul_xzero_pop
+    rrca
+    rrca
+    ld c,a                      ; C = x.exp
+    ld a,d
+    and 003h
+    or 004h
+    ld d,a                      ; D:E = x mant11
+    ld h,d
+    ld l,e                      ; HL = x mant11
+    pop de                      ; DE = y mant11
+
+    ; ---- half exp → f24-biased ----
+    ld a,b
+    add a,c
+    sub 15
+    jp Z,hmul_uzero_s           ; under (sign still on stack)
+    jp C,hmul_uzero_s
+    cp 31
+    jp NC,hmul_uinf_s
+
+    add a,127-15
+    ld b,a                      ; B = f24 exp
+    push bc                     ; [f24exp][sign][uret]  (C free)
+
+    call f16_8085_mulu_32_16x16 ; DE * HL → DEHL (11×11, early-out)
+
+    pop bc                      ; B = f24 exp
+    ; D = 0 for 11×11; bit21 of p is E[5]
+    ld a,e
+    and 020h
+    jr NZ,hmul_ge2
+
+    ; mant = p >> 5  (logical: clear C, then rra E→H→L ×5)
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    jr Z,hmul_pack
+    ld a,l
+    or 001h
+    ld l,a
+    jr hmul_pack
+
+.hmul_ge2
+    inc b
+    jr Z,hmul_uinf_pop
+    ; mant = p >> 6
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    rra
+    ld e,a
+    ld a,h
+    rra
+    ld h,a
+    ld a,l
+    rra
+    ld l,a
+    ld a,e
+    or a
+    jr Z,hmul_pack
+    ld a,l
+    or 001h
+    ld l,a
+
+.hmul_pack
+    pop af                      ; sign
+    ld e,a
+    ld d,b                      ; f24 exp
     jp asm_f16_f24
+
+.hmul_xzero_pop
+    pop hl                      ; drop y mant11
+.hmul_uzero
+    pop af                      ; sign
+    ld e,a
+    jp asm_f16_zero
+
+.hmul_uzero_s
+    pop af                      ; sign (ym already popped)
+    ld e,a
+    jp asm_f16_zero
+
+.hmul_uinf_s
+    pop af
+    ld e,a
+    jp asm_f16_inf
+
+.hmul_uinf_pop
+    pop af                      ; sign (f24 exp already popped)
+    ld e,a
+    jp asm_f16_inf
+
 
 .asm_f24_mul_callee
 .asm_f24_mul_f24

--- a/libsrc/math/float/math16/asm/z80/asm_f16_add.asm
+++ b/libsrc/math/float/math16/asm/z80/asm_f16_add.asm
@@ -108,7 +108,7 @@ PUBLIC asm_f24_add_f24
                                 ; x mantissa: hl  = 1mmmmmmm mmmmmmmm
 
     cp a,d                      ; nc if a>=b
-    jp Z,alignzero              ; no alignment needed, exponents equal
+    jr Z,alignzero              ; no alignment needed, exponents equal
     jr NC,sort                  ; if a larger than b
     ld a,d
     exx
@@ -116,7 +116,7 @@ PUBLIC asm_f24_add_f24
 .sort
     sub a,d                     ; positive difference in a
     cp  a,1                     ; if one difference, special case
-    jp Z,alignone               ; smaller mantissa on top
+    jr Z,alignone               ; smaller mantissa on top
 
     cp a,16                     ; check for too many shifts
     jr C,align                  ; if 15 or fewer shifts

--- a/libsrc/math/float/math16/asm/z80/asm_f16_f32.asm
+++ b/libsrc/math/float/math16/asm/z80/asm_f16_f32.asm
@@ -91,17 +91,16 @@ PUBLIC asm_f32_f16
     cp 31
     jp NC,asm_f16_inf           ; infinity if number too large
 
-    sla l                       ; position mantissa
-    rl h                        ; remove implicit bit
-    sla l
-    rl h
-    rla                         ; move mantissa into a
-    sla l
-    rl h
+    ; Position mantissa into half layout (bit-identical to sla l/rl h ×3).
+    ; add hl,hl is 11T vs sla l+rl h = 16T per double — ~15T saved here.
+    add hl,hl                   ; shift out implicit 1 (discarded by next)
+    add hl,hl                   ; first explicit mant bit → C
+    rla                         ; mix into exp field
+    add hl,hl
     rla
-    rla                         ; set a ready for sign
-    sla e                       ; move sign to carry
-    rra                         ; place it in a, with exponent and mantissa
+    rla                         ; room for sign at bit 7
+    sla e                       ; sign → C
+    rra                         ; place sign with exp+mant
     ld l,h                      ; position f16 in hl
     ld h,a
     ret

--- a/libsrc/math/float/math16/asm/z80/asm_f16_mul.asm
+++ b/libsrc/math/float/math16/asm/z80/asm_f16_mul.asm
@@ -91,7 +91,7 @@ PUBLIC asm_f24_mul_f24
     ; ---- x: exp + mant11 ----
     ld a,d
     and 07ch
-    jr Z,hmul_xzero_pop
+    jp Z,hmul_xzero_pop         ; jp: far labels (r4k/r2ka encoding can exceed jr)
     rrca
     rrca
     ld c,a                      ; C = x.exp
@@ -153,7 +153,7 @@ ENDIF
 
 .hmul_ge2
     inc b
-    jr Z,hmul_uinf
+    jp Z,hmul_uinf
     srl e
     rr h
     rr l

--- a/libsrc/math/float/math16/asm/z80/asm_f16_mul.asm
+++ b/libsrc/math/float/math16/asm/z80/asm_f16_mul.asm
@@ -42,6 +42,8 @@ SECTION code_fp_math16
 
 EXTERN asm_f24_f16
 EXTERN asm_f16_f24
+EXTERN asm_f16_zero
+EXTERN asm_f16_inf
 EXTERN asm_f24_zero
 EXTERN asm_f24_inf
 
@@ -51,19 +53,147 @@ PUBLIC asm_f24_mul_callee
 
 PUBLIC asm_f24_mul_f24
 
-; enter here for floating asm_f16_mul_callee, x+y, x on stack, y in hl, result in hl
+;-------------------------------------------------------------------------
+; Half×half mul (packed): field extract + 11×11 product + pack.
+; Keeps f24_mul for poly/inv/div intermediates (left-aligned 16-bit mants).
+;
+; Half: S EEEEE MMMMMMMMMM.  Finite mant11 = (hl & 0x3ff) | 0x400.
+; Product p of two mant11 is in [2^20, ~2^22) and fits in EHL (D=0).
+; Build f24-compatible left-aligned 16-bit mant:
+;   p <  2^21:  mant = p >> 5
+;   p >= 2^21:  mant = p >> 6, exp++
+; then pack with asm_f16_f24.
+;-------------------------------------------------------------------------
+
+; enter: y in HL, x on stack → half product in HL
 .asm_f16_mul_callee
-    call asm_f24_f16            ; expand to dehl
-    exx                         ; y    d'  = eeeeeeee e = s-------
-                                ;      hl' = 1mmmmmmm mmmmmmmm
-    pop hl                      ; pop return address
-    ex (sp),hl                  ; get second operand off of the stack,
-                                ; return address on stack
-    call asm_f24_f16            ; expand to dehl
-                                ; x     d  = eeeeeeee e = s-------
-                                ;       hl = 1mmmmmmm mmmmmmmm
-    call asm_f24_mul_f24
+    pop bc                      ; return
+    pop de                      ; x half
+    push bc                     ; return back
+
+    ld a,d
+    xor h
+    ex af,af                    ; result sign in A'[7]
+
+    ; ---- y: exp + mant11 ----
+    ld a,h
+    and 07ch
+    jp Z,hmul_uzero
+    rrca
+    rrca
+    ld b,a                      ; B = y.exp
+    ld a,h
+    and 003h
+    or 004h
+    ld h,a                      ; HL = y mant11
+    push hl
+
+    ; ---- x: exp + mant11 ----
+    ld a,d
+    and 07ch
+    jr Z,hmul_xzero_pop
+    rrca
+    rrca
+    ld c,a                      ; C = x.exp
+    ld a,d
+    and 003h
+    or 004h
+    ld d,a                      ; D:E = x mant11 (E = original half low)
+    ld h,d
+    ld l,e                      ; HL = x mant11
+    pop de                      ; DE = y mant11
+
+    ; ---- result half exp, then f24-biased for pack ----
+    ld a,b
+    add a,c
+    sub 15
+    jp Z,hmul_uzero
+    jp C,hmul_uzero
+    cp 31
+    jp NC,hmul_uinf
+
+    add a,127-15
+    push af                     ; B gets f24 exp on pop (push af → pop bc: B=A)
+
+    ; ---- 11×11 product (small high byte → early-out mulu) ----
+IF __CPU_Z80__
+    call mulu_32_16x16_gen
+ELSE
+    EXTERN l_mulu_32_16x16
+    call l_mulu_32_16x16
+ENDIF
+    ; DEHL = p, D = 0 always for 11×11
+
+    pop bc                      ; B = f24 exp
+
+    bit 5,e                     ; bit21 of p?
+    jr NZ,hmul_ge2
+
+    ; mant = p >> 5  (EHL >> 5 → HL)
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    ld a,e
+    or a
+    jr Z,hmul_pack
+    set 0,l
+    jr hmul_pack
+
+.hmul_ge2
+    inc b
+    jr Z,hmul_uinf
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    srl e
+    rr h
+    rr l
+    ld a,e
+    or a
+    jr Z,hmul_pack
+    set 0,l
+
+.hmul_pack
+    ex af,af                    ; A = result sign
+    ld e,a
+    ld d,b                      ; f24 exp
     jp asm_f16_f24
+
+.hmul_xzero_pop
+    pop hl                      ; drop y mant11
+.hmul_uzero
+    ex af,af
+    ld e,a
+    jp asm_f16_zero
+
+.hmul_uinf
+    ex af,af
+    ld e,a
+    jp asm_f16_inf
 
 
 ; enter here for floating asm_f24_mul_callee, x+y, x on stack, y in dehl, result in dehl
@@ -101,18 +231,7 @@ PUBLIC asm_f24_mul_f24
     ld a,b
     add a,d                     ; sum of exponents
     jr C,mulovl
-    jr fmnouf
-
-.fmchkuf
-    exx                         ; main = x
-
-    ld b,a
-    ld a,d                      ; x.exp
-    or a
-    jr Z,mulzero
-    ld a,b
-    add a,d                     ; add the exponents
-    jr NC,mulzero
+    ; fall through to fmnouf (common finite path)
 
 .fmnouf
     ld b,a
@@ -168,6 +287,18 @@ ENDIF
     ld e,c                      ; put sign into e[7]
     ret                         ; return f24 in DEHL
 
+.fmchkuf
+    exx                         ; main = x
+
+    ld b,a
+    ld a,d                      ; x.exp
+    or a
+    jr Z,mulzero
+    ld a,b
+    add a,d                     ; add the exponents
+    jr NC,mulzero
+    jr fmnouf
+
 .mulovl
     ex af,af                    ; get sign
     ld e,a
@@ -181,21 +312,18 @@ ENDIF
 
 IF __CPU_Z80__
 
-; Made by Runer112
-; Analysed by Zeda
+; Made by Runer112 / Analysed by Zeda / Tested by jacobly
 ; https://raw.githubusercontent.com/Zeda/z80float/master/common/mul16.z80
-; Tested by jacobly
+;
+; Two entries, one unrolled body:
+;   mulu_32_16x16     — f24 path: bit15 set, skip leading-zero scan
+;   mulu_32_16x16_gen — packed half: 11-bit mants, full early-out
 ;
 ; DE*HL --> DEHL
-;
-; enter : de   = 16-bit multiplicand  = x
-;         hl   = 16-bit multiplier = y
-;
-; exit  : dehl = 32-bit product
-;
 ; uses  : af, bc, de, hl
 
-.mulu_32_16x16
+; Packed-half entry first: early-out jumps forward into shared body
+.mulu_32_16x16_gen
 
     ld a,d
     ld d,0
@@ -241,6 +369,16 @@ IF __CPU_Z80__
     ld h,d
     ld l,e
     ret
+
+; f24 entry: bit15 set → fall into shared chain
+.mulu_32_16x16
+
+    ld b,h
+    ld c,l
+    ld a,d
+    ld d,0
+    add a,a                     ; D7 always 1; C set
+                                ; fall through to .bit14
 
 .bit14
     add hl,hl


### PR DESCRIPTION
# math16 optimisation outcomes (Z80 and 8085)
Measured with this tree’s suite and classic TIMER recipes.

---

## Scope

| Path | Product | Sources |
|------|---------|---------|
| Z80 family | `math16.lib` | `asm/z80/`, shared `asm/` |
| Intel 8085 | `math16_8085.lib` | `asm/8085/`, shared `asm/` |

Cores are **not** a single cross-CPU source. Half/f24 semantics match; encoding and register/stack strategy differ (see `libsrc/math/float/math16/README.md`).

---

## What changed

### Both CPUs

- **Half×half multiply** (`asm_f16_mul_callee`): packed path — field extract, 11-bit mantissas, integer product, place, `asm_f16_f24`.  
  **`asm_f24_mul_f24`** remains for poly / inv / div / sqrt intermediates.

### Z80 only (`asm/z80/`)

- Pack (`asm_f16_f24`): mant positioning with `add hl,hl`.
- f24 mulu: shared Runer112 body; early-out entry for 11-bit packed; bit15 fall-through entry for normalised f24.
- Add: `jr` for alignzero / alignone where in range.

### 8085 only (`asm/8085/`)

- Packed half mul with stack sign, open-coded logical EHL shifts, existing early-out 16×16 helper.
- Expand/pack already used field + `add hl,hl` forms (no further change required for this pass).

---

## Suite (`test/suites/math`)

All gates green: 13 run, 13 passed, 0 failed (each product).  
**% faster** = `(before − after) / before × 100` (fewer ticks = faster).

| Binary | Before | After | % faster |
|--------|-------:|------:|---------:|
| `test_math16` (Z80) | 522 079 | 514 881 | **1.38 %** |
| `test_math16_8085` | 708 992 | 701 991 | **0.99 %** |

---

## Classic TIMER (sccz80, published recipe flags)

Half range: n-body uses `DT=1e-1` under `__MATH_MATH16`.

### n-body (`support/benchmarks/n-body/z88dk-classic`)

| Config | Before | After | % faster |
|--------|-------:|------:|---------:|
| `+test` math16 Z80 | 363 824 289 | 296 298 262 | **18.56 %** |
| `+test -clib=8085` math16 | 428 771 307 | 346 611 815 | **19.16 %** |

### mandelbrot (`support/benchmarks/mandelbrot/z88dk-classic`)

| Config | Before | After | % faster |
|--------|-------:|------:|---------:|
| `+test` math16 Z80 | 924 216 002 | 835 883 280 | **9.56 %** |
| `+test -clib=8085` math16 | 1 142 010 284 | 1 028 644 046 | **9.93 %** |

---

## Strategy alignment (short)

| | Aligned | Divergent (by design) |
|--|---------|------------------------|
| Packed half mul algorithm | yes | register/stack / shift opcodes |
| f24 for series (poly, inv, …) | yes | `exx` vs stack frame |
| Expand | goal same | Z80 `rr hl` vs 8085 field+`add hl,hl` |
| Pack | `add hl,hl` positioning | surrounding sign/exp moves |

Documented in `libsrc/math/float/math16/README.md` and `asm/8085/README`.
