### PR TITLE
zsdcc - fix loose ___memcpy issuance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ ifdef BUILD_SDCC
 		--disable-pdk13-port --disable-pdk14-port \
 		--disable-pdk15-port --disable-pdk16-port \
 		--disable-mos6502-port --disable-mos65c02-port \
-		--disable-r2k-port --disable-f8-port \
+		--disable-r2k-port --disable-f8-port --disable-f8l-port\
 		--disable-non-free --disable-device-lib \
 		--disable-ucsim --disable-packihx \
 		--disable-sdcpp --disable-sdcdb --disable-sdbinutil
@@ -291,7 +291,7 @@ examples-clean:
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	SNAP_OPTS=
-else 
+else
 	SNAP_OPTS= --use-lxd
 endif
 

--- a/src/zsdcc/sdcc-16639-z88dk.patch
+++ b/src/zsdcc/sdcc-16639-z88dk.patch
@@ -127,6 +127,21 @@ Index: src/SDCCmain.c
      {
        struct dbuf_s adbFile;
  
+@@ -2921,6 +2912,13 @@
+          wassert (yyin);
+          yyparse ();
+          fclose (yyin);
++          /* Preamble just declared __builtin_memcpy. initBuiltIns() ran
++             first and bound builtin_memcpy to the __memcpy fallback. */
++          {
++            symbol *bm = findSym (SymbolTab, NULL, "__builtin_memcpy");
++            if (bm)
++              builtin_memcpy = bm;
++          }
+         }
+ 
+       preProcess (envp); // Sets yyin to pipe from preprocessor
+ 
 Index: src/SDCCopt.c
 ===================================================================
 --- src/SDCCopt.c	(revision 16639)

--- a/src/zsdcc/sdcc-16639-z88dk.patch
+++ b/src/zsdcc/sdcc-16639-z88dk.patch
@@ -128,9 +128,9 @@ Index: src/SDCCmain.c
        struct dbuf_s adbFile;
  
 @@ -2921,6 +2912,13 @@
-          wassert (yyin);
-          yyparse ();
-          fclose (yyin);
+           wassert (yyin);
+           yyparse ();
+           fclose (yyin);
 +          /* Preamble just declared __builtin_memcpy. initBuiltIns() ran
 +             first and bound builtin_memcpy to the __memcpy fallback. */
 +          {

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -127,6 +127,21 @@ Index: src/SDCCmain.c
      {
        struct dbuf_s adbFile;
  
+@@ -2921,6 +2912,13 @@
+          wassert (yyin);
+          yyparse ();
+          fclose (yyin);
++          /* Preamble just declared __builtin_memcpy. initBuiltIns() ran
++             first and bound builtin_memcpy to the __memcpy fallback. */
++          {
++            symbol *bm = findSym (SymbolTab, NULL, "__builtin_memcpy");
++            if (bm)
++              builtin_memcpy = bm;
++          }
+         }
+ 
+       preProcess (envp); // Sets yyin to pipe from preprocessor
+ 
 Index: src/SDCCopt.c
 ===================================================================
 --- src/SDCCopt.c	(revision 16639)

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -128,9 +128,9 @@ Index: src/SDCCmain.c
        struct dbuf_s adbFile;
  
 @@ -2921,6 +2912,13 @@
-          wassert (yyin);
-          yyparse ();
-          fclose (yyin);
+           wassert (yyin);
+           yyparse ();
+           fclose (yyin);
 +          /* Preamble just declared __builtin_memcpy. initBuiltIns() ran
 +             first and bound builtin_memcpy to the __memcpy fallback. */
 +          {


### PR DESCRIPTION
## Summary

The Drystone benchmark fails.

SDCC 4.6.0 runs `initBuiltIns()` before it parses the Z80 preamble that declares `__builtin_memcpy`. Struct assignment (Dhrystone `structassign`, and any other struct copy) therefore called the `__memcpy` fallback and emitted call `___memcpy` with no `EXTERN`. Classic `+test` failed to assemble.

This was not a miss in the existing `SDCCopt.c` hunk. That hunk only renames `__builtin_memcpy` when a builtin is converted to a library call. Dhrystone never took that path.

## Fix

After the preamble `yyparse()`, re-bind `builtin_memcpy` to the real `__builtin_memcpy`. Constant-size struct copies then use the Z80 builtin path (`ldir` / `ldi`). The existing `_memcpy` remaps stay in place for the convert-to-library-call case.

Applied in both `src/zsdcc/sdcc-z88dk.patch` and `src/zsdcc/sdcc-16639-z88dk.patch`.

## Check

Classic Dhrystone TIMER (+test -compiler=sdcc -SO3) links. The two Rec_Type copies emit `ldir`, not call `___memcpy`.

## Action / To Do

@suborb 
We need to rebuild the tarball. I won't attach it here to avoid bloating the history.
Merge when you're ready.