### PR TITLE
zsdcc - minimum fix for #3077 from sdcc r16827/8

### DIFF
--- a/src/zsdcc/readme.md
+++ b/src/zsdcc/readme.md
@@ -14,7 +14,7 @@ For Linux users follow the instructions on the [installation page](https://githu
 
 `sdcc-z88dk.patch` is the current default standard patch.
 
-`sdcc-16639-z88dk.patch` is the current zsdcc patch, for comparison and building against sdcc 4.6.0 r16639 (final release tag).
+`sdcc-16639-z88dk.patch` is the current zsdcc patch, for comparison and building against sdcc 4.6.0 r16639 (final release tag). The r16639 patch also backports SDCC [r16827](https://sourceforge.net/p/sdcc/code/16827/) and [r16828](https://sourceforge.net/p/sdcc/code/16828/) (`nextreg` in the Z80N peephole; SDCC bug [#4062](https://sourceforge.net/p/sdcc/bugs/4062/), z88dk [#3077](https://github.com/z88dk/z88dk/issues/3077)). The r16827 `gen.c` change does not apply to this pin.
 
 `sdcc-15248-z88dk.patch` is the previous zsdcc patch, retained for comparison and building against sdcc 4.5.0 r15248.
 

--- a/src/zsdcc/sdcc-16639-z88dk.patch
+++ b/src/zsdcc/sdcc-16639-z88dk.patch
@@ -141,7 +141,6 @@ Index: src/SDCCmain.c
          }
  
        preProcess (envp); // Sets yyin to pipe from preprocessor
- 
 Index: src/SDCCopt.c
 ===================================================================
 --- src/SDCCopt.c	(revision 16639)
@@ -391,7 +390,17 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -420,6 +502,16 @@
+@@ -378,7 +460,8 @@
+     lineIsInst (pl, "bsra") ||
+     lineIsInst (pl, "bsrl") ||
+     lineIsInst (pl, "bsrf") ||
+-    lineIsInst (pl, "brlc")))
++    lineIsInst (pl, "brlc") ||
++    lineIsInst (pl, "nextreg")))
+     return(false);
+ 
+   if((IS_Z180 || IS_EZ80 || IS_Z80N) &&
+@@ -420,6 +503,16 @@
    if(lineIsInst (pl, "call") && strcmp(what, "sp") == 0)
      return TRUE;
  
@@ -408,7 +417,25 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -1023,6 +1115,16 @@
+@@ -731,6 +824,9 @@
+     lineIsInst (pl, "brlc")))
+     return(strchr("bde", *what));
+ 
++  if (IS_Z80N && lineIsInst (pl, "nextreg") && rarg)
++    return (!STRNCASECMP (rarg, "a", 1) && !strcmp (what, "a"));
++
+   if(IS_TLCS90 &&
+     (lineIsInst (pl, "decx") ||
+     lineIsInst (pl, "incx")))
+@@ -910,6 +1006,7 @@
+     lineIsInst (pl, "bsra") ||
+     lineIsInst (pl, "bsrl") ||
+     lineIsInst (pl, "bsrf") ||
++    lineIsInst (pl, "nextreg") ||
+     lineIsInst (pl, "swap")))
+     return false;
+     
+@@ -1023,6 +1120,16 @@
    if(!strcmp(what, "ix"))
      return(false);
  

--- a/src/zsdcc/sdcc-16639-z88dk.patch
+++ b/src/zsdcc/sdcc-16639-z88dk.patch
@@ -111,7 +111,7 @@ Index: src/SDCCmain.c
  #endif
 -           " #%s (%s)\n", getBuildNumber (), getBuildEnvironment ());
 -  fprintf (stream, "published under GNU General Public License (GPL)\n");
-+    " #%s (%s) " __DATE__ "\n\n", getBuildNumber(), getBuildEnvironment());
++    " #%s (%s) pr3093 " __DATE__ "\n\n", getBuildNumber(), getBuildEnvironment());
 +  fprintf(stream, "sdcc website:\nhttps://sourceforge.net/projects/sdcc/\n\n");
 +  fprintf(stream, "patch details:\nhttps://github.com/z88dk/z88dk/blob/master/src/zsdcc/sdcc-z88dk.patch\n\n");
 +  fprintf(stream, "published under GNU General Public License (GPL)\n");

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -141,7 +141,6 @@ Index: src/SDCCmain.c
          }
  
        preProcess (envp); // Sets yyin to pipe from preprocessor
- 
 Index: src/SDCCopt.c
 ===================================================================
 --- src/SDCCopt.c	(revision 16639)
@@ -391,7 +390,17 @@ Index: src/z80/peep.c
  static bool
  z80MightBeParmInCallFromCurrentFunction(const char *what)
  {
-@@ -420,6 +502,16 @@
+@@ -378,7 +460,8 @@
+     lineIsInst (pl, "bsra") ||
+     lineIsInst (pl, "bsrl") ||
+     lineIsInst (pl, "bsrf") ||
+-    lineIsInst (pl, "brlc")))
++    lineIsInst (pl, "brlc") ||
++    lineIsInst (pl, "nextreg")))
+     return(false);
+ 
+   if((IS_Z180 || IS_EZ80 || IS_Z80N) &&
+@@ -420,6 +503,16 @@
    if(lineIsInst (pl, "call") && strcmp(what, "sp") == 0)
      return TRUE;
  
@@ -408,7 +417,25 @@ Index: src/z80/peep.c
    if(strcmp(pl->line, "call\t__initrleblock") == 0 && (strchr(what, 'd') != 0 || strchr(what, 'e') != 0))
      return TRUE;
  
-@@ -1023,6 +1115,16 @@
+@@ -731,6 +824,9 @@
+     lineIsInst (pl, "brlc")))
+     return(strchr("bde", *what));
+ 
++  if (IS_Z80N && lineIsInst (pl, "nextreg") && rarg)
++    return (!STRNCASECMP (rarg, "a", 1) && !strcmp (what, "a"));
++
+   if(IS_TLCS90 &&
+     (lineIsInst (pl, "decx") ||
+     lineIsInst (pl, "incx")))
+@@ -910,6 +1006,7 @@
+     lineIsInst (pl, "bsra") ||
+     lineIsInst (pl, "bsrl") ||
+     lineIsInst (pl, "bsrf") ||
++    lineIsInst (pl, "nextreg") ||
+     lineIsInst (pl, "swap")))
+     return false;
+     
+@@ -1023,6 +1120,16 @@
    if(!strcmp(what, "ix"))
      return(false);
  

--- a/src/zsdcc/sdcc-z88dk.patch
+++ b/src/zsdcc/sdcc-z88dk.patch
@@ -111,7 +111,7 @@ Index: src/SDCCmain.c
  #endif
 -           " #%s (%s)\n", getBuildNumber (), getBuildEnvironment ());
 -  fprintf (stream, "published under GNU General Public License (GPL)\n");
-+    " #%s (%s) " __DATE__ "\n\n", getBuildNumber(), getBuildEnvironment());
++    " #%s (%s) pr3093 " __DATE__ "\n\n", getBuildNumber(), getBuildEnvironment());
 +  fprintf(stream, "sdcc website:\nhttps://sourceforge.net/projects/sdcc/\n\n");
 +  fprintf(stream, "patch details:\nhttps://github.com/z88dk/z88dk/blob/master/src/zsdcc/sdcc-z88dk.patch\n\n");
 +  fprintf(stream, "published under GNU General Public License (GPL)\n");


### PR DESCRIPTION
I've pulled the minimum fix from sdcc svn that closes #3077, in this patch.

On updating the source tarball, and updating the MacOS and Windows binaries, we can close #3077.