### PR TITLE
Recordbench mixes signed and unsigned int resulting in undefined behavior

### DIFF
--- a/test/suites/recordbench/recordbench.c
+++ b/test/suites/recordbench/recordbench.c
@@ -21,7 +21,7 @@
 #define ITERS  6000
 #define CHK    4389u        /* host-verified */
 
-struct st { int a, b, c, d, e; };
+struct st { unsigned int a, b, c, d, e; };
 static struct st S;
 
 static unsigned int churn(struct st *p, int it)
@@ -34,7 +34,7 @@ static unsigned int churn(struct st *p, int it)
         if (p->c & 1) p->d = (p->d + p->e) & 0x7fff;
         else          p->e = (p->e + p->a) & 0x7fff;
         p->b = (p->b + p->c) & 0x7fff;
-        chk = (chk + (unsigned int)p->a + (unsigned int)p->d) & 0xffffu;
+        chk = (chk + p->a + p->d) & 0xffffu;
     }
     return chk;
 }


### PR DESCRIPTION
Recordbench does unsigned arithmetic on signed ints and masking off the sign bit afterwards, which results in undefined behavior. 

This is not a problem with z88dk compilers but allowed llvmz80 to do an incorrect optimization.

My guess is that the correct fix is to avoid undefined behavior which is  done by switching purely to unsigned ints.