### PR TITLE
math32 - further diet of normalisation (f32, z80)

### DIFF
--- a/libsrc/math/float/math32/asm/z80/f32_fsnormalize.asm
+++ b/libsrc/math/float/math32/asm/z80/f32_fsnormalize.asm
@@ -1,5 +1,6 @@
 ;
 ;  feilipu, 2026 August
+;  ped7g, 2026 August
 ;
 ;  This Source Code Form is subject to the terms of the Mozilla Public
 ;  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,7 +10,7 @@
 ; m32_fsnormalize - z80 / z180 / z80n normalisation
 ;-------------------------------------------------------------------------
 ;
-;  unpacked: h==0; mantissa=lde, sign in b, exponent in c
+;  unpacked: h==0 (discarded); mantissa=lde, sign in b, exponent in c
 ;
 ;  ex de,hl → E:HL; D = total left-shift count (byte align + residual).
 ;  Sign stays in B (no push).  Residual: jp m tree, add hl,hl / rl e.
@@ -31,99 +32,53 @@ PUBLIC m32_fsnormalize
     ld d,0                      ; shift total
 
     ; ---------------------------------------------------------------
-    ; Byte scan on E:HL
+    ; Byte scan on E:HL and byte-alignment of it
     ; ---------------------------------------------------------------
 
     ld a,e
     or a
-    jp m,no_bit_shift           ; already normalised, D = 0
-    jr nz,bitwalk               ; residual only (D = 0)
+    jp m,normalised             ; already normalised (hot path)
+    jr nz,need_shift            ; non-zero lead in E, D = 0, A:HL ready
+    or h
+    jr nz,need8                 ; non-zero lead in H, align by byte first
+    or l
+    jr z,normzero               ; all zeroes (no lead), return zero float
 
-    ld a,h
-    or a
-    jr nz,need8
-
-    ld a,l
-    or a
-    jr z,normzero
-
-    ; leading in L → align 16
-    ld e,l
-    ld hl,0
+; .need16 ; A == L ; leading non zero is in L → exp -16
+    ld l,h                      ; A:HL shifted by 16 (hl = 0)
     ld d,16
-    jr got_lead
+    jr bitshift_check           ; process byte-aligned non-zero lead
 
 .need8
-    ld e,h
+    ; A == H ; leading non zero is in H → exp -8
     ld h,l
-    ld l,0
+    ld l,e                      ; A:HL shifted by 8 (l = 0)
     ld d,8
-    ; fall through — E was non-zero H
-
-.got_lead
-    ld a,e
-    or a
-    jp m,no_bit_shift           ; normalised after byte align only
-    ; E non-zero; fall into bitwalk (A = E, D = 8 or 16)
+.bitshift_check                 ; check SF set by last `or` instruction
+    jp m,normalised             ; normalised by 8/16 shift, pack it
+    ; fall through to need_shift ; process byte-aligned non-zero lead
 
     ; ---------------------------------------------------------------
-    ; Residual walk on A; D accumulates 1..7; jump into shift tree
+    ; Normalization shifts of A:HL; D incremented by shifts (+1..7)
+    ; A is 0x01..0x7F upon entry (0x80+ → normalised, 0x00 → normzero)
     ; ---------------------------------------------------------------
 
-.bitwalk
-    inc d
-    add a,a
-    jp m,s1
-    inc d
-    add a,a
-    jp m,s2
-    inc d
-    add a,a
-    jp m,s3
-    inc d
-    add a,a
-    jp m,s4
-    inc d
-    add a,a
-    jp m,s5
-    inc d
-    add a,a
-    jp m,s6
-    inc d
-    add a,a
-    jp p,normzero               ; 7th trial still clear → zero
-    ; fall through to s7 (D = base+7)
+.need_shift
+    inc d                       ; ++shifts (to --exp)
+    add hl,hl
+    adc a,a                     ; A:HL << 1 and check for leading one
+    jp p,need_shift             ; not leading yet, keep shifting
 
-.s7
-    add hl,hl
-    rl e
-.s6
-    add hl,hl
-    rl e
-.s5
-    add hl,hl
-    rl e
-.s4
-    add hl,hl
-    rl e
-.s3
-    add hl,hl
-    rl e
-.s2
-    add hl,hl
-    rl e
-.s1
-    add hl,hl
-    rl e
-
-.no_bit_shift
+.normalised                     ; calculate final exp and prepare for packing
+    add a,a                     ; drop implicit 1 (preparing mant for pack)
+    ld e,a
     ; A = C − D (final exp); B = sign; E:HL = normalised mant
     ld a,c
-    sub d
+    sub d                       ; a = final exp
     jr c,normzero
 
-    ; pack IEEE DEHL (mul/sqr style on E high)
-    sla e                       ; drop implicit 1 → C
+; pack IEEE DEHL (mul/sqr style on E high)
+    ; sla e ; implicit 1 was already dropped above
     rl b                        ; sign → C
     rra                         ; A = sign|exp
     ld d,a


### PR DESCRIPTION
From 152 to ~~96~~ ~~85~~ ~~53~~ 55 bytes.
Also marginally faster, no code path is slower.

Related to #3043